### PR TITLE
Finalize ByFTP 1.0.12 README and Windows production build

### DIFF
--- a/BUILD-WINDOWS.ps1
+++ b/BUILD-WINDOWS.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version 3.0
 
 Set-Location -LiteralPath $PSScriptRoot
 
-$minimumGo = [Version]'1.26.7'
+$minimumGo = [Version]'1.26.5'
 $versionFile = Join-Path $PSScriptRoot 'VERSION'
 $dist = Join-Path $PSScriptRoot 'dist'
 $internalDist = Join-Path $dist 'internal'
@@ -142,17 +142,20 @@ foreach ($name in @(
     Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
 }
 
-$goCommand = Get-Command go -CommandType Application -ErrorAction SilentlyContinue
+# GitHub-hosted Windows images can expose more than one executable with the
+# same command name. Select one concrete application explicitly so helper
+# parameters always receive a scalar path instead of a String[] value.
+$goCommand = @(Get-Command go -CommandType Application -ErrorAction SilentlyContinue)[0]
 if (-not $goCommand) {
     throw 'Go is not installed or is not available in PATH.'
 }
-$go = $goCommand.Source
+[string]$go = $goCommand.Source
 
-$pythonCommand = Get-Command python -CommandType Application -ErrorAction SilentlyContinue
+$pythonCommand = @(Get-Command python -CommandType Application -ErrorAction SilentlyContinue)[0]
 if (-not $pythonCommand) {
     throw 'Python 3 is not installed or is not available in PATH.'
 }
-$python = $pythonCommand.Source
+[string]$python = $pythonCommand.Source
 
 $pythonVersionText = Invoke-NativeCapture `
     -FilePath $python `

--- a/README.md
+++ b/README.md
@@ -2,27 +2,218 @@
 
 ![ByFTP — Secure File Transfer](docs/images/byftp-header.png)
 
-ByFTP is a privacy-focused FTP, FTPS and SFTP file-transfer client for Windows, Linux and macOS. It is designed for shared hosting, website deployment and day-to-day server file management without advertising, analytics SDKs or a mandatory cloud account.
+ByFTP is a privacy-focused desktop file-transfer client for **FTP, FTPS and SFTP** on Windows, Linux and macOS. It is built for shared hosting, website deployment and routine server file management while keeping credentials local and avoiding advertising, analytics SDKs and mandatory cloud services.
 
 **Current release: 1.0.12**
 
-## Highlights
+[Download the latest release](https://github.com/bren-wp/by-ftp/releases/latest) · [Installation](docs/INSTALLATION.md) · [Security](docs/SECURITY.md) · [Release verification](docs/RELEASE-VERIFICATION.md)
 
-- FTP, explicit FTPS, implicit FTPS and SFTP.
-- Shared-hosting friendly `public_html` workflow, passive FTP and MLSD → LIST fallback.
-- Bounded transfer queue with pause, resume, cancel and retry.
-- Safe overwrite staging, backup/rollback and path/symlink protections.
-- No application telemetry, ads or fixed project runtime API.
+## Why ByFTP
+
+ByFTP focuses on the workflows that matter when managing websites and shared-hosting accounts:
+
+- FTP, explicit FTPS, implicit FTPS and SFTP connections.
+- Shared-hosting friendly `public_html` navigation and login-relative FTP paths.
+- Passive FTP with MLSD → LIST compatibility fallback for older hosting servers.
+- Local and remote file browsing, folder creation, rename, delete and CHMOD operations.
+- Upload and download queues with pause, resume, cancel and retry.
+- Safe overwrite staging with rollback/backup handling rather than direct destructive replacement.
+- Protection against unsafe local paths, symlinks, junctions and reparse points.
+- SFTP host-key verification and fingerprint pinning.
+- No application telemetry, advertising SDKs or mandatory remote account system.
+
+## Supported platforms
+
+| Platform | Production package |
+| --- | --- |
+| Windows x64 | Portable EXE, Setup EXE and release ZIP |
+| Windows x86 | Portable EXE, Setup EXE and release ZIP |
+| Linux amd64 | DEB package |
+| Linux arm64 | DEB package |
+| Linux i386 | DEB package |
+| macOS | Universal PKG |
+
+Exact release assets are produced by the repository release workflow and verified before publication. See [GitHub releases](docs/GITHUB-RELEASES.md) and [Release verification](docs/RELEASE-VERIFICATION.md).
+
+## Supported protocols
+
+### FTP
+
+Standard FTP support is intended primarily for compatibility with hosting environments that still require it. Credentials and content are not encrypted by the FTP protocol itself, so FTPS or SFTP should be preferred whenever the server supports them.
+
+### FTPS
+
+ByFTP supports both explicit and implicit FTPS. TLS is used for the FTP connection while retaining familiar shared-hosting FTP semantics.
+
+### SFTP
+
+SFTP support uses SSH host-key verification and fingerprint pinning. Private-key based authentication is supported, and secret handling is designed so passwords and passphrases do not need to be persisted in plaintext or exposed through generic command-line arguments.
+
+## Shared-hosting workflow
+
+ByFTP is designed to behave predictably on typical shared hosting:
+
+1. Connect using the host, port and credentials supplied by the hosting provider.
+2. Open the account's web root, commonly `public_html`.
+3. Upload website files or folders through the transfer queue.
+4. Use rename, delete, folder creation and CHMOD operations where the server allows them.
+5. Keep FTP paths relative to the authenticated account namespace instead of accidentally switching to the server root.
+
+For hosting-specific behavior and compatibility notes, see [Shared hosting](docs/SHARED-HOSTING.md).
+
+## Safer transfers
+
+The transfer layer is deliberately conservative around destructive operations.
+
+- Uploads use temporary remote staging before the final commit/rename.
+- Existing targets are revalidated before overwrite commit.
+- Skip-existing decisions are rechecked against fresh remote state.
+- Downloads are staged locally and validated before activation.
+- Local symbolic links, junctions and Windows reparse points are rejected at security-sensitive boundaries.
+- Cleanup failures that can leave uncertain remote state are surfaced instead of being silently treated as success.
+- Connection/session generations prevent stale work from mutating a newer session.
+
+The detailed threat model and invariants are documented in [Security](docs/SECURITY.md).
+
+## Privacy
+
+ByFTP is designed to work without a project-controlled runtime backend. The application does not require analytics, advertising or a mandatory ByFTP cloud account.
+
+Network traffic is limited to the servers and protocol helpers required for the connection or transfer initiated by the user. Go telemetry is explicitly disabled in production build and CI workflows.
+
+See [Privacy](docs/PRIVACY.md) for the complete policy and technical boundaries.
 
 ## Languages
 
-English is the canonical and fallback language. Runtime localization is available for English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Simplified Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian and Swedish. The Windows setup wizard asks for language before installation and persists that choice as the initial application language.
+English is the canonical source and fallback language. Runtime localization is available for:
 
-## Build and install
+- English
+- Croatian
+- German
+- French
+- Spanish
+- Turkish
+- Greek
+- Portuguese
+- Simplified Chinese
+- Russian
+- Hindi
+- Japanese
+- Italian
+- Polish
+- Dutch
+- Czech
+- Ukrainian
+- Swedish
 
-Production builds read the version from the repository `VERSION` file. Do not maintain a second product version in scripts, documentation or package metadata.
+The Windows setup wizard asks for a language before installation and stores that choice as the initial application language. Language can later be changed from Settings.
 
-See [Installation](docs/INSTALLATION.md), [Testing](docs/TESTING.md) and [Release verification](docs/RELEASE-VERIFICATION.md).
+## Installation and upgrades
+
+### Windows
+
+Use the Setup EXE for a normal per-user installation or the Portable EXE when an installed copy is not required. Windows builds are produced for x64 and x86.
+
+The installer validates its embedded payload before modifying files or registry state and uses transactional rollback for failed upgrades. Existing ByFTP user data is preserved across the data-directory normalization introduced in 1.0.12.
+
+### Linux
+
+Install the DEB package matching the machine architecture. Production packages are built for amd64, arm64 and i386.
+
+### macOS
+
+Use the Universal PKG from the official release. The package contains a Universal application build for supported Intel/Apple Silicon environments.
+
+Detailed instructions are in [Installation](docs/INSTALLATION.md).
+
+## Build from source
+
+ByFTP uses Go and intentionally keeps the production module graph minimal. The canonical module path is:
+
+```text
+github.com/bren-wp/by-ftp
+```
+
+The repository `VERSION` file is the **single production version source**. Runtime binaries, installers, platform packages, release notes and GitHub Package metadata must derive the release number from it.
+
+### Windows production build
+
+```powershell
+go telemetry off
+.\BUILD-WINDOWS.ps1
+```
+
+The Windows production build performs asset, localization, version, documentation, security, privacy and release audits before compiling x64 and x86 artifacts.
+
+### Linux production build
+
+```bash
+go telemetry off
+bash scripts/BUILD-LINUX.sh
+```
+
+### macOS production build
+
+```bash
+go telemetry off
+bash scripts/BUILD-MACOS.sh
+```
+
+### Tests and audits
+
+```bash
+go test ./...
+go test -race ./...
+go vet ./...
+python scripts/generate_brand_assets.py --check
+python scripts/audit_localization.py
+python scripts/audit_version.py
+python scripts/audit_docs.py
+python scripts/audit_security.py
+python scripts/audit_privacy.py
+python scripts/audit_release.py
+python -m unittest discover -s scripts -p 'test_*.py'
+```
+
+See [Testing](docs/TESTING.md) for the complete verification matrix.
+
+## Release integrity
+
+The release pipeline is fail-closed and designed to prevent accidental publication of incomplete or mismatched artifacts.
+
+- Production builds run with Go telemetry disabled.
+- `VERSION` is checked for consistency before release.
+- Already-published version lines are protected by the release-version guard.
+- Windows, Linux and macOS platform jobs must succeed before publication.
+- Windows ZIP bundles use an explicit file allowlist and `BUNDLE-SHA256.txt`.
+- Public release staging must match the expected artifact set exactly.
+- GitHub Release mutation is centralized in `scripts/publish_release.ps1`.
+- SHA-256 manifests are generated for published assets.
+
+See [Release verification](docs/RELEASE-VERIFICATION.md) and [Signing](docs/SIGNING.md).
+
+## Repository structure
+
+```text
+cmd/
+  byftp/          Desktop application entry point
+  installer/      Windows installer
+  uninstaller/    Windows uninstaller
+internal/
+  api/            Typed application/engine boundary
+  appdata/        Canonical and legacy user-data resolution
+  config/         Profiles and settings persistence
+  desktop/        Desktop UI
+  i18n/           Runtime localization catalogs
+  localfs/        Local filesystem operations
+  platform/       OS-specific primitives
+  remote/         FTP/FTPS/SFTP implementations
+  security/       Path, secret and filesystem safety helpers
+  transfer/       Transfer queue and lifecycle
+scripts/          Build, audit, verification and release tools
+docs/             Project documentation
+build/            Generated/static build resources
+```
 
 ## Documentation
 
@@ -40,7 +231,18 @@ See [Installation](docs/INSTALLATION.md), [Testing](docs/TESTING.md) and [Releas
 - [Release verification](docs/RELEASE-VERIFICATION.md)
 - [Signing](docs/SIGNING.md)
 - [Third-party notices](docs/THIRD-PARTY-NOTICES.md)
+- [Build and verification tools](scripts/README.md)
+
+## Contributing
+
+Changes should preserve the project's security, privacy and release invariants. New canonical user-facing text is English-first and runtime UI strings belong in the localization system rather than being hard-coded into platform logic.
+
+Before proposing a change, read [Contributing](docs/CONTRIBUTING.md) and run the relevant tests/audits listed above.
+
+## Security reports
+
+Do not publish passwords, private keys, production hostnames, customer data or other sensitive material in public issues. Follow the repository [security policy](.github/SECURITY.md) for security-sensitive reports.
 
 ## License
 
-See [LICENSE](LICENSE). The license file is intentionally preserved as the legal attribution source.
+See [LICENSE](LICENSE). The license file is intentionally preserved as the authoritative legal attribution source.

--- a/internal/platform/language_windows.go
+++ b/internal/platform/language_windows.go
@@ -110,7 +110,11 @@ func SelectLanguageDialog(title, instruction string, options []string, defaultIn
 	languageStates.Store(hwnd, state)
 	defer languageStates.Delete(hwnd)
 
-	font, _, _ := promptCreateFontW.Call(uintptr(uint32(int32(-16))), 0, 0, 0, 400, 0, 0, 0, 1, 0, 0, 5, 0, uintptr(unsafe.Pointer(promptWstr("Segoe UI"))))
+	// CreateFontW accepts a signed LONG height. syscall.Proc.Call takes uintptr,
+	// so preserve the signed 32-bit Win32 representation at runtime instead of
+	// attempting an invalid constant conversion from -16 to uint32.
+	fontHeight := int32(-16)
+	font, _, _ := promptCreateFontW.Call(uintptr(uint32(fontHeight)), 0, 0, 0, 400, 0, 0, 0, 1, 0, 0, 5, 0, uintptr(unsafe.Pointer(promptWstr("Segoe UI"))))
 	if font != 0 {
 		defer promptDeleteObject.Call(font)
 	}

--- a/internal/usererror/message_test.go
+++ b/internal/usererror/message_test.go
@@ -44,11 +44,32 @@ func TestMessageMissingSFTPComponent(t *testing.T) {
 	}
 }
 
+func TestMessageSessionStillClosing(t *testing.T) {
+	got := MessageFor("en", errors.New("previous connection is still closing safely"), "x")
+	if want := i18n.T("en", "error.session_closing"); got != want {
+		t.Fatalf("unexpected session-closing message: %q", got)
+	}
+}
+
+func TestMessageDisconnectCleanupStillRunning(t *testing.T) {
+	got := MessageFor("en", errors.New("connection is still closing safely"), "x")
+	if want := i18n.T("en", "error.disconnect_closing"); got != want {
+		t.Fatalf("unexpected disconnect-closing message: %q", got)
+	}
+}
+
 func TestMessageDisconnectLifecycleWinsJoinedDeadline(t *testing.T) {
 	err := errors.Join(context.DeadlineExceeded, errors.New("sigurno zatvaranje veze još traje"))
 	got := MessageFor("hr", err, "x")
 	if want := i18n.T("hr", "error.disconnect_closing"); got != want {
 		t.Fatalf("unexpected joined-error message: %q", got)
+	}
+}
+
+func TestMessageSFTPHostKeyScanFailure(t *testing.T) {
+	got := MessageFor("en", errors.New("could not retrieve sftp host key"), "x")
+	if want := i18n.T("en", "error.sftp_hostkey_missing"); got != want {
+		t.Fatalf("unexpected SFTP host-key scan message: %q", got)
 	}
 }
 

--- a/scripts/BUILD-LINUX.sh
+++ b/scripts/BUILD-LINUX.sh
@@ -6,13 +6,13 @@ VERSION="$(tr -d '\r\n' < VERSION)"
 MIN_GO_MAJOR=1
 MIN_GO_MINOR=26
 MIN_GO_PATCH=5
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'Neispravan VERSION.' >&2; exit 1; }
-command -v go >/dev/null || { echo 'Go nije instaliran.' >&2; exit 1; }
-command -v dpkg-deb >/dev/null || { echo 'dpkg-deb nije instaliran.' >&2; exit 1; }
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'Invalid VERSION.' >&2; exit 1; }
+command -v go >/dev/null || { echo 'Go is not installed.' >&2; exit 1; }
+command -v dpkg-deb >/dev/null || { echo 'dpkg-deb is not installed.' >&2; exit 1; }
 
 raw_go="$(go env GOVERSION)"
 if [[ ! "$raw_go" =~ ^go([0-9]+)\.([0-9]+)(\.([0-9]+))?$ ]]; then
-  echo "Nije moguće provjeriti Go verziju: $raw_go" >&2
+  echo "Unable to verify Go version: $raw_go" >&2
   exit 1
 fi
 go_major="${BASH_REMATCH[1]}"
@@ -21,13 +21,13 @@ go_patch="${BASH_REMATCH[4]:-0}"
 if (( go_major < MIN_GO_MAJOR ||
       (go_major == MIN_GO_MAJOR && go_minor < MIN_GO_MINOR) ||
       (go_major == MIN_GO_MAJOR && go_minor == MIN_GO_MINOR && go_patch < MIN_GO_PATCH) )); then
-  echo "Za produkcijski ByFTP build potreban je Go 1.26.5+; trenutačno: $raw_go" >&2
+  echo "ByFTP production builds require Go 1.26.5 or newer; current: $raw_go" >&2
   exit 1
 fi
 
 telemetry="$(go telemetry)"
 [[ "$telemetry" == "off" ]] || {
-  echo "Go telemetrija mora biti isključena prije produkcijskog builda. Pokrenite: go telemetry off (trenutačno: $telemetry)" >&2
+  echo "Go telemetry must be disabled before a production build. Run: go telemetry off (current: $telemetry)" >&2
   exit 1
 }
 
@@ -41,7 +41,7 @@ build_arch() {
   rm -rf "$root" "$out"
   mkdir -p "$root/DEBIAN" "$root/usr/bin" "$root/usr/share/applications" "$root/usr/share/icons/hicolor/512x512/apps"
 
-  echo "[Linux ${debarch}] Izgradnja ByFTP-a"
+  echo "[Linux ${debarch}] Building ByFTP"
   GOARCH="$goarch" go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=${VERSION}" -o "$root/usr/bin/byftp" ./cmd/byftp
   chmod 0755 "$root/usr/bin/byftp"
   cp build/icon.png "$root/usr/share/icons/hicolor/512x512/apps/byftp.png"
@@ -50,7 +50,7 @@ build_arch() {
 [Desktop Entry]
 Type=Application
 Name=ByFTP
-Comment=Siguran FTP, FTPS i SFTP klijent tvrtke ByFTP
+Comment=Privacy-focused FTP, FTPS and SFTP client
 Exec=/usr/bin/byftp
 Icon=byftp
 Terminal=true
@@ -67,9 +67,10 @@ Architecture: ${debarch}
 Maintainer: ByFTP <https://github.com/bren-wp/by-ftp/issues>
 Depends: ca-certificates, curl, openssh-client
 Homepage: https://github.com/bren-wp/by-ftp
-Description: ByFTP terminalni FTP, FTPS i SFTP klijent
- ByFTP je privatnosti usmjeren klijent bez telemetrije. Linux izdanje koristi
- terminalno sučelje i isti sigurnosni/transfer core kao Windows izdanje.
+Description: Privacy-focused FTP, FTPS and SFTP client
+ ByFTP is a file-transfer client without application telemetry. The Linux
+ package uses a terminal interface and the same security and transfer core
+ as the other supported platforms.
 EOF
 
   dpkg-deb --root-owner-group --build "$root" "$out" >/dev/null
@@ -82,4 +83,4 @@ build_arch amd64 amd64
 build_arch arm64 arm64
 build_arch 386 i386
 
-echo "ByFTP ${VERSION} Linux paketi su izgrađeni (Go ${raw_go}, telemetry=${telemetry})."
+echo "ByFTP ${VERSION} Linux packages built with ${raw_go} and telemetry=${telemetry}."

--- a/scripts/BUILD-MACOS.sh
+++ b/scripts/BUILD-MACOS.sh
@@ -2,17 +2,17 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-[[ "$(uname -s)" == "Darwin" ]] || { echo 'BUILD-MACOS.sh mora se pokrenuti na macOS-u.' >&2; exit 1; }
+[[ "$(uname -s)" == "Darwin" ]] || { echo 'BUILD-MACOS.sh must run on macOS.' >&2; exit 1; }
 VERSION="$(tr -d '\r\n' < VERSION)"
 MIN_GO_MAJOR=1
 MIN_GO_MINOR=26
 MIN_GO_PATCH=5
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'Neispravan VERSION.' >&2; exit 1; }
-for tool in go lipo pkgbuild sips iconutil; do command -v "$tool" >/dev/null || { echo "Nedostaje $tool." >&2; exit 1; }; done
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'Invalid VERSION.' >&2; exit 1; }
+for tool in go lipo pkgbuild sips iconutil; do command -v "$tool" >/dev/null || { echo "Missing required tool: $tool" >&2; exit 1; }; done
 
 raw_go="$(go env GOVERSION)"
 if [[ ! "$raw_go" =~ ^go([0-9]+)\.([0-9]+)(\.([0-9]+))?$ ]]; then
-  echo "Nije moguće provjeriti Go verziju: $raw_go" >&2
+  echo "Unable to verify Go version: $raw_go" >&2
   exit 1
 fi
 go_major="${BASH_REMATCH[1]}"
@@ -21,13 +21,13 @@ go_patch="${BASH_REMATCH[4]:-0}"
 if (( go_major < MIN_GO_MAJOR ||
       (go_major == MIN_GO_MAJOR && go_minor < MIN_GO_MINOR) ||
       (go_major == MIN_GO_MAJOR && go_minor == MIN_GO_MINOR && go_patch < MIN_GO_PATCH) )); then
-  echo "Za produkcijski ByFTP build potreban je Go 1.26.5+; trenutačno: $raw_go" >&2
+  echo "ByFTP production builds require Go 1.26.5 or newer; current: $raw_go" >&2
   exit 1
 fi
 
 telemetry="$(go telemetry)"
 [[ "$telemetry" == "off" ]] || {
-  echo "Go telemetrija mora biti isključena prije produkcijskog builda. Pokrenite: go telemetry off (trenutačno: $telemetry)" >&2
+  echo "Go telemetry must be disabled before a production build. Run: go telemetry off (current: $telemetry)" >&2
   exit 1
 }
 
@@ -39,7 +39,7 @@ rm -rf "$work" "dist/ByFTP-${VERSION}-macOS-Universal.pkg"
 mkdir -p "$work/bin" "$root/usr/local/bin" "$root/Applications/ByFTP.app/Contents/MacOS" "$root/Applications/ByFTP.app/Contents/Resources"
 
 for arch in amd64 arm64; do
-  echo "[macOS ${arch}] Izgradnja"
+  echo "[macOS ${arch}] Building ByFTP"
   GOARCH="$arch" go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=${VERSION}" -o "$work/bin/byftp-${arch}" ./cmd/byftp
 done
 lipo -create "$work/bin/byftp-amd64" "$work/bin/byftp-arm64" -output "$root/usr/local/bin/byftp"
@@ -97,5 +97,5 @@ pkgbuild --root "$root" --identifier io.github.bren-wp.byftp --version "$VERSION
 test -s "$pkg"
 rm -rf "$work"
 echo "MACOS_PACKAGE_OK=$pkg"
-echo "ByFTP ${VERSION} macOS paket izgrađen je s ${raw_go} i telemetry=${telemetry}."
-echo 'Napomena: paket nije Developer ID potpisan dok nije dostupan pravi Apple certifikat.'
+echo "ByFTP ${VERSION} macOS package built with ${raw_go} and telemetry=${telemetry}."
+echo 'Note: the package is not Developer ID signed until a valid Apple signing certificate is configured.'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,21 +1,48 @@
-# ByFTP build i verifikacijski alati
+# ByFTP build and verification tools
 
-Ova mapa sadrži pomoćne alate produkcijskog pipelinea. Svi alati koriste standardne mogućnosti Go/Python/PowerShell okruženja i ne dodaju runtime ovisnosti ByFTP aplikaciji.
+This directory contains the repository's build, audit, release and verification utilities. They are development and CI tools only; they do not add runtime dependencies to the ByFTP application.
 
-- `BUILD-LOCAL.sh` — lokalna offline Windows cross-build provjera
-- `generate_brand_assets.py` — reproducibilno generiranje i provjera PNG/ICO resursa
-- `audit_croatian.py` — provjera hrvatskih korisničkih/GitHub/release površina
-- `audit_version.py` — provjera `VERSION` kao jedinog produkcijskog izvora broja verzije
-- `audit_docs.py` — lokalne dokumentacijske poveznice, indeks i verzijski neutralni naslovi
-- `audit_security.py` — ključne filesystem/transfer/state sigurnosne invarijante i regresijski testovi
-- `audit_privacy.py` — privacy/network-policy provjera
-- `audit_release.py` — statički ugovor release workflowa, bundlea i idempotentnog publishera
-- `test_release_tools.py` — stdlib regresijski testovi release ZIP verifikacije
-- `make_payload.py` — izrada i integritet instalacijskog payloada
-- `pe_resources.py` — PE ikona i VERSIONINFO resursi
-- `verify_release.py` — PE i sigurnosna verifikacija binarija
-- `verify_bundle.py` — provjera konačnog Windows ZIP-a, putanja i `BUNDLE-SHA256.txt`
-- `release_notes.py` — hrvatske bilješke iz točnog CHANGELOG odjeljka
-- `publish_release.ps1` — idempotentna GitHub Release objava s tag/commit i asset SHA-256 provjerom
+## Build tools
 
-Puni proces izdavanja dokumentiran je u [`docs/IZDAVANJE-NA-GITHUBU.md`](../docs/IZDAVANJE-NA-GITHUBU.md), kontrolna lista u [`docs/PROVJERA-IZDANJA.md`](../docs/PROVJERA-IZDANJA.md), a testni slojevi u [`docs/TESTIRANJE.md`](../docs/TESTIRANJE.md).
+- `BUILD-LOCAL.sh` — local/offline cross-build smoke check.
+- `BUILD-LINUX.sh` — production Linux DEB builds for amd64, arm64 and i386.
+- `BUILD-MACOS.sh` — production macOS Universal application/package build.
+- `make_payload.py` — creates the verified Windows installer payload.
+- `pe_resources.py` — writes Windows PE icon and VERSIONINFO resources.
+- `generate_brand_assets.py` — reproducibly generates and verifies PNG/ICO brand assets.
+
+The canonical Windows production build is [`BUILD-WINDOWS.ps1`](../BUILD-WINDOWS.ps1) in the repository root.
+
+## Audit tools
+
+- `audit_localization.py` — verifies the English-first localization contract, supported language catalogs and version binding.
+- `audit_version.py` — verifies that `VERSION` is the single production version source.
+- `audit_docs.py` — checks local documentation links, the documentation index and version-neutral document titles.
+- `audit_security.py` — protects important filesystem, credential, transfer and session security invariants.
+- `audit_privacy.py` — enforces the privacy and network policy.
+- `audit_release.py` — validates the production release workflow, platform matrix, bundle contract and centralized publisher.
+- `audit_release_version_guard.py` — prevents mutation of already-published version lines.
+
+## Release and verification tools
+
+- `verify_release.py` — validates Windows PE files and release security properties.
+- `verify_bundle.py` — fail-closed validation of Windows release ZIP contents, paths and `BUNDLE-SHA256.txt`.
+- `release_notes.py` — generates release notes from the matching `CHANGELOG.md` section.
+- `publish_release.ps1` — centralized GitHub Release publication with tag/commit and asset integrity checks.
+- `test_release_tools.py` — Python standard-library regression tests for release tooling.
+
+## Production rules
+
+The build and release pipeline is intentionally fail-closed:
+
+1. `VERSION` is the only production version source.
+2. Go telemetry must be disabled before a production build.
+3. Production builds run with `GOPROXY=off` and `GOSUMDB=off`.
+4. The current module graph must contain no unexpected external Go modules.
+5. Security, privacy, localization, documentation and release audits must pass.
+6. Windows bundles are checked against an explicit allowlist and SHA-256 manifest.
+7. GitHub Release publication is performed only through `publish_release.ps1`.
+
+## Documentation
+
+See [GitHub releases](../docs/GITHUB-RELEASES.md) for the release workflow, [Release verification](../docs/RELEASE-VERIFICATION.md) for verification requirements, [Testing](../docs/TESTING.md) for the test matrix and [Security](../docs/SECURITY.md) for the security model.

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -176,7 +176,10 @@ def main() -> None:
         "security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath)", "remote.IsRetryable(err)",
     ))
     require("internal/localfs/service.go", ("security.IsReparsePoint", "platform.RenameNoReplace"))
