### PR TITLE
ByFTP 1.0.0 — FTPS TLS hardening i verzijska konzistentnost

### DIFF
--- a/docs/PLAN-RAZVOJA.md
+++ b/docs/PLAN-RAZVOJA.md
@@ -1,6 +1,6 @@
 # ByFTP — plan razvoja
 
-## Završeno u 2.16 liniji
+## Završene produkcijske cjeline
 
 - izvorni Win32 desktop bez browser/localhost sloja
 - zajednički tipizirani Engine za Windows, Linux i macOS frontend
@@ -10,6 +10,8 @@
 - uklonjen SFTP batch/AskPass konflikt; Windows password/passphrase AskPass ostaje funkcionalan
 - fail-closed AskPass koji ne šalje tajnu MFA/OTP/nepoznatom promptu
 - Linux/macOS terminalni app nad istim remote/transfer coreom
+- Linux/macOS terminal sigurno parsira quoted lokalne i udaljene putanje s razmacima bez shell evaluacije
+- terminalno čekanje transfera koristi autoritativni snapshot reda i ne ovisi o zadržavanju završnog eventa u bounded povijesti
 - Linux/macOS procesno runtime spremište FTP/FTPS tajne bez disk persistencije
 - process-level FTP/SFTP child-process smoke regresije na Linux i macOS runnerima
 - Windows x64 + x86 produkcijski build
@@ -38,7 +40,7 @@
 2. **Kontrolirani interoperability test serveri** — automatizirani FTP/FTPS/SFTP testovi s jednokratnim testnim računima, potpuno odvojeni od produkcijskih credentiala.
 3. **Windows Authenticode** — uvesti tek kada postoji stvarni Brendigo code-signing certifikat i siguran secret/signing workflow.
 4. **macOS Developer ID i notarizacija** — uvesti tek kada postoji stvarni Apple Developer identitet i odgovarajući secrets.
-5. **macOS/Linux UX** — poboljšati terminal help, completion i ergonomiju bez stvaranja lažnog GUI pariteta.
+5. **macOS/Linux UX** — dodati sigurnu command history/completion ergonomiju bez stvaranja lažnog GUI pariteta ili spremanja tajni.
 6. **Pristupačnost Windows GUI-ja** — dodatna keyboard/focus navigacija, screen-reader oznake i DPI provjere.
 7. **Transfer observability bez vanjske telemetrije** — stvarna lokalna brzina/ETA i statusi uz bounded event churn.
 8. **Memory skaliranje** — daljnja optimizacija vrlo velikih rekurzivnih planova, queue eventa i directory prikaza.

--- a/docs/PRIVATNOST.md
+++ b/docs/PRIVATNOST.md
@@ -19,6 +19,12 @@ ByFTP mrežni adapteri razgovaraju s korisnički odabranim FTP/FTPS/SFTP endpoin
 
 curl dobiva sanitizirano okruženje bez naslijeđenog proxy/TLS overridea. OpenSSH dobiva ByFTP-managed session config koji blokira ProxyCommand, ProxyJump, agent, PKCS#11 provider, KnownHostsCommand i forwarding.
 
+### FTPS provjera opoziva certifikata
+
+ByFTP više ne koristi curl opciju `ssl-no-revoke`, jer bi ona na Windows Schannelu potpuno isključila provjeru opoziva certifikata. Windows FTPS koristi `ssl-revoke-best-effort`: Schannel smije provjeriti status opoziva certifikata, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu.
+
+Takvu provjeru može izvršiti Windows TLS/certificate infrastruktura i ona može kontaktirati CA/CRL infrastrukturu navedenu u certifikatu. To nije ByFTP telemetrija niti Brendigo API, ali jest mogući OS-vođeni sigurnosni mrežni promet izvan korisnički odabranog FTP endpointa. Linux/macOS ne dobivaju Schannel-specifičnu curl opciju i koriste ponašanje vlastitog TLS backend-a.
+
 ## Windows podaci
 
 Windows profili i postavke ostaju u ByFTP korisničkoj podatkovnoj mapi. Profilne tajne koriste DPAPI. UI prikazuje samo činjenicu da je spremljena tajna dostupna, ne vraća stvarnu spremljenu vrijednost u edit kontrolu.
@@ -78,7 +84,7 @@ go telemetry off
 
 i zahtijeva da `go telemetry` vrati `off`.
 
