### PR TITLE
Agent/byftp 1.0.11 UI stability hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>FTP bez komplikacija. Više kontrole nad vašim hostingom.</strong><br>
-  ByFTP je Brendigo klijent za FTP, FTPS i SFTP namijenjen brzom i sigurnom upravljanju web datotekama, shared-hosting računima i svakodnevnim prijenosima — bez oglasa, obaveznog cloud računa i aplikacijske telemetrije.
+  ByFTP je Brendigo klijent za FTP, FTPS i SFTP namijenjen brzom i sigurnom upravljanju web datotekama i shared-hosting računima — bez oglasa, obaveznog cloud računa i aplikacijske telemetrije.
 </p>
 
 <p align="center">
@@ -24,27 +24,42 @@
 
 ByFTP je klijent za korisnike koji žele otvoriti hosting, pronaći `public_html`, prenijeti datoteke i nastaviti raditi bez nepotrebnih koraka. Windows izdanje koristi izvorni dvopanelni Win32 GUI, dok Linux i macOS koriste terminalno sučelje nad istim Go engineom.
 
-**Trenutačno izdanje: 1.0.10**
+**Trenutačno izdanje: 1.0.11**
 
 ## Što ByFTP radi
 
 - **FTP, eksplicitni FTPS, implicitni FTPS i SFTP** u jednom klijentu.
 - **Shared hosting bez putanjskih iznenađenja** — FTP/FTPS rad zadržava login/home semantiku servera.
 - **Dvopanelni Windows rad** — lokalne datoteke lijevo, udaljene desno.
-- **Transfer queue** — više prijenosa, pause/resume, cancel i retry.
+- **Transfer queue** — više prijenosa, pauziranje, nastavak, otkazivanje i ponavljanje.
 - **Sigurniji overwrite** — privremeni upload, ponovna provjera odredišta, backup i rollback.
 - **SFTP host-key pinning** — prvi kontakt traži potvrdu SHA-256 fingerprinta, a promjena pina blokira vezu.
-- **Bez aplikacijske telemetrije i oglasa** — ByFTP nema analytics SDK ni obavezni Brendigo cloud račun.
+- **Bez aplikacijske telemetrije i oglasa** — nema analytics SDK-a ni obaveznog Brendigo cloud računa.
+
+## Što donosi 1.0.11
+
+1.0.11 fokusira se na svakodnevni Windows rad i uklanjanje stale-UI rubova koji se pojavljuju tijekom refresha, parcijalnih mrežnih operacija i brzog disconnect/reconnect slijeda.
+
+- Windows prozor se prilagođava dostupnoj veličini zaslona, a uži prikaz prebacuje connection formu u kompaktniji raspored umjesto da desne kontrole izlaze iz vidljivog područja.
+- Širine file i transfer stupaca računaju se prema stvarnom client area prostoru, pa veliki i mali prozori bolje koriste dostupnu širinu.
+- Lokalni, udaljeni i transfer popisi čuvaju odabir kroz automatski refresh gdje je ista stavka još prisutna; punjenje liste privremeno gasi redraw kako bi bilo manje treperenja.
+- Akcijski gumbi prate stvarni kontekst: preimenovanje traži jednu stavku, brisanje/prijenos valjan odabir, a cancel/retry status odgovaraju odabranim transferima i aktualnoj vezi.
+- Profilne i connection kontrole zaključane su tijekom aktivnog pokušaja povezivanja, a asinkroni callbackovi vezani su uz connection generation kako stari rezultat ne bi mijenjao novu sesiju.
+- Health-check stare veze više ne može naknadno prekinuti novu sesiju nakon brzog reconnecta.
+- Višestruko remote brisanje i CHMOD prikazuju koliko je stavki stvarno uspjelo i koliko nije; ako je dio operacije uspio, remote lista odmah se osvježava umjesto da prikazuje zastarjelo stanje.
+- CHMOD preskače simboličke poveznice u Windows UI-u kao defense-in-depth zaštitu.
+- Red prijenosa koristi autoritativno paused stanje koje emitira transfer manager, pa gumbi Pauziraj/Nastavi ne ovise samo o lokalnoj pretpostavci UI-a.
+- Profil se validira prije obrade upisanih vjerodajnica, pa neispravan host/port/username završava ranom, jasnom porukom.
 
 ## Shared hosting — spojite se u nekoliko koraka
 
-Za tipični shared-hosting račun obično su potrebni host, korisničko ime, lozinka te protokol/port. Korisničko ime može biti i u obliku `korisnik@domena.hr`.
+Za tipični shared-hosting račun obično su potrebni host, korisničko ime, lozinka te protokol i port. Korisničko ime može biti i u obliku `korisnik@domena.hr`.
 
-Za FTP/FTPS logička putanja `/public_html` predstavlja `public_html` unutar direktorija u koji je server smjestio korisnika nakon prijave. ByFTP raw FTP naredbe koriste isti login/home namespace kao listing i upload/download, pa početni `/` ne pretvara korisničku putanju u proizvoljni fizički root servera.
+Za FTP/FTPS logička putanja `/public_html` predstavlja `public_html` unutar direktorija u koji je server smjestio korisnika nakon prijave. ByFTP raw FTP naredbe koriste isti login/home namespace kao listing i upload/download.
 
 ByFTP prvo pokušava strojno čitljiv `MLSD`. Ako ga stariji ili nestandardni shared-hosting FTP servis ne podržava ili vrati neupotrebljiv format, klijent prelazi na `LIST` i taj fallback pamti do kraja sesije.
 
-Detaljni vodič: [ByFTP za shared hosting](docs/SHARED-HOSTING.md).
+Detalji i primjeri: [ByFTP za shared hosting](docs/SHARED-HOSTING.md).
 
 ## Produkcijska podrška
 
@@ -93,31 +108,17 @@ Svako izdanje uključuje SHA-256 i release metapodatke za provjeru distribucije.
 
 Za instalaciju, prvi spoj, nadogradnju i uklanjanje otvorite [Vodič za instalaciju i brzi početak](docs/INSTALACIJA.md).
 
+Windows installer koristi transakcijski backup i rollback s provjerom identiteta i SHA-256 sadržaja datoteka. Svježa instalacija koristi no-replace aktivaciju, a rollback odbija dirati datoteku ako više ne može dokazati da je to isti objekt koji je installer postavio.
+
 Windows korisnicima preporučujemo Setup x64 paket. Portable izdanje je prikladno kada ne želite klasičnu instalaciju. Linux koristi DEB paket prema arhitekturi, a macOS Universal PKG pokriva Intel i Apple Silicon.
