### PR TITLE
Dovrši ByFTP 2.14.0 verzijsku konzistentnost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Provjeri hrvatski korisnički sadržaj
         run: python scripts/audit_croatian.py
 
+      - name: Provjeri verzijsku konzistentnost
+        run: python scripts/audit_version.py
+
       - name: Jedinični testovi
         run: go test ./...
 

--- a/BUILD-WINDOWS.ps1
+++ b/BUILD-WINDOWS.ps1
@@ -2,70 +2,102 @@ $ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
 $versionFile = Join-Path $PSScriptRoot 'VERSION'
-if (-not (Test-Path -LiteralPath $versionFile -PathType Leaf)) { throw 'Nedostaje VERSION datoteka.' }
+if (-not (Test-Path -LiteralPath $versionFile -PathType Leaf)) {
+    throw 'Nedostaje VERSION datoteka.'
+}
 $version = (Get-Content -LiteralPath $versionFile -Raw).Trim()
-if ($version -notmatch '^\d+\.\d+\.\d+$') { throw "Neispravna ByFTP verzija u VERSION datoteci: $version" }
+if ($version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Neispravna ByFTP verzija u VERSION datoteci: $version"
+}
 
 $minimumGo = [Version]'1.26.5'
 $dist = Join-Path $PWD 'dist'
 $payload = Join-Path $PWD 'cmd\installer\payload'
 $icon = Join-Path $PWD 'build\icon.ico'
-$env:GOTOOLCHAIN='local'; $env:GOPROXY='off'; $env:GOSUMDB='off'; $env:GOTELEMETRY='off'
+
+# Produkcijski build namjerno je offline: ByFTP nema vanjske Go module i ne
+# smije automatski preuzimati toolchain ili module tijekom produkcijske izgradnje.
+$env:GOTOOLCHAIN='local'
+$env:GOPROXY='off'
+$env:GOSUMDB='off'
+$env:GOTELEMETRY='off'
+
 if (-not (Get-Command go -ErrorAction SilentlyContinue)) { throw 'Go nije instaliran.' }
 if (-not (Get-Command python -ErrorAction SilentlyContinue)) { throw 'Python 3 nije instaliran.' }
+
 $rawGoVersion = (go env GOVERSION).Trim()
-if ($rawGoVersion -notmatch '^go(\d+)\.(\d+)(?:\.(\d+))?$') { throw "Nije moguće provjeriti Go verziju: $rawGoVersion" }
+if ($rawGoVersion -notmatch '^go(\d+)\.(\d+)(?:\.(\d+))?$') {
+    throw "Nije moguće provjeriti Go verziju: $rawGoVersion"
+}
 $patch = if ($Matches[3]) { [int]$Matches[3] } else { 0 }
 $goVersion = [Version]::new([int]$Matches[1], [int]$Matches[2], $patch)
-if ($goVersion -lt $minimumGo) { throw "Za produkcijski ByFTP build potreban je Go $minimumGo ili noviji sigurnosni patch. Trenutačno: $rawGoVersion" }
+if ($goVersion -lt $minimumGo) {
+    throw "Za produkcijski ByFTP build potreban je Go $minimumGo ili noviji sigurnosni patch. Trenutačno: $rawGoVersion"
+}
 
 Write-Host "ByFTP $version"
 Write-Host '[1/12] Provjera slikovnih resursa'
 python scripts/generate_brand_assets.py --check
 if ($LASTEXITCODE -ne 0) { throw 'Slikovni resursi nisu prošli provjeru.' }
+
 Write-Host '[2/12] Provjera hrvatskog korisničkog sadržaja'
 python scripts/audit_croatian.py
 if ($LASTEXITCODE -ne 0) { throw 'Provjera hrvatskog sadržaja nije prošla.' }
+
+python scripts/audit_version.py
+if ($LASTEXITCODE -ne 0) { throw 'Provjera verzijske konzistentnosti nije prošla.' }
+
 Write-Host '[3/12] Provjera privatnosti i mrežne politike'
 python scripts/audit_privacy.py
 if ($LASTEXITCODE -ne 0) { throw 'Provjera privatnosti nije prošla.' }
+
 Write-Host "[4/12] Testovi i statička provjera ($rawGoVersion)"
 go test ./...
 if ($LASTEXITCODE -ne 0) { throw 'Go testovi nisu prošli.' }
 go vet ./...
 if ($LASTEXITCODE -ne 0) { throw 'Go vet nije prošao.' }
