### PR TITLE
Bind WEB profile credentials to account identity

### DIFF
--- a/ByFTP WEB/app/Storage/ProfileStore.php
+++ b/ByFTP WEB/app/Storage/ProfileStore.php
@@ -41,8 +41,8 @@ final class ProfileStore
 
     /**
      * Build and validate a connection profile from the current form without persisting it.
-     * Blank secrets on an existing profile preserve the stored value unless the matching
-     * clear_* flag is explicitly set.
+     * Blank secrets preserve stored values only while the endpoint/account binding remains
+     * unchanged. Key passphrases are additionally bound to the same private key material.
      */
     public function connectionDraft(array $input): array
     {
@@ -55,24 +55,32 @@ final class ProfileStore
             }
         }
 
+        $sameAccount = is_array($old) && self::accountMatches($old, $draft);
+        $sameSftpAccount = $sameAccount && $draft['protocol'] === 'sftp';
+        $oldPrivateKey = $sameSftpAccount ? (string)($old['private_key'] ?? '') : '';
+
         $password = $this->resolvePlainSecret(
             $draft['password'],
-            is_array($old) ? (string)($old['password'] ?? '') : '',
+            $sameAccount ? (string)($old['password'] ?? '') : '',
             $draft['clear_password']
         );
         $publicKey = $this->resolvePlainSecret(
             $draft['public_key'],
-            is_array($old) ? (string)($old['public_key'] ?? '') : '',
+            $sameSftpAccount ? (string)($old['public_key'] ?? '') : '',
             $draft['clear_key_material']
         );
         $privateKey = $this->resolvePlainSecret(
             $draft['private_key'],
-            is_array($old) ? (string)($old['private_key'] ?? '') : '',
+            $oldPrivateKey,
             $draft['clear_key_material']
         );
+        $samePrivateKey = $sameSftpAccount
+            && $oldPrivateKey !== ''
+            && $privateKey !== ''
+            && hash_equals($oldPrivateKey, $privateKey);
         $keyPassphrase = $this->resolvePlainSecret(
             $draft['key_passphrase'],
-            is_array($old) ? (string)($old['key_passphrase'] ?? '') : '',
+            $samePrivateKey ? (string)($old['key_passphrase'] ?? '') : '',
             $draft['clear_key_passphrase'] || $draft['clear_key_material']
         );
 
@@ -120,25 +128,38 @@ final class ProfileStore
             }
 
             $old = $existingIndex !== null && is_array($rows[$existingIndex] ?? null) ? $rows[$existingIndex] : null;
+            $oldPlain = is_array($old) ? $this->hydrate($old, true) : null;
+            $sameAccount = is_array($oldPlain) && self::accountMatches($oldPlain, $normalized);
+            $sameSftpAccount = $sameAccount && $normalized['protocol'] === 'sftp';
+            $oldPrivateKey = $sameSftpAccount ? (string)($oldPlain['private_key'] ?? '') : '';
+
             $passwordEnc = $this->resolveEncryptedSecret(
                 $normalized['password'],
-                is_array($old) ? (string)($old['password_enc'] ?? '') : '',
+                $sameAccount && is_array($old) ? (string)($old['password_enc'] ?? '') : '',
                 $normalized['clear_password'],
                 true
             );
             $publicKeyEnc = $this->resolveEncryptedSecret(
                 $normalized['public_key'],
-                is_array($old) ? (string)($old['public_key_enc'] ?? '') : '',
+                $sameSftpAccount && is_array($old) ? (string)($old['public_key_enc'] ?? '') : '',
                 $normalized['clear_key_material']
             );
             $privateKeyEnc = $this->resolveEncryptedSecret(
                 $normalized['private_key'],
-                is_array($old) ? (string)($old['private_key_enc'] ?? '') : '',
+                $sameSftpAccount && is_array($old) ? (string)($old['private_key_enc'] ?? '') : '',
                 $normalized['clear_key_material']
             );
