### PR TITLE
ByFTP 1.0.0 — trajniji atomski state/config zapisi

### DIFF
--- a/internal/config/replace_other.go
+++ b/internal/config/replace_other.go
@@ -2,6 +2,30 @@
 
 package config
 
-import "os"
+import (
+	"errors"
+	"os"
+)
 
 func replaceFile(src, dst string) error { return os.Rename(src, dst) }
+
+// syncStateDirectory makes the directory-entry update from rename visible to
+// the filesystem's durability boundary. The temporary file itself is synced
+// before rename; syncing the containing directory afterwards closes the Linux
+// metadata durability gap and requests the corresponding best-effort fsync on
+// other supported Unix platforms.
+func syncStateDirectory(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if !st.IsDir() {
+		return errors.New("state putanja nije direktorij")
+	}
+	return f.Sync()
+}

--- a/internal/config/replace_windows.go
+++ b/internal/config/replace_windows.go
@@ -40,3 +40,8 @@ func replaceFile(src, dst string) error {
 	}
 	return nil
 }
+
+// MoveFileExW with MOVEFILE_WRITE_THROUGH already requests write-through for
+// the replacement operation. There is no portable Windows directory-fsync
+// equivalent needed by Store after a successful replaceFile call.
+func syncStateDirectory(string) error { return nil }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -135,6 +135,49 @@ func readLimitedWithOpen(path string, openFile stateOpenFunc) ([]byte, error) {
 	return data, nil
 }
 