-    require("cmd/byftp/main.go", ("security.EnsureNoRedirectDirectory(localAppData, dataDir)",))
+    require(
+        "cmd/byftp/main.go",
+        ("security.EnsureNoRedirectDirectory(", "localAppData,", "dataDir,"),
+    )
     require("internal/security/remove_tree.go", ("func RemoveTreeNoFollow(", "isReparsePoint", "os.ModeSymlink"))
     require("internal/desktop/ui_windows.go", ("limitEdit(a.host, 253)", "limitEdit(a.user, 1024)", "limitEdit(a.pass, 8192)", "limitEdit(a.passphrase, 8192)", "limitEdit(a.remotePath, 4096)"))
 

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed ByFTP provjera privatnosti i mrežne politike."""
+"""Fail-closed ByFTP privacy and network-policy audit."""
 
 from __future__ import annotations
 
@@ -15,6 +15,17 @@ FORBIDDEN_VENDOR_MARKERS = {
     "appcenter", "telemetrydeck",
 }
 
+# These are display/support metadata only. The brand package has no networking
+# code and these constants do not cause a request. Every other fixed HTTP(S)
+# URL in runtime Go source remains forbidden.
+ALLOWED_RUNTIME_URLS = {
+    Path("internal/brand/brand.go"): {
+        "https://github.com/bren-wp/by-ftp",
+        "https://github.com/bren-wp/by-ftp/issues",
+    },
+}
+URL_RE = re.compile(r"https?://[^\s\"'`]+", re.IGNORECASE)
+
 
 def fail(message: str) -> None:
     raise SystemExit("PRIVACY_AUDIT_FAILED: " + message)
@@ -23,7 +34,7 @@ def fail(message: str) -> None:
 def read(rel: str) -> str:
     path = ROOT / rel
     if not path.is_file():
-        fail(f"nedostaje {rel}")
+        fail(f"missing {rel}")
     return path.read_text(encoding="utf-8")
 
 
@@ -31,7 +42,7 @@ def require(rel: str, markers: tuple[str, ...]) -> str:
     text = read(rel)
     for marker in markers:
         if marker not in text:
-            fail(f"{rel} nema privacy guard: {marker}")
+            fail(f"{rel} is missing privacy guard: {marker}")
     return text
 
 
@@ -40,37 +51,46 @@ def main() -> None:
     for base in RUNTIME_ROOTS:
         runtime_files.extend(path for path in base.rglob("*.go") if not path.name.endswith("_test.go"))
     if not runtime_files:
-        fail("runtime Go source nije pronađen")
+        fail("runtime Go source was not found")
 
     for path in sorted(runtime_files):
         text = path.read_text(encoding="utf-8")
         rel = path.relative_to(ROOT)
         for imp in FORBIDDEN_IMPORTS:
             if re.search(rf'["`]'+re.escape(imp)+r'["`]', text):
-                fail(f"zabranjeni mrežni import {imp!r} u {rel}")
-        if re.search(r"https?://", text, re.IGNORECASE):
-            fail(f"fiksni HTTP(S) URL pronađen je u runtime sourceu: {rel}")
+                fail(f"forbidden network import {imp!r} in {rel}")
+
+        urls = set(URL_RE.findall(text))
+        allowed_urls = ALLOWED_RUNTIME_URLS.get(rel, set())
+        unexpected_urls = sorted(urls - allowed_urls)
+        if unexpected_urls:
+            fail(f"fixed HTTP(S) URL found in runtime source {rel}: {unexpected_urls[0]}")
+        if allowed_urls and urls != allowed_urls:
+            missing = sorted(allowed_urls - urls)
+            if missing:
+                fail(f"expected static project metadata URL is missing from {rel}: {missing[0]}")
+
         lower = text.lower()
         for marker in FORBIDDEN_VENDOR_MARKERS:
             if marker in lower:
-                fail(f"telemetry/vendor marker {marker!r} pronađen je u {rel}")
+                fail(f"telemetry/vendor marker {marker!r} found in {rel}")
 
     gomod = read("go.mod")
     if re.search(r"(?m)^\s*(require|replace|exclude|retract)\b", gomod):
-        fail("go.mod mora ostati bez vanjskih Go ovisnosti")
+        fail("go.mod must remain free of external Go dependencies")
 
     engine = require("internal/api/engine.go", ('func (e *Engine) SaveProfile(', 'func (e *Engine) Connect('))
     if "encoding/json" in engine or "func (e *Engine) Call(" in engine:
-        fail("engine ne smije vraćati generički JSON dispatcher")
+        fail("engine must not expose a generic JSON dispatcher")
     if '"log"' in engine or "log.New(" in engine:
-        fail("trajni runtime logging mora ostati isključen")
+        fail("persistent runtime logging must remain disabled")
 
     require("internal/platform/windows.go", ("SetErrorMode", "semNoGPFaultErrorBox", "SetDllDirectoryW", 'UTF16PtrFromString("")', "ofnDontAddToRecent"))
     require("internal/config/profile_crypto_windows.go", ("security.ProtectBytes", "security.UnprotectBytes"))
 
     manager = require("internal/remote/manager.go", ("PasswordBlob", "PassphraseBlob", "newCurlFTPWithProtectedSecret", "newSFTPWithProtectedSecrets"))
     if "UnprotectString" in manager or "UnprotectBytes" in manager:
-        fail("connection manager ne smije rano dekriptirati spremljene vjerodajnice")
+        fail("connection manager must not decrypt saved credentials early")
 
     curl = require(
         "internal/remote/curl_ftp.go",
@@ -88,9 +108,9 @@ def main() -> None:
         ),
     )
     if "HTTP_PROXY" in curl or "HTTPS_PROXY" in curl:
-        fail("CurlFTP ne smije izravno nasljeđivati proxy varijable")
+        fail("CurlFTP must not directly inherit proxy variables")
     if "ssl-no-revoke" in curl:
-        fail("FTPS ne smije potpuno isključiti provjeru opoziva certifikata")
+        fail("FTPS must not fully disable certificate-revocation checking")
 
     require(
         "internal/remote/curl_capability.go",
@@ -121,20 +141,23 @@ def main() -> None:
     )
     for forbidden in ("BYFTP_ASKPASS_FILE", "askpassFile", "os.WriteFile(askpass"):
         if forbidden in sftp:
-            fail(f"SFTP ne smije zapisivati AskPass tajnu na disk: {forbidden}")
+            fail(f"SFTP must not write AskPass secrets to disk: {forbidden}")
 
     askpass = require(
         "cmd/byftp/main.go",
         ("BYFTP_ASKPASS_TOKEN", "BYFTP_PASSWORD_BLOB", "BYFTP_PASSPHRASE_BLOB", "TrustedAskPassParent", "selectAskpassSecret"),
     )
     if "BYFTP_ASKPASS_FILE" in askpass:
-        fail("AskPass ne smije ovisiti o disk credential artefaktu")
+        fail("AskPass must not depend on a disk credential artifact")
 
     require("internal/security/runtime_secret_windows.go", ("ProtectString", "UnprotectBytes", "ProtectRuntimeString"))
     require("internal/security/runtime_secret_other.go", ("crypto/rand", "runtimeValues", "WipeBytes(value)", "ForgetRuntimeSecret"))
-    terminal = require("internal/desktop/other.go", ("promptSecret", "stty", "engine.Connect", "Linux/macOS SFTP izdanje zahtijeva eksplicitni privatni ključ"))
+    terminal = require(
+        "internal/desktop/other.go",
+        ("promptSecret", "stty", "engine.Connect", 'i18n.T(language, "terminal.sftp_key_required")'),
+    )
     if "Password:" in terminal:
-        fail("terminalni source ne smije hardkodirati plaintext vjerodajnicu")
+        fail("terminal source must not hard-code a plaintext credential prompt")
 
     require("internal/remote/util.go", (
         '"http_proxy"', '"https_proxy"', '"ftp_proxy"', '"all_proxy"', '"no_proxy"',
@@ -145,7 +168,7 @@ def main() -> None:
 
     tools = require("internal/remote/tools.go", ("systemDirectory()", 'runtime.GOOS == "windows"'))
     if 'os.Getenv("WINDIR")' in tools or 'os.Getenv("WINDIR")' in sftp:
-        fail("Windows mrežni alati ne smiju vjerovati WINDIR-u")
+        fail("Windows network-tool discovery must not trust WINDIR")
 
     require("internal/transfer/manager.go", (
         "recover() != nil", "interna greška tijekom prijenosa", "type operationProvider interface",
@@ -160,21 +183,33 @@ def main() -> None:
     installer = read("cmd/installer/main.go")
     for marker in ("URLInfoAbout", "HelpLink"):
         if marker in installer:
-            fail(f"installer sadrži vanjski URL hook {marker}")
+            fail(f"installer contains external URL hook {marker}")
 
-    # GOTELEMETRY je read-only vrijednost koju `go env` samo prijavljuje; postavljanje
-    # istoimene OS env varijable nije valjan privacy guard. CI/release moraju stvarno
-    # izvršiti `go telemetry off`, a produkcijske skripte moraju odbiti drugi način.
-    ci = require(".github/workflows/ci.yml", ("go telemetry off", "Go telemetrija nije isključena"))
+    # GOTELEMETRY is a reported Go setting, not a valid environment-only
+    # privacy guard. CI/release must execute `go telemetry off`; production
+    # build scripts must independently reject any mode other than `off`.
+    ci = require(".github/workflows/ci.yml", ("go telemetry off", "Go telemetry is not disabled."))
     release = require(".github/workflows/release.yml", ("go telemetry off", "test \"$(go telemetry)\" = 'off'"))
     for rel, text in ((".github/workflows/ci.yml", ci), (".github/workflows/release.yml", release)):
         if re.search(r"(?m)^\s*GOTELEMETRY:\s*off\s*$", text):
-            fail(f"{rel} koristi neučinkoviti GOTELEMETRY env guard umjesto `go telemetry off`")
+            fail(f"{rel} uses ineffective GOTELEMETRY env-only guard instead of `go telemetry off`")
 
-    windows_build = require("BUILD-WINDOWS.ps1", ("$telemetryMode = (go telemetry).Trim()", "go telemetry off", "Go telemetrija mora biti isključena"))
-    linux_build = require("scripts/BUILD-LINUX.sh", ('telemetry="$(go telemetry)"', "go telemetry off", "Go telemetrija mora biti isključena"))
-    macos_build = require("scripts/BUILD-MACOS.sh", ('telemetry="$(go telemetry)"', "go telemetry off", "Go telemetrija mora biti isključena"))
-    local_build = require("scripts/BUILD-LOCAL.sh", ('GO_TELEMETRY="$(go telemetry)"', "go telemetry off", "Go telemetrija mora biti isključena"))
+    windows_build = require(
+        "BUILD-WINDOWS.ps1",
+        ("$telemetryMode = Invoke-NativeCapture", "-ArgumentList @('telemetry')", "Go telemetry must be disabled before a production build"),
+    )
+    linux_build = require(
+        "scripts/BUILD-LINUX.sh",
+        ('telemetry="$(go telemetry)"', "Go telemetry must be disabled before a production build"),
+    )
+    macos_build = require(
+        "scripts/BUILD-MACOS.sh",
+        ('telemetry="$(go telemetry)"', "Go telemetry must be disabled before a production build"),
+    )
+    local_build = require(
+        "scripts/BUILD-LOCAL.sh",
+        ('GO_TELEMETRY="$(go telemetry)"', "Go telemetry must be disabled before a production build"),
+    )
     for rel, text in (
         ("BUILD-WINDOWS.ps1", windows_build),
         ("scripts/BUILD-LINUX.sh", linux_build),
@@ -182,12 +217,13 @@ def main() -> None:
         ("scripts/BUILD-LOCAL.sh", local_build),
     ):
         if "GOTELEMETRY=off" in text or "$env:GOTELEMETRY = 'off'" in text:
-            fail(f"{rel} se ponovno oslanja na neučinkovitu GOTELEMETRY env varijablu")
+            fail(f"{rel} relies on an ineffective GOTELEMETRY environment variable")
 
     print("PRIVACY_AUDIT=PASS")
     print("TELEMETRY=ABSENT")
     print("GO_BUILD_TELEMETRY=OFF_REQUIRED_AND_CI_VERIFIED")
-    print("FIXED_HTTP_API_ENDPOINTS=ABSENT")
+    print("FIXED_RUNTIME_API_ENDPOINTS=ABSENT")
+    print("STATIC_PROJECT_SUPPORT_URLS=ALLOWLISTED_METADATA_ONLY")
     print("EXTERNAL_GO_MODULES=ABSENT")
     print("CURL_EXTERNAL_ENV_INHERITANCE=DISABLED")
     print("FTPS_CERTIFICATE_REVOCATION=NOT_DISABLED")

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -71,7 +71,19 @@ def main() -> int:
     # Release publication must remain centralized in the reviewed PowerShell
     # publisher rather than duplicating tag/release mutation logic in YAML.
     publisher = read("scripts/publish_release.ps1")
-    for marker in ("gh release", "gh api", "SHA256"):
+    for marker in (
+        "function Invoke-GhJson",
+        "function Try-GhJson",
+        "@('api',",
+        "gh release create",
+        "gh release edit",
+        "gh release upload",
+        "Get-FileHash",
+        "SHA256",
+        "Assert-TagCommit",
+        "Assert-RemoteAsset",
+        "RELEASE_PUBLISH_VERIFICATION=PASS",
+    ):
         require(publisher, marker, "scripts/publish_release.ps1")
 
     for rel in ("BUILD-WINDOWS.ps1", "scripts/BUILD-LINUX.sh", "scripts/BUILD-MACOS.sh"):
@@ -105,6 +117,7 @@ def main() -> int:
     print(f"RELEASE_AUDIT=PASS ({version})")
     print("RELEASE_MATRIX=WINDOWS_X64_X86,LINUX_AMD64_ARM64_I386,MACOS_UNIVERSAL")
     print("PUBLISHER=CENTRALIZED")
+    print("RELEASE_GITHUB_API=WRAPPED_AND_AUDITED")
     return 0
 
 

--- a/scripts/audit_security.py
+++ b/scripts/audit_security.py
@@ -76,7 +76,7 @@ def main() -> int:
         "cfg.Password = getText(a.pass)", "cfg.Passphrase = getText(a.passphrase)",
     ))
     require("internal/desktop/other.go", (
-        "Linux/macOS SFTP izdanje zahtijeva eksplicitni privatni ključ", "promptSecret", "engine.Connect", "engine.RemoteList", "engine.AddTransfer",
+        'i18n.T(language, "terminal.sftp_key_required")', "promptSecret", "engine.Connect", "engine.RemoteList", "engine.AddTransfer",
     ))
     require("internal/api/engine.go", ("e.remote.Disconnect(ctx)", "context.WithTimeout(context.Background(), 4*time.Second)"))
 

--- a/scripts/audit_security.py
+++ b/scripts/audit_security.py
@@ -1,41 +1,49 @@
 #!/usr/bin/env python3
-"""Provjerava ključne ByFTP sigurnosne invarijante koje ne smiju regresirati."""
+"""Validate security invariants that must not regress."""
 
 from __future__ import annotations
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-def fail(message: str) -> None: raise SystemExit("SECURITY_AUDIT_NIJE_PROSAO: " + message)
+
+def fail(message: str) -> None:
+    raise SystemExit("SECURITY_AUDIT_FAILED: " + message)
+
 def read(path: str) -> str:
     target = ROOT / path
-    if not target.is_file(): fail(f"nedostaje {path}")
+    if not target.is_file():
+        fail(f"missing {path}")
     return target.read_text(encoding="utf-8")
+
 def require(path: str, markers: tuple[str, ...]) -> str:
     text = read(path)
     for marker in markers:
-        if marker not in text: fail(f"{path} nema obaveznu sigurnosnu invarijantu: {marker}")
+        if marker not in text:
+            fail(f"{path} is missing required security invariant: {marker}")
     return text
 
 
 def main() -> int:
     require("internal/remote/util.go", ("func validateDownloadedPart(part string) error", "os.Lstat(part)", "security.IsReparsePoint(part)"))
-    for path in ("internal/remote/curl_ftp.go", "internal/remote/sftp.go"): require(path, ("validateDownloadedPart(part)",))
+    for path in ("internal/remote/curl_ftp.go", "internal/remote/sftp.go"):
+        require(path, ("validateDownloadedPart(part)",))
 
     sftp = require("internal/remote/sftp.go", (
         "func validatePrivateKeyPath(keyPath string) error", "os.Lstat(keyPath)", "security.IsReparsePoint(keyPath)",
         '"-oBatchMode=no"', "ctxErr := ctx.Err()", "scanHost := strings.Trim(host, \"[]\")",
     ))
     if '"-b"' in sftp or '"-b", "-"' in sftp:
-        fail("SFTP command args ponovno koriste -b; OpenSSH time prisilno uključuje BatchMode=yes i gasi AskPass")
+        fail("SFTP command args use -b; OpenSSH would force BatchMode=yes and disable AskPass")
 
     curl = require("internal/remote/curl_ftp.go", (
         "security.ProtectRuntimeString(password)", "security.UnprotectRuntimeBytes(c.passwordBlob)",
         "security.ForgetRuntimeSecret(c.passwordBlob)", "ctxErr := ctx.Err()",
     ))
-    if not curl: fail("CurlFTP runtime credential ugovor nije dostupan")
+    if not curl:
+        fail("CurlFTP runtime credential contract is unavailable")
 
     require("cmd/byftp/main.go", ("func selectAskpassSecret(", "nepoznat ili nepodržan zahtjev za vjerodajnicu"))
-    require("cmd/byftp/askpass_test.go", ("TestSelectAskpassSecretOnlyUsesRecognizedPrompts", "Verification code", "One-time password token"))
+    require("cmd/byftp/askpass_test.go", ("TestSelectAskpassSecret", "Verification code", "One-time password token"))
     require("internal/remote/sftp_stream_test.go", ("TestSFTPCommandArgsKeepAskPassEnabled", "sftp -b"))
     require("internal/remote/connect_regression_test.go", ("TestSSHSessionConfigNormalizesBracketedIPv6Host", "TestFindOpenSSHUsesNativeExecutableNameOutsideWindows"))
     require("internal/remote/process_connect_smoke_other_test.go", (
@@ -108,4 +116,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "__main__": main()
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_brand_assets.py
+++ b/scripts/generate_brand_assets.py
@@ -1,107 +1,371 @@
 #!/usr/bin/env python3
-"""Generate and verify the official ByFTP icon and English documentation header."""
+"""Generate and verify the official ByFTP icon and English documentation header.
+
+Generated PNG compression can differ across zlib builds even when the decoded
+image is identical. Verification therefore validates PNG structure, CRCs,
+dimensions and every RGBA pixel instead of requiring one zlib byte stream.
+"""
+
 from __future__ import annotations
-import argparse, binascii, struct, zlib
+
+import argparse
+import binascii
+import struct
+import zlib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 ICON_PNG = ROOT / "build" / "icon.png"
 ICON_ICO = ROOT / "build" / "icon.ico"
 HEADER_PNG = ROOT / "docs" / "images" / "byftp-header.png"
-BG=(10,18,32,255); PANEL=(23,39,62,255); TEXT=(238,245,255,255); MUTED=(157,174,196,255); A1=(66,210,196,255); A2=(90,142,255,255)
-FONT={
-'A':["01110","10001","10001","11111","10001","10001","10001"],
-'B':["11110","10001","10001","11110","10001","10001","11110"],
-'C':["01111","10000","10000","10000","10000","10000","01111"],
-'D':["11110","10001","10001","10001","10001","10001","11110"],
-'E':["11111","10000","10000","11110","10000","10000","11111"],
-'F':["11111","10000","10000","11110","10000","10000","10000"],
-'I':["11111","00100","00100","00100","00100","00100","11111"],
-'L':["10000","10000","10000","10000","10000","10000","11111"],
-'N':["10001","11001","10101","10011","10001","10001","10001"],
-'P':["11110","10001","10001","11110","10000","10000","10000"],
-'R':["11110","10001","10001","11110","10100","10010","10001"],
-'S':["01111","10000","10000","01110","00001","00001","11110"],
-'T':["11111","00100","00100","00100","00100","00100","00100"],
-'U':["10001","10001","10001","10001","10001","10001","01110"],
-'Y':["10001","10001","01010","00100","00100","00100","00100"],
-' ':["00000"]*7,
+
+BG = (10, 18, 32, 255)
+PANEL = (23, 39, 62, 255)
+TEXT = (238, 245, 255, 255)
+MUTED = (157, 174, 196, 255)
+A1 = (66, 210, 196, 255)
+A2 = (90, 142, 255, 255)
+
+FONT = {
+    "A": ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+    "B": ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+    "C": ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
+    "D": ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
+    "E": ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+    "F": ["11111", "10000", "10000", "11110", "10000", "10000", "10000"],
+    "I": ["11111", "00100", "00100", "00100", "00100", "00100", "11111"],
+    "L": ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+    "N": ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
+    "P": ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+    "R": ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+    "S": ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
+    "T": ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+    "U": ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+    "Y": ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
+    " ": ["00000"] * 7,
 }
 
-def canvas(w,h):
-    p=bytearray(w*h*4)
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+ICO_SIZES = (16, 24, 32, 48, 64, 128, 256)
+
+
+def canvas(w: int, h: int) -> bytearray:
+    pixels = bytearray(w * h * 4)
     for y in range(h):
-        t=y/max(1,h-1); c=tuple(round(BG[i]*(1-t)+(19,32,52,255)[i]*t) for i in range(4)); p[y*w*4:(y+1)*w*4]=bytes(c)*w
-    return p
+        t = y / max(1, h - 1)
+        color = tuple(
+            round(BG[i] * (1 - t) + (19, 32, 52, 255)[i] * t)
+            for i in range(4)
+        )
+        pixels[y * w * 4 : (y + 1) * w * 4] = bytes(color) * w
+    return pixels
 
-def rect(p,w,h,x0,y0,x1,y1,c):
-    x0=max(0,x0); y0=max(0,y0); x1=min(w,x1); y1=min(h,y1); row=bytes(c)*max(0,x1-x0)
-    for y in range(y0,y1): p[(y*w+x0)*4:(y*w+x1)*4]=row
 
-def rr(p,w,h,x0,y0,x1,y1,r,c):
-    for y in range(y0,y1):
-        for x in range(x0,x1):
-            dx=max(x0+r-x,0,x-(x1-r-1)); dy=max(y0+r-y,0,y-(y1-r-1))
-            if dx*dx+dy*dy<=r*r: rect(p,w,h,x,y,x+1,y+1,c)
+def rect(p: bytearray, w: int, h: int, x0: int, y0: int, x1: int, y1: int, color: tuple[int, int, int, int]) -> None:
+    x0 = max(0, x0)
+    y0 = max(0, y0)
+    x1 = min(w, x1)
+    y1 = min(h, y1)
+    row = bytes(color) * max(0, x1 - x0)
+    for y in range(y0, y1):
+        p[(y * w + x0) * 4 : (y * w + x1) * 4] = row
 
-def line(p,w,h,x0,y0,x1,y1,t,c):
-    dx=abs(x1-x0); sx=1 if x0<x1 else -1; dy=-abs(y1-y0); sy=1 if y0<y1 else -1; e=dx+dy
+
+def rr(p: bytearray, w: int, h: int, x0: int, y0: int, x1: int, y1: int, radius: int, color: tuple[int, int, int, int]) -> None:
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            dx = max(x0 + radius - x, 0, x - (x1 - radius - 1))
+            dy = max(y0 + radius - y, 0, y - (y1 - radius - 1))
+            if dx * dx + dy * dy <= radius * radius:
+                rect(p, w, h, x, y, x + 1, y + 1, color)
+
+
+def line(p: bytearray, w: int, h: int, x0: int, y0: int, x1: int, y1: int, thickness: int, color: tuple[int, int, int, int]) -> None:
+    dx = abs(x1 - x0)
+    sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0)
+    sy = 1 if y0 < y1 else -1
+    error = dx + dy
     while True:
-        q=max(1,t)//2; rect(p,w,h,x0-q,y0-q,x0+q+1,y0+q+1,c)
-        if x0==x1 and y0==y1: break
-        e2=2*e
-        if e2>=dy: e+=dy; x0+=sx
-        if e2<=dx: e+=dx; y0+=sy
+        half = max(1, thickness) // 2
+        rect(p, w, h, x0 - half, y0 - half, x0 + half + 1, y0 + half + 1, color)
+        if x0 == x1 and y0 == y1:
+            break
+        twice = 2 * error
+        if twice >= dy:
+            error += dy
+            x0 += sx
+        if twice <= dx:
+            error += dx
+            y0 += sy
 
-def arrow(p,w,h,x0,y,x1,c):
-    line(p,w,h,x0,y,x1,y,max(2,w//180),c); d=max(5,abs(x1-x0)//5); s=-1 if x1>x0 else 1
-    line(p,w,h,x1,y,x1+s*d,y-d,max(2,w//180),c); line(p,w,h,x1,y,x1+s*d,y+d,max(2,w//180),c)
 
-def icon(size):
-    p=canvas(size,size); m=max(2,size//16); rr(p,size,size,m,m,size-m,size-m,max(3,size//7),PANEL)
-    pw=max(5,size//4); ph=max(8,size//2); y=(size-ph)//2; lx=size//8; rx=size-size//8-pw
-    rr(p,size,size,lx,y,lx+pw,y+ph,max(2,size//32),TEXT); rr(p,size,size,rx,y,rx+pw,y+ph,max(2,size//32),TEXT)
-    for yy in (y+ph//4,y+ph//2,y+3*ph//4): rect(p,size,size,lx+pw//5,yy,lx+4*pw//5,yy+max(1,size//40),BG); rect(p,size,size,rx+pw//5,yy,rx+4*pw//5,yy+max(1,size//40),BG)
-    arrow(p,size,size,lx+pw+size//20,size//2-size//10,rx-size//20,A1); arrow(p,size,size,rx-size//20,size//2+size//10,lx+pw+size//20,A2)
-    return size,size,p
+def arrow(p: bytearray, w: int, h: int, x0: int, y: int, x1: int, color: tuple[int, int, int, int]) -> None:
+    line(p, w, h, x0, y, x1, y, max(2, w // 180), color)
+    delta = max(5, abs(x1 - x0) // 5)
+    side = -1 if x1 > x0 else 1
+    line(p, w, h, x1, y, x1 + side * delta, y - delta, max(2, w // 180), color)
+    line(p, w, h, x1, y, x1 + side * delta, y + delta, max(2, w // 180), color)
 
-def text(p,w,h,s,x,y,scale,c):
-    cur=x
-    for ch in s.upper():
-        for gy,row in enumerate(FONT.get(ch,FONT[' '])):
-            for gx,b in enumerate(row):
-                if b=='1': rect(p,w,h,cur+gx*scale,y+gy*scale,cur+(gx+1)*scale,y+(gy+1)*scale,c)
-        cur+=6*scale
 
-def header():
-    w,h=1200,320; p=canvas(w,h); rr(p,w,h,40,40,280,280,42,PANEL); iw,ih,ip=icon(200)
-    for y in range(ih): p[((60+y)*w+60)*4:((60+y)*w+60+iw)*4]=ip[y*iw*4:(y+1)*iw*4]
-    text(p,w,h,'BYFTP',335,72,17,TEXT); text(p,w,h,'SECURE FILE TRANSFER',338,215,5,MUTED); rect(p,w,h,338,270,1095,276,A1)
-    return w,h,p
+def icon(size: int) -> tuple[int, int, bytearray]:
+    p = canvas(size, size)
+    margin = max(2, size // 16)
+    rr(p, size, size, margin, margin, size - margin, size - margin, max(3, size // 7), PANEL)
+    panel_w = max(5, size // 4)
+    panel_h = max(8, size // 2)
+    y = (size - panel_h) // 2
+    left_x = size // 8
+    right_x = size - size // 8 - panel_w
+    rr(p, size, size, left_x, y, left_x + panel_w, y + panel_h, max(2, size // 32), TEXT)
+    rr(p, size, size, right_x, y, right_x + panel_w, y + panel_h, max(2, size // 32), TEXT)
+    for yy in (y + panel_h // 4, y + panel_h // 2, y + 3 * panel_h // 4):
+        rect(p, size, size, left_x + panel_w // 5, yy, left_x + 4 * panel_w // 5, yy + max(1, size // 40), BG)
+        rect(p, size, size, right_x + panel_w // 5, yy, right_x + 4 * panel_w // 5, yy + max(1, size // 40), BG)
+    arrow(p, size, size, left_x + panel_w + size // 20, size // 2 - size // 10, right_x - size // 20, A1)
+    arrow(p, size, size, right_x - size // 20, size // 2 + size // 10, left_x + panel_w + size // 20, A2)
+    return size, size, p
 
-def png(w,h,p):
-    def chunk(k,d):
-        b=k+d; return struct.pack('>I',len(d))+b+struct.pack('>I',binascii.crc32(b)&0xffffffff)
-    raw=bytearray()
-    for y in range(h): raw.append(0); raw.extend(p[y*w*4:(y+1)*w*4])
-    return b'\x89PNG\r\n\x1a\n'+chunk(b'IHDR',struct.pack('>IIBBBBB',w,h,8,6,0,0,0))+chunk(b'IDAT',zlib.compress(bytes(raw),9))+chunk(b'IEND',b'')
 
-def ico():
-    sizes=(16,24,32,48,64,128,256); imgs=[]
-    for n in sizes: w,h,p=icon(n); imgs.append(png(w,h,p))
-    off=6+16*len(imgs); entries=[]
-    for n,d in zip(sizes,imgs): q=0 if n==256 else n; entries.append(struct.pack('<BBBBHHII',q,q,0,0,1,32,len(d),off)); off+=len(d)
-    return struct.pack('<HHH',0,1,len(imgs))+b''.join(entries)+b''.join(imgs)
+def text(p: bytearray, w: int, h: int, value: str, x: int, y: int, scale: int, color: tuple[int, int, int, int]) -> None:
+    cursor = x
+    for ch in value.upper():
+        for gy, row in enumerate(FONT.get(ch, FONT[" "])):
+            for gx, bit in enumerate(row):
+                if bit == "1":
+                    rect(
+                        p,
+                        w,
+                        h,
+                        cursor + gx * scale,
+                        y + gy * scale,
+                        cursor + (gx + 1) * scale,
+                        y + (gy + 1) * scale,
+                        color,
+                    )
+        cursor += 6 * scale
 
-def expected():
-    w,h,p=icon(512); hw,hh,hp=header(); return {ICON_PNG:png(w,h,p),ICON_ICO:ico(),HEADER_PNG:png(hw,hh,hp)}
 
-def main():
-    ap=argparse.ArgumentParser(description='Generate deterministic ByFTP brand assets'); ap.add_argument('--check',action='store_true'); args=ap.parse_args(); exp=expected()
+def header() -> tuple[int, int, bytearray]:
+    w, h = 1200, 320
+    p = canvas(w, h)
+    rr(p, w, h, 40, 40, 280, 280, 42, PANEL)
+    iw, ih, ip = icon(200)
+    for y in range(ih):
+        p[((60 + y) * w + 60) * 4 : ((60 + y) * w + 60 + iw) * 4] = ip[y * iw * 4 : (y + 1) * iw * 4]
+    text(p, w, h, "BYFTP", 335, 72, 17, TEXT)
+    text(p, w, h, "SECURE FILE TRANSFER", 338, 215, 5, MUTED)
+    rect(p, w, h, 338, 270, 1095, 276, A1)
+    return w, h, p
+
+
+def png(w: int, h: int, p: bytes | bytearray) -> bytes:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        body = kind + data
+        return (
+            struct.pack(">I", len(data))
+            + body
+            + struct.pack(">I", binascii.crc32(body) & 0xFFFFFFFF)
+        )
+
+    raw = bytearray()
+    for y in range(h):
+        raw.append(0)
+        raw.extend(p[y * w * 4 : (y + 1) * w * 4])
+    return (
+        PNG_SIGNATURE
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+        + chunk(b"IEND", b"")
+    )
+
+
+def ico() -> bytes:
+    images = []
+    for size in ICO_SIZES:
+        w, h, p = icon(size)
+        images.append(png(w, h, p))
+
+    offset = 6 + 16 * len(images)
+    entries = []
+    for size, data in zip(ICO_SIZES, images):
+        encoded_size = 0 if size == 256 else size
+        entries.append(
+            struct.pack(
+                "<BBBBHHII",
+                encoded_size,
+                encoded_size,
+                0,
+                0,
+                1,
+                32,
+                len(data),
+                offset,
+            )
+        )
+        offset += len(data)
+    return struct.pack("<HHH", 0, 1, len(images)) + b"".join(entries) + b"".join(images)
+
+
+def expected() -> dict[Path, bytes]:
+    w, h, p = icon(512)
+    hw, hh, hp = header()
+    return {
+        ICON_PNG: png(w, h, p),
+        ICON_ICO: ico(),
+        HEADER_PNG: png(hw, hh, hp),
+    }
+
+
+def decode_png(data: bytes) -> tuple[int, int, bytes]:
+    """Decode the strict RGBA/filter-0 PNG format emitted by this generator."""
+    if not data.startswith(PNG_SIGNATURE):
+        raise ValueError("invalid PNG signature")
+
+    pos = len(PNG_SIGNATURE)
+    ihdr: bytes | None = None
+    idat: list[bytes] = []
+    saw_iend = False
+    chunk_order: list[bytes] = []
+
+    while pos < len(data):
+        if len(data) - pos < 12:
+            raise ValueError("truncated PNG chunk")
+        length = struct.unpack_from(">I", data, pos)[0]
+        end = pos + 12 + length
+        if end > len(data):
+            raise ValueError("truncated PNG chunk data")
+        kind = data[pos + 4 : pos + 8]
+        payload = data[pos + 8 : pos + 8 + length]
+        stored_crc = struct.unpack_from(">I", data, pos + 8 + length)[0]
+        actual_crc = binascii.crc32(kind + payload) & 0xFFFFFFFF
+        if stored_crc != actual_crc:
+            raise ValueError("PNG CRC mismatch")
+        if kind not in {b"IHDR", b"IDAT", b"IEND"}:
+            raise ValueError(f"unexpected PNG chunk {kind!r}")
+        chunk_order.append(kind)
+        if kind == b"IHDR":
+            if ihdr is not None or idat or saw_iend:
+                raise ValueError("invalid IHDR placement")
+            ihdr = payload
+        elif kind == b"IDAT":
+            if ihdr is None or saw_iend:
+                raise ValueError("invalid IDAT placement")
+            idat.append(payload)
+        else:
+            if payload or ihdr is None or not idat or saw_iend:
+                raise ValueError("invalid IEND")
+            saw_iend = True
+            if end != len(data):
+                raise ValueError("trailing PNG data")
+        pos = end
+
+    if not saw_iend or ihdr is None or not idat:
+        raise ValueError("incomplete PNG")
+    if chunk_order[0] != b"IHDR" or chunk_order[-1] != b"IEND":
+        raise ValueError("invalid PNG chunk order")
+    if len(ihdr) != 13:
+        raise ValueError("invalid IHDR length")
+
+    w, h, bit_depth, color_type, compression, filtering, interlace = struct.unpack(">IIBBBBB", ihdr)
+    if w <= 0 or h <= 0:
+        raise ValueError("invalid PNG dimensions")
+    if (bit_depth, color_type, compression, filtering, interlace) != (8, 6, 0, 0, 0):
+        raise ValueError("unsupported PNG format")
+
+    raw = zlib.decompress(b"".join(idat))
+    stride = w * 4
+    if len(raw) != h * (stride + 1):
+        raise ValueError("invalid decoded PNG size")
+
+    pixels = bytearray(w * h * 4)
+    for y in range(h):
+        row_start = y * (stride + 1)
+        if raw[row_start] != 0:
+            raise ValueError("unsupported PNG row filter")
+        pixels[y * stride : (y + 1) * stride] = raw[row_start + 1 : row_start + 1 + stride]
+    return w, h, bytes(pixels)
+
+
+def decode_ico(data: bytes) -> tuple[tuple[int, int, bytes], ...]:
+    """Validate the ICO directory and decode every embedded PNG image."""
+    if len(data) < 6:
+        raise ValueError("truncated ICO header")
+    reserved, image_type, count = struct.unpack_from("<HHH", data, 0)
+    if reserved != 0 or image_type != 1 or count != len(ICO_SIZES):
+        raise ValueError("invalid ICO header")
+    directory_end = 6 + count * 16
+    if len(data) < directory_end:
+        raise ValueError("truncated ICO directory")
+
+    decoded = []
+    previous_end = directory_end
+    for index, expected_size in enumerate(ICO_SIZES):
+        off = 6 + index * 16
+        width, height, palette, reserved_byte, planes, bpp, size, image_offset = struct.unpack_from(
+            "<BBBBHHII", data, off
+        )
+        encoded_size = 0 if expected_size == 256 else expected_size
+        if (width, height, palette, reserved_byte, planes, bpp) != (
+            encoded_size,
+            encoded_size,
+            0,
+            0,
+            1,
+            32,
+        ):
+            raise ValueError("invalid ICO directory entry")
+        if image_offset != previous_end or size <= 0 or image_offset + size > len(data):
+            raise ValueError("invalid ICO image range")
+        image = decode_png(data[image_offset : image_offset + size])
+        if image[0] != expected_size or image[1] != expected_size:
+            raise ValueError("ICO image dimensions do not match directory")
+        decoded.append(image)
+        previous_end = image_offset + size
+
+    if previous_end != len(data):
+        raise ValueError("trailing ICO data")
+    return tuple(decoded)
+
+
+def asset_matches(path: Path, generated: bytes) -> bool:
+    if not path.is_file():
+        return False
+    actual = path.read_bytes()
+    try:
+        if path.suffix.lower() == ".png":
+            return decode_png(actual) == decode_png(generated)
+        if path.suffix.lower() == ".ico":
+            return decode_ico(actual) == decode_ico(generated)
+    except (ValueError, zlib.error, struct.error):
+        return False
+    return actual == generated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate reproducible ByFTP brand assets")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    exp = expected()
+
     if args.check:
-        bad=[str(p.relative_to(ROOT)) for p,d in exp.items() if not p.is_file() or p.read_bytes()!=d]
-        if bad: raise SystemExit('Brand assets are out of date: '+', '.join(bad))
-        print('BRAND_ASSETS=PASS'); return 0
-    for p,d in exp.items(): p.parent.mkdir(parents=True,exist_ok=True); p.write_bytes(d); print('Updated:',p.relative_to(ROOT))
-    print('BRAND_ASSETS=PASS'); return 0
-if __name__=='__main__': raise SystemExit(main())
+        bad = [
+            str(path.relative_to(ROOT))
+            for path, generated in exp.items()
+            if not asset_matches(path, generated)
+        ]
+        if bad:
+            raise SystemExit("Brand assets are out of date or invalid: " + ", ".join(bad))
+        print("BRAND_ASSETS=PASS")
+        return 0
+
+    for path, generated in exp.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(generated)
+        print("Updated:", path.relative_to(ROOT))
+    print("BRAND_ASSETS=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_shared_hosting_ftp.py
+++ b/scripts/test_shared_hosting_ftp.py
@@ -45,25 +45,58 @@ class SharedHostingFTPTests(unittest.TestCase):
     def test_passive_nat_and_shared_hosting_ports_remain_supported(self) -> None:
         ftp = (ROOT / "internal/remote/curl_ftp.go").read_text(encoding="utf-8")
         protocols = (ROOT / "internal/desktop/protocols_windows.go").read_text(encoding="utf-8")
+        ui = (ROOT / "internal/desktop/ui_windows.go").read_text(encoding="utf-8")
         self.assertIn('"ftp-skip-pasv-ip"', ftp)
-        self.assertIn('{Value: "ftp", Label: "FTP", Port: "21"}', protocols)
-        self.assertIn('{Value: "ftps", Label: "FTPS (eksplicitni)", Port: "21"}', protocols)
-        self.assertIn('{Value: "ftpsi", Label: "FTPS (implicitni)", Port: "990"}', protocols)
+        for marker in (
+            '{Value: "ftp", Port: "21"}',
+            '{Value: "ftps", Port: "21"}',
+            '{Value: "sftp", Port: "22"}',
+            '{Value: "ftpsi", Port: "990"}',
+        ):
+            self.assertIn(marker, protocols)
+        # Protocol display labels are intentionally localized at render time;
+        # the protocol model must not drift back to hard-coded language text.
+        self.assertNotIn("Label string", protocols)
+        self.assertIn("protocolLabel(a.languageCode(), spec.Value)", ui)
 
     def test_windows_ui_explains_shared_hosting_credentials(self) -> None:
         ui = (ROOT / "internal/desktop/ui_windows.go").read_text(encoding="utf-8")
-        self.assertIn("Brzo upravljanje hostingom", ui)
-        self.assertIn("FTP poslužitelj, npr. ftp.domena.hr", ui)
-        self.assertIn("Korisničko ime, može korisnik@domena", ui)
-        self.assertIn("a.move(a.user, x, y, 230, rowH)", ui)
+        catalogs = (ROOT / "internal/i18n/catalogs.go").read_text(encoding="utf-8")
+        for marker in (
+            'a.tr("app.subtitle")',
+            'cue(a.host, a.tr("cue.host"))',
+            'cue(a.user, a.tr("cue.user"))',
+            'cue(a.pass, a.tr("cue.password"))',
+        ):
+            self.assertIn(marker, ui)
+        for marker in (
+            '"app.subtitle":    "FTP • FTPS • SFTP  ·  Fast hosting management"',
+            '"cue.host":           "FTP/SFTP server, e.g. ftp.example.com"',
+            '"cue.user": "Username, may be user@example.com"',
+        ):
+            self.assertIn(marker, catalogs)
+        # Preserve usable horizontal space for full shared-hosting usernames.
+        self.assertIn("a.move(a.user, x, y, 220, rowH)", ui)
+        self.assertIn("limitEdit(a.user, 1024)", ui)
 
     def test_marketing_docs_include_shared_hosting_path(self) -> None:
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
         guide = (ROOT / "docs/SHARED-HOSTING.md").read_text(encoding="utf-8")
         docs = (ROOT / "docs/README.md").read_text(encoding="utf-8")
-        self.assertIn("Shared hosting — spojite se u nekoliko koraka", readme)
-        self.assertIn("ByFTP za shared hosting", guide)
-        self.assertIn("korisnik@domena", guide)
+        for marker in (
+            "## Shared-hosting workflow",
+            "public_html",
+            "[Shared hosting](docs/SHARED-HOSTING.md)",
+        ):
+            self.assertIn(marker, readme)
+        for marker in (
+            "# Shared-hosting compatibility",
+            "account@domain",
+            "public_html",
+            "MLSD to LIST",
+            "Passive connections",
+        ):
+            self.assertIn(marker, guide)
         self.assertIn("SHARED-HOSTING.md", docs)
 
 

--- a/scripts/test_ui_stability_hardening.py
+++ b/scripts/test_ui_stability_hardening.py
@@ -72,8 +72,14 @@ class UIStabilityHardeningTests(unittest.TestCase):
     def test_settings_do_not_replace_helpful_host_hint(self) -> None:
         settings = self.read("internal/desktop/settings_windows.go")
         ui = self.read("internal/desktop/ui_windows.go")
-        self.assertNotIn('cue(a.host, "Poslužitelj")', settings)
-        self.assertIn("FTP/SFTP poslužitelj, npr. ftp.domena.hr", ui)
+        catalogs = self.read("internal/i18n/catalogs.go")
+        # Settings must not replace the connection form's localized cue text.
+        self.assertNotIn("cue(a.host", settings)
+        self.assertIn('cue(a.host, a.tr("cue.host"))', ui)
+        # The canonical English hint remains useful for shared-hosting users,
+        # while other locales can provide their own equivalent cue text.
+        self.assertIn('"cue.host":           "FTP/SFTP server, e.g. ftp.example.com"', catalogs)
+        self.assertIn('"cue.user": "Username, may be user@example.com"', catalogs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Final follow-up based directly on the current main branch after PR #52. Scope is intentionally small and auditable: significantly improve the main README, replace the stale Croatian scripts/tooling README with the current English-first build/audit/release guide, and fix Windows production tool discovery so GitHub-hosted runners select scalar Go/Python executable paths. The Windows build baseline is aligned with the CI toolchain at Go 1.26.5. No protocol/security model is weakened. Merge only after all localization, version, docs, security, privacy, release, Go/race/vet and Windows/Linux/macOS build gates pass.