### PR TITLE
ByFTP 1.0.0 — brža i stabilnija curl capability provjera

### DIFF
--- a/internal/remote/curl_capability.go
+++ b/internal/remote/curl_capability.go
@@ -8,10 +8,22 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
 const maxCurlVersionOutput = 16 << 10
+
+type curlCapabilityResult struct {
+	once      sync.Once
+	supported bool
+}
+
+var curlRevokeCapabilityCache sync.Map
+
+func protocolNeedsRevokeCapability(protocol string) bool {
+	return protocol == "ftps" || protocol == "ftpsi"
+}
 
 // curlVersionSupportsRevokeBestEffort provjerava verziju iz prvog curl --version
 // retka. Opcija --ssl-revoke-best-effort postoji od curl 7.70.0.
@@ -59,13 +71,7 @@ func curlVersionSupportsRevokeBestEffort(output string) bool {
 	return patch >= 0
 }
 
-// curlSupportsRevokeBestEffort je lokalna capability provjera bez mrežnog
-// prometa. Ako provjera zakaže ili je curl prestar, ByFTP ne dodaje nepoznatu
-// opciju; Schannel tada zadržava svoj zadani revocation model.
-func curlSupportsRevokeBestEffort(curlPath string) bool {
-	if runtime.GOOS != "windows" || strings.TrimSpace(curlPath) == "" {
-		return false
-	}
+func probeCurlRevokeBestEffort(curlPath string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, curlPath, "--version")
@@ -81,4 +87,21 @@ func curlSupportsRevokeBestEffort(curlPath string) bool {
 		return false
 	}
 	return curlVersionSupportsRevokeBestEffort(out.String())
+}
+
+// curlSupportsRevokeBestEffort je lokalna capability provjera bez mrežnog
+// prometa. Rezultat je cacheiran po očišćenoj trusted curl putanji i konkurentni
+// pozivi dijele isti sync.Once probe. Ako provjera zakaže ili je curl prestar,
+// ByFTP ne dodaje nepoznatu opciju i Schannel zadržava zadani revocation model.
+func curlSupportsRevokeBestEffort(curlPath string) bool {
+	if runtime.GOOS != "windows" || strings.TrimSpace(curlPath) == "" {
+		return false
+	}
+	key := filepath.Clean(curlPath)
+	entryValue, _ := curlRevokeCapabilityCache.LoadOrStore(key, &curlCapabilityResult{})
+	entry := entryValue.(*curlCapabilityResult)
+	entry.once.Do(func() {
+		entry.supported = probeCurlRevokeBestEffort(key)
+	})
+	return entry.supported
 }

--- a/internal/remote/curl_capability_test.go
+++ b/internal/remote/curl_capability_test.go
@@ -2,6 +2,24 @@ package remote
 
 import "testing"
 