+            $finalPrivateKey = '';
+            if (!$normalized['clear_key_material']) {
+                $finalPrivateKey = $normalized['private_key'] !== '' ? $normalized['private_key'] : $oldPrivateKey;
+            }
+            $samePrivateKey = $sameSftpAccount
+                && $oldPrivateKey !== ''
+                && $finalPrivateKey !== ''
+                && hash_equals($oldPrivateKey, $finalPrivateKey);
             $keyPassphraseEnc = $this->resolveEncryptedSecret(
                 $normalized['key_passphrase'],
-                is_array($old) ? (string)($old['key_passphrase_enc'] ?? '') : '',
+                $samePrivateKey && is_array($old) ? (string)($old['key_passphrase_enc'] ?? '') : '',
                 $normalized['clear_key_passphrase'] || $normalized['clear_key_material']
             );
 
@@ -263,6 +284,15 @@ final class ProfileStore
         $passive = !isset($input['passive']) || filter_var($input['passive'], FILTER_VALIDATE_BOOLEAN);
         $utf8 = !isset($input['utf8']) || filter_var($input['utf8'], FILTER_VALIDATE_BOOLEAN);
 
+        if ($protocol !== 'sftp') {
+            // SFTP-only trust/key state must never survive a protocol switch. Keeping it
+            // hidden in an FTP/FTPS profile could resurrect stale credentials later.
+            $fingerprint = '';
+            $publicKey = '';
+            $privateKey = '';
+            $keyPassphrase = '';
+        }
+
         if ($label === '' || $host === '' || $username === '') {
             throw new RuntimeException('Naziv, host i korisničko ime su obavezni.');
         }
@@ -344,6 +374,27 @@ final class ProfileStore
             return '';
         }
         return $newValue !== '' ? $newValue : $oldValue;
+    }
+
+    private static function accountMatches(array $old, array $next): bool
+    {
+        return self::endpointMatches($old, $next)
+            && hash_equals((string)($old['username'] ?? ''), (string)($next['username'] ?? ''));
+    }
+
+    private static function endpointMatches(array $old, array $next): bool
+    {
+        return (string)($old['protocol'] ?? '') === (string)($next['protocol'] ?? '')
+            && (int)($old['port'] ?? 0) === (int)($next['port'] ?? 0)
+            && hash_equals(
+                self::canonicalBindingHost((string)($old['host'] ?? '')),
+                self::canonicalBindingHost((string)($next['host'] ?? ''))
+            );
+    }
+
+    private static function canonicalBindingHost(string $host): string
+    {
+        return strtolower(rtrim($host, '.'));
     }
 
     private function hydrate(array $row, bool $withSecrets): array

--- a/ByFTP WEB/tests/unit.php
+++ b/ByFTP WEB/tests/unit.php
@@ -6,6 +6,11 @@ function byftp_truncate(string $value, int $length): string
     return substr($value, 0, $length);
 }
 
+function byftp_config(bool $fresh = false): array
+{
+    return ['secret_key' => base64_encode(str_repeat('K', 32))];
+}
+
 $testStorage = sys_get_temp_dir() . '/byftp-web-unit-' . bin2hex(random_bytes(6));
 define('BYFTP_STORAGE', $testStorage);
 
@@ -14,6 +19,8 @@ require __DIR__ . '/../app/Remote/RemoteClientInterface.php';
 require __DIR__ . '/../app/Operations/RemoteOperations.php';
 require __DIR__ . '/../app/Security/HostGuard.php';
 require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/Security/Crypto.php';
+require __DIR__ . '/../app/Storage/UserWorkspace.php';
 require __DIR__ . '/../app/Security/RateLimiter.php';
 require __DIR__ . '/../app/Storage/ProfileStore.php';
 