-Produkcijske build skripte ponovno čitaju stvarni način rada i fail-closed odbijaju build ako nije `off`. Time dokumentacija više ne ovisi o običnoj istoimenoj OS environment varijabli koja ne predstavlja stvarno stanje Go telemetry postavke.
+Produkcijske build skripte ponovno čitaju stvarni način rada i fail-closed odbijaju build ako nije `off`; ne oslanjaju se na običnu istoimenu OS environment varijablu koja ne predstavlja stvarno stanje Go telemetry postavke.
 
 Lokalna skripta ne mijenja globalnu Go postavku potajno. Ako telemetry nije `off`, build se prekida i korisniku se navodi potrebna naredba.
 
@@ -117,6 +123,6 @@ To smanjuje istodobne publish operacije i čini provenance jednog izdanja jednos
 
 ## Što ByFTP ne može kontrolirati
 
-Odredišni poslužitelj nužno vidi mrežne i autentikacijske podatke potrebne za vezu. OS, DNS, firewall, EDR, backup/sync sustavi ili udaljeni poslužitelj mogu imati vlastita pravila zapisivanja.
+Odredišni poslužitelj nužno vidi mrežne i autentikacijske podatke potrebne za vezu. OS, DNS, certificate revocation infrastruktura, firewall, EDR, backup/sync sustavi ili udaljeni poslužitelj mogu imati vlastita pravila zapisivanja.
 
 Lokalno brisanje datoteke ili procesne tajne nije isto što i forenzičko brisanje fizičkih SSD blokova ili svih kopija koje je napravio operativni sustav, backup ili sigurnosni proizvod.

--- a/docs/PRIVATNOST.md
+++ b/docs/PRIVATNOST.md
@@ -21,7 +21,9 @@ curl dobiva sanitizirano okruženje bez naslijeđenog proxy/TLS overridea. OpenS
 
 ### FTPS provjera opoziva certifikata
 
-ByFTP više ne koristi curl opciju `ssl-no-revoke`, jer bi ona na Windows Schannelu potpuno isključila provjeru opoziva certifikata. Windows FTPS koristi `ssl-revoke-best-effort`: Schannel smije provjeriti status opoziva certifikata, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu.
+ByFTP više ne koristi curl opciju `ssl-no-revoke`, jer bi ona na Windows Schannelu potpuno isključila provjeru opoziva certifikata.
+
+Na Windowsu ByFTP lokalno pokreće bounded `curl --version` capability provjeru bez mrežnog prometa. Ako curl podržava `ssl-revoke-best-effort`, ByFTP uključuje tu opciju: Schannel smije provjeriti status opoziva certifikata, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu. Ako je curl prestar ili capability provjera ne uspije, ta se opcija ne šalje i ostaje zadano Schannel ponašanje; revocation provjera se ne isključuje.
 
 Takvu provjeru može izvršiti Windows TLS/certificate infrastruktura i ona može kontaktirati CA/CRL infrastrukturu navedenu u certifikatu. To nije ByFTP telemetrija niti Brendigo API, ali jest mogući OS-vođeni sigurnosni mrežni promet izvan korisnički odabranog FTP endpointa. Linux/macOS ne dobivaju Schannel-specifičnu curl opciju i koriste ponašanje vlastitog TLS backend-a.
 

--- a/docs/SIGURNOST.md
+++ b/docs/SIGURNOST.md
@@ -88,6 +88,16 @@ Spremljeni pin koristi se samo za isti endpoint. Privremena promjena hosta ili p
 - bez eksplicitnog SFTP ključa koristi se `IdentitiesOnly yes` i `IdentityFile none`
 - host, korisnik i private-key putanja nisu na OpenSSH command lineu
 
+### FTPS certifikat i opoziv
+
+FTPS uvijek zadržava provjeru TLS certifikata koju pruža aktivni curl TLS backend i postavlja minimalni TLS zahtjev kroz `tlsv1.2`; eksplicitni FTPS dodatno zahtijeva TLS pomoću `ssl-reqd`.
+
+ByFTP ne koristi `ssl-no-revoke`. Na Windowsu se za Schannel koristi `ssl-revoke-best-effort`: provjera opoziva certifikata ostaje uključena kada su potrebni podaci dostupni, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu. To je svjesno sigurnosno/stabilnosno uravnoteženje i jače je od potpunog isključivanja revocation provjere.
+
+Linux/macOS ne dobivaju Schannel-specifičnu opciju. Ponašanje provjere certifikata i opoziva tamo ostaje u odgovornosti TLS backend-a sistemskog curl-a.
+
+Regresijski Go test i `audit_privacy.py` zajedno moraju odbiti ponovno uvođenje `ssl-no-revoke` i moraju potvrditi Windows best-effort revocation politiku.
+
 ## Datoteke i putanje
 
 - udaljene i lokalne putanje prolaze traversal/control-character validaciju
