### PR TITLE
ByFTP 1.0.0 — stabilniji terminal i putanje s razmacima

### DIFF
--- a/internal/api/transfer_snapshot.go
+++ b/internal/api/transfer_snapshot.go
@@ -1,0 +1,11 @@
+package api
+
+import "brendigo.com/byftp/internal/model"
+
+// Transfers vraća izolirani snapshot trenutnog reda prijenosa. Pozivatelj ne
+// dobiva interne sliceove transfer managera i zato ne može mutirati njegovo
+// stanje. Snapshot je autoritativan za terminalne statuse čak i kada je stariji
+// event već izbačen iz ograničene povijesti događaja.
+func (e *Engine) Transfers() []model.TransferJob {
+	return e.transfers.List()
+}

--- a/internal/desktop/other.go
+++ b/internal/desktop/other.go
@@ -129,15 +129,26 @@ func runTerminal(engine *api.Engine, version string) error {
 	current := "/"; if cfg.Protocol == "sftp" { current = "." }
 	fmt.Printf("Povezano: %s:%d\n", cfg.Host, cfg.Port)
 	fmt.Println("Naredbe: ls, cd, mkdir, rename, delete, chmod, get, put, pwd, help, quit")
+	fmt.Println("Putanje i nazive s razmacima stavite u jednostruke ili dvostruke navodnike.")
 	for {
 		fmt.Printf("byftp:%s> ", current)
 		line, readErr := reader.ReadString('\n'); if readErr != nil && len(line) == 0 { return nil }
-		fields := strings.Fields(strings.TrimSpace(line)); if len(fields) == 0 { continue }
+		fields, parseErr := parseTerminalArgs(line)
+		if parseErr != nil { fmt.Println("Neispravna naredba: " + parseErr.Error()); continue }
+		if len(fields) == 0 { continue }
 		switch strings.ToLower(fields[0]) {
-		case "quit", "exit": return nil
-		case "help": fmt.Println("ls [putanja] | cd <putanja> | mkdir <ime> | rename <staro> <novo> | delete <ime> | chmod <mode> <ime> | get <remote> <local> | put <local> <remote> | pwd | quit")
-		case "pwd": fmt.Println(current)
+		case "quit", "exit":
+			if len(fields) != 1 { fmt.Println("Upotreba: quit"); continue }
+			return nil
+		case "help":
+			if len(fields) != 1 { fmt.Println("Upotreba: help"); continue }
+			fmt.Println("ls [putanja] | cd <putanja> | mkdir <ime> | rename <staro> <novo> | delete <ime> | chmod <mode> <ime> | get <remote> <local> | put <local> <remote> | pwd | quit")
+			fmt.Println("Primjer: get \"Ugovori/račun 2026.pdf\" \"/home/korisnik/Preuzeto/račun 2026.pdf\"")
+		case "pwd":
+			if len(fields) != 1 { fmt.Println("Upotreba: pwd"); continue }
+			fmt.Println(current)
 		case "ls":
+			if len(fields) > 2 { fmt.Println("Upotreba: ls [putanja]"); continue }
 			target := current; if len(fields) > 1 { target = fields[1] }
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second); items, e := engine.RemoteList(ctx, target); cancel()
 			if e != nil { fmt.Println(usererror.Message(e, "Udaljeni direktorij nije moguće pročitati.")); continue }; printRemoteItems(items)

--- a/internal/desktop/other.go
+++ b/internal/desktop/other.go
@@ -65,22 +65,44 @@ func terminalStatus(status string) bool {
 	switch status { case "done", "failed", "cancelled", "skipped": return true; default: return false }
 }
 
+func terminalTransferResult(job model.TransferJob) (bool, error) {
+	if !terminalStatus(job.Status) {
+		return false, nil
+	}
+	switch job.Status {
+	case "done":
+		fmt.Println("Prijenos dovršen.")
+		return true, nil
+	case "skipped":
+		return true, errors.New("prijenos je preskočen jer odredište već postoji")
+	case "cancelled":
+		return true, context.Canceled
+	default:
+		if strings.TrimSpace(job.Error) != "" {
+			return true, errors.New(job.Error)
+		}
+		return true, errors.New("prijenos nije uspio")
+	}
+}
+
 func waitTransfer(engine *api.Engine, jobID string) error {
-	seq := int64(0)
+	seen := false
 	for {
-		events, next := engine.TransferEvents(seq); seq = next
-		for _, event := range events {
-			if event.Job == nil || event.Job.ID != jobID { continue }
-			job := *event.Job
-			if !terminalStatus(job.Status) { continue }
-			switch job.Status {
-			case "done": fmt.Println("Prijenos dovršen."); return nil
-			case "skipped": return errors.New("prijenos je preskočen jer odredište već postoji")
-			case "cancelled": return context.Canceled
-			default:
-				if strings.TrimSpace(job.Error) != "" { return errors.New(job.Error) }
-				return errors.New("prijenos nije uspio")
+		jobs := engine.Transfers()
+		found := false
+		for _, job := range jobs {
+			if job.ID != jobID {
+				continue
 			}
+			found = true
+			seen = true
+			if done, err := terminalTransferResult(job); done {
+				return err
+			}
+			break
+		}
+		if seen && !found {
+			return errors.New("prijenos više nije dostupan u redu")
 		}
 		time.Sleep(150 * time.Millisecond)
 	}

--- a/internal/desktop/terminal_parser_other.go
+++ b/internal/desktop/terminal_parser_other.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package desktop
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	maxTerminalCommandLength = 32 << 10
+	maxTerminalArguments     = 64
+)
+
+// parseTerminalArgs parsira interaktivnu naredbu bez pokretanja ljuske.
+// Navodnici služe samo grupiranju argumenata s razmacima; rezultat se i dalje
+// prosljeđuje isključivo tipiziranim ByFTP operacijama, nikada shellu.
+func parseTerminalArgs(line string) ([]string, error) {
+	line = strings.TrimSuffix(line, "\n")
+	line = strings.TrimSuffix(line, "\r")
+	if len(line) > maxTerminalCommandLength {
+		return nil, errors.New("naredba je preduga")
+	}
+	if strings.ContainsAny(line, "\x00\r\n") {
+		return nil, errors.New("naredba sadrži nedopuštene kontrolne znakove")
+	}
+
+	args := make([]string, 0, 4)
+	var token strings.Builder
+	var quote byte
+	tokenStarted := false
+
+	appendToken := func() error {
+		args = append(args, token.String())
+		token.Reset()
+		tokenStarted = false
+		if len(args) > maxTerminalArguments {
+			return errors.New("naredba ima previše argumenata")
+		}
+		return nil
+	}
+
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+				tokenStarted = true
+				continue
+			}
+			if ch == '\\' && i+1 < len(line) && (line[i+1] == quote || line[i+1] == '\\') {
+				i++
+				token.WriteByte(line[i])
+				tokenStarted = true
+				continue
+			}
+			token.WriteByte(ch)
+			tokenStarted = true
+			continue
+		}
+
+		switch ch {
+		case '\'', '"':
+			quote = ch
+			tokenStarted = true
+		case ' ', '\t':
+			if tokenStarted {
+				if err := appendToken(); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			token.WriteByte(ch)
+			tokenStarted = true
+		}
+	}
+	if quote != 0 {
+		return nil, errors.New("navodnik u naredbi nije zatvoren")
+	}
+	if tokenStarted {
+		if err := appendToken(); err != nil {
+			return nil, err
+		}
+	}
+	return args, nil
+}

--- a/internal/desktop/terminal_parser_other_test.go
+++ b/internal/desktop/terminal_parser_other_test.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package desktop
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTerminalArgsSupportsQuotedPaths(t *testing.T) {
+	tests := []struct {
+		line string
+		want []string
+	}{
+		{`get "remote file.txt" "/tmp/local file.txt"`, []string{"get", "remote file.txt", "/tmp/local file.txt"}},
+		{`rename 'stari naziv.txt' "novi naziv.txt"`, []string{"rename", "stari naziv.txt", "novi naziv.txt"}},
+		{`mkdir "Nova mapa"`, []string{"mkdir", "Nova mapa"}},
+		{`put C:\Temp\file.txt remote.txt`, []string{"put", `C:\Temp\file.txt`, "remote.txt"}},
+		{`get "a\"b.txt" lokalno.txt`, []string{"get", `a"b.txt`, "lokalno.txt"}},
+		{`cd ""`, []string{"cd", ""}},
+	}
+	for _, tc := range tests {
+		got, err := parseTerminalArgs(tc.line)
+		if err != nil {
+			t.Fatalf("parseTerminalArgs(%q): %v", tc.line, err)
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("parseTerminalArgs(%q) = %#v, want %#v", tc.line, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("parseTerminalArgs(%q)[%d] = %q, want %q", tc.line, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestParseTerminalArgsRejectsMalformedInput(t *testing.T) {
+	invalid := []string{
+		`get "nezatvoreno`,
+		"mkdir bad\x00name",
+		"ls foo\rbar",
+		strings.Repeat("a", maxTerminalCommandLength+1),
+		strings.Repeat("x ", maxTerminalArguments+1),
+	}
+	for _, line := range invalid {
+		if _, err := parseTerminalArgs(line); err == nil {
+			t.Fatalf("parseTerminalArgs(%q) unexpectedly succeeded", line)
+		}
+	}
+}
+
+func TestParseTerminalArgsEmptyLine(t *testing.T) {
+	got, err := parseTerminalArgs("  \t  \n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no arguments, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Sažetak

- zamjenjuje `strings.Fields` sigurnim internim parserom terminalskih argumenata
- podržava jednostruke i dvostruke navodnike za lokalne i udaljene putanje s razmacima
- podržava escapirani navodnik i backslash unutar navodnika bez pokretanja shella
- ograničava naredbu na 32 KiB i najviše 64 argumenta
- odbija NUL, CR/LF umetnute u naredbu i nezatvorene navodnike
- pooštrava broj argumenata za `ls`, `pwd`, `help`, `quit/exit` i postojeće naredbe
- dodaje jasnu pomoć i primjer za `get` s putanjama koje sadrže razmake
- terminalsko čekanje transfera više ne ovisi o ograničenoj event povijesti, nego provjerava autoritativni snapshot reda preko `Engine.Transfers()`

## Sigurnost i stabilnost

Parser samo razdvaja argumente; rezultat se prosljeđuje postojećim tipiziranim `api.Engine` operacijama. Nema `sh -c`, shell evaluacije, command substitutiona niti novih vanjskih procesa. Postojeća validacija udaljenih putanja i lokalnih granica ostaje aktivna.

`Engine.Transfers()` vraća kopiju transfer reda iz postojećeg thread-safe `transfer.Manager.List()`, pa terminal ne može mutirati interni slice i ne može zaglaviti samo zato što je završni event izbačen iz bounded event historyja.

## Regresijski testovi

Pokriveni su: quoted remote/local paths, rename i mkdir s razmacima, očuvanje backslasha, escapirani navodnik, prazan quoted argument, prazna naredba te odbijanje nezatvorenog navodnika, NUL/CR, preduge naredbe i previše argumenata.

PR ostaje draft dok puni CI ne potvrdi Linux/macOS parser testove te postojeće quality/security/privacy/release, race/vet i platformske build gateove.