+
 Write-Host '[5/12] Čišćenje izlaznih datoteka'
 Remove-Item -Recurse -Force $dist -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $dist,$payload | Out-Null
 Remove-Item "$payload\payload.zip" -Force -ErrorAction SilentlyContinue
 $env:GOOS='windows'; $env:GOARCH='amd64'; $env:CGO_ENABLED='0'
+
 $portable = Join-Path $dist "ByFTP-$version-Portable-x64.exe"
 $uninstall = Join-Path $dist 'ByFTP-Uninstall.exe'
 $setup = Join-Path $dist "ByFTP-$version-Setup-x64.exe"
 $ldflags = "-s -w -H=windowsgui -X main.version=$version"
+
 Write-Host '[6/12] Portable'
 go build -trimpath -buildvcs=false -ldflags $ldflags -o $portable ./cmd/byftp
 if ($LASTEXITCODE -ne 0) { throw 'Portable build nije uspio.' }
 python scripts/pe_resources.py $portable --ico $icon --version $version --role portable --original-filename "ByFTP-$version-Portable-x64.exe"
 if ($LASTEXITCODE -ne 0) { throw 'PE resource obrada Portable builda nije uspjela.' }
+
 Write-Host '[7/12] Program za uklanjanje'
 go build -trimpath -buildvcs=false -ldflags $ldflags -o $uninstall ./cmd/uninstaller
 if ($LASTEXITCODE -ne 0) { throw 'Build programa za uklanjanje nije uspio.' }
 python scripts/pe_resources.py $uninstall --ico $icon --version $version --role uninstaller --original-filename 'ByFTP-Uninstall.exe'
 if ($LASTEXITCODE -ne 0) { throw 'PE resource obrada programa za uklanjanje nije uspjela.' }
+
 Write-Host '[8/12] Komprimirani instalacijski paket'
 python scripts/make_payload.py --app $portable --uninstaller $uninstall --output "$payload\payload.zip"
 if ($LASTEXITCODE -ne 0) { throw 'Kompresija instalacijskog payloada nije uspjela.' }
+
 Write-Host '[9/12] Instalacijski program'
 try {
     go build -trimpath -buildvcs=false -ldflags $ldflags -o $setup ./cmd/installer
     if ($LASTEXITCODE -ne 0) { throw 'Setup build nije uspio.' }
-} finally { Remove-Item "$payload\payload.zip" -Force -ErrorAction SilentlyContinue }
+} finally {
+    Remove-Item "$payload\payload.zip" -Force -ErrorAction SilentlyContinue
+}
 python scripts/pe_resources.py $setup --ico $icon --version $version --role setup --original-filename "ByFTP-$version-Setup-x64.exe"
 if ($LASTEXITCODE -ne 0) { throw 'PE resource obrada Setup builda nije uspjela.' }
+
 Write-Host '[10/12] PE i sigurnosna provjera'
 python scripts/verify_release.py $setup $portable $uninstall | Tee-Object -FilePath "$dist\verification.txt"
 if ($LASTEXITCODE -ne 0) { throw 'Provjera izdanja nije prošla.' }