@@ -159,7 +169,7 @@ Windows paketi nisu Authenticode/Verified Publisher dok ne postoji stvarni Brend
 
 `scripts/audit_security.py` zaključava SFTP procesne granice, connect smoke, AskPass prompt, context propagation, IPv6 normalizaciju, runtime tajne, profile binding, session lifecycle i filesystem zaštite.
 
-`scripts/audit_privacy.py` zaključava runtime mrežnu politiku i stvarno gašenje Go build telemetrije.
+`scripts/audit_privacy.py` zaključava runtime mrežnu politiku, FTPS revocation pravilo i stvarno gašenje Go build telemetrije.
 
 `scripts/audit_release.py` zaključava single-trigger/serialized release model, production quality gate, platformsku matricu, staging allowlist i završni javni asset ugovor.
 

--- a/docs/SIGURNOST.md
+++ b/docs/SIGURNOST.md
@@ -92,11 +92,13 @@ Spremljeni pin koristi se samo za isti endpoint. Privremena promjena hosta ili p
 
 FTPS uvijek zadržava provjeru TLS certifikata koju pruža aktivni curl TLS backend i postavlja minimalni TLS zahtjev kroz `tlsv1.2`; eksplicitni FTPS dodatno zahtijeva TLS pomoću `ssl-reqd`.
 
-ByFTP ne koristi `ssl-no-revoke`. Na Windowsu se za Schannel koristi `ssl-revoke-best-effort`: provjera opoziva certifikata ostaje uključena kada su potrebni podaci dostupni, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu. To je svjesno sigurnosno/stabilnosno uravnoteženje i jače je od potpunog isključivanja revocation provjere.
+ByFTP ne koristi `ssl-no-revoke`. Na Windowsu prvo lokalno i bounded provjerava `curl --version`. Ako curl podržava opciju uvedenu u 7.70.0, koristi `ssl-revoke-best-effort`: provjera opoziva ostaje uključena kada su potrebni podaci dostupni, ali nedostupan ili offline distribution point sam po sebi ne ruši vezu.
+
+Ako je Windows curl stariji, version probe ne uspije ili izlaz nije prepoznatljiv, ByFTP ne šalje nepoznatu curl opciju. U tom slučaju zadržava se zadano Schannel ponašanje provjere opoziva umjesto prelaska na `ssl-no-revoke`. Time stari Windows/curl ne gubi FTPS samo zbog nepodržanog argumenta, a sigurnosna provjera se ne isključuje.
 
 Linux/macOS ne dobivaju Schannel-specifičnu opciju. Ponašanje provjere certifikata i opoziva tamo ostaje u odgovornosti TLS backend-a sistemskog curl-a.
 
-Regresijski Go test i `audit_privacy.py` zajedno moraju odbiti ponovno uvođenje `ssl-no-revoke` i moraju potvrditi Windows best-effort revocation politiku.
+Regresijski Go testovi i `audit_privacy.py` zajedno moraju odbiti ponovno uvođenje `ssl-no-revoke`, potvrditi capability-gated Windows best-effort politiku te fallback bez nepoznate opcije.
 
 ## Datoteke i putanje
 

--- a/docs/SIGURNOST.md
+++ b/docs/SIGURNOST.md
@@ -43,7 +43,7 @@ Testni procesi ne kontaktiraju vanjsku mrežu i ne koriste stvarne vjerodajnice.
 
 ### IPv6
 
-Bracketirani IPv6 unos prihvaća se kao korisnički host, ali se `[]` uklanjaju prije OpenSSH `HostName` i `ssh-keyscan` ulaza.
+Bracketirani IPv6 unos prihvaća se kao korisnički host, ali samo kada postoji točno jedan ispravno uparen par `[]`. Nepotpune ili višestruke zagrade i bracketirani IPv4 odbijaju se prije mrežnog pokušaja. Ispravne IPv6 zagrade uklanjaju se prije OpenSSH `HostName` i `ssh-keyscan` ulaza.
 
 ## Vjerodajnice
 
@@ -98,6 +98,8 @@ Spremljeni pin koristi se samo za isti endpoint. Privremena promjena hosta ili p
 - rekurzivne operacije imaju depth/item limite
 - queued transfer ponovno validira lokalni root prije svakog pokušaja
 