+// writeSyncedTemp writes one complete generation into an unpredictable private
+// temporary file in the final directory and syncs its contents before rename.
+// The caller owns the returned path and must either replace it or remove it.
+func writeSyncedTemp(dir, pattern string, data []byte) (string, error) {
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(name)
+	}
+	if err = f.Chmod(0600); err != nil {
+		cleanup()
+		return "", err
+	}
+	if _, err = f.Write(data); err != nil {
+		cleanup()
+		return "", err
+	}
+	if err = f.Sync(); err != nil {
+		cleanup()
+		return "", err
+	}
+	if err = f.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", err
+	}
+	return name, nil
+}
+
+func replaceSyncedGeneration(dir, tmp, dst string) error {
+	if err := replaceFile(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	// A successful rename changes directory metadata. On Unix this explicit
+	// directory sync is needed to request durable visibility of the new entry;
+	// Windows replaceFile already uses MOVEFILE_WRITE_THROUGH.
+	return syncStateDirectory(dir)
+}
+
 func (s *Store) Write(name string, value any) error {
 	if err := validateStateName(name); err != nil {
 		return err
@@ -154,57 +197,22 @@ func (s *Store) Write(name string, value any) error {
 	data = append(data, '\n')
 	path := filepath.Join(s.dir, name)
 
-	// Keep only a known-valid previous generation. Temporary files are created
-	// with unpredictable names in the same directory and exclusive creation,
-	// so stale/symlinked predictable .tmp paths cannot be followed.
+	// Keep only a known-valid previous generation. The previous generation is
+	// synced before the new current generation is activated, preserving a
+	// recovery point if a crash happens between the two replacements.
 	if existing, e := readLimited(path); e == nil && json.Valid(existing) {
-		prevTmp, e := os.CreateTemp(s.dir, "."+name+".previous-*.tmp")
+		prevTmp, e := writeSyncedTemp(s.dir, "."+name+".previous-*.tmp", existing)
 		if e != nil {
 			return e
 		}
-		prevName := prevTmp.Name()
-		if e = prevTmp.Chmod(0600); e == nil {
-			_, e = prevTmp.Write(existing)
-		}
-		if e == nil {
-			e = prevTmp.Sync()
-		}
-		closeErr := prevTmp.Close()
-		if e == nil {
-			e = closeErr
-		}
-		if e != nil {
-			_ = os.Remove(prevName)
-			return e
-		}
-		if e = replaceFile(prevName, path+".previous"); e != nil {
-			_ = os.Remove(prevName)
+		if e = replaceSyncedGeneration(s.dir, prevTmp, path+".previous"); e != nil {
 			return e
 		}
 	}
 
-	f, err := os.CreateTemp(s.dir, "."+name+"-*.tmp")
+	tmp, err := writeSyncedTemp(s.dir, "."+name+"-*.tmp", data)
 	if err != nil {
 		return err
 	}
-	tmp := f.Name()
-	if err = f.Chmod(0600); err == nil {
-		_, err = f.Write(data)
-	}
-	if err == nil {
-		err = f.Sync()
-	}
-	closeErr := f.Close()
-	if err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err = replaceFile(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
+	return replaceSyncedGeneration(s.dir, tmp, path)
 }

--- a/internal/config/store_durability_other_test.go
+++ b/internal/config/store_durability_other_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSyncStateDirectoryAcceptsRealDirectory(t *testing.T) {
+	if err := syncStateDirectory(t.TempDir()); err != nil {
+		t.Fatalf("syncStateDirectory: %v", err)
+	}
+}
+
+func TestSyncStateDirectoryRejectsRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncStateDirectory(path); err == nil {
+		t.Fatal("expected regular file to be rejected")
+	}
+}
+
+func TestStoreWriteLeavesNoTemporaryGenerationFiles(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	if err := s.Write("state.json", testState{Value: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Write("state.json", testState{Value: 2}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".tmp") {
+			t.Fatalf("temporary state generation leaked after successful write: %s", entry.Name())
+		}
+	}
+	for _, name := range []string{"state.json", "state.json.previous"} {
+		info, err := os.Lstat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("missing generation %s: %v", name, err)
+		}
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("generation %s is not a regular file: %v", name, info.Mode())
+		}
+		if info.Mode().Perm()&0077 != 0 {
+			t.Fatalf("generation %s is too permissive: %o", name, info.Mode().Perm())
+		}
+	}
+}

--- a/scripts/test_state_durability.py
+++ b/scripts/test_state_durability.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class StateDurabilitySourceTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_store_syncs_temp_before_replace_and_directory_after_replace(self) -> None:
+        store = self.read("internal/config/store.go")
+        for marker in (
+            "func writeSyncedTemp(",
+            "f.Sync()",
+            "func replaceSyncedGeneration(",
+            "replaceFile(tmp, dst)",
+            "syncStateDirectory(dir)",
+            'replaceSyncedGeneration(s.dir, prevTmp, path+".previous")',
+            "replaceSyncedGeneration(s.dir, tmp, path)",
+        ):
+            self.assertIn(marker, store)
+
+    def test_unix_replace_has_directory_sync(self) -> None:
+        other = self.read("internal/config/replace_other.go")
+        for marker in (
+            "func syncStateDirectory(dir string) error",
+            "os.Open(dir)",
+            "st.IsDir()",
+            "f.Sync()",
+        ):
+            self.assertIn(marker, other)
+
+    def test_windows_replace_keeps_write_through(self) -> None:
+        windows = self.read("internal/config/replace_windows.go")
+        self.assertIn("moveFileWriteThrough", windows)
+        self.assertIn("moveFileReplaceExisting|moveFileWriteThrough", windows)
+        self.assertIn("func syncStateDirectory(string) error { return nil }", windows)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ovlaštenje

- [x] Ovu izmjenu izvornog koda izričito je zatražio vlasnik repozitorija `bren-wp/by-ftp` u ovom radu.
- [x] Promjena ne mijenja licencu ni vlasnički/source-available model projekta.

## Sažetak

- refaktorira duplicirani state-write kod u jednu `writeSyncedTemp` primitivu
- svaka generacija se zapisuje u nasumični privatni temp file, radi `fsync`, zatvara i tek zatim atomically zamjenjuje cilj
- nakon uspješnog renamea Unix radi dodatni `fsync` direktorija kako bi se sinkronizirala promjena directory entryja
- `.previous` generacija se sinkronizira prije aktivacije novog current statea
- Windows zadržava `MoveFileExW(... MOVEFILE_WRITE_THROUGH)` i ne radi nepotreban drugi directory flush
- greška directory synca se vraća pozivatelju fail-closed; ne prikriva se kao uspješan zapis
- `VERSION` ostaje `1.0.0`

## Stabilnost i recovery

Redoslijed je sada: validni current → synced `.previous` temp → replace + directory sync → synced novi current temp → replace + directory sync. Time recovery generacija dobiva durability granicu prije aktivacije novog current zapisa.

Linux zahtijeva zaseban directory `fsync` za sinkronizaciju directory entryja nakon renamea. macOS koristi best-effort `fsync`; implementacija zato ne tvrdi apsolutnu zaštitu od svakog hardverskog gubitka napajanja.

## Regresije i provjera

- [x] Unix test potvrđuje directory sync i odbijanje regularne datoteke kao direktorija
- [x] nema zaostalih `.tmp` generacija nakon uspješnog zapisa
- [x] current i previous ostaju regularne privatne datoteke
- [x] `scripts/test_state_durability.py` zaključava temp fsync, directory sync i Windows write-through invarijante
- [x] security/privacy/version/release auditi prošli
- [x] Python regresije prošle
- [x] `go test ./...` prošao
- [x] `go test -race ./...` prošao
- [x] `go vet ./...` prošao
- [x] Windows x64/x86 produkcijski build prošao
- [x] Linux amd64/arm64/i386 DEB build prošao
- [x] macOS Universal PKG build prošao

PR je spreman za squash merge u `main`.