### PR TITLE
Fix WEB failed setup rollback artifacts

### DIFF
--- a/ByFTP WEB/setup.php
+++ b/ByFTP WEB/setup.php
@@ -98,10 +98,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 AppLogger::event('install.complete', ['email' => strtolower($email)]);
                 byftp_redirect('login', ['installed' => 1]);
             } catch (Throwable $e) {
-                @unlink(byftp_config_path());
-                @unlink(BYFTP_STORAGE . '/users.json');
-                @unlink(BYFTP_STORAGE . '/users.json.lock');
+                // existingDataDetected was false before this setup transaction. Therefore
+                // these config/user JSON generations and lock files can only be empty
+                // pre-existing scaffolding or artifacts created by this failed attempt.
+                // Remove the complete JsonStore generations so a stale users.json.bak
+                // cannot be mistaken for recoverable production data on the next request.
+                $rollbackArtifacts = [
+                    byftp_config_path(),
+                    byftp_config_path() . '.bak',
+                    byftp_config_path() . '.lock',
+                    BYFTP_STORAGE . '/users.json',
+                    BYFTP_STORAGE . '/users.json.bak',
+                    BYFTP_STORAGE . '/users.json.lock',
+                ];
+                foreach ($rollbackArtifacts as $artifact) {
+                    @unlink($artifact);
+                }
                 $GLOBALS['byftp_config_cache'] = [];
+                unset($GLOBALS['byftp_config_error']);
                 $error = $e->getMessage();
             } finally {
                 flock($setupLock, LOCK_UN);

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -188,6 +188,23 @@ def main() -> int:
         require(auth, marker, "ByFTP WEB/app/Security/Auth.php")
     require(read("ByFTP WEB/app/bootstrap.php"), "'samesite' => 'Strict'", "ByFTP WEB/app/bootstrap.php")
 
+    setup = read("ByFTP WEB/setup.php")
+    rollback_match = re.search(r"\$rollbackArtifacts\s*=\s*\[(.*?)\];", setup, re.DOTALL)
+    if rollback_match is None:
+        fail("ByFTP WEB/setup.php has no explicit failed-setup artifact rollback list")
+    rollback_artifacts = rollback_match.group(1)
+    for marker in (
+        "byftp_config_path()",
+        "byftp_config_path() . '.bak'",
+        "byftp_config_path() . '.lock'",
+        "BYFTP_STORAGE . '/users.json'",
+        "BYFTP_STORAGE . '/users.json.bak'",
+        "BYFTP_STORAGE . '/users.json.lock'",
+    ):
+        require(rollback_artifacts, marker, "ByFTP WEB/setup.php rollback artifacts")
+    require(setup, "foreach ($rollbackArtifacts as $artifact)", "ByFTP WEB/setup.php")
+    require(setup, "unset($GLOBALS['byftp_config_error']);", "ByFTP WEB/setup.php")
+
     index = read("ByFTP WEB/index.php")
     if "icon-192.png" in index or "icon-512.png" in index:
         fail("web UI references removed duplicate PNG PWA assets")
@@ -230,6 +247,7 @@ def main() -> int:
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")
     print("WEB_PRIVATE_HOSTS=BLOCKED_BY_DEFAULT")
     print("WEB_CREDENTIAL_LIFETIME=POST_AUTH_CLEARED")
+    print("WEB_SETUP_FAILED_TRANSACTION_ARTIFACTS=CLEANED")
     print("WEB_RUNTIME_STORAGE=NOT_TRACKED")
     return 0
 


### PR DESCRIPTION
## Sažetak

- ispravlja recovery nakon neuspjelog prvog ByFTP WEB setupa
- failed setup sada uklanja kompletne `app.json` i `users.json` JsonStore artefakte koje je taj pokušaj mogao stvoriti: primary, `.bak` i `.lock`
- resetira i config error cache uz postojeći config cache
- sprječava da `users.json.bak` sa djelomično stvorenim/rollbackanim admin računom sljedeći setup lažno prepozna kao postojeće produkcijske podatke
- `scripts/audit_web.py` sada eksplicitno provjerava kompletan failed-setup rollback ugovor

## Zašto

`UserStore::create()` prvo zapisuje korisnika pa izrađuje izolirani workspace. Ako izrada workspacea zakaže, njegov interni rollback može ostaviti prethodnu generaciju u `users.json.bak`. Dosadašnji `setup.php` catch brisao je `users.json` i `users.json.lock`, ali ne i `.bak`. Sljedeći request tada je mogao aktivirati `existingDataDetected` i zaključati setup iako su podaci nastali samo iz neuspjelog prvog pokušaja.

Rollback se izvršava samo u setup transakciji koja je započela nakon što je `existingDataDetected === false`, pa se ne brišu recovery podaci postojeće instalacije.

## Opseg

Nema promjene verzije ni korisničkog sadržaja. Stabilnosni/recovery bug-fix za ByFTP WEB 1.7.1.