### PR TITLE
ByFTP 1.2.0: finalize Android/iOS CI and release docs

### DIFF
--- a/android/app/src/test/java/com/byftp/client/model/ConnectionConfigTest.java
+++ b/android/app/src/test/java/com/byftp/client/model/ConnectionConfigTest.java
@@ -4,10 +4,12 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class ConnectionConfigTest {
+    private static final String VALID_SHA256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
     @Test public void defaultsPortsByProtocol() {
         assertEquals(21, ConnectionConfig.create(ConnectionConfig.Protocol.FTP, "example.com", "", "u", "p", "").port());
         assertEquals(990, ConnectionConfig.create(ConnectionConfig.Protocol.FTPS_IMPLICIT, "example.com", "", "u", "p", "").port());
-        assertEquals(22, ConnectionConfig.create(ConnectionConfig.Protocol.SFTP, "example.com", "", "u", "p", "SHA256:abc").port());
+        assertEquals(22, ConnectionConfig.create(ConnectionConfig.Protocol.SFTP, "example.com", "", "u", "p", "SHA256:" + VALID_SHA256).port());
     }
 
     @Test public void sftpRequiresFingerprint() {
@@ -19,8 +21,15 @@ public class ConnectionConfigTest {
     }
 
     @Test public void normalizesBracketedIpv6AndFingerprint() {
-        ConnectionConfig c = ConnectionConfig.create(ConnectionConfig.Protocol.SFTP, "[2001:db8::1]", "22", "user", "pw", "abc=");
+        ConnectionConfig c = ConnectionConfig.create(
+            ConnectionConfig.Protocol.SFTP,
+            "[2001:db8::1]",
+            "22",
+            "user",
+            "pw",
+            VALID_SHA256 + "="
+        );
         assertEquals("2001:db8::1", c.host());
-        assertEquals("SHA256:abc", c.fingerprint());
+        assertEquals("SHA256:" + VALID_SHA256, c.fingerprint());
     }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,15 @@
 # Contributing
 
-Keep changes small, testable and consistent with the existing security model. English is the canonical language for source-facing user text, documentation and repository metadata; runtime translations belong in `internal/i18n`.
+Keep changes small, testable and consistent with the existing security model. English is the canonical language for source-facing user text, documentation and repository metadata; desktop runtime translations belong in `internal/i18n` and mobile translations should be added only as complete reviewed platform resource sets.
 
 Do not add telemetry, advertising SDKs, hidden network destinations, insecure credential transport or certificate/host-key bypasses. Add regression tests for transfer, installer and security-sensitive behavior whenever practical.
 
-Before opening a pull request, run formatting, unit tests, `go vet` and the relevant repository audit scripts.
+Platform code must stay within its intended boundary:
+
+- desktop/Go behavior belongs in `cmd/` and `internal/`,
+- Android-native code belongs in `android/`,
+- iOS-native Swift/Xcode code belongs in `ios/`.
+
+Do not replace the native Android or iOS applications with WebView wrappers or hidden project-controlled backend services. New mobile transports must preserve platform certificate/host verification, credential lifetime, path safety and lifecycle cleanup before they are advertised as supported.
+
+Before opening or merging a pull request, run the relevant repository audits and platform build gates. Changes that affect release packaging must keep `VERSION` as the single production version source and update the exact release allowlist, SHA-256 metadata contract and documentation together.

--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -10,7 +10,8 @@ Publication waits for all of these independent jobs:
 - Windows x64/x86 production builds,
 - Linux amd64/arm64/i386 DEB builds,
 - macOS Universal PKG build,
-- Android JUnit, debug/release lint, debug/release APK compilation and structural APK validation.
+- Android JUnit, debug/release lint, debug/release APK compilation and structural APK validation,
+- iOS model/path regressions, native iPhoneOS arm64 Xcode build and structural unsigned IPA/app-bundle validation.
 
 ## Android artifacts
 
@@ -20,6 +21,27 @@ Starting with 1.1.1, Android is part of the public artifact contract rather than
 - `ByFTP-<version>-Android-release-unsigned.apk` is optimized/minified but intentionally unsigned.
 
 The workflow must never present either artifact as a production store-signed package. Production Android distribution still requires a stable private signing identity managed outside the repository.
+
+## iOS artifacts
+
+Starting with 1.2.0, iOS is an independent native release platform under `ios/` and part of the public artifact contract:
+
+- `ByFTP-<version>-iOS-arm64-unsigned.ipa` contains the validated arm64 iPhoneOS application under `Payload/ByFTP.app`.
+- `ByFTP-<version>-iOS-arm64-unsigned-app.zip` contains the same validated unsigned `.app` bundle for inspection and external signing workflows.
+
+These artifacts prove source/build/package integrity only. They are not App Store, TestFlight, ad-hoc or enterprise distributions until a legitimate Apple signing identity and provisioning profile are applied outside this repository and separately verified.
+
+## Public asset contract
+
+The 1.2.0+ workflow stages exactly 14 platform artifacts before shared metadata:
+
+- six Windows packages,
+- three Linux DEBs,
+- one macOS PKG,
+- two Android APKs,
+- two iOS unsigned arm64 artifacts.
+
+It then adds `SHA256.txt`, `RELEASE-NOTES.txt` and `BUILD-METADATA.txt`, producing 17 public release files in total.
 
 ## Publication integrity
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 English is the canonical documentation language. Runtime translations belong in `internal/i18n`; technical documentation stays English-first so code, CI and release instructions have one authoritative source.
 
+## Core documentation
+
 - [Installation](INSTALLATION.md)
 - [Shared hosting](SHARED-HOSTING.md)
 - [Architecture](ARCHITECTURE.md)
@@ -15,3 +17,11 @@ English is the canonical documentation language. Runtime translations belong in 
 - [Release verification](RELEASE-VERIFICATION.md)
 - [Signing](SIGNING.md)
 - [Third-party notices](THIRD-PARTY-NOTICES.md)
+
+## Platform guides
+
+- [Android source and APK build guide](../android/README.md)
+- [iOS source, Xcode and unsigned IPA build guide](../ios/README.md)
+- [Build and verification tooling](../scripts/README.md)
+
+The native mobile implementations intentionally live in separate top-level platform directories: Android under `android/` and iOS under `ios/`. Neither mobile app is a WebView wrapper around the desktop client.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,8 +2,10 @@
 
 The roadmap is capability-based rather than tied to speculative product-version numbers.
 
-Current priorities are clearer shared-hosting diagnostics, secure Android Keystore-backed SFTP private-key handling, secure Unix credential handling for SFTP cases that cannot safely use command-line secrets, real platform signing when publisher credentials are available, further keyboard/accessibility improvements and broader server compatibility without weakening TLS, host-key or path protections.
+Current priorities are clearer shared-hosting diagnostics, secure Android Keystore-backed SFTP private-key handling, secure iOS SFTP and explicit-FTPS support only when those transports can preserve the same fail-closed trust model, secure Unix credential handling for SFTP cases that cannot safely use command-line secrets, real platform signing when publisher credentials are available, further keyboard/accessibility improvements and broader server compatibility without weakening TLS, host-key or path protections.
 
-Android debug and unsigned release APK generation is now part of the verified release pipeline. The remaining Android distribution milestone is a real externally managed production signing identity plus a signing-verification gate; the repository will not substitute a debug or fabricated key for that requirement.
+Android debug and unsigned release APK generation is part of the verified release pipeline. The remaining Android distribution milestone is a real externally managed production signing identity plus a signing-verification gate; the repository will not substitute a debug or fabricated key for that requirement.
+
+iOS 1.2.0 introduces a native SwiftUI client and verified unsigned arm64 IPA/app artifacts. Future iOS transport work must not claim SFTP or explicit FTPS until a reviewed implementation has host/certificate verification, credential handling, path safety, lifecycle tests and a real iPhoneOS CI gate. Production iOS distribution additionally requires a legitimate Apple signing identity and provisioning profile managed outside the repository.
 
 A feature is complete only when its failure modes are understood, regression coverage exists where practical and every affected platform build gate remains green.

--- a/docs/SHARED-HOSTING.md
+++ b/docs/SHARED-HOSTING.md
@@ -10,10 +10,18 @@ The desktop FTP/FTPS implementation uses login/home-relative control and transfe
 
 ## Android
 
-Starting with 1.1.1, Android records the server `PWD` after FTP/FTPS login and treats that working directory as the UI `/`. For example, if the account logs in at `/home/example`, UI `/public_html` maps to `/home/example/public_html` rather than forcing `/public_html` outside the account home.
+Android records the server `PWD` after FTP/FTPS login and treats that working directory as the UI `/`. For example, if the account logs in at `/home/example`, UI `/public_html` maps to `/home/example/public_html` rather than forcing `/public_html` outside the account home.
 
 If the server cannot report `PWD`, Android uses login-relative paths (`public_html/...`). Traversal (`..`), duplicate separators, backslashes, NUL characters and other noncanonical UI paths are rejected before an FTP operation is sent.
 
+## iOS
+
+The native iOS client follows the same account-root concept. It maps UI `/` to the authenticated FTP login working directory when the server reports `PWD`; otherwise it stays login-relative. `public_html` therefore remains inside the authenticated hosting account instead of being rewritten as an unrelated server filesystem path.
+
+iOS rejects traversal, duplicate separators, dot components, backslashes, NUL/control characters and noncanonical server login roots. Passive mode prefers EPSV and falls back to PASV, but deliberately ignores the host address supplied inside a PASV response and reconnects the data channel only to the user-selected server host. This prevents a server response from redirecting file data to an unrelated address while remaining compatible with NAT/shared-hosting servers that advertise private PASV addresses.
+
 ## Transport security
 
-Plain FTP remains available for compatibility but is unencrypted. Prefer FTPS or SFTP. SFTP remains fail-closed for host-key verification, while FTPS keeps platform certificate-chain and endpoint/hostname verification enabled. Do not disable those checks to accommodate a misconfigured host; verify or correct the server endpoint instead.
+Plain FTP remains available for compatibility but is unencrypted. Prefer FTPS or SFTP where implemented. Desktop and Android support FTP, explicit/implicit FTPS and SFTP. iOS 1.2.0 supports FTP and implicit FTPS; explicit FTPS and SFTP are intentionally not claimed on iOS until reviewed native implementations preserve the required trust and credential boundaries.
+
+SFTP remains fail-closed for host-key verification where supported, while FTPS keeps platform certificate-chain and endpoint/hostname verification enabled. Do not disable those checks to accommodate a misconfigured host; verify or correct the server endpoint instead.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,5 +1,13 @@
 # Support
 
-Use GitHub Issues for reproducible bugs and feature requests. Include the ByFTP version from `VERSION`, operating system, protocol, relevant non-secret server behavior and exact error text.
+Use GitHub Issues for reproducible bugs and feature requests. Include the ByFTP version from `VERSION`, operating system/platform, protocol, relevant non-secret server behavior and exact error text.
 
-Never post passwords, private keys, access tokens or full credential-bearing configuration files. For a security vulnerability, use the private reporting process described by the repository Security policy.
+For platform-specific reports, include enough build context to reproduce the issue without exposing secrets:
+
+- Windows: x64/x86 and Setup or Portable.
+- Linux: amd64, arm64 or i386 package.
+- macOS: macOS version and Intel/Apple Silicon context when relevant.
+- Android: Android/API version and whether the debug or externally signed release APK was used.
+- iOS: iOS/device version and whether the issue came from the Xcode source build or externally signed form of the verified unsigned arm64 app/IPA artifact.
+
+Never post passwords, private keys, host-key private material, signing certificates, provisioning profiles, access tokens, customer data or full credential-bearing configuration files. For a security vulnerability, use the private reporting process described by the repository Security policy.

--- a/ios/ByFTP/ConnectionConfig.swift
+++ b/ios/ByFTP/ConnectionConfig.swift
@@ -31,10 +31,15 @@ struct ConnectionConfig: Equatable, Sendable {
         password rawPassword: String
     ) throws -> ConnectionConfig {
         let host = try normalizeHost(rawHost)
-        let username = rawUsername.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !username.isEmpty else { throw ValidationError("Username is required.") }
-        try rejectControlCharacters(username, field: "Username")
+
+        // Validate the raw credentials before normalization. Trimming first would
+        // silently remove CR/LF at the edges and turn an invalid FTP command
+        // argument into an accepted value instead of rejecting it fail-closed.
+        try rejectControlCharacters(rawUsername, field: "Username")
         try rejectControlCharacters(rawPassword, field: "Password")
+
+        let username = rawUsername.trimmingCharacters(in: .whitespaces)
+        guard !username.isEmpty else { throw ValidationError("Username is required.") }
 
         return ConnectionConfig(
             protocolKind: protocolKind,

--- a/ios/ByFTP/ConnectionConfig.swift
+++ b/ios/ByFTP/ConnectionConfig.swift
@@ -32,9 +32,8 @@ struct ConnectionConfig: Equatable, Sendable {
     ) throws -> ConnectionConfig {
         let host = try normalizeHost(rawHost)
 
-        // Validate the raw credentials before normalization. Trimming first would
-        // silently remove CR/LF at the edges and turn an invalid FTP command
-        // argument into an accepted value instead of rejecting it fail-closed.
+        // Validate raw credentials before normalization. Otherwise CR/LF at an
+        // edge could be removed by trimming instead of being rejected.
         try rejectControlCharacters(rawUsername, field: "Username")
         try rejectControlCharacters(rawPassword, field: "Password")
 
@@ -53,7 +52,7 @@ struct ConnectionConfig: Equatable, Sendable {
     static func normalizeHost(_ raw: String) throws -> String {
         var host = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { throw ValidationError("Host is required.") }
-        guard !host.contains("://"), !host.contains("/"), !host.contains("\\"), !host.contains("\0") else {
+        guard !host.contains("://"), !host.contains("/"), !host.contains("\\"), !host.unicodeScalars.contains(where: { $0.value == 0 }) else {
             throw ValidationError("Enter a host name or IP address, not a URL or path.")
         }
         guard host.unicodeScalars.allSatisfy({ !CharacterSet.whitespacesAndNewlines.contains($0) }) else {
@@ -77,7 +76,10 @@ struct ConnectionConfig: Equatable, Sendable {
     }
 
     private static func rejectControlCharacters(_ value: String, field: String) throws {
-        guard !value.contains("\r"), !value.contains("\n"), !value.contains("\0") else {
+        let hasProtocolControl = value.unicodeScalars.contains { scalar in
+            scalar.value == 0 || scalar.value == 10 || scalar.value == 13
+        }
+        guard !hasProtocolControl else {
             throw ValidationError("\(field) contains an unsafe control character.")
         }
     }

--- a/ios/ByFTP/SessionStore.swift
+++ b/ios/ByFTP/SessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 @MainActor
 final class SessionStore: ObservableObject {

--- a/ios/ByFTP/SocketConnection.swift
+++ b/ios/ByFTP/SocketConnection.swift
@@ -22,22 +22,15 @@ final class SocketConnection {
 
     func start() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            let lock = NSLock()
-            var pending: CheckedContinuation<Void, Error>? = continuation
+            let pending = StartContinuationBox(continuation)
             connection.stateUpdateHandler = { state in
-                lock.lock()
-                defer { lock.unlock() }
-                guard let current = pending else { return }
                 switch state {
                 case .ready:
-                    pending = nil
-                    current.resume()
+                    pending.resume(.success(()))
                 case .failed(let error):
-                    pending = nil
-                    current.resume(throwing: error)
+                    pending.resume(.failure(error))
                 case .cancelled:
-                    pending = nil
-                    current.resume(throwing: NetworkError.connectionClosed)
+                    pending.resume(.failure(NetworkError.connectionClosed))
                 default:
                     break
                 }
@@ -110,7 +103,9 @@ final class SocketConnection {
     }
 
     func receiveToFile(_ url: URL, maxBytes: Int64 = 4 * 1024 * 1024 * 1024) async throws {
-        FileManager.default.createFile(atPath: url.path, contents: nil)
+        guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+            throw NetworkError.fileCreateFailed
+        }
         let handle = try FileHandle(forWritingTo: url)
         defer { try? handle.close() }
         var total: Int64 = 0
@@ -141,16 +136,42 @@ final class SocketConnection {
     }
 }
 
+private final class StartContinuationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(_ continuation: CheckedContinuation<Void, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ result: Result<Void, Error>) {
+        lock.lock()
+        let current = continuation
+        continuation = nil
+        lock.unlock()
+
+        guard let current else { return }
+        switch result {
+        case .success:
+            current.resume()
+        case .failure(let error):
+            current.resume(throwing: error)
+        }
+    }
+}
+
 enum NetworkError: LocalizedError {
     case connectionClosed
     case encodingFailed
     case responseTooLarge
+    case fileCreateFailed
 
     var errorDescription: String? {
         switch self {
         case .connectionClosed: return "The server closed the connection."
         case .encodingFailed: return "The server returned text that could not be decoded."
         case .responseTooLarge: return "The server response exceeded the safety limit."
+        case .fileCreateFailed: return "The destination file could not be created."
         }
     }
 }

--- a/ios/Tests/ModelTests.swift
+++ b/ios/Tests/ModelTests.swift
@@ -3,7 +3,8 @@ import Foundation
 @main
 struct ModelTests {
     static func main() throws {
-        try expect(ConnectionConfig.normalizeHost(" [2001:db8::1] ") == "2001:db8::1", "IPv6 brackets were not normalized")
+        let normalizedHost = try ConnectionConfig.normalizeHost(" [2001:db8::1] ")
+        try expect(normalizedHost == "2001:db8::1", "IPv6 brackets were not normalized")
 
         let config = try ConnectionConfig.make(
             protocolKind: .ftpsImplicit,
@@ -14,13 +15,19 @@ struct ModelTests {
         )
         try expect(config.port == 990, "implicit FTPS default port changed")
 
-        try expect(RemotePath.child("/", "public_html") == "/public_html", "root child path is wrong")
-        try expect(RemotePath.child("/public_html", "index.html") == "/public_html/index.html", "nested child path is wrong")
-        try expect(RemotePath.parent("/public_html/site") == "/public_html", "parent path is wrong")
+        let rootChild = try RemotePath.child("/", "public_html")
+        let nestedChild = try RemotePath.child("/public_html", "index.html")
+        let parent = try RemotePath.parent("/public_html/site")
+        try expect(rootChild == "/public_html", "root child path is wrong")
+        try expect(nestedChild == "/public_html/index.html", "nested child path is wrong")
+        try expect(parent == "/public_html", "parent path is wrong")
 
-        try expect(FTPPathMapper.map(loginRoot: "/home/account", uiPath: "/") == "/home/account", "login root mapping changed")
-        try expect(FTPPathMapper.map(loginRoot: "/home/account", uiPath: "/public_html") == "/home/account/public_html", "shared-hosting mapping changed")
-        try expect(FTPPathMapper.map(loginRoot: nil, uiPath: "/public_html") == "public_html", "login-relative fallback changed")
+        let mappedRoot = try FTPPathMapper.map(loginRoot: "/home/account", uiPath: "/")
+        let mappedWebRoot = try FTPPathMapper.map(loginRoot: "/home/account", uiPath: "/public_html")
+        let relativeFallback = try FTPPathMapper.map(loginRoot: nil, uiPath: "/public_html")
+        try expect(mappedRoot == "/home/account", "login root mapping changed")
+        try expect(mappedWebRoot == "/home/account/public_html", "shared-hosting mapping changed")
+        try expect(relativeFallback == "public_html", "login-relative fallback changed")
 
         try expectThrows("path traversal was accepted") {
             _ = try RemotePath.normalizeDirectory("/public_html/../etc")
@@ -29,10 +36,10 @@ struct ModelTests {
             _ = try FTPPathMapper.normalizeLoginRoot("/home/../root")
         }
         try expectThrows("CRLF username injection was accepted") {
-            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user\r\nDELE /", password: "x")
+            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user\r\nNEXT", password: "x")
         }
         try expectThrows("CRLF password injection was accepted") {
-            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user", password: "x\r\nQUIT")
+            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user", password: "x\r\nNEXT")
         }
 
         print("IOS_MODEL_TESTS=PASS")

--- a/ios/Tests/ModelTests.swift
+++ b/ios/Tests/ModelTests.swift
@@ -35,11 +35,19 @@ struct ModelTests {
         try expectThrows("unsafe server login root was accepted") {
             _ = try FTPPathMapper.normalizeLoginRoot("/home/../root")
         }
+
+        let cr = String(UnicodeScalar(13)!)
+        let lf = String(UnicodeScalar(10)!)
+        let crlf = cr + lf
         try expectThrows("CRLF username injection was accepted") {
-            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user\r\nNEXT", password: "x")
+            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user" + crlf + "NEXT", password: "x")
         }
         try expectThrows("CRLF password injection was accepted") {
-            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user", password: "x\r\nNEXT")
+            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user", password: "x" + crlf + "NEXT")
+        }
+        let nul = String(UnicodeScalar(0)!)
+        try expectThrows("NUL username injection was accepted") {
+            _ = try ConnectionConfig.make(protocolKind: .ftp, host: "example.com", port: "21", username: "user" + nul + "NEXT", password: "x")
         }
 
         print("IOS_MODEL_TESTS=PASS")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,22 +7,25 @@ This directory contains development/CI build, audit, packaging, release and veri
 - `BUILD-LOCAL.sh` — local/offline cross-build smoke check.
 - `BUILD-LINUX.sh` — production Linux DEB builds for amd64, arm64 and i386.
 - `BUILD-MACOS.sh` — production macOS Universal application/package build.
+- `BUILD-IOS.sh` — native iPhoneOS arm64 build, iOS model/path regressions, deterministic icon generation and unsigned IPA/app packaging.
 - `make_payload.py` — creates the verified Windows installer payload.
 - `pe_resources.py` — writes Windows PE icon and VERSIONINFO resources.
 - `generate_brand_assets.py` — reproducibly generates and verifies PNG/ICO brand assets.
 - `package_android.py` — validates debug/release APK structure and stages versioned Android release artifacts.
+- `package_ios.py` — validates the native iOS `.app`, version/bundle identity, Mach-O executable and archive paths before staging versioned unsigned IPA/app artifacts.
 
 The canonical Windows production build is [`BUILD-WINDOWS.ps1`](../BUILD-WINDOWS.ps1) in the repository root.
 
 ## Audit tools
 
 - `audit_localization.py` — verifies English-first localization, supported desktop catalogs and Windows startup fallback policy.
-- `audit_version.py` — verifies that `VERSION` is the single production version source.
+- `audit_version.py` — verifies that `VERSION` is the single production version source across desktop, Android and iOS packaging.
 - `audit_android.py` — verifies Android TLS/SSH, permissions, login-root paths, lifecycle, picker-state and version invariants.
+- `audit_ios.py` — verifies native iOS project structure, transport/path hardening, privacy/lifecycle rules, Xcode version binding and unsigned IPA packaging contract.
 - `audit_docs.py` — checks local documentation links, the documentation index and version-neutral document titles.
 - `audit_security.py` — protects filesystem, credential, transfer and session security invariants.
 - `audit_privacy.py` — enforces privacy and network policy.
-- `audit_release.py` — validates the production platform matrix, Android APK contract and centralized publisher.
+- `audit_release.py` — validates the production Windows/Linux/macOS/Android/iOS matrix and centralized publisher.
 - `audit_release_version_guard.py` — prevents mutation of already-published version lines.
 
 ## Release and verification tools
@@ -30,23 +33,26 @@ The canonical Windows production build is [`BUILD-WINDOWS.ps1`](../BUILD-WINDOWS
 - `verify_release.py` — validates Windows PE files and release security properties.
 - `verify_bundle.py` — fail-closed validation of Windows release ZIP contents, paths and `BUNDLE-SHA256.txt`.
 - `package_android.py` — fail-closed Android APK container/path validation and versioned staging.
+- `package_ios.py` — fail-closed iOS app/IPA validation and versioned staging.
 - `release_notes.py` — generates release notes from the exact matching `CHANGELOG.md` section.
 - `publish_release.ps1` — centralized GitHub Release publication with tag/commit and remote asset integrity checks.
 - `test_release_tools.py` — regression tests for release tooling.
 - `test_package_android.py` — regression tests for Android APK staging/validation.
+- `test_package_ios.py` — regression tests for iOS app/IPA staging, version checks and unsafe archive rejection.
 
 ## Production rules
 
 1. `VERSION` is the only production version source.
 2. Go telemetry must be disabled before production desktop builds.
 3. Production Go builds run with `GOPROXY=off` and `GOSUMDB=off`.
-4. Security, privacy, localization, documentation, Android and release audits must pass.
+4. Security, privacy, localization, documentation, Android, iOS and release audits must pass.
 5. Windows bundles are checked against an explicit allowlist and SHA-256 manifest.
 6. Android debug and unsigned release APKs must pass structural/path validation before staging.
-7. Public release staging must match the exact Windows/Linux/macOS/Android artifact allowlist.
-8. GitHub Release publication is performed only through `publish_release.ps1` and final remote assets are re-verified.
-9. Production code-signing identities are external secrets and must never be fabricated or committed.
+7. iOS must compile as a native arm64 iPhoneOS app and its unsigned IPA/app artifacts must pass bundle/version/Mach-O/path validation before staging.
+8. Public release staging must match the exact Windows/Linux/macOS/Android/iOS artifact allowlist.
+9. GitHub Release publication is performed only through `publish_release.ps1` and final remote assets are re-verified.
+10. Production code-signing identities are external secrets and must never be fabricated or committed.
 
 ## Documentation
 
-See [GitHub releases](../docs/GITHUB-RELEASES.md), [Release verification](../docs/RELEASE-VERIFICATION.md), [Testing](../docs/TESTING.md), [Security](../docs/SECURITY.md) and the [Android guide](../android/README.md).
+See [GitHub releases](../docs/GITHUB-RELEASES.md), [Release verification](../docs/RELEASE-VERIFICATION.md), [Testing](../docs/TESTING.md), [Security](../docs/SECURITY.md), the [Android guide](../android/README.md) and the [iOS guide](../ios/README.md).

--- a/scripts/audit_ios.py
+++ b/scripts/audit_ios.py
@@ -50,6 +50,7 @@ def main() -> int:
         "case ftp", "case ftpsImplicit", "rejectControlCharacters", "Port must be between 1 and 65535",
         'rejectControlCharacters(rawUsername, field: "Username")',
         'rejectControlCharacters(rawPassword, field: "Password")',
+        "scalar.value == 0", "scalar.value == 10", "scalar.value == 13",
     ))
     username_check = config.find('rejectControlCharacters(rawUsername, field: "Username")')
     username_trim = config.find("rawUsername.trimmingCharacters")
@@ -82,7 +83,8 @@ def main() -> int:
             fail(f"unsafe iOS transport marker found: {forbidden}")
 
     session = require("ios/ByFTP/SessionStore.swift", (
-        "generation &+= 1", 'password = ""', "startAccessingSecurityScopedResource", "clearDownloadedFile",
+        "import Combine", "ObservableObject", "@Published", "generation &+= 1", 'password = ""',
+        "startAccessingSecurityScopedResource", "clearDownloadedFile",
     ))
     app = require("ios/ByFTP/ByFTPApp.swift", ("scenePhase", "store.disconnect()"))
     combined_source = "\n".join(path.read_text(encoding="utf-8") for path in (IOS / "ByFTP").glob("*.swift"))
@@ -127,6 +129,7 @@ def main() -> int:
     model_tests = require("ios/Tests/ModelTests.swift", (
         "IOS_MODEL_TESTS=PASS", "path traversal was accepted",
         "CRLF username injection was accepted", "CRLF password injection was accepted",
+        "NUL username injection was accepted", "UnicodeScalar(13)", "UnicodeScalar(10)", "UnicodeScalar(0)",
     ))
     if not model_tests:
         fail("iOS model/path tests are unavailable")

--- a/scripts/audit_ios.py
+++ b/scripts/audit_ios.py
@@ -67,7 +67,11 @@ def main() -> int:
 
     socket = require("ios/ByFTP/SocketConnection.swift", (
         "import Network", "NWParameters(tls:", "responseTooLarge", "sendLine", "receiveToFile",
+        "StartContinuationBox", "@unchecked Sendable", "private let lock = NSLock()",
+        "guard FileManager.default.createFile",
     ))
+    if "var pending: CheckedContinuation" in socket:
+        fail("iOS NWConnection state handler captures a mutable local continuation")
     if "NWParameters(tls: nil" in socket:
         fail("iOS FTPS disables TLS")
 
@@ -147,6 +151,7 @@ def main() -> int:
     print("IOS_TRANSPORTS=FTP,FTPS_IMPLICIT")
     print("IOS_PASV_HOST_REDIRECT=BLOCKED")
     print("IOS_CREDENTIAL_CONTROL_CHARACTERS=REJECTED_BEFORE_NORMALIZATION")
+    print("IOS_NWCONNECTION_CONTINUATION=LOCKED_SINGLE_RESUME")
     print("IOS_CREDENTIAL_PERSISTENCE=BLOCKED")
     print("IOS_LOGIN_PASSWORD_LIFETIME=CONNECT_ONLY")
     print("IOS_BACKGROUND_SESSION=DISCONNECTED")

--- a/scripts/audit_ios.py
+++ b/scripts/audit_ios.py
@@ -48,7 +48,13 @@ def main() -> int:
 
     config = require("ios/ByFTP/ConnectionConfig.swift", (
         "case ftp", "case ftpsImplicit", "rejectControlCharacters", "Port must be between 1 and 65535",
+        'rejectControlCharacters(rawUsername, field: "Username")',
+        'rejectControlCharacters(rawPassword, field: "Password")',
     ))
+    username_check = config.find('rejectControlCharacters(rawUsername, field: "Username")')
+    username_trim = config.find("rawUsername.trimmingCharacters")
+    if username_check < 0 or username_trim < 0 or username_check > username_trim:
+        fail("iOS username control characters are not rejected before normalization")
     if "case sftp" in config.lower() or "case ftpsExplicit" in config:
         fail("iOS claims an unimplemented transport in TransferProtocol")
 
@@ -137,6 +143,7 @@ def main() -> int:
     print("IOS_NATIVE_UI=SWIFTUI")
     print("IOS_TRANSPORTS=FTP,FTPS_IMPLICIT")
     print("IOS_PASV_HOST_REDIRECT=BLOCKED")
+    print("IOS_CREDENTIAL_CONTROL_CHARACTERS=REJECTED_BEFORE_NORMALIZATION")
     print("IOS_CREDENTIAL_PERSISTENCE=BLOCKED")
     print("IOS_LOGIN_PASSWORD_LIFETIME=CONNECT_ONLY")
     print("IOS_BACKGROUND_SESSION=DISCONNECTED")


### PR DESCRIPTION
## Summary

Clean correction PR created directly from the current `main` after PR #58 merged before the final mobile fixes. `v1.2.0` has not been tagged, so these corrections remain within the unpublished 1.2.0 line.

## Changes

- Fix Android tests to use a structurally valid 32-byte SHA-256 SFTP fingerprint while keeping the stricter production validator.
- Fix Swift model/path test compilation without weakening throwing validation.
- Keep Android native code under `android/` and iOS native Swift/Xcode code under `ios/`.
- Complete iOS release/shared-hosting/tooling/support/contribution documentation.
- Document the 1.2.0 public release contract: 14 platform artifacts + `SHA256.txt`, `RELEASE-NOTES.txt`, `BUILD-METADATA.txt`.

## Required validation

Merge only after all six jobs are green:

1. central tests/race/vet/security/privacy/docs/release audits,
2. Windows x64/x86,
3. Linux amd64/arm64/i386,
4. macOS Universal,
5. Android JUnit + debug/release lint/build + APK validation,
6. native iPhoneOS arm64 Xcode build + model tests + unsigned IPA/app validation.

No production Android or Apple signing identity is fabricated or committed.