### PR TITLE
Harden recursive upload root validation

### DIFF
--- a/internal/api/tree_transfer.go
+++ b/internal/api/tree_transfer.go
@@ -116,7 +116,7 @@ func buildUploadPlan(ctx context.Context, localRoot, remoteRoot string) (treePla
 		if entry.IsDir() {
 			plan.remoteDirs = append(plan.remoteDirs, remoteTarget)
 		} else {
-			plan.requests = append(plan.requests, transfer.Request{Direction: "upload", LocalPath: local, RemotePath: remoteTarget, LocalRoot: localRoot})
+			plan.requests = append(plan.requests, transfer.Request{Direction: "upload", LocalPath: local, RemotePath: remoteTarget, LocalRoot: filepath.Dir(localRoot)})
 		}
 		return plan.checkLimit()
 	})

--- a/internal/api/tree_transfer_security_test.go
+++ b/internal/api/tree_transfer_security_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"brendigo.com/byftp/internal/security"
+)
+
+func TestUploadTreeBoundaryRejectsLateRootRedirect(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "upload")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := buildUploadPlan(context.Background(), root, "/remote")
+	if err != nil {
+		t.Fatalf("buildUploadPlan: %v", err)
+	}
+	if len(plan.requests) != 1 {
+		t.Fatalf("requests=%d want 1", len(plan.requests))
+	}
+	job := plan.requests[0]
+	if job.LocalRoot != base {
+		t.Fatalf("upload boundary=%q want parent %q", job.LocalRoot, base)
+	}
+
+	if err := os.Remove(filepath.Join(root, "file.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, root); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+	if err := security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath); err == nil {
+		t.Fatal("late upload-root symlink redirect unexpectedly accepted")
+	}
+}


### PR DESCRIPTION
## Što je promijenjeno

- recursive upload poslovi sada vežu `LocalRoot` uz roditeljski direktorij odabranog upload korijena, umjesto uz sam upload korijen
- time se pri svakom pokušaju prijenosa ponovno provjerava i sam odabrani root, pa naknadna zamjena root direktorija symlinkom/junctionom više ne može preusmjeriti queued upload izvan izvorno dopuštene lokalne granice
- dodan je regresijski test `TestUploadTreeBoundaryRejectsLateRootRedirect` koji reproducira kasnu zamjenu upload root direktorija symlinkom i zahtijeva odbijanje prijenosa

## Zašto

`buildUploadPlan` je ispravno odbijao symlink/junction root tijekom planiranja, ali je za datoteke unutar direktorija postavljao `LocalRoot` na sam odabrani root. Runtime provjera `EnsureLocalWithinRoot` namjerno dopušta da je njezin root korisnički odabrana poveznica, pa bi root nakon planiranja mogao biti zamijenjen symlinkom/junctionom prije izvršenja queued transfera. Nova granica postavljena na roditelja čini odabrani upload root dijelom provjeravanog potomka.

## Utjecaj

Nema promjene u normalnom FTP/FTPS/SFTP workflowu niti u korisničkom sučelju. Promjena samo zatvara TOCTOU/redirect rubni slučaj za recursive upload i zadržava postojeće ponašanje za legitimne korisnički odabrane putanje.

## Provjere

- targeted regression tests: PASS
- `go test ./...`: PASS
- `go test -race ./...`: PASS
- `go vet ./...`: PASS
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./...`: PASS
- `python3 scripts/audit_privacy.py`: PASS
- Windows x64 GUI cross-build: PASS (`PE32+`, x86-64)