+func TestProtocolNeedsRevokeCapability(t *testing.T) {
+	tests := []struct {
+		protocol string
+		want     bool
+	}{
+		{"ftp", false},
+		{"ftps", true},
+		{"ftpsi", true},
+		{"sftp", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := protocolNeedsRevokeCapability(tc.protocol); got != tc.want {
+			t.Fatalf("protocolNeedsRevokeCapability(%q) = %v, want %v", tc.protocol, got, tc.want)
+		}
+	}
+}
+
 func TestCurlVersionSupportsRevokeBestEffort(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -21,15 +21,15 @@ import (
 )
 
 type CurlFTP struct {
-	protocol             string
-	host                 string
-	username             string
-	passwordBlob         string
-	port                 int
-	connectTimeout       int
-	curl                 string
-	revokeBestEffort     bool
-	mlsdState            atomic.Int32
+	protocol         string
+	host             string
+	username         string
+	passwordBlob     string
+	port             int
+	connectTimeout   int
+	curl             string
+	revokeBestEffort bool
+	mlsdState        atomic.Int32
 }
 
 func NewCurlFTP(protocol, host string, port int, username, password string) (*CurlFTP, error) {
@@ -64,7 +64,7 @@ func newCurlFTPWithProtectedSecret(protocol, host string, port int, username, pa
 		passwordBlob:     passwordBlob,
 		connectTimeout:   connectTimeout,
 		curl:             p,
-		revokeBestEffort: curlSupportsRevokeBestEffort(p),
+		revokeBestEffort: protocolNeedsRevokeCapability(protocol) && curlSupportsRevokeBestEffort(p),
 	}, nil
 }
 

--- a/scripts/test_curl_capability_cache.py
+++ b/scripts/test_curl_capability_cache.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CurlCapabilityCacheSourceTests(unittest.TestCase):
+    def test_constructor_skips_probe_for_plain_ftp(self) -> None:
+        text = (ROOT / "internal/remote/curl_ftp.go").read_text(encoding="utf-8")
+        self.assertIn(
+            "protocolNeedsRevokeCapability(protocol) && curlSupportsRevokeBestEffort(p)",
+            text,
+        )
+
+    def test_capability_is_cached_concurrently_per_curl_path(self) -> None:
+        text = (ROOT / "internal/remote/curl_capability.go").read_text(encoding="utf-8")
+        for marker in (
+            "var curlRevokeCapabilityCache sync.Map",
+            "once      sync.Once",
+            "curlRevokeCapabilityCache.LoadOrStore(key, &curlCapabilityResult{})",
+            "entry.once.Do(func()",
+            "entry.supported = probeCurlRevokeBestEffort(key)",
+        ):
+            self.assertIn(marker, text)
+
+    def test_only_ftps_protocols_need_revocation_capability(self) -> None:
+        text = (ROOT / "internal/remote/curl_capability.go").read_text(encoding="utf-8")
+        self.assertIn('return protocol == "ftps" || protocol == "ftpsi"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ovlaštenje

- [x] Ovu izmjenu izvornog koda izričito je zatražio vlasnik repozitorija `bren-wp/by-ftp` u ovom radu.
- [x] Promjena ne mijenja licencu ni vlasnički/source-available model projekta.

## Sažetak

- plain FTP više ne pokreće FTPS certificate-revocation capability provjeru
- samo `ftps` i `ftpsi` trebaju `ssl-revoke-best-effort` capability
- Windows rezultat `curl --version` cacheira se po očišćenoj trusted curl putanji
- `sync.Map` + `sync.Once` osiguravaju da paralelna spajanja ne pokreću više istodobnih probe procesa za isti curl executable
- prvi probe i dalje ostaje lokalni, bounded, s 3-sekundnim timeoutom i sanitiziranim environmentom
- sigurni fallback na zadano Schannel ponašanje ostaje nepromijenjen ako probe ne uspije ili je curl prestar
- `VERSION` ostaje `1.0.0`

## Stabilnost i performanse

Prije ove izmjene konstruktor je pozivao `curlSupportsRevokeBestEffort` za svaki FTP/FTPS adapter. To je značilo nepotreban child-process probe i za plain FTP, a kod više FTPS veza isti `curl --version` mogao se ponavljati. Novi short-circuit i concurrency-safe cache uklanjaju taj nepotreban rad bez promjene TLS sigurnosne politike.

## Regresije

- Go test potvrđuje da `ftp` i `sftp` ne trebaju revocation capability, a `ftps`/`ftpsi` trebaju
- postojeći curl version testovi i dalje pokrivaju granicu 7.70.0 i malformed output
- `scripts/test_curl_capability_cache.py` zaključava short-circuit u konstruktoru, `sync.Map`, `sync.Once`, `LoadOrStore` i jedinstveni probe po putanji
- postojeći privacy audit i FTPS regression testovi ostaju aktivni

PR ostaje draft dok puni CI ne potvrdi unit, race, vet, security/privacy/release audite te Windows/Linux/macOS produkcijske buildove.