-
-### Sigurnija Windows instalacijska transakcija u 1.0.9
-
-Windows installer više ne smatra zasebni `Lstat` dovoljnim dokazom za backup postojeće instalacije. Otvoreni file handle mora odgovarati istom filesystem objektu, veličini i vremenu izmjene, a sadržaj se tijekom backupa provjerava dvostrukim SHA-256 čitanjem preko istog otvorenog handlea. Zamjena putanje ili in-place promjena tijekom kopiranja blokira nadogradnju prije aktivacije novih binarija.
-
-Kod svježe instalacije novi `ByFTP.exe` i `Uninstall.exe` aktiviraju se no-replace semantikom. Ako se ciljna datoteka pojavi nakon početne provjere, installer je neće pregaziti. Rollback dodatno pamti je li installer stvarno aktivirao vlastitu datoteku te prije uklanjanja ili vraćanja stare verzije ponovno provjerava identitet i SHA-256 aktiviranog objekta. Ako je datoteku u međuvremenu promijenio drugi proces, rollback se zaustavlja umjesto da briše ili prepisuje nepoznat sadržaj.
-
-Ove provjere namjerno daju prednost očuvanju podataka pred pokušajem “popravka pod svaku cijenu”. Potpuno uklanjanje svakog mogućeg same-user path race prozora na Windowsu zahtijevalo bi dodatne handle-relative platformske primitive; ByFTP ne tvrdi da ih ova promjena univerzalno eliminira.
-
-## Stabilniji cancel i timeout u 1.0.10
-
-ByFTP za FTP/FTPS koristi `curl`, a za SFTP sistemski OpenSSH. Prekid mrežne operacije više se ne oslanja samo na gašenje jednog glavnog procesa ako taj alat ima potomke. Na Linuxu i macOS-u svaki mrežni/helper proces dobiva vlastitu process group i cancel prekida cijelu grupu. Na Windowsu se pri cancelu zaustavlja glavni proces, zatim se preko sistemskog popisa procesa rekurzivno uklanjaju njegovi potomci, uz dodatni svježi prolaz nakon gašenja roditelja.
-
-To je posebno važno za SFTP autentikaciju: OpenSSH može pokrenuti ByFTP AskPass helper za lozinku ili passphrase. Timeout, korisnički cancel ili gašenje aktivne operacije sada imaju process-tree zaštitu kako helper ne bi nastavio živjeti nakon prekinute SFTP radnje. Zaštita se primjenjuje i na `ssh-keyscan`, `ssh-keygen`, `curl --version` capability provjeru i redovne FTP/FTPS/SFTP operacije jer svi postojeći `exec.CommandContext` ulazi prolaze kroz isti lifecycle konfigurator.
-
-Regresijski test u stvarnom procesu pokreće parent i child helper, čeka dokaz da je child nastao, cancelira parent te potvrđuje da child nije preživio dovoljno dugo da ostavi marker. Time CI provjerava ponašanje, a ne samo prisutnost zaštitnog koda.
 
 ## Upravljanje datotekama
 
-Windows GUI podržava pregled lokalnih i udaljenih datoteka, višestruki odabir, upload/download, stvaranje mapa, preimenovanje, rekurzivno brisanje uz zaštitne limite, CHMOD gdje ga server podržava, profile i transfer queue.
+Windows GUI podržava pregled lokalnih i udaljenih datoteka, višestruki odabir, upload/download, prijenos mapa, stvaranje mapa, preimenovanje, rekurzivno brisanje uz zaštitne limite, CHMOD gdje ga server podržava, profile i transfer queue.
 
 Linux/macOS terminal koristi isti engine za `ls`, `cd`, `mkdir`, `rename`, `delete`, `chmod`, `get`, `put`, `pwd` i transfere.
 
-Od 1.0.7 pojedinačni upload/download zahtijeva konkretnu remote datoteku. Root, `.` i putanja koja završava direktorijskim separatorom odbijaju se prije dodavanja posla u red, dok prijenos cijele mape ostaje zasebna tree-transfer operacija. U 1.0.8 ista provjera postoji i u transfer queueu te neposredno u FTP/SFTP adapterima kao defense-in-depth zaštita.
+Pojedinačni upload/download zahtijeva konkretnu remote datoteku. Root, `.` i putanje koje završavaju direktorijskim separatorom odbijaju se prije transfer reda i mrežnog rada. Folder/tree transfer ostaje zasebna operacija.
 
 ## Sigurnost transfera
 
@@ -130,34 +131,15 @@ ByFTP je projektiran tako da greška ne izgleda kao uspjeh. Ključne zaštite uk
 - SHA-256 provjeru upload snapshota prije i nakon mrežnog čitanja;
 - provjeru da vidljivi remote `.byftp-part-*` staging objekt nije direktorij ili symlink;
 - ponovnu provjeru finalnog remote odredišta neposredno prije rename/backup commita;
-- fresh `SkipExisting` odluku nakon dugog uploada;
-- fail-closed prijavu ako se remote staging/rollback cleanup ne može potvrditi;
-- blokiranje automatskog retryja dok prethodni remote pokušaj možda ima zaostali privremeni objekt;
-- vezanje retry/batch poslova uz istu connection identity i transfer generation;
+- fail-closed prijavu kada cleanup remote staging/rollback objekta nije moguće potvrditi;
+- blokiranje automatskog retryja dok prethodno remote stanje možda nije čisto;
+- vezanje transfera i retryja uz connection identity i transfer generation;
 - bounded stdout/stderr mrežnih child procesa;
-- timeout i cancel propagaciju s process-tree zaštitom za vanjske mrežne/helper procese;
-- FTPS certificate-revocation zaštitu bez globalnog `ssl-no-revoke` gašenja;
+- timeout i cancel propagaciju s process-tree zaštitom za vanjske `curl` i OpenSSH procese;
+- FTPS certificate-revocation zaštitu bez globalnog gašenja revocation provjere;
 - SFTP SHA-256 fingerprint pinning i privatni `known_hosts` lifecycle.
 
 Sigurniji upload snapshot zahtijeva dodatni privremeni lokalni prostor približno veličini datoteke koja se šalje. To je namjeran tradeoff u korist stabilnog sadržaja.
-
-## Cleanup i lifecycle hardening u 1.0.8
-
-1.0.8 razlikuje običnu mrežnu grešku od situacije u kojoj ByFTP **ne može potvrditi da je vlastiti privremeni remote objekt uklonjen**. U tom drugom slučaju transfer završava kao greška i automatsko ponavljanje se blokira, jer novi pokušaj ne smije stvarati dodatne `.byftp-part-*` ili rollback ostatke dok prethodno stanje nije sigurno poznato.
-
-Ako je nova datoteka već uspješno aktivirana, ali brisanje starog rollback objekta zakaže, poruka to izričito navodi umjesto da transfer prijavi kao potpuno uspješan ili da ponovno pokrene overwrite. `SkipExisting` i korisnički cancel također više ne mogu sakriti cleanup nesigurnost iza statusa “preskočeno” ili “otkazano”.
-
-Lokalni download staging sada se uklanja i kada završni no-replace rename zakaže na ranije nepostojećem cilju. Transfer worker shutdown koristi jedan dijeljeni idle signal umjesto stvaranja dodatnog waiter goroutina pri svakom timeoutanom čekanju.
-
-## SFTP RSA sigurnost u 1.0.7
-
-RSA host ključ i algoritam kojim server potpisuje SSH handshake nisu ista stvar. ByFTP i dalje pin-a isti RSA javni ključ kroz `known_hosts` i SHA-256 fingerprint, ali više ne pretvara skenirani tip ključa `ssh-rsa` u prisilni session `HostKeyAlgorithms ssh-rsa`.
-
-Time moderni OpenSSH može za isti pinani RSA ključ pregovarati moderni RSA/SHA-2 potpis. Ed25519 i ECDSA ostaju eksplicitno vezani uz skenirani tip ključa.
-
-## Unix runtime cleanup u 1.0.7
-
-Na Linuxu i macOS-u ByFTP sada traži native executable `curl`. Windows-specifični naziv `curl.exe` više nema prednost u Unix PATH-u, a Windows i dalje koristi fail-closed sistemsku `curl.exe` putanju.
 
 ## Privatnost
 
