### PR TITLE
Fix WEB rate-limit reset and enforce repository audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
         run: python scripts/audit_localization.py
       - name: Verify version consistency
         run: python scripts/audit_version.py
+      - name: Verify repository hygiene
+        run: python scripts/audit_repository.py
+      - name: Verify ByFTP WEB
+        run: python scripts/audit_web.py
       - name: Verify Android invariants
         run: python scripts/audit_android.py
       - name: Verify iOS invariants

--- a/ByFTP WEB/app/Security/RateLimiter.php
+++ b/ByFTP WEB/app/Security/RateLimiter.php
@@ -7,40 +7,45 @@ use ByFTP\Storage\JsonStore;
 
 final class RateLimiter
 {
-    public function __construct(private readonly int $maxAttempts = 5, private readonly int $window = 900)
-    {
-    }
-
-    private function path(string $key): string
-    {
-        return BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
+    public function __construct(
+        private readonly string $root,
+        private readonly int $maxHits = 8,
+        private readonly int $windowSeconds = 900,
+    ) {
     }
 
     public function blocked(string $key): bool
     {
-        $data = (new JsonStore($this->path($key)))->read(['first' => time(), 'count' => 0]);
-        if ((int)($data['first'] ?? 0) + $this->window < time()) {
-            $this->clear($key);
-            return false;
-        }
-        return (int)($data['count'] ?? 0) >= $this->maxAttempts;
+        $cutoff = time() - $this->windowSeconds;
+        $store = new JsonStore($this->pathFor($key));
+        $data = $store->read(['hits' => []]);
+        $hits = array_values(array_filter((array)($data['hits'] ?? []), static fn($time): bool => is_int($time) && $time >= $cutoff));
+        return count($hits) >= $this->maxHits;
     }
 
     public function hit(string $key): void
     {
-        (new JsonStore($this->path($key)))->update(function (array $data): array {
-            if ((int)($data['first'] ?? 0) + $this->window < time()) {
-                $data = ['first' => time(), 'count' => 0];
-            }
-            $data['first'] = (int)($data['first'] ?? time());
-            $data['count'] = (int)($data['count'] ?? 0) + 1;
-            return $data;
-        }, ['first' => time(), 'count' => 0]);
+        $cutoff = time() - $this->windowSeconds;
+        $store = new JsonStore($this->pathFor($key));
+        $store->update(static function (array $data) use ($cutoff): array {
+            $hits = array_values(array_filter((array)($data['hits'] ?? []), static fn($time): bool => is_int($time) && $time >= $cutoff));
+            $hits[] = time();
+            return ['hits' => $hits];
+        }, ['hits' => []]);
     }
 
     public function clear(string $key): void
     {
-        @unlink($this->path($key));
-        @unlink($this->path($key) . '.lock');
+        // Reset through JsonStore instead of unlinking the primary/lock files.
+        // JsonStore may have a last-known-good .bak file, so deleting only the
+        // primary can resurrect stale hits on the next read. Keeping the same
+        // lock file also preserves cross-request serialization while clearing.
+        $store = new JsonStore($this->pathFor($key));
+        $store->write(['hits' => []]);
+    }
+
+    private function pathFor(string $key): string
+    {
+        return rtrim($this->root, '/\\') . '/rate-' . hash('sha256', $key) . '.json';
     }
 }

--- a/ByFTP WEB/app/Security/RateLimiter.php
+++ b/ByFTP WEB/app/Security/RateLimiter.php
@@ -7,45 +7,43 @@ use ByFTP\Storage\JsonStore;
 
 final class RateLimiter
 {
-    public function __construct(
-        private readonly string $root,
-        private readonly int $maxHits = 8,
-        private readonly int $windowSeconds = 900,
-    ) {
+    public function __construct(private readonly int $maxAttempts = 5, private readonly int $window = 900)
+    {
+    }
+
+    private function path(string $key): string
+    {
+        return BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
     }
 
     public function blocked(string $key): bool
     {
-        $cutoff = time() - $this->windowSeconds;
-        $store = new JsonStore($this->pathFor($key));
-        $data = $store->read(['hits' => []]);
-        $hits = array_values(array_filter((array)($data['hits'] ?? []), static fn($time): bool => is_int($time) && $time >= $cutoff));
-        return count($hits) >= $this->maxHits;
+        $data = (new JsonStore($this->path($key)))->read(['first' => time(), 'count' => 0]);
+        if ((int)($data['first'] ?? 0) + $this->window < time()) {
+            $this->clear($key);
+            return false;
+        }
+        return (int)($data['count'] ?? 0) >= $this->maxAttempts;
     }
 
     public function hit(string $key): void
     {
-        $cutoff = time() - $this->windowSeconds;
-        $store = new JsonStore($this->pathFor($key));
-        $store->update(static function (array $data) use ($cutoff): array {
-            $hits = array_values(array_filter((array)($data['hits'] ?? []), static fn($time): bool => is_int($time) && $time >= $cutoff));
-            $hits[] = time();
-            return ['hits' => $hits];
-        }, ['hits' => []]);
+        (new JsonStore($this->path($key)))->update(function (array $data): array {
+            if ((int)($data['first'] ?? 0) + $this->window < time()) {
+                $data = ['first' => time(), 'count' => 0];
+            }
+            $data['first'] = (int)($data['first'] ?? time());
+            $data['count'] = (int)($data['count'] ?? 0) + 1;
+            return $data;
+        }, ['first' => time(), 'count' => 0]);
     }
 
     public function clear(string $key): void
     {
-        // Reset through JsonStore instead of unlinking the primary/lock files.
-        // JsonStore may have a last-known-good .bak file, so deleting only the
-        // primary can resurrect stale hits on the next read. Keeping the same
-        // lock file also preserves cross-request serialization while clearing.
-        $store = new JsonStore($this->pathFor($key));
-        $store->write(['hits' => []]);
-    }
-
-    private function pathFor(string $key): string
-    {
-        return rtrim($this->root, '/\\') . '/rate-' . hash('sha256', $key) . '.json';
+        // Reset through JsonStore instead of unlinking the primary and lock files.
+        // JsonStore keeps a last-known-good .bak generation; deleting only the
+        // primary would make the next read restore stale failed-login attempts.
+        // Reusing the same lock file also preserves cross-request serialization.
+        (new JsonStore($this->path($key)))->write(['first' => time(), 'count' => 0]);
     }
 }

--- a/ByFTP WEB/tests/unit.php
+++ b/ByFTP WEB/tests/unit.php
@@ -6,6 +6,9 @@ function byftp_truncate(string $value, int $length): string
     return substr($value, 0, $length);
 }
 
+$testStorage = sys_get_temp_dir() . '/byftp-web-unit-' . bin2hex(random_bytes(6));
+define('BYFTP_STORAGE', $testStorage);
+
 require __DIR__ . '/../app/Remote/PathGuard.php';
 require __DIR__ . '/../app/Security/HostGuard.php';
 require __DIR__ . '/../app/Storage/JsonStore.php';
@@ -73,12 +76,8 @@ throws(fn() => $method->invoke($store, $bad), 'fingerprint edge whitespace rejec
 $bad = $base; $bad['username'] = "user\r\nnext";
 throws(fn() => $method->invoke($store, $bad), 'credential protocol controls rejected');
 
-$rateRoot = sys_get_temp_dir() . '/byftp-rate-' . bin2hex(random_bytes(6));
-if (!mkdir($rateRoot, 0700, true) && !is_dir($rateRoot)) {
-    throw new RuntimeException('Unable to create rate limiter test directory.');
-}
 try {
-    $limiter = new RateLimiter($rateRoot, 1, 3600);
+    $limiter = new RateLimiter(1, 3600);
     $rateKey = 'login:203.0.113.10';
     $limiter->hit($rateKey);
     $limiter->hit($rateKey); // Creates a last-known-good backup containing stale hits.
@@ -86,12 +85,14 @@ try {
     $limiter->clear($rateKey);
     check(!$limiter->blocked($rateKey), 'rate limiter clear removes stale backup hits');
 } finally {
-    foreach (glob($rateRoot . '/*') ?: [] as $path) {
+    $logDir = BYFTP_STORAGE . '/logs';
+    foreach (glob($logDir . '/*') ?: [] as $path) {
         if (is_file($path)) {
             @unlink($path);
         }
     }
-    @rmdir($rateRoot);
+    @rmdir($logDir);
+    @rmdir(BYFTP_STORAGE);
 }
 
 if ($failed > 0) {

--- a/ByFTP WEB/tests/unit.php
+++ b/ByFTP WEB/tests/unit.php
@@ -8,10 +8,13 @@ function byftp_truncate(string $value, int $length): string
 
 require __DIR__ . '/../app/Remote/PathGuard.php';
 require __DIR__ . '/../app/Security/HostGuard.php';
+require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/Security/RateLimiter.php';
 require __DIR__ . '/../app/Storage/ProfileStore.php';
 
 use ByFTP\Remote\PathGuard;
 use ByFTP\Security\HostGuard;
+use ByFTP\Security\RateLimiter;
 use ByFTP\Storage\ProfileStore;
 
 $passed = 0;
@@ -69,6 +72,27 @@ $bad = $base; $bad['host_fingerprint'] = ' SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 throws(fn() => $method->invoke($store, $bad), 'fingerprint edge whitespace rejected');
 $bad = $base; $bad['username'] = "user\r\nnext";
 throws(fn() => $method->invoke($store, $bad), 'credential protocol controls rejected');
+
+$rateRoot = sys_get_temp_dir() . '/byftp-rate-' . bin2hex(random_bytes(6));
+if (!mkdir($rateRoot, 0700, true) && !is_dir($rateRoot)) {
+    throw new RuntimeException('Unable to create rate limiter test directory.');
+}
+try {
+    $limiter = new RateLimiter($rateRoot, 1, 3600);
+    $rateKey = 'login:203.0.113.10';
+    $limiter->hit($rateKey);
+    $limiter->hit($rateKey); // Creates a last-known-good backup containing stale hits.
+    check($limiter->blocked($rateKey), 'rate limiter blocks at threshold');
+    $limiter->clear($rateKey);
+    check(!$limiter->blocked($rateKey), 'rate limiter clear removes stale backup hits');
+} finally {
+    foreach (glob($rateRoot . '/*') ?: [] as $path) {
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+    @rmdir($rateRoot);
+}
 
 if ($failed > 0) {
     fwrite(STDERR, "WEB_UNIT_TESTS=FAIL passed={$passed} failed={$failed}\n");


### PR DESCRIPTION
## Sažetak

- ispravlja `RateLimiter::clear()` tako da se stanje resetira atomski kroz `JsonStore`
- sprječava ponovno učitavanje starih failed-login pokušaja iz `.bak` datoteke nakon uspješne prijave
- više se ne briše aktivna `.lock` datoteka pri resetiranju rate limitera, čime se čuva cross-request serializacija
- dodaje regresijski WEB unit test za stale-backup scenarij
- uključuje postojeći `scripts/audit_repository.py` u glavni GitHub Actions CI
- uključuje postojeći `scripts/audit_web.py` u glavni CI

## WEB audit sada automatski provjerava

- PHP 8.1+ runtime ugovor
- PHP syntax lint za sve WEB PHP datoteke
- `ByFTP WEB/tests/unit.php`
- JavaScript syntax za WEB assete i service worker
- PWA, privacy, path-guard, host-guard i storage invarijante koje već definira `audit_web.py`

## Repository audit sada automatski provjerava

- tracked/generated artefakte i zabranjene putanje
- case-insensitive kolizije putanja
- UTF-8, trailing whitespace i merge-conflict markere
- drift aktivne verzije

## Opseg

Nema bumpa verzije i nema promjene korisničkog sadržaja. Promjene su bug-fix + regresijski test + CI hardening za postojeći ByFTP 1.7.1.