@@ -177,6 +184,133 @@ throws(fn() => $method->invoke($store, $bad), 'fingerprint edge whitespace rejec
 $bad = $base; $bad['username'] = "user\r\nnext";
 throws(fn() => $method->invoke($store, $bad), 'credential protocol controls rejected');
 
+$profileStore = new ProfileStore('profile-binding-test');
+$ftpBase = [
+    'label' => 'FTP binding',
+    'protocol' => 'ftp',
+    'host' => 'ftp.example.com',
+    'port' => '21',
+    'base_path' => '/',
+    'username' => 'alice',
+    'password' => 'secret-one',
+    'timeout' => '30',
+    'auth_method' => 'password',
+];
+$ftpSaved = $profileStore->save($ftpBase);
+$ftpId = (string)($ftpSaved['id'] ?? '');
+$sameAccount = $ftpBase;
+$sameAccount['id'] = $ftpId;
+$sameAccount['password'] = '';
+$profileStore->save($sameAccount);
+check(
+    (string)($profileStore->find($ftpId, true)['password'] ?? '') === 'secret-one',
+    'profile password preserved for same account'
+);
+$draftSame = $profileStore->connectionDraft($sameAccount);
+check((string)($draftSame['password'] ?? '') === 'secret-one', 'connection draft preserves password for same account');
+
+$changedEndpoint = $sameAccount;
+$changedEndpoint['host'] = 'other.example.com';
+$draftChanged = $profileStore->connectionDraft($changedEndpoint);
+check((string)($draftChanged['password'] ?? '') === '', 'connection draft clears password when endpoint changes');
+$profileStore->save($changedEndpoint);
+check(
+    (string)($profileStore->find($ftpId, true)['password'] ?? '') === '',
+    'profile password cleared when endpoint changes'
+);
+
+$changedEndpoint['host'] = 'ftp.example.com';
+$changedEndpoint['username'] = 'bob';
+$changedEndpoint['password'] = 'secret-two';
+$profileStore->save($changedEndpoint);
+$usernameChange = $changedEndpoint;
+$usernameChange['username'] = 'carol';
+$usernameChange['password'] = '';
+check(
+    (string)($profileStore->connectionDraft($usernameChange)['password'] ?? '') === '',
+    'connection draft clears password when username changes'
+);
+$profileStore->save($usernameChange);
+check(
+    (string)($profileStore->find($ftpId, true)['password'] ?? '') === '',
+    'profile password cleared when username changes'
+);
+
+$sftpSaved = $profileStore->save([
+    'label' => 'SFTP binding',
+    'protocol' => 'sftp',
+    'host' => 'sftp.example.com',
+    'port' => '22',
+    'base_path' => '/',
+    'username' => 'deploy',
+    'password' => '',
+    'timeout' => '30',
+    'host_fingerprint' => str_repeat('a', 64),
+    'auth_method' => 'key',
+    'public_key' => 'public-key-a',
+    'private_key' => 'private-key-a',
+    'key_passphrase' => 'passphrase-a',
+]);
+$sftpId = (string)($sftpSaved['id'] ?? '');
+$sftpChangedKey = [
+    'id' => $sftpId,
+    'label' => 'SFTP binding',
+    'protocol' => 'sftp',
+    'host' => 'sftp.example.com',
+    'port' => '22',
+    'base_path' => '/',
+    'username' => 'deploy',
+    'password' => '',
+    'timeout' => '30',
+    'host_fingerprint' => str_repeat('a', 64),
+    'auth_method' => 'key',
+    'public_key' => 'public-key-b',
+    'private_key' => 'private-key-b',
+    'key_passphrase' => '',
+];
+$profileStore->save($sftpChangedKey);
+$sftpAfterKeyChange = $profileStore->find($sftpId, true);
+check(
+    (string)($sftpAfterKeyChange['private_key'] ?? '') === 'private-key-b'
+        && (string)($sftpAfterKeyChange['key_passphrase'] ?? '') === '',
+    'key passphrase cleared when private key changes'
+);
+
+$sftpOtherHost = $sftpChangedKey;
+$sftpOtherHost['host'] = 'new-sftp.example.com';
+$sftpOtherHost['public_key'] = '';
+$sftpOtherHost['private_key'] = '';
+throws(
+    fn() => $profileStore->connectionDraft($sftpOtherHost),
+    'SFTP key material is not inherited across endpoint changes'
+);
+
+$profileStore->save([
+    'id' => $sftpId,
+    'label' => 'FTP after SFTP',
+    'protocol' => 'ftp',
+    'host' => 'ftp-after-sftp.example.com',
+    'port' => '21',
+    'base_path' => '/',
+    'username' => 'deploy',
+    'password' => 'ftp-secret',
+    'timeout' => '30',
+    'host_fingerprint' => str_repeat('b', 64),
+    'auth_method' => 'key',
+    'public_key' => 'must-not-survive',
+    'private_key' => 'must-not-survive',
+    'key_passphrase' => 'must-not-survive',
+]);
+$ftpAfterSftp = $profileStore->find($sftpId, true);
+check(
+    ($ftpAfterSftp['protocol'] ?? '') === 'ftp'
+        && ($ftpAfterSftp['host_fingerprint'] ?? '') === ''
+        && ($ftpAfterSftp['public_key'] ?? '') === ''
+        && ($ftpAfterSftp['private_key'] ?? '') === ''
+        && ($ftpAfterSftp['key_passphrase'] ?? '') === '',
+    'non-SFTP profile strips SFTP-only state'
+);
+
 $renameClient = new BatchRenameFakeClient(['/a' => 'A', '/x-a' => 'B'], 4);
 $renameOps = new RemoteOperations($renameClient);
 throws(
@@ -208,6 +342,15 @@ try {
         }
     }
     @rmdir($logDir);
+
+    $profileDir = BYFTP_STORAGE . '/users/profile-binding-test';
+    foreach (glob($profileDir . '/*') ?: [] as $path) {
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+    @rmdir($profileDir);
+    @rmdir(BYFTP_STORAGE . '/users');
     @rmdir(BYFTP_STORAGE);
 }
 


### PR DESCRIPTION
## Sažetak

- veže nasljeđivanje spremljene WEB lozinke uz isti protokol, host, port i točan username
- `connectionDraft()` i `save()` sada koriste ista pravila, pa test veze i spremanje profila ne mogu koristiti različite/stare vjerodajnice
- SFTP public/private key material nasljeđuje se samo za isti SFTP račun
- key passphrase nasljeđuje se samo ako je ostao isti privatni ključ
- prelazak sa SFTP na FTP/FTPS čisti fingerprint i sav SFTP-only key/passphrase state
- dodaje funkcionalne PHP regresijske testove koji stvarno spremaju i dešifriraju profile

## Sigurnosni problem

Dosadašnja logika tretirala je prazno secret polje kao `reuse old value` bez provjere identiteta profila. Zato je uređivanje hosta, porta, protokola ili usernamea uz prazno polje lozinke moglo prenijeti staru spremljenu vjerodajnicu na drugi račun/server. Isto je vrijedilo za SFTP key material i passphrase.

Desktop dio ByFTP-a već koristi strogo endpoint/account/private-key binding pravilo. Ovaj PR dovodi WEB backend na isti princip i provodi ga server-side, neovisno o UI-u.

## Regresijski testovi

Testovi provjeravaju da:
- lozinka ostaje dostupna kod uređivanja istog računa
- promjena endpointa briše naslijeđenu lozinku i u `connectionDraft()` i u spremljenom profilu
- promjena usernamea ne prenosi staru lozinku
- promjena privatnog SFTP ključa ne prenosi stari passphrase
- SFTP ključ se ne nasljeđuje na drugi endpoint
- FTP profil nakon SFTP-a nema fingerprint, public/private key ni passphrase

## Opseg

Nema promjene verzije ni korisničkog sadržaja. Sigurnosno/stabilnosni hardening za postojeći ByFTP 1.7.1.