+
 Write-Host '[11/12] SHA-256'
 $hashLines = foreach ($file in @($setup,$portable,$uninstall)) {
     $item = Get-Item -LiteralPath $file
@@ -73,7 +105,10 @@ $hashLines = foreach ($file in @($setup,$portable,$uninstall)) {
     "$hash  $($item.Name)"
 }
 $hashLines | Set-Content "$dist\SHA256.txt" -Encoding ascii
+
 Write-Host '[12/12] Status digitalnog potpisa'
 $verification = Get-Content "$dist\verification.txt" -Raw
-if ($verification -match 'AUTHENTICODE_SIGNED=NO') { Write-Warning 'Binariji nisu Authenticode potpisani. Za širu javnu distribuciju potpišite Portable, Uninstaller i Setup nakon PE resource obrade pa ponovno pokrenite provjeru.' }
+if ($verification -match 'AUTHENTICODE_SIGNED=NO') {
+    Write-Warning 'Binariji nisu Authenticode potpisani. Za širu javnu distribuciju potpišite Portable, Uninstaller i Setup nakon PE resource obrade pa ponovno pokrenite provjeru.'
+}
 Write-Host "ByFTP $version build dovršen: $dist"

--- a/cmd/byftp/main.go
+++ b/cmd/byftp/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-var version = "2.12.0"
+var version = "dev"
 
 func validAskpassInvocation(exePath, askpassExe, require, token string) bool {
 	if askpassExe == "" || !strings.EqualFold(strings.TrimSpace(require), "force") || len(token) != 32 {

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -138,7 +138,7 @@ func validatePayloadManifest(data []byte, files map[string][]byte) error {
 	return nil
 }
 
-var version = "2.12.0"
+var version = "dev"
 
 const uninstallKey = `Software\Microsoft\Windows\CurrentVersion\Uninstall\ByFTP`
 

--- a/docs/TESTIRANJE.md
+++ b/docs/TESTIRANJE.md
@@ -46,3 +46,7 @@ Merge se ne smatra spremnim dok oba joba nisu zelena.
 ## Release metadata
 
 CI čita `VERSION`, generira bilješke iz odgovarajućeg `CHANGELOG.md` odjeljka i zahtijeva da izlaz nije prazan. Time se sprječava objava verzije bez dokumentirane povijesti promjena.
+
+## Konzistentnost verzije
+
+`scripts/audit_version.py` provjerava da `VERSION` ostaje jedini produkcijski izvor broja verzije, da razvojni build ne glumi staro izdanje te da README, CHANGELOG i build skripte ostaju usklađeni.

--- a/scripts/BUILD-LOCAL.sh
+++ b/scripts/BUILD-LOCAL.sh
@@ -12,7 +12,9 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+# Produkcijski build namjerno je offline i koristi samo standardnu Go biblioteku.
 export GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off GOTELEMETRY=off
+
 command -v go >/dev/null
 command -v python3 >/dev/null
 GO_VERSION="$(go env GOVERSION)"
@@ -30,39 +32,54 @@ PY
 
 echo "[1/12] Provjera slikovnih resursa"
 python3 scripts/generate_brand_assets.py --check
+
 echo "[2/12] Provjera hrvatskog korisničkog sadržaja"
 python3 scripts/audit_croatian.py
+
+python3 scripts/audit_version.py
+
 echo "[3/12] Provjera privatnosti i mrežne politike"
 python3 scripts/audit_privacy.py
+
 echo "[4/12] Testovi i statička provjera ($GO_VERSION)"
 go test ./...
 go vet ./...
+
 echo "[5/12] Čišćenje izlaznih datoteka"
 rm -rf "$DIST"
 mkdir -p "$DIST" "$PAYLOAD"
 rm -f "$PAYLOAD/payload.zip"
+
 export GOOS=windows GOARCH=amd64 CGO_ENABLED=0
 LDFLAGS="-s -w -H=windowsgui -X main.version=$VERSION"
+
 echo "[6/12] Portable"
 go build -trimpath -buildvcs=false -ldflags="$LDFLAGS" -o "$DIST/ByFTP-$VERSION-Portable-x64.exe" ./cmd/byftp
 python3 scripts/pe_resources.py "$DIST/ByFTP-$VERSION-Portable-x64.exe" --ico "$ICON" --version "$VERSION" --role portable --original-filename "ByFTP-$VERSION-Portable-x64.exe"
+
 echo "[7/12] Program za uklanjanje"
 go build -trimpath -buildvcs=false -ldflags="$LDFLAGS" -o "$DIST/ByFTP-Uninstall.exe" ./cmd/uninstaller
 python3 scripts/pe_resources.py "$DIST/ByFTP-Uninstall.exe" --ico "$ICON" --version "$VERSION" --role uninstaller --original-filename "ByFTP-Uninstall.exe"
+
 echo "[8/12] Komprimirani instalacijski paket"
 python3 scripts/make_payload.py --app "$DIST/ByFTP-$VERSION-Portable-x64.exe" --uninstaller "$DIST/ByFTP-Uninstall.exe" --output "$PAYLOAD/payload.zip"
 trap 'rm -f "$PAYLOAD/payload.zip"' EXIT
+
 echo "[9/12] Instalacijski program"
 go build -trimpath -buildvcs=false -ldflags="$LDFLAGS" -o "$DIST/ByFTP-$VERSION-Setup-x64.exe" ./cmd/installer
 rm -f "$PAYLOAD/payload.zip"
 trap - EXIT
 python3 scripts/pe_resources.py "$DIST/ByFTP-$VERSION-Setup-x64.exe" --ico "$ICON" --version "$VERSION" --role setup --original-filename "ByFTP-$VERSION-Setup-x64.exe"
+
 echo "[10/12] PE i sigurnosna provjera"
 python3 scripts/verify_release.py "$DIST/ByFTP-$VERSION-Setup-x64.exe" "$DIST/ByFTP-$VERSION-Portable-x64.exe" "$DIST/ByFTP-Uninstall.exe" | tee "$DIST/verification.txt"
+
 echo "[11/12] SHA-256"
 sha256sum "$DIST/ByFTP-$VERSION-Setup-x64.exe" "$DIST/ByFTP-$VERSION-Portable-x64.exe" "$DIST/ByFTP-Uninstall.exe" > "$DIST/SHA256.txt"
+
 echo "[12/12] Status digitalnog potpisa"
 if grep -q 'AUTHENTICODE_SIGNED=NO' "$DIST/verification.txt"; then
   echo 'UPOZORENJE: binariji nisu Authenticode potpisani; potpišite release binarije prije šire javne distribucije.' >&2
 fi
+
 echo "ByFTP $VERSION build dovršen: $DIST"

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Provjerava da ByFTP koristi VERSION kao jedini produkcijski izvor verzije."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def fail(message: str) -> None:
+    raise SystemExit("VERSION_AUDIT_NIJE_PROSAO: " + message)
+
+
+def read(path: str) -> str:
+    p = ROOT / path
+    if not p.is_file():
+        fail(f"nedostaje {path}")
+    return p.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    version = read("VERSION").strip()
+    if not VERSION_RE.fullmatch(version):
+        fail(f"VERSION nije semantička verzija: {version!r}")
+
+    # Izravno pokretanje `go run`/`go build` bez produkcijskih ldflags mora
+    # jasno pokazati razvojni build, a ne zastarjelu produkcijsku verziju.
+    for rel in ("cmd/byftp/main.go", "cmd/installer/main.go"):
+        text = read(rel)
+        if 'var version = "dev"' not in text:
+            fail(f"{rel} nema sigurni razvojni fallback verzije")
+        stale = re.search(r'var\s+version\s*=\s*"\d+\.\d+\.\d+"', text)
+        if stale:
+            fail(f"{rel} sadrži hardkodiranu produkcijsku verziju: {stale.group(0)}")
+
+    readme = read("README.md")
+    if f"Trenutačno izdanje: {version}" not in readme:
+        fail("README ne prikazuje VERSION kao trenutačno izdanje")
+
+    changelog = read("CHANGELOG.md")
+    if f"## {version}" not in changelog:
+        fail("CHANGELOG nema odjeljak za VERSION")
+
+    windows_build = read("BUILD-WINDOWS.ps1")
+    if "Get-Content -LiteralPath $versionFile" not in windows_build or "-X main.version=$version" not in windows_build:
+        fail("Windows build ne povezuje VERSION u runtime verziju")
+
+    local_build = read("scripts/BUILD-LOCAL.sh")
+    if "VERSION=\"$(tr -d '\\r\\n' < VERSION)\"" not in local_build or "-X main.version=$VERSION" not in local_build:
+        fail("lokalni build ne koristi VERSION kao runtime verziju")
+
+    print(f"VERSION_AUDIT=PROSAO ({version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sažetak

Završni follow-up nakon 2.14.0 mergea. Ovaj PR uklanja preostale zastarjele hardkodirane fallback verzije i uvodi trajnu automatsku provjeru da `VERSION` ostane jedini produkcijski izvor broja verzije.

### Ispravci
- `cmd/byftp/main.go` i `cmd/installer/main.go` koriste `dev` fallback umjesto zastarjele `2.12.0`
- dodan `scripts/audit_version.py`
- CI automatski provjerava verzijsku konzistentnost
- Windows i lokalni build pokreću isti version audit
- dokumentacija testiranja opisuje novu zaštitu

### Lokalna provjera
- asset audit ✅
- hrvatski audit ✅
- version audit ✅
- privacy audit ✅
- `go test ./...` ✅
- `go test -race ./...` ✅
- `go vet ./...` ✅

Cilj je da obični razvojni `go build/go run` više nikada ne prikazuje staru produkcijsku verziju te da CI blokira buduća razilaženja `VERSION`, README-a, CHANGELOG-a i build skripti.