+Path-based provjere znatno smanjuju traversal i link rizik, ali stdlib operacije koje rade po imenima putanja ne mogu dokazati potpunu otpornost na namjerno, istodobno preimenovanje komponenti od drugog procesa istog korisnika između provjere i operacije. Potpuno zatvaranje takve TOCTOU klase zahtijeva platform-specific handle-relative filesystem primitive; dokumentacija zato ne tvrdi jaču garanciju od one koju kod stvarno daje.
+
 ## Session lifecycle
 
 Svaka `Operation` registrira aktivnu referencu. Disconnect prvo blokira nove operacije, zatim otkazuje session context i čeka postojeće reference. Adapter se ne zatvara ispod aktivnog `List`, rename, chmod ili transfer poziva.
@@ -107,6 +109,8 @@ Ako caller deadline istekne, cleanup nastavlja odvojeno. Reconnect je blokiran d
 ## Transfer izolacija
 
 Transfer posao pamti connection generation i opaque connection identity. Retry na drugi server/account nije dopušten. Event API vraća duboke kopije. Kasni cancel nakon uspješnog ili preskočenog transfera ne mijenja autoritativni završni status.
+
+Terminal koristi autoritativni snapshot transfer reda za završni status, pa ne ovisi o tome je li završni event još prisutan u ograničenoj event povijesti.
 
 ## State/config
 
@@ -130,7 +134,7 @@ Ovo se odnosi na Go **build toolchain**, ne na ByFTP runtime. ByFTP aplikacija s
 
 ## Release sigurnost
 
-2.16.2 dodatno učvršćuje release granicu:
+Aktualna produkcijska bazna linija dodatno učvršćuje release granicu:
 
 - `VERSION` je jedini kanonski broj
 - automatski release okidač je samo promjena `VERSION` na `main`
@@ -145,6 +149,7 @@ Ovo se odnosi na Go **build toolchain**, ne na ByFTP runtime. ByFTP aplikacija s
 - centralni publisher veže tag uz točan commit i uspoređuje postojeći asset po veličini i SHA-256 digestu
 - rerun smije nadopuniti samo nedostajući potvrđeni asset
 - dodatni ili neočekivani javni asset zaustavlja izdanje
+- GitHub Windows Package mora koristiti isti kanonski `VERSION` kao aplikacija i GitHub Release
 
 ## Potpisivanje
 
@@ -157,3 +162,5 @@ Windows paketi nisu Authenticode/Verified Publisher dok ne postoji stvarni Brend
 `scripts/audit_privacy.py` zaključava runtime mrežnu politiku i stvarno gašenje Go build telemetrije.
 
 `scripts/audit_release.py` zaključava single-trigger/serialized release model, production quality gate, platformsku matricu, staging allowlist i završni javni asset ugovor.
+
+`scripts/audit_version.py` dodatno blokira drift trenutačne verzije u README/CHANGELOG i verzionirane aktualne tvrdnje u produkcijskoj dokumentaciji.

--- a/internal/remote/curl_capability.go
+++ b/internal/remote/curl_capability.go
@@ -1,0 +1,84 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxCurlVersionOutput = 16 << 10
+
+// curlVersionSupportsRevokeBestEffort provjerava verziju iz prvog curl --version
+// retka. Opcija --ssl-revoke-best-effort postoji od curl 7.70.0.
+func curlVersionSupportsRevokeBestEffort(output string) bool {
+	line := output
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "curl") {
+		return false
+	}
+	parts := strings.Split(fields[1], ".")
+	if len(parts) < 2 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return false
+	}
+	patch := 0
+	if len(parts) >= 3 {
+		digits := parts[2]
+		if i := strings.IndexFunc(digits, func(r rune) bool { return r < '0' || r > '9' }); i >= 0 {
+			digits = digits[:i]
+		}
+		if digits == "" {
+			return false
+		}
+		patch, err = strconv.Atoi(digits)
+		if err != nil || patch < 0 {
+			return false
+		}
+	}
+	if major != 7 {
+		return major > 7
+	}
+	if minor != 70 {
+		return minor > 70
+	}
+	return patch >= 0
+}
+
+// curlSupportsRevokeBestEffort je lokalna capability provjera bez mrežnog
+// prometa. Ako provjera zakaže ili je curl prestar, ByFTP ne dodaje nepoznatu
+// opciju; Schannel tada zadržava svoj zadani revocation model.
+func curlSupportsRevokeBestEffort(curlPath string) bool {
+	if runtime.GOOS != "windows" || strings.TrimSpace(curlPath) == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, curlPath, "--version")
+	configureToolCommand(cmd)
+	cmd.WaitDelay = time.Second
+	cmd.Dir = filepath.Dir(curlPath)
+	cmd.Env = sanitizedToolEnv(os.Environ())
+	out := newBoundedOutput(maxCurlVersionOutput)
+	errOut := newBoundedOutput(maxCurlVersionOutput)
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+	if err := cmd.Run(); err != nil || ctx.Err() != nil || out.Err("curl version odgovor") != nil {
+		return false
+	}
+	return curlVersionSupportsRevokeBestEffort(out.String())
+}