@@ -217,6 +199,8 @@ shasum -a 256 ByFTP-<verzija>-macOS-Universal.pkg
 ByFTP ne može jamčiti kompatibilnost sa svakom nestandardnom FTP/SFTP implementacijom ili pravilima svakog hosting providera. Hosting može zasebno ograničiti write, rename, CHMOD, broj konekcija, TLS/SSH algoritme ili pristup pojedinim direktorijima.
 
 Windows binariji neće imati Verified Publisher status bez stvarnog Authenticode certifikata, a macOS paket neće biti Developer ID notariziran bez stvarnog Apple signing identiteta. Projekt te statuse ne simulira.
+
+Sigurnosni hardening smanjuje i fail-closed obrađuje poznate race/lifecycle rubove, ali nijedna desktop aplikacija ne može razumno jamčiti da ne postoji nijedan nepoznati bug na svakoj kombinaciji OS-a, servera i mreže. Produkcijska izdanja zato ostaju vezana uz regresije, race detector, vet i platformske build gateove.
 
 ---
 

--- a/internal/desktop/action_state.go
+++ b/internal/desktop/action_state.go
@@ -22,8 +22,8 @@ func deriveTransferActionState(jobs []model.TransferJob, selected []int, connect
 			hasTerminal = true
 		}
 	}
-	state.Pause = hasActive && !paused
-	state.Resume = paused
+	state.Pause = connected && hasActive && !paused
+	state.Resume = connected && hasActive && paused
 	state.Clear = hasTerminal
 	if len(selected) == 0 {
 		return state

--- a/internal/desktop/action_state_test.go
+++ b/internal/desktop/action_state_test.go
@@ -38,3 +38,13 @@ func TestDeriveTransferActionStateRequiresConnectionForRetry(t *testing.T) {
 		t.Fatal("terminal job should allow clear")
 	}
 }
+
+func TestDeriveTransferActionStateDisablesQueueControlsWhileDisconnected(t *testing.T) {
+	jobs := []model.TransferJob{{ID: "q", Status: "queued"}}
+	for _, paused := range []bool{false, true} {
+		state := deriveTransferActionState(jobs, nil, false, paused)
+		if state.Pause || state.Resume {
+			t.Fatalf("queue pause/resume must be disabled while disconnected: %+v", state)
+		}
+	}
+}

