### PR TITLE
ByFTP — spriječi release drift bez VERSION bumpa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Dohvati izvorni kod
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Postavi Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -45,6 +47,11 @@ jobs:
         run: python scripts/audit_croatian.py
       - name: Provjeri verzijsku konzistentnost
         run: python scripts/audit_version.py
+      - name: Provjeri nepromjenjivost objavljene verzije
+        env:
+          BYFTP_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BYFTP_HEAD_SHA: ${{ github.sha }}
+        run: python scripts/audit_release_version_guard.py --base "$BYFTP_BASE_SHA" --head "$BYFTP_HEAD_SHA"
       - name: Provjeri dokumentaciju
         run: python scripts/audit_docs.py
       - name: Provjeri sigurnosne invarijante

--- a/scripts/audit_release_version_guard.py
+++ b/scripts/audit_release_version_guard.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Blokira produkcijske promjene nakon objavljenog taga bez novog VERSION-a."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Datoteke koje mijenjaju runtime, instalacijske pakete ili javni sadržaj
+# izdanja. CI/audit skripte i sami workflowi namjerno nisu ovdje: njih se mora
+# moći ojačati bez izmišljanja nove korisničke verzije proizvoda.
+PRODUCTION_PREFIXES = (
+    "cmd/",
+    "internal/",
+    "build/",
+    "docs/",
+)
+PRODUCTION_FILES = {
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "go.mod",
+    "BUILD-WINDOWS.cmd",
+    "BUILD-WINDOWS.ps1",
+    "scripts/BUILD-LOCAL.sh",
+    "scripts/BUILD-LINUX.sh",
+    "scripts/BUILD-MACOS.sh",
+    "scripts/release_notes.py",
+    "scripts/publish_release.ps1",
+}
+
+
+def git(*args: str, root: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def is_production_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lstrip("./")
+    return normalized in PRODUCTION_FILES or normalized.startswith(PRODUCTION_PREFIXES)
+
+
+def tag_commit(version: str, root: Path = ROOT) -> str | None:
+    result = git("rev-parse", "-q", "--verify", f"refs/tags/v{version}^{{commit}}", root=root, check=False)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def changed_paths(base: str, head: str, root: Path = ROOT) -> list[str]:
+    result = git("diff", "--name-only", "--diff-filter=ACMRTUXB", base, head, root=root)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def validate_release_version(base: str, head: str, root: Path = ROOT) -> tuple[bool, str]:
+    version_path = root / "VERSION"
+    if not version_path.is_file():
+        return False, "nedostaje VERSION"
+    version = version_path.read_text(encoding="utf-8").strip()
+    if not version:
+        return False, "VERSION je prazan"
+
+    released = tag_commit(version, root)
+    if released is None:
+        return True, f"v{version} još nije tagiran; produkcijske promjene su dopuštene prije prvog izdanja"
+
+    if not base or not head or set(base) == {"0"}:
+        return True, "nema pouzdanog event base SHA; verzijski guard nije primijenjen na ovaj ručni/početni run"
+
+    try:
+        paths = changed_paths(base, head, root)
+    except subprocess.CalledProcessError as exc:
+        return False, f"nije moguće izračunati diff {base}..{head}: {exc.stderr.strip()}"
+
+    if "VERSION" in paths:
+        return True, "VERSION je promijenjen u ovom skupu promjena"
+
+    production = sorted(path for path in paths if is_production_path(path))
+    if not production:
+        return True, "promjene ne mijenjaju runtime/pakete/javni sadržaj izdanja"
+
+    preview = ", ".join(production[:12])
+    if len(production) > 12:
+        preview += f", ... (+{len(production) - 12})"
+    return False, (
+        f"v{version} već postoji na {released[:12]}, ali ovaj skup mijenja produkcijski sadržaj bez promjene VERSION: "
+        f"{preview}. Objavljena verzija je nepromjenjiva; povećajte VERSION prije spajanja novih produkcijskih promjena."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="")
+    parser.add_argument("--head", default="HEAD")
+    args = parser.parse_args()
+
+    ok, message = validate_release_version(args.base.strip(), args.head.strip())
+    if not ok:
+        print("RELEASE_VERSION_GUARD=FAILED", file=sys.stderr)
+        print(message, file=sys.stderr)
+        return 1
+    print("RELEASE_VERSION_GUARD=PASS")
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_version_guard.py
+++ b/scripts/test_release_version_guard.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("audit_release_version_guard.py")
+SPEC = importlib.util.spec_from_file_location("release_version_guard", MODULE_PATH)
+assert SPEC and SPEC.loader
+GUARD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GUARD)
+
+
+class ReleaseVersionGuardTests(unittest.TestCase):
+    def make_repo(self) -> tuple[Path, str]:
+        root = Path(tempfile.mkdtemp(prefix="byftp-version-guard-"))
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "ByFTP Test"], cwd=root, check=True)
+        (root / "VERSION").write_text("1.0.0\n", encoding="utf-8")
+        (root / "internal").mkdir()
+        (root / "internal" / "core.go").write_text("package internal\n", encoding="utf-8")
+        (root / "scripts").mkdir()
+        (root / "scripts" / "audit_only.py").write_text("print('ok')\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "base"], cwd=root, check=True)
+        base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+        subprocess.run(["git", "tag", "v1.0.0"], cwd=root, check=True)
+        return root, base
+
+    def commit(self, root: Path, message: str) -> str:
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", message], cwd=root, check=True)
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+    def test_production_change_after_existing_tag_requires_version_bump(self) -> None:
+        root, base = self.make_repo()
+        (root / "internal" / "core.go").write_text("package internal\n// hardened\n", encoding="utf-8")
+        head = self.commit(root, "runtime change")
+        ok, message = GUARD.validate_release_version(base, head, root)
+        self.assertFalse(ok)
+        self.assertIn("povećajte VERSION", message)
+
+    def test_version_bump_allows_production_change(self) -> None:
+        root, base = self.make_repo()
+        (root / "internal" / "core.go").write_text("package internal\n// hardened\n", encoding="utf-8")
+        (root / "VERSION").write_text("1.0.1\n", encoding="utf-8")
+        head = self.commit(root, "new version")
+        ok, message = GUARD.validate_release_version(base, head, root)
+        self.assertTrue(ok, message)
+
+    def test_audit_only_change_does_not_force_product_version(self) -> None:
+        root, base = self.make_repo()
+        (root / "scripts" / "audit_only.py").write_text("print('stronger audit')\n", encoding="utf-8")
+        head = self.commit(root, "audit change")
+        ok, message = GUARD.validate_release_version(base, head, root)
+        self.assertTrue(ok, message)
+
+    def test_unreleased_version_allows_production_work(self) -> None:
+        root, base = self.make_repo()
+        (root / "VERSION").write_text("2.0.0\n", encoding="utf-8")
+        head = self.commit(root, "start unreleased line")
+        ok, message = GUARD.validate_release_version(base, head, root)
+        self.assertTrue(ok, message)
+        self.assertIn("još nije tagiran", message)
+
+    def test_public_docs_are_release_content(self) -> None:
+        self.assertTrue(GUARD.is_production_path("docs/SIGURNOST.md"))
+        self.assertTrue(GUARD.is_production_path("README.md"))
+        self.assertFalse(GUARD.is_production_path("scripts/audit_privacy.py"))
+        self.assertFalse(GUARD.is_production_path(".github/workflows/ci.yml"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ovlaštenje

- [x] Ovu izmjenu izvornog koda izričito je zatražio vlasnik repozitorija `bren-wp/by-ftp` u ovom radu.
- [x] Promjena ne mijenja licencu ni vlasnički/source-available model projekta.

## Problem

Objavljeni tag `v1.0.0` pokazuje na commit `cd5f29eab60da0248c319602544a911759a5a24e`, dok je aktualni `main` nakon kasnijih hardening PR-ova četiri produkcijska commita ispred. To znači da novi source može odlutati od već objavljene verzije ako se produkcijske promjene spajaju bez povećanja `VERSION`.

Postojeći publisher pravilno odbija prepisivanje taga/asseta drugim sadržajem, ali normalni PR CI dosad nije zaustavljao takav drift prije mergea.

## Rješenje

- dodaje `scripts/audit_release_version_guard.py`
- test job koristi `actions/checkout` s `fetch-depth: 0` kako bi guard vidio postojeće tagove
- guard čita `VERSION` i provjerava postoji li `v$VERSION`
- ako tag ne postoji, razvoj netagirane verzije normalno se nastavlja
- ako tag postoji i konkretni PR/push mijenja runtime, build payload ili javni release sadržaj bez promjene `VERSION`, CI pada
- ako je `VERSION` promijenjen u istom skupu promjena, guard prolazi
- CI/audit-only promjene ne zahtijevaju lažni novi broj proizvoda
- ručni run bez pouzdanog base SHA ne donosi lažni zaključak o diffu

## Produkcijski sadržaj koji zahtijeva novu verziju nakon taga

`cmd/`, `internal/`, `build/`, `docs/`, README, CHANGELOG, LICENSE, `go.mod`, Windows build ulazi te stvarne build/release skripte koje mijenjaju paket ili release sadržaj.

## Regresijski testovi

`scripts/test_release_version_guard.py` u privremenim stvarnim Git repozitorijima provjerava:

- postojeći `v1.0.0` + promjena `internal/` bez VERSION bumpa = FAIL
- isti runtime change + VERSION `1.0.1` = PASS
- audit-only promjena = PASS
- netagirana razvojna verzija = PASS
- javna dokumentacija je release sadržaj, CI workflow/audit helper nije

## Napomena o aktualnom 1.0.0

Ovaj PR namjerno **ne pomiče i ne prepisuje `v1.0.0`** i ne mijenja `VERSION`, koji ostaje `1.0.0` kako je zatraženo. Postojeći objavljeni tag smatra se nepromjenjivim; za budući javni paket koji uključuje post-tag produkcijske promjene bit će potrebna nova semantička verzija umjesto tihog prepisivanja 1.0.0.

PR ostaje draft dok puni CI ne potvrdi novi guard, Python regresije, unit/race/vet i Windows/Linux/macOS buildove.