--- a/internal/remote/curl_capability_test.go
+++ b/internal/remote/curl_capability_test.go
@@ -1,0 +1,27 @@
+package remote
+
+import "testing"
+
+func TestCurlVersionSupportsRevokeBestEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"before feature", "curl 7.69.1 (Windows) libcurl/7.69.1 Schannel", false},
+		{"feature baseline", "curl 7.70.0 (Windows) libcurl/7.70.0 Schannel", true},
+		{"newer seven", "curl 7.83.1 (Windows) libcurl/7.83.1 Schannel", true},
+		{"modern eight", "curl 8.0.1 (Windows) libcurl/8.0.1 Schannel", true},
+		{"newer major", "curl 10.1.0 libcurl/10.1.0 Schannel", true},
+		{"malformed", "curl unknown Schannel", false},
+		{"not curl", "other 8.0.1", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := curlVersionSupportsRevokeBestEffort(tc.output); got != tc.want {
+				t.Fatalf("curlVersionSupportsRevokeBestEffort(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -123,10 +124,14 @@ func (c *CurlFTP) configFor(password []byte, lines []string) []byte {
 	if c.protocol == "ftps" {
 		cfg = appendConfigLine(cfg, "ssl-reqd")
 		cfg = appendConfigLine(cfg, "tlsv1.2")
-		cfg = appendConfigLine(cfg, "ssl-no-revoke")
+		if runtime.GOOS == "windows" {
+			cfg = appendConfigLine(cfg, "ssl-revoke-best-effort")
+		}
 	} else if c.protocol == "ftpsi" {
 		cfg = appendConfigLine(cfg, "tlsv1.2")
-		cfg = appendConfigLine(cfg, "ssl-no-revoke")
+		if runtime.GOOS == "windows" {
+			cfg = appendConfigLine(cfg, "ssl-revoke-best-effort")
+		}
 	}
 	for _, line := range lines {
 		cfg = appendConfigLine(cfg, line)

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -21,14 +21,15 @@ import (
 )
 
 type CurlFTP struct {
-	protocol       string
-	host           string
-	username       string
-	passwordBlob   string
-	port           int
-	connectTimeout int
-	curl           string
-	mlsdState      atomic.Int32
+	protocol             string
+	host                 string
+	username             string
+	passwordBlob         string
+	port                 int
+	connectTimeout       int
+	curl                 string
+	revokeBestEffort     bool
+	mlsdState            atomic.Int32
 }
 
 func NewCurlFTP(protocol, host string, port int, username, password string) (*CurlFTP, error) {
@@ -55,7 +56,16 @@ func newCurlFTPWithProtectedSecret(protocol, host string, port int, username, pa
 			return nil, err
 		}
 	}
-	return &CurlFTP{protocol: protocol, host: host, port: port, username: username, passwordBlob: passwordBlob, connectTimeout: connectTimeout, curl: p}, nil
+	return &CurlFTP{
+		protocol:         protocol,
+		host:             host,
+		port:             port,
+		username:         username,
+		passwordBlob:     passwordBlob,
+		connectTimeout:   connectTimeout,
+		curl:             p,
+		revokeBestEffort: curlSupportsRevokeBestEffort(p),
+	}, nil
 }
 
 func (c *CurlFTP) Protocol() string { return c.protocol }
@@ -124,12 +134,12 @@ func (c *CurlFTP) configFor(password []byte, lines []string) []byte {
 	if c.protocol == "ftps" {
 		cfg = appendConfigLine(cfg, "ssl-reqd")
 		cfg = appendConfigLine(cfg, "tlsv1.2")
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" && c.revokeBestEffort {
 			cfg = appendConfigLine(cfg, "ssl-revoke-best-effort")
 		}
 	} else if c.protocol == "ftpsi" {
 		cfg = appendConfigLine(cfg, "tlsv1.2")
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" && c.revokeBestEffort {
 			cfg = appendConfigLine(cfg, "ssl-revoke-best-effort")
 		}
 	}

--- a/internal/remote/privacy_test.go
+++ b/internal/remote/privacy_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -120,6 +121,9 @@ func TestFindCurlPrefersWindowsSystemBinary(t *testing.T) {
 
 func TestFindOpenSSHPreferWindowsSystemBinary(t *testing.T) {
 	system32 := filepath.Join(t.TempDir(), "System32")
+	if err := os.MkdirAll(system32, 0700); err != nil {
+		t.Fatal(err)
+	}
 	sshDir := filepath.Join(system32, "OpenSSH")
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		t.Fatal(err)
@@ -180,14 +184,25 @@ func TestSSHSessionConfigIsPrivateDirectAndScoped(t *testing.T) {
 	}
 }
 
-func TestFTPSConfigDisablesExternalRevocationFetch(t *testing.T) {
+func TestFTPSConfigNeverDisablesCertificateRevocation(t *testing.T) {
 	for _, protocol := range []string{"ftps", "ftpsi"} {
 		c := &CurlFTP{protocol: protocol, username: "user"}
 		cfg := string(c.configFor([]byte("secret"), nil))
-		for _, required := range []string{"ssl-no-revoke", "tlsv1.2"} {
-			if !strings.Contains(cfg, required) {
-				t.Fatalf("%s config missing FTPS security option %q: %q", protocol, required, cfg)
+		if strings.Contains(cfg, "ssl-no-revoke") {
+			t.Fatalf("%s config disables certificate revocation: %q", protocol, cfg)
+		}
+		if !strings.Contains(cfg, "tlsv1.2") {
+			t.Fatalf("%s config missing TLS minimum: %q", protocol, cfg)
+		}
+		if protocol == "ftps" && !strings.Contains(cfg, "ssl-reqd") {
+			t.Fatalf("explicit FTPS config must require TLS: %q", cfg)
+		}
+		if runtime.GOOS == "windows" {
+			if !strings.Contains(cfg, "ssl-revoke-best-effort") {
+				t.Fatalf("%s Windows config missing best-effort certificate revocation: %q", protocol, cfg)
 			}
+		} else if strings.Contains(cfg, "ssl-revoke-best-effort") {
+			t.Fatalf("%s non-Windows config contains Schannel-only revocation option: %q", protocol, cfg)
 		}
 	}
 }

--- a/internal/remote/privacy_test.go
+++ b/internal/remote/privacy_test.go
@@ -186,7 +186,7 @@ func TestSSHSessionConfigIsPrivateDirectAndScoped(t *testing.T) {
 
 func TestFTPSConfigNeverDisablesCertificateRevocation(t *testing.T) {
 	for _, protocol := range []string{"ftps", "ftpsi"} {
-		c := &CurlFTP{protocol: protocol, username: "user"}
+		c := &CurlFTP{protocol: protocol, username: "user", revokeBestEffort: runtime.GOOS == "windows"}
 		cfg := string(c.configFor([]byte("secret"), nil))
 		if strings.Contains(cfg, "ssl-no-revoke") {
 			t.Fatalf("%s config disables certificate revocation: %q", protocol, cfg)
@@ -199,10 +199,23 @@ func TestFTPSConfigNeverDisablesCertificateRevocation(t *testing.T) {
 		}
 		if runtime.GOOS == "windows" {
 			if !strings.Contains(cfg, "ssl-revoke-best-effort") {
-				t.Fatalf("%s Windows config missing best-effort certificate revocation: %q", protocol, cfg)
+				t.Fatalf("%s Windows config missing supported best-effort revocation: %q", protocol, cfg)
 			}
 		} else if strings.Contains(cfg, "ssl-revoke-best-effort") {
 			t.Fatalf("%s non-Windows config contains Schannel-only revocation option: %q", protocol, cfg)
+		}
+	}
+}
+
+func TestFTPSConfigFallsBackWhenBestEffortOptionIsUnavailable(t *testing.T) {
+	for _, protocol := range []string{"ftps", "ftpsi"} {
+		c := &CurlFTP{protocol: protocol, username: "user", revokeBestEffort: false}
+		cfg := string(c.configFor([]byte("secret"), nil))
+		if strings.Contains(cfg, "ssl-no-revoke") || strings.Contains(cfg, "ssl-revoke-best-effort") {
+			t.Fatalf("%s fallback config must use TLS backend default revocation behavior: %q", protocol, cfg)
+		}
+		if !strings.Contains(cfg, "tlsv1.2") {
+			t.Fatalf("%s fallback config lost TLS minimum: %q", protocol, cfg)
 		}
 	}
 }

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -82,14 +82,28 @@ def main() -> None:
             "security.ProtectRuntimeString(password)",
             "security.UnprotectRuntimeBytes(c.passwordBlob)",
             "security.ForgetRuntimeSecret(c.passwordBlob)",
-            'runtime.GOOS == "windows"',
+            'runtime.GOOS == "windows" && c.revokeBestEffort',
             '"ssl-revoke-best-effort"',
+            "curlSupportsRevokeBestEffort(p)",
         ),
     )
     if "HTTP_PROXY" in curl or "HTTPS_PROXY" in curl:
         fail("CurlFTP ne smije izravno nasljeđivati proxy varijable")
     if "ssl-no-revoke" in curl:
         fail("FTPS ne smije potpuno isključiti provjeru opoziva certifikata")
+
+    require(
+        "internal/remote/curl_capability.go",
+        (
+            "func curlVersionSupportsRevokeBestEffort(",
+            "func curlSupportsRevokeBestEffort(",
+            'runtime.GOOS != "windows"',
+            'exec.CommandContext(ctx, curlPath, "--version")',
+            "context.WithTimeout(context.Background(), 3*time.Second)",
+            "newBoundedOutput(maxCurlVersionOutput)",
+            "sanitizedToolEnv(os.Environ())",
+        ),
+    )
 
     sftp = require(
         "internal/remote/sftp.go",
@@ -177,7 +191,7 @@ def main() -> None:
     print("EXTERNAL_GO_MODULES=ABSENT")
     print("CURL_EXTERNAL_ENV_INHERITANCE=DISABLED")
     print("FTPS_CERTIFICATE_REVOCATION=NOT_DISABLED")
-    print("WINDOWS_FTPS_REVOCATION=BEST_EFFORT")
+    print("WINDOWS_FTPS_REVOCATION=CAPABILITY_GATED_BEST_EFFORT")
     print("OPENSSH_USER_CONFIG_AND_HELPER_INHERITANCE=DISABLED")
     print("WINDOWS_ERROR_REPORTING=DISABLED_FOR_BYFTP_PROCESS")
     print("PERSISTENT_RUNTIME_LOGGING=DISABLED")

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -82,10 +82,14 @@ def main() -> None:
             "security.ProtectRuntimeString(password)",
             "security.UnprotectRuntimeBytes(c.passwordBlob)",
             "security.ForgetRuntimeSecret(c.passwordBlob)",
+            'runtime.GOOS == "windows"',
+            '"ssl-revoke-best-effort"',
         ),
     )
     if "HTTP_PROXY" in curl or "HTTPS_PROXY" in curl:
         fail("CurlFTP ne smije izravno nasljeđivati proxy varijable")
+    if "ssl-no-revoke" in curl:
+        fail("FTPS ne smije potpuno isključiti provjeru opoziva certifikata")
 
     sftp = require(
         "internal/remote/sftp.go",
@@ -172,13 +176,15 @@ def main() -> None:
     print("FIXED_HTTP_API_ENDPOINTS=ABSENT")
     print("EXTERNAL_GO_MODULES=ABSENT")
     print("CURL_EXTERNAL_ENV_INHERITANCE=DISABLED")
+    print("FTPS_CERTIFICATE_REVOCATION=NOT_DISABLED")
+    print("WINDOWS_FTPS_REVOCATION=BEST_EFFORT")
     print("OPENSSH_USER_CONFIG_AND_HELPER_INHERITANCE=DISABLED")
     print("WINDOWS_ERROR_REPORTING=DISABLED_FOR_BYFTP_PROCESS")
     print("PERSISTENT_RUNTIME_LOGGING=DISABLED")
     print("SAVED_PROFILE_METADATA=WINDOWS_DPAPI_PROTECTED")
     print("ACTIVE_RUNTIME_SECRETS=WINDOWS_DPAPI_OR_PROCESS_MEMORY")
     print("ASKPASS_DISK_SECRET_ARTIFACTS=DISABLED")
-    print("NETWORK_POLICY=NO_TELEMETRY_NO_EXTERNAL_APIS_USER_SELECTED_SERVER")
+    print("NETWORK_POLICY=NO_TELEMETRY_NO_EXTERNAL_APIS_USER_SELECTED_SERVER_PLUS_OS_CERTIFICATE_VALIDATION")
 
 
 if __name__ == "__main__":

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -43,6 +43,28 @@ def main() -> int:
     if f"## {version}" not in changelog:
         fail("CHANGELOG nema odjeljak za VERSION")
 
+    # Detaljna dokumentacija treba biti dugovječna i ne smije skrivati stari
+    # "trenutačni" broj verzije u proznom tekstu. Ako neki dokument ipak ima
+    # eksplicitnu oznaku trenutačnog izdanja, ona mora odgovarati VERSION-u.
+    for path in sorted((ROOT / "docs").rglob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        rel = path.relative_to(ROOT)
+        for match in re.finditer(r"Trenutačno izdanje:\s*(\d+\.\d+\.\d+)", text):
+            if match.group(1) != version:
+                fail(f"{rel} prikazuje zastarjelo trenutačno izdanje {match.group(1)}")
+
+    security_doc = read("docs/SIGURNOST.md")
+    if "Aktualna produkcijska bazna linija dodatno učvršćuje release granicu:" not in security_doc:
+        fail("SIGURNOST.md mora opisivati release sigurnost bez hardkodiranog starog broja verzije")
+    if re.search(r"(?m)^\d+\.\d+\.\d+\s+dodatno učvršćuje release granicu:", security_doc):
+        fail("SIGURNOST.md hardkodira broj verzije u aktualni release-sigurnosni opis")
+
+    plan = read("docs/PLAN-RAZVOJA.md")
+    if "## Završene produkcijske cjeline" not in plan:
+        fail("PLAN-RAZVOJA.md mora koristiti verzijski neutralan naslov završenih cjelina")
+    if re.search(r"(?m)^##\s+Završeno u\s+\d", plan):
+        fail("PLAN-RAZVOJA.md sadrži zastarjeli verzionirani naslov završenih cjelina")
+
     windows_build = read("BUILD-WINDOWS.ps1")
     if "Get-Content -LiteralPath $versionFile" not in windows_build or "-X main.version=$version" not in windows_build:
         fail("Windows build ne povezuje VERSION u runtime verziju")
@@ -93,6 +115,7 @@ def main() -> int:
     print(f"VERSION_AUDIT=PROSAO ({version})")
     print("PLATFORM_VERSION_SOURCES=WINDOWS,LINUX,MACOS")
     print("GITHUB_PACKAGE_VERSION_SOURCE=VERSION")
+    print("PRODUCTION_DOC_VERSION_DRIFT=BLOCKED")
     return 0
 
 


### PR DESCRIPTION
## Sažetak

- uklanja `ssl-no-revoke` iz FTPS curl konfiguracije jer bi potpuno isključio provjeru opoziva certifikata
- Windows FTPS capability-checkom provjerava podržava li sistemski curl `ssl-revoke-best-effort` (opcija postoji od curl 7.70.0)
- podržani Windows curl koristi best-effort revocation; stariji/nečitljiv curl dobiva sigurni fallback na zadano Schannel ponašanje bez nepoznate opcije
- Linux/macOS ne dobivaju Schannel-specifičnu opciju
- zadržava `tlsv1.2`, a eksplicitni FTPS i dalje zahtijeva `ssl-reqd`
- capability probe koristi samo lokalni `curl --version`, 3-sekundni timeout, sanitizirani environment i bounded output
- dodaje regresije za curl 7.69, 7.70, 7.83, 8.0.1, noviji major i neispravne version izlaze
- proširuje `audit_privacy.py` tako da CI pada ako se vrati `ssl-no-revoke`, nestane capability gate ili se izgube timeout/bounded-output zaštite
- uklanja zastarjele 2.16.x formulacije iz aktualne sigurnosne i razvojne dokumentacije
- proširuje `audit_version.py` tako da budući drift aktualne verzije u produkcijskim dokumentima ruši CI
- dokumentira stvarnu path-based TOCTOU granicu umjesto davanja jače garancije od implementacije

## Sigurnost i privatnost

Promjena ne dira stdin credential transport, runtime-secret zaštitu, DPAPI, SFTP host-key pinning, proxy/TLS environment sanitizaciju, bounded transfer output ni session/transfer zaštite.

Windows certificate revocation provjera može koristiti OS/CA infrastrukturu navedenu u certifikatu. To nije ByFTP telemetrija ni Brendigo API, ali je transparentno dokumentirano kao mogući OS-vođeni sigurnosni mrežni promet.

## Regresijski gateovi

- `internal/remote/privacy_test.go` odbija `ssl-no-revoke` i provjerava capability/fallback konfiguraciju
- `internal/remote/curl_capability_test.go` provjerava granicu curl 7.70.0 i neispravan output
- `scripts/audit_privacy.py` zaključava istu invarijantu na source razini
- `scripts/audit_version.py` zaključava verzijski neutralne aktualne sigurnosne/razvojne dokumente
- puni CI mora ponovno proći unit, race, vet, security/privacy/release audite te Windows/Linux/macOS buildove prije mergea

`VERSION` se ovim PR-om ne mijenja i ostaje `1.0.0`.