--- a/internal/desktop/connection_profiles_windows.go
+++ b/internal/desktop/connection_profiles_windows.go
@@ -6,6 +6,7 @@ import (
 	"brendigo.com/byftp/internal/model"
 	"brendigo.com/byftp/internal/platform"
 	"brendigo.com/byftp/internal/profilebinding"
+	"brendigo.com/byftp/internal/security"
 	"brendigo.com/byftp/internal/usererror"
 	"context"
 	"strconv"
@@ -19,6 +20,23 @@ func (a *app) cancelConnectionAttempt() {
 		a.connectionCancel()
 		a.connectionCancel = nil
 	}
+}
+
+func (a *app) cancelHealthCheck() {
+	if a.healthCheckCancel != nil {
+		a.healthCheckCancel()
+		a.healthCheckCancel = nil
+	}
+	a.healthCheckRunning = false
+}
+
+// beginConnectionTransition invalidates every asynchronous callback that was
+// created for an older session. The counter is UI-thread owned and is checked
+// again when asynchronous work dispatches its result back to the window.
+func (a *app) beginConnectionTransition() uint64 {
+	a.connectionGeneration++
+	a.cancelHealthCheck()
+	return a.connectionGeneration
 }
 
 func (a *app) connectionContext(timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -51,36 +69,40 @@ func (a *app) setConnectionBusy(busy bool) {
 	}
 	for _, h := range []uintptr{
 		a.connect, a.disconnect, a.profilesCombo, a.protocol, a.host, a.port, a.user, a.pass,
-		a.keyPath, a.chooseKey, a.passphrase,
+		a.keyPath, a.chooseKey, a.passphrase, a.saveProfile, a.removeProfile, a.settingsBtn,
 	} {
-		enableWindow.Call(h, 0)
+		setControlEnabled(h, false)
 	}
 	a.setRemoteControls(false)
+	a.updateActionControls()
 }
 
 func (a *app) setConnectionUI(connected bool) {
 	a.connected = connected
 	a.connectionBusy = false
-	connectedVal, disconnectedVal := uintptr(0), uintptr(1)
-	if connected {
-		connectedVal, disconnectedVal = 1, 0
+	setControlEnabled(a.connect, !connected)
+	setControlEnabled(a.disconnect, connected)
+	for _, h := range []uintptr{a.profilesCombo, a.protocol, a.host, a.port, a.user, a.pass} {
+		setControlEnabled(h, !connected)
 	}
-	enableWindow.Call(a.connect, disconnectedVal)
-	enableWindow.Call(a.disconnect, connectedVal)
-	for _, h := range []uintptr{a.profilesCombo, a.protocol, a.host, a.port, a.user, a.pass, a.keyPath, a.chooseKey, a.passphrase} {
-		enableWindow.Call(h, disconnectedVal)
-	}
-	a.setRemoteControls(connected)
 	if connected {
+		for _, h := range []uintptr{a.keyPath, a.chooseKey, a.passphrase} {
+			setControlEnabled(h, false)
+		}
 		setText(a.connectionBadge, "● POVEZANO")
 	} else {
 		setText(a.connectionBadge, "● NIJE POVEZANO")
 		a.updateProtocolControls()
 	}
+	a.setRemoteControls(connected)
+	a.updateActionControls()
 	invalidateRect.Call(a.hwnd, 0, 1)
 }
 
 func (a *app) connectNow() {
+	if a.connectionBusy || a.connected {
+		return
+	}
 	host := strings.TrimSpace(getText(a.host))
 	user := strings.TrimSpace(getText(a.user))
 	password := getText(a.pass)
@@ -89,8 +111,13 @@ func (a *app) connectNow() {
 		platform.ErrorDialog("ByFTP", "Neispravan port", "Port mora biti broj između 1 i 65535.")
 		return
 	}
+	protocol := a.protocolValue()
+	if err := security.ValidateConnection(protocol, host, user, port); err != nil {
+		platform.ErrorDialog("ByFTP — povezivanje", "Neispravni podaci veze", usererror.Message(err, "Provjerite poslužitelj, port i korisničko ime."))
+		return
+	}
 	cfg := model.ConnectionConfig{
-		Protocol:       a.protocolValue(),
+		Protocol:       protocol,
 		Host:           host,
 		Port:           port,
 		Username:       user,
@@ -98,10 +125,7 @@ func (a *app) connectNow() {
 		PrivateKeyPath: strings.TrimSpace(getText(a.keyPath)),
 		Passphrase:     getText(a.passphrase),
 	}
-	if host == "" || user == "" {
-		platform.ErrorDialog("ByFTP", "Nedostaju podaci", "Upišite poslužitelj i korisničko ime.")
-		return
-	}
+	generation := a.beginConnectionTransition()
 	// Unesene tajne ostaju u zaključanim edit kontrolama dok veza stvarno ne
 	// uspije. Time korisnik nakon mrežne/port greške može ponoviti pokušaj bez
 	// ponovnog upisa, a onConnected ih briše odmah nakon potvrđenog spajanja.
@@ -115,6 +139,9 @@ func (a *app) connectNow() {
 		cfg.Password = ""
 		cfg.Passphrase = ""
 		a.dispatch(func() {
+			if generation != a.connectionGeneration {
+				return
+			}
 			a.connectionCancel = nil
 			if err != nil {
 				a.setConnectionUI(false)
@@ -129,7 +156,7 @@ func (a *app) connectNow() {
 					a.setStatus("SFTP povezivanje otkazano.")
 					return
 				}
-				a.connectTrusted(profileID, cfg, r.Fingerprint)
+				a.connectTrusted(profileID, cfg, r.Fingerprint, generation)
 				return
 			}
 			a.onConnected(host)
@@ -137,7 +164,10 @@ func (a *app) connectNow() {
 	})
 }
 
-func (a *app) connectTrusted(profileID string, cfg model.ConnectionConfig, fingerprint string) {
+func (a *app) connectTrusted(profileID string, cfg model.ConnectionConfig, fingerprint string, generation uint64) {
+	if generation != a.connectionGeneration {
+		return
+	}
 	// Brzi SFTP spoj ne ovisi samo o kratkotrajnom pending-trust cacheu.
 	// Kontrole su tijekom pokušaja zaključane pa se upravo unesena tajna može
 	// sigurno ponovno uzeti. Za spremljeni profil prazno polje i dalje dopušta
@@ -156,6 +186,9 @@ func (a *app) connectTrusted(profileID string, cfg model.ConnectionConfig, finge
 		cfg.Password = ""
 		cfg.Passphrase = ""
 		a.dispatch(func() {
+			if generation != a.connectionGeneration {
+				return
+			}
 			a.connectionCancel = nil
 			if err != nil {
 				a.setConnectionUI(false)
@@ -182,6 +215,7 @@ func (a *app) currentEndpointMatchesProfile(p model.PublicProfile) bool {
 func (a *app) onConnected(host string) {
 	setText(a.pass, "")
 	setText(a.passphrase, "")
+	a.queuePaused = false
 	a.setConnectionUI(true)
 	a.setStatus("Povezano: " + host)
 	remoteStart := "/"
@@ -199,14 +233,35 @@ func (a *app) onConnected(host string) {
 		a.refreshLocal(localStart)
 	}
 	a.refreshRemote(remoteStart)
+	a.refreshTransfers()
+}
+
+func (a *app) finishDisconnected(status string) {
+	if a.remoteNavCancel != nil {
+		a.remoteNavCancel()
+		a.remoteNavCancel = nil
+	}
+	a.remoteNavSeq++
+	a.queuePaused = true
+	a.setConnectionUI(false)
+	clearList(a.remoteList)
+	a.remoteItems = nil
+	a.updateActionControls()
+	if strings.TrimSpace(status) != "" {
+		a.setStatus(status)
+	}
 }
 
 func (a *app) disconnectNow() {
+	if a.connectionBusy || !a.connected {
+		return
+	}
 	if a.hasActiveTransfers() {
 		if !platform.ConfirmDialog("ByFTP — prekid veze", "Prekinuti vezu i aktivne prijenose?", "Svi prijenosi koji su na čekanju ili u tijeku bit će otkazani prije prekida veze.") {
 			return
 		}
 	}
+	generation := a.beginConnectionTransition()
 	a.setConnectionBusy(true)
 	a.setStatus("Prekid veze…")
 	a.goSafe(func() {
@@ -214,18 +269,13 @@ func (a *app) disconnectNow() {
 		defer cancel()
 		err := a.engine.Disconnect(ctx)
 		a.dispatch(func() {
-			if a.remoteNavCancel != nil {
-				a.remoteNavCancel()
-				a.remoteNavCancel = nil
+			if generation != a.connectionGeneration {
+				return
 			}
-			a.remoteNavSeq++
-			a.setConnectionUI(false)
-			clearList(a.remoteList)
-			a.remoteItems = nil
 			if err != nil {
-				a.setStatus(usererror.Message(err, "Veza je zatvorena uz upozorenje."))
+				a.finishDisconnected(usererror.Message(err, "Veza je zatvorena uz upozorenje."))
 			} else {
-				a.setStatus("Veza prekinuta.")
+				a.finishDisconnected("Veza prekinuta.")
 			}
 		})
 	})
@@ -243,7 +293,7 @@ func (a *app) choosePrivateKey() {
 }
 
 func (a *app) resetProfileCredentialCues() {
-	cue(a.pass, "Lozinka")
+	cue(a.pass, "FTP / SFTP lozinka")
 	cue(a.passphrase, "Zaporka privatnog ključa")
 }
 
@@ -251,7 +301,7 @@ func (a *app) setProfileCredentialCues(p model.PublicProfile) {
 	if p.HasPassword {
 		cue(a.pass, "Spremljena lozinka — prazno koristi spremljenu")
 	} else {
-		cue(a.pass, "Lozinka")
+		cue(a.pass, "FTP / SFTP lozinka")
 	}
 	if p.HasPassphrase && p.PrivateKeyPath != "" {
 		cue(a.passphrase, "Spremljena zaporka ključa — prazno koristi spremljenu")
@@ -300,6 +350,7 @@ func (a *app) applyProfiles(profiles []model.PublicProfile, loadErr error) {
 		a.setProfileCredentialCues(selectedProfile)
 	}
 	sendMessageW.Call(a.profilesCombo, cbSetCurSel, uintptr(selected), 0)
+	a.updateActionControls()
 }
 
 func (a *app) currentProfile() (model.PublicProfile, bool) {
@@ -315,12 +366,16 @@ func (a *app) currentProfile() (model.PublicProfile, bool) {
 }
 
 func (a *app) selectProfile() {
+	if a.connectionBusy || a.connected {
+		return
+	}
 	idx, _, _ := sendMessageW.Call(a.profilesCombo, cbGetCurSel, 0, 0)
 	if idx == 0 || int(idx) > len(a.profiles) {
 		a.selectedProfileID = ""
 		setText(a.pass, "")
 		setText(a.passphrase, "")
 		a.resetProfileCredentialCues()
+		a.updateActionControls()
 		return
 	}
 	p := a.profiles[int(idx)-1]
@@ -339,11 +394,12 @@ func (a *app) selectProfile() {
 		setText(a.remotePath, p.RemotePath)
 	}
 	a.setProfileCredentialCues(p)
+	a.updateActionControls()
 }
 
 func (a *app) saveCurrentProfile() {
-	if a.connected {
-		platform.InfoDialog("ByFTP", "Profil nije moguće mijenjati tijekom veze", "Prekinite vezu pa spremite promjene profila.")
+	if a.connected || a.connectionBusy {
+		platform.InfoDialog("ByFTP", "Profil nije moguće mijenjati tijekom veze", "Pričekajte završetak povezivanja ili prekinite vezu pa spremite promjene profila.")
 		return
 	}
 	existing, editing := a.currentProfile()
@@ -355,11 +411,24 @@ func (a *app) saveCurrentProfile() {
 	if !ok {
 		return
 	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		platform.ErrorDialog("ByFTP — profil", "Naziv profila nedostaje", "Upišite naziv po kojem ćete prepoznati ovu vezu.")
+		return
+	}
 	protocol := a.protocolValue()
 	host := strings.TrimSpace(getText(a.host))
 	username := strings.TrimSpace(getText(a.user))
+	port, err := strconv.Atoi(strings.TrimSpace(getText(a.port)))
+	if err != nil || port < 1 || port > 65535 {
+		platform.ErrorDialog("ByFTP — profil", "Neispravan port", "Port mora biti broj između 1 i 65535.")
+		return
+	}
+	if err := security.ValidateConnection(protocol, host, username, port); err != nil {
+		platform.ErrorDialog("ByFTP — profil", "Neispravni podaci veze", usererror.Message(err, "Provjerite poslužitelj, port i korisničko ime."))
+		return
+	}
 	keyPath := strings.TrimSpace(getText(a.keyPath))
-	port, _ := strconv.Atoi(strings.TrimSpace(getText(a.port)))
 	password := getText(a.pass)
 	passphrase := getText(a.passphrase)
 	clearPassword := false
@@ -424,7 +493,7 @@ func (a *app) saveCurrentProfile() {
 
 	payload := model.ProfileInput{
 		ID:              a.selectedProfileID,
-		Name:            strings.TrimSpace(name),
+		Name:            name,
 		Protocol:        protocol,
 		Host:            host,
 		Port:            port,
@@ -461,6 +530,9 @@ func (a *app) saveCurrentProfile() {
 }
 
 func (a *app) removeCurrentProfile() {
+	if a.connectionBusy {
+		return
+	}
 	p, ok := a.currentProfile()
 	if !ok {
 		platform.InfoDialog("ByFTP", "Nije odabran spremljeni profil", "Odaberite profil koji želite obrisati.")
@@ -485,6 +557,7 @@ func (a *app) removeCurrentProfile() {
 			a.resetProfileCredentialCues()
 			a.loadProfiles()
 			a.setStatus("Profil obrisan.")
+			a.updateActionControls()
 		})
 	})
 }

--- a/internal/desktop/files_actions_windows.go
+++ b/internal/desktop/files_actions_windows.go
@@ -33,6 +33,10 @@ func (a *app) chooseLocalDirectory() {
 }
 
 func (a *app) refreshLocal(p string) {
+	selected := map[string]struct{}{}
+	if strings.TrimSpace(p) != "" && a.localCurrent != "" && filepath.Clean(p) == filepath.Clean(a.localCurrent) {
+		selected = selectedItemNames(a.localList, a.localItems)
+	}
 	if a.localNavCancel != nil {
 		a.localNavCancel()
 	}
@@ -50,18 +54,21 @@ func (a *app) refreshLocal(p string) {
 			a.localNavCancel = nil
 			if err != nil {
 				a.setStatus(usererror.Message(err, "Lokalnu mapu nije moguće otvoriti."))
+				a.updateActionControls()
 				return
 			}
 			a.localCurrent = resolvedPath
 			a.localItems = items
 			setText(a.localPath, resolvedPath)
 			fillItems(a.localList, items)
+			restoreItemSelection(a.localList, items, selected)
+			a.updateActionControls()
 		})
 	})
 }
 
 func (a *app) refreshRemote(p string) {
-	if !a.connected {
+	if !a.connected || a.connectionBusy {
 		return
 	}
 	if strings.TrimSpace(p) == "" {
@@ -72,11 +79,16 @@ func (a *app) refreshRemote(p string) {
 		}
 	}
 	p = cleanRemote(p)
+	selected := map[string]struct{}{}
+	if p == a.remoteCurrent {
+		selected = selectedItemNames(a.remoteList, a.remoteItems)
+	}
 	if a.remoteNavCancel != nil {
 		a.remoteNavCancel()
 	}
 	a.remoteNavSeq++
 	seq := a.remoteNavSeq
+	generation := a.connectionGeneration
 	target := p
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	a.remoteNavCancel = cancel
@@ -84,7 +96,7 @@ func (a *app) refreshRemote(p string) {
 		defer cancel()
 		items, err := a.engine.RemoteList(ctx, target)
 		a.dispatch(func() {
-			if seq != a.remoteNavSeq || !a.connected {
+			if seq != a.remoteNavSeq || generation != a.connectionGeneration || !a.connected {
 				return
 			}
 			a.remoteNavCancel = nil
@@ -100,6 +112,8 @@ func (a *app) refreshRemote(p string) {
 			a.remoteItems = items
 			setText(a.remotePath, a.remoteCurrent)
 			fillItems(a.remoteList, items)
+			restoreItemSelection(a.remoteList, items, selected)
+			a.updateActionControls()
 		})
 	})
 }
@@ -118,14 +132,14 @@ func (a *app) openSelectedLocal() {
 		a.refreshLocal(filepath.Join(a.localCurrent, it.Name))
 		return
 	}
-	if a.connected {
+	if a.connected && !a.connectionBusy {
 		a.addTransfer("upload", filepath.Join(a.localCurrent, it.Name), path.Join(a.remoteCurrent, it.Name), a.localCurrent)
 	}
 }
 
 func (a *app) openSelectedRemote() {
 	idx := selectedIndex(a.remoteList)
-	if idx < 0 || idx >= len(a.remoteItems) {
+	if idx < 0 || idx >= len(a.remoteItems) || !a.connected || a.connectionBusy {
 		return
 	}
 	it := a.remoteItems[idx]
@@ -135,6 +149,10 @@ func (a *app) openSelectedRemote() {
 	}
 	if it.IsDirectory {
 		a.refreshRemote(path.Join(a.remoteCurrent, it.Name))
+		return
+	}
+	if it.IsSymlink {
+		a.setStatus("Simbolička poveznica nije automatski preuzeta radi sigurnosti.")
 		return
 	}
 	local, err := security.SafeLocalChild(a.localCurrent, it.Name)
@@ -231,13 +249,13 @@ func (a *app) localDeleteAction() {
 				platform.ErrorDialog("ByFTP", "Nisu obrisane sve stavke", usererror.Message(err, "Dio odabranih stavki nije moguće obrisati."))
 			}
 			a.refreshLocal(a.localCurrent)
-			a.setStatus("Obrisano lokalnih stavki: " + strconv.Itoa(deleted))
+			a.setStatus("Obrisano lokalnih stavki: " + strconv.Itoa(deleted) + " • neuspjelo: " + strconv.Itoa(len(items)-deleted))
 		})
 	})
 }
 
 func (a *app) remoteMkdirAction() {
-	if !a.connected {
+	if !a.connected || a.connectionBusy {
 		return
 	}
 	name, ok := platform.PromptDialog("ByFTP — nova mapa na poslužitelju", "Naziv nove mape:", "Nova mapa")
@@ -251,7 +269,7 @@ func (a *app) remoteMkdirAction() {
 
 func (a *app) remoteRenameAction() {
 	indices := selectedIndices(a.remoteList)
-	if len(indices) != 1 || indices[0] < 0 || indices[0] >= len(a.remoteItems) {
+	if len(indices) != 1 || indices[0] < 0 || indices[0] >= len(a.remoteItems) || a.connectionBusy {
 		a.setStatus("Za preimenovanje odaberite točno jednu udaljenu stavku.")
 		return
 	}
@@ -268,7 +286,7 @@ func (a *app) remoteRenameAction() {
 
 func (a *app) remoteDeleteAction() {
 	indices := selectedIndices(a.remoteList)
-	if len(indices) == 0 {
+	if len(indices) == 0 || a.connectionBusy {
 		a.setStatus("Odaberite jednu ili više udaljenih stavki za brisanje.")
 		return
 	}
@@ -291,20 +309,15 @@ func (a *app) remoteDeleteAction() {
 		}
 	}
 	base := a.remoteCurrent
-	a.runRemoteMutationWithTimeout("Brisanje", remoteBatchTimeout(len(items)), func(ctx context.Context) error {
-		var errs []error
-		for _, item := range items {
-			if err := a.engine.RemoteDelete(ctx, base, item.Name, item.IsDirectory); err != nil {
-				errs = append(errs, err)
-			}
-		}
-		return errors.Join(errs...)
-	}, "Udaljene stavke obrisane: "+strconv.Itoa(len(items)))
+	a.runRemoteBatchMutationWithTimeout("Brisanje", remoteBatchTimeout(len(items)), len(items), func(ctx context.Context, index int) error {
+		item := items[index]
+		return a.engine.RemoteDelete(ctx, base, item.Name, item.IsDirectory)
+	}, "Obrisano udaljenih stavki: ", 0)
 }
 
 func (a *app) remoteChmodAction() {
 	indices := selectedIndices(a.remoteList)
-	if len(indices) == 0 {
+	if len(indices) == 0 || a.connectionBusy {
 		a.setStatus("Odaberite jednu ili više stavki za promjenu dozvola.")
 		return
 	}
@@ -313,12 +326,20 @@ func (a *app) remoteChmodAction() {
 		return
 	}
 	items := make([]model.Item, 0, len(indices))
+	skippedLinks := 0
 	for _, idx := range indices {
-		if idx >= 0 && idx < len(a.remoteItems) {
-			items = append(items, a.remoteItems[idx])
+		if idx < 0 || idx >= len(a.remoteItems) {
+			continue
 		}
+		item := a.remoteItems[idx]
+		if item.IsSymlink {
+			skippedLinks++
+			continue
+		}
+		items = append(items, item)
 	}
 	if len(items) == 0 {
+		a.setStatus("Dozvole nisu mijenjane: simboličke poveznice preskaču se radi sigurnosti.")
 		return
 	}
 	base := a.remoteCurrent
@@ -327,15 +348,9 @@ func (a *app) remoteChmodAction() {
 		return
 	}
 	mode = strings.TrimSpace(mode)
-	a.runRemoteMutationWithTimeout("Promjena dozvola", remoteBatchTimeout(len(items)), func(ctx context.Context) error {
-		var errs []error
-		for _, item := range items {
-			if err := a.engine.RemoteChmod(ctx, base, item.Name, mode); err != nil {
-				errs = append(errs, err)
-			}
-		}
-		return errors.Join(errs...)
-	}, "Dozvole promijenjene za stavki: "+strconv.Itoa(len(items)))
+	a.runRemoteBatchMutationWithTimeout("Promjena dozvola", remoteBatchTimeout(len(items)), len(items), func(ctx context.Context, index int) error {
+		return a.engine.RemoteChmod(ctx, base, items[index].Name, mode)
+	}, "Dozvole promijenjene za stavki: ", skippedLinks)
 }
 
 func remoteBatchTimeout(count int) time.Duration {
@@ -354,16 +369,20 @@ func (a *app) runRemoteMutation(label string, operation func(context.Context) er
 }
 
 func (a *app) runRemoteMutationWithTimeout(label string, timeout time.Duration, operation func(context.Context) error, success string) {
-	if !a.connected {
+	if !a.connected || a.connectionBusy {
 		return
 	}
-	baseGeneration := a.remoteNavSeq
+	baseNavGeneration := a.remoteNavSeq
+	connectionGeneration := a.connectionGeneration
 	a.setStatus(label + "…")
 	a.goSafe(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		err := operation(ctx)
 		a.dispatch(func() {
+			if connectionGeneration != a.connectionGeneration || !a.connected {
+				return
+			}
 			if err != nil {
 				if a.suppressExpectedDisconnectError(err) {
 					return
@@ -374,8 +393,47 @@ func (a *app) runRemoteMutationWithTimeout(label string, timeout time.Duration, 
 				return
 			}
 			a.setStatus(success)
-			if baseGeneration == a.remoteNavSeq {
+			if baseNavGeneration == a.remoteNavSeq {
 				a.refreshRemote(a.remoteCurrent)
+			}
+		})
+	})
+}
+
+func (a *app) runRemoteBatchMutationWithTimeout(label string, timeout time.Duration, count int, operation func(context.Context, int) error, successPrefix string, skipped int) {
+	if !a.connected || a.connectionBusy || count <= 0 {
+		return
+	}
+	baseNavGeneration := a.remoteNavSeq
+	connectionGeneration := a.connectionGeneration
+	a.setStatus(label + "…")
+	a.goSafe(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		result := executeBatchMutation(ctx, count, operation)
+		a.dispatch(func() {
+			if connectionGeneration != a.connectionGeneration || !a.connected {
+				return
+			}
+			status := successPrefix + strconv.Itoa(result.Succeeded)
+			if result.Failed > 0 {
+				status += " • neuspjelo: " + strconv.Itoa(result.Failed)
+			}
+			if skipped > 0 {
+				status += " • preskočeno poveznica: " + strconv.Itoa(skipped)
+			}
+			a.setStatus(status)
+			if result.Err != nil && !a.suppressExpectedDisconnectError(result.Err) {
+				platform.ErrorDialog("ByFTP — poslužitelj", label+" nije dovršeno za sve stavke", usererror.Message(result.Err, "Dio odabranih stavki nije moguće promijeniti."))
+			}
+			if result.Succeeded > 0 && baseNavGeneration == a.remoteNavSeq {
+				// Refresh itself proves whether the connection is still usable, so do
+				// not start a redundant probe in parallel after partial success.
+				a.refreshRemote(a.remoteCurrent)
+				return
+			}
+			if result.Err != nil && !a.suppressExpectedDisconnectError(result.Err) {
+				a.checkConnectionAfterError()
 			}
 		})
 	})
@@ -395,40 +453,54 @@ func (a *app) queueSelection(direction string, files []api.TransferRequest, tree
 		}
 		return
 	}
+	generation := a.connectionGeneration
 	a.setStatus("Dodavanje odabranih stavki u red prijenosa…")
 	a.goSafe(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 		queuedFiles := 0
 		queuedDirs := 0
-		var firstErr error
+		failedSelections := 0
+		var errs []error
 		if len(files) > 0 {
 			jobs, err := a.engine.AddTransfers(files)
 			if err != nil {
-				firstErr = err
+				failedSelections += len(files)
+				errs = append(errs, err)
 			} else {
 				queuedFiles += len(jobs)
 			}
 		}
-		if firstErr == nil {
-			for _, tree := range trees {
-				result, err := a.engine.AddTreeTransfer(ctx, direction, tree.localPath, tree.remotePath)
-				if err != nil {
-					firstErr = err
-					break
-				}
-				queuedFiles += result.Queued
-				queuedDirs += result.Directories
-				skipped += result.SkippedSymlinks
+		for _, tree := range trees {
+			if ctx.Err() != nil {
+				failedSelections++
+				errs = append(errs, ctx.Err())
+				continue
 			}
+			result, err := a.engine.AddTreeTransfer(ctx, direction, tree.localPath, tree.remotePath)
+			if err != nil {
+				failedSelections++
+				errs = append(errs, err)
+				continue
+			}
+			queuedFiles += result.Queued
+			queuedDirs += result.Directories
+			skipped += result.SkippedSymlinks
 		}
+		err := errors.Join(errs...)
 		a.dispatch(func() {
-			if firstErr != nil {
-				platform.ErrorDialog("ByFTP — prijenos", "Nisu dodane sve odabrane stavke", usererror.Message(firstErr, "Dio odabranih stavki nije moguće dodati u prijenos."))
+			if generation != a.connectionGeneration {
+				return
+			}
+			if err != nil && !a.suppressExpectedDisconnectError(err) {
+				platform.ErrorDialog("ByFTP — prijenos", "Nisu dodane sve odabrane stavke", usererror.Message(err, "Dio odabranih stavki nije moguće dodati u prijenos."))
 			}
 			text := "Dodano u red: " + strconv.Itoa(queuedFiles) + " datoteka"
 			if queuedDirs > 0 {
 				text += ", " + strconv.Itoa(queuedDirs) + " mapa"
+			}
+			if failedSelections > 0 {
+				text += " • neuspjelo odabira: " + strconv.Itoa(failedSelections)
 			}
 			if skipped > 0 {
 				text += " • preskočeno poveznica: " + strconv.Itoa(skipped)
@@ -508,12 +580,16 @@ func (a *app) downloadSelected() {
 }
 
 func (a *app) addTreeTransfer(direction, local, remotePath string) {
+	generation := a.connectionGeneration
 	a.setStatus("Priprema prijenosa cijele mape…")
 	a.goSafe(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		result, err := a.engine.AddTreeTransfer(ctx, direction, local, remotePath)
 		a.dispatch(func() {
+			if generation != a.connectionGeneration {
+				return
+			}
 			if err != nil {
 				if a.suppressExpectedDisconnectError(err) {
 					return
@@ -529,37 +605,47 @@ func (a *app) addTreeTransfer(direction, local, remotePath string) {
 }
 
 func (a *app) checkConnectionAfterError() {
-	if a.healthCheckRunning || !a.connected {
+	if a.healthCheckRunning || !a.connected || a.connectionBusy {
 		return
 	}
+	generation := a.connectionGeneration
 	a.healthCheckRunning = true
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	a.healthCheckCancel = cancel
 	a.goSafe(func() {
 		err := a.engine.Probe(ctx)
 		cancel()
-		if err == nil {
-			a.dispatch(func() {
-				a.healthCheckRunning = false
-				a.healthCheckCancel = nil
-			})
-			return
-		}
-		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		_ = a.engine.Disconnect(disconnectCtx)
-		disconnectCancel()
 		a.dispatch(func() {
+			if generation != a.connectionGeneration || !a.connected {
+				return
+			}
 			a.healthCheckRunning = false
 			a.healthCheckCancel = nil
-			if a.remoteNavCancel != nil {
-				a.remoteNavCancel()
-				a.remoteNavCancel = nil
+			if err == nil {
+				return
 			}
-			a.remoteNavSeq++
-			a.setConnectionUI(false)
-			clearList(a.remoteList)
-			a.remoteItems = nil
-			a.setStatus("Veza više nije dostupna. Aktivni prijenosi su zaustavljeni; poslužitelj i korisničko ime ostali su uneseni.")
+			if a.suppressExpectedDisconnectError(err) {
+				return
+			}
+
+			disconnectGeneration := a.beginConnectionTransition()
+			a.setConnectionBusy(true)
+			a.setStatus("Veza više nije dostupna. Zaustavljanje prijenosa…")
+			a.goSafe(func() {
+				disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				disconnectErr := a.engine.Disconnect(disconnectCtx)
+				disconnectCancel()
+				a.dispatch(func() {
+					if disconnectGeneration != a.connectionGeneration {
+						return
+					}
+					status := "Veza više nije dostupna. Aktivni prijenosi su zaustavljeni; poslužitelj i korisničko ime ostali su uneseni."
+					if disconnectErr != nil {
+						status = usererror.Message(disconnectErr, status)
+					}
+					a.finishDisconnected(status)
+				})
+			})
 		})
 	})
 }

--- a/internal/desktop/settings_windows.go
+++ b/internal/desktop/settings_windows.go
@@ -11,14 +11,16 @@ import (
 )
 
 func (a *app) loadSettings() {
-	// Osiguraj hrvatski cue tekst i kod nadogradnje sa starijeg UI resursa.
-	cue(a.host, "Poslužitelj")
 	a.goSafe(func() {
 		settings, err := a.engine.Settings()
-		if err != nil {
-			return
-		}
-		a.dispatch(func() { a.settings = settings })
+		a.dispatch(func() {
+			if err != nil {
+				a.setStatus(usererror.Message(err, "Postavke nisu učitane; koriste se sigurne zadane vrijednosti."))
+				return
+			}
+			a.settings = settings
+			a.updateActionControls()
+		})
 	})
 }
 
@@ -36,6 +38,9 @@ func promptNumber(title, instruction string, current, min, max int) (int, bool) 
 }
 
 func (a *app) openSettings() {
+	if a.connectionBusy {
+		return
+	}
 	settings := a.settings
 	if settings.Parallelism < 1 {
 		settings.Parallelism = 2
@@ -104,6 +109,7 @@ func (a *app) openSettings() {
 				overwriteText = "postojeće datoteke se preskaču"
 			}
 			a.setStatus("Postavke spremljene. Paralelni prijenosi: " + strconv.Itoa(saved.Parallelism) + " • spajanje: " + strconv.Itoa(saved.ConnectionTimeoutSeconds) + " s • " + retryText + " • " + overwriteText)
+			a.updateActionControls()
 		})
 	})
 }

--- a/internal/desktop/transfers_windows.go
+++ b/internal/desktop/transfers_windows.go
@@ -57,6 +57,11 @@ func (a *app) addTransfer(direction, local, remotePath, localRoot string) {
 }
 
 func (a *app) applyTransferEvents(events []transfer.Event) bool {
+	for _, event := range events {
+		if event.Type == "state" {
+			a.queuePaused = event.Paused
+		}
+	}
 	jobs, changed := applyTransferEventsToJobs(a.transferJobs, events)
 	a.transferJobs = jobs
 	return changed

--- a/scripts/test_ui_stability_hardening.py
+++ b/scripts/test_ui_stability_hardening.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class UIStabilityHardeningTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_connection_callbacks_are_generation_bound(self) -> None:
+        text = self.read("internal/desktop/connection_profiles_windows.go")
+        for marker in (
+            "connectionGeneration++",
+            "beginConnectionTransition()",
+            "generation != a.connectionGeneration",
+            "cancelHealthCheck()",
+            "finishDisconnected(",
+        ):
+            self.assertIn(marker, text)
+        busy = text.split("func (a *app) setConnectionBusy", 1)[1].split("func (a *app) setConnectionUI", 1)[0]
+        for marker in ("a.saveProfile", "a.removeProfile", "a.settingsBtn"):
+            self.assertIn(marker, busy)
+
+    def test_profile_endpoint_is_validated_before_reading_typed_secrets(self) -> None:
+        text = self.read("internal/desktop/connection_profiles_windows.go")
+        save = text.split("func (a *app) saveCurrentProfile()", 1)[1]
+        self.assertLess(save.index("security.ValidateConnection("), save.index("password := getText(a.pass)"))
+        self.assertIn("port < 1 || port > 65535", save)
+
+    def test_partial_remote_mutations_refresh_real_state(self) -> None:
+        text = self.read("internal/desktop/files_actions_windows.go")
+        for marker in (
+            "runRemoteBatchMutationWithTimeout",
+            "executeBatchMutation(ctx, count, operation)",
+            "result.Succeeded > 0",
+            "failedSelections",
+            "skippedLinks",
+        ):
+            self.assertIn(marker, text)
+        self.assertIn("disconnectGeneration := a.beginConnectionTransition()", text)
+        self.assertIn("generation != a.connectionGeneration", text)
+
+    def test_refreshes_preserve_selection_and_reduce_flicker(self) -> None:
+        helpers = self.read("internal/desktop/helpers_windows.go")
+        files = self.read("internal/desktop/files_actions_windows.go")
+        transfers = self.read("internal/desktop/transfers_windows.go")
+        for marker in ("selectedItemNames", "restoreItemSelection", "wmSetRedraw", "lvmSetItemState"):
+            self.assertIn(marker, helpers)
+        self.assertGreaterEqual(files.count("restoreItemSelection("), 2)
+        for marker in ("selectedTransferIDSet", "restoreTransferSelection", 'event.Type == "state"', "event.Paused"):
+            self.assertIn(marker, transfers)
+
+    def test_windows_layout_and_actions_follow_current_context(self) -> None:
+        ui = self.read("internal/desktop/ui_windows.go")
+        windows = self.read("internal/desktop/windows.go")
+        actions = self.read("internal/desktop/action_state_windows.go")
+        for marker in ("preferredWindowBounds", "compact := width < 1180", "resizeListColumns", "layoutPanelWidth"):
+            self.assertIn(marker, ui)
+        for marker in ("wmGetMinMaxInfo", "lvnItemChanged", "updateActionControls()"):
+            self.assertIn(marker, windows)
+        for marker in ("localSelected == 1", "remoteSelected == 1", "deriveTransferActionState"):
+            self.assertIn(marker, actions)
+
+    def test_settings_do_not_replace_helpful_host_hint(self) -> None:
+        settings = self.read("internal/desktop/settings_windows.go")
+        ui = self.read("internal/desktop/ui_windows.go")
+        self.assertNotIn('cue(a.host, "Poslužitelj")', settings)
+        self.assertIn("FTP/SFTP poslužitelj, npr. ftp.domena.hr", ui)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ovlaštenje

- [ ] Ovu izmjenu izvornog koda Brendigo je izričito zatražio ili odobrio.
- [ ] Pročitao/la sam `LICENSE` i `docs/DOPRINOS.md` te ću ih poštovati.

> ByFTP je vlasnički/source-available softver. Otvaranje pull requesta ili forka samo po sebi ne daje pravo izmjene, redistribucije, rebrandinga, prodaje, sublicenciranja ili izrade izvedenih distribucija izvan prava koja je Brendigo izričito dao i ograničenih GitHub platformskih prava.

## Sažetak

Opišite izmjenu i razlog zbog kojeg je potrebna.

## Sigurnost i privatnost

- [ ] Nije dodana telemetrija, analitika, oglašivački SDK ni vanjski servis za izvještavanje o rušenju.
- [ ] Nije dodan automatski vanjski API ni skriveno mrežno odredište.
- [ ] Lozinke, zaporke i privatni ključ ne završavaju u argumentima naredbenog retka ni trajnim zapisima.
- [ ] SFTP host-key provjera i pinning ostaju aktivni.
- [ ] Lokalna path traversal, symlink, junction i reparse-point zaštita ostaju aktivni.
- [ ] Nije dodan vanjski Go modul bez izričite arhitekturne/sigurnosne provjere.
- [ ] Testovi, slike i fixturei ne sadrže stvarne vjerodajnice, produkcijske poslužitelje ili podatke klijenata.
- [ ] Korisnički tekst i nova dokumentacija napisani su na hrvatskom.

## Provjera

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/generate_brand_assets.py --check`
- [ ] `python scripts/audit_croatian.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] Windows produkcijski build provjeren je ako izmjena dira Windows-specifičan kod.

## Regresijski testovi

Opišite testove dodane ili izmijenjene za vezu, transfere, putanje, profile, instalaciju/uklanjanje ili drugo pogođeno ponašanje.
