### PR TITLE
Fix WEB user creation workspace transaction

### DIFF
--- a/ByFTP WEB/app/Storage/UserStore.php
+++ b/ByFTP WEB/app/Storage/UserStore.php
@@ -54,49 +54,41 @@ final class UserStore
             throw new RuntimeException('Nije moguće sigurno hashirati lozinku.');
         }
 
-        $created = null;
-        $this->store->update(function (array $rows) use ($name, $email, $hash, $role, &$created): array {
-            foreach ($rows as $row) {
-                if (is_array($row) && hash_equals((string)($row['email'] ?? ''), $email)) {
-                    throw new RuntimeException('Korisnički račun s tom e-mail adresom već postoji.');
-                }
-            }
-            $created = [
-                'id' => bin2hex(random_bytes(12)),
-                'name' => $name,
-                'email' => $email,
-                'password_hash' => $hash,
-                'role' => $role,
-                'active' => true,
-                'created_at' => gmdate('c'),
-                'updated_at' => gmdate('c'),
-                'last_login_at' => null,
-                'session_version' => 1,
-            ];
-            $rows[] = $created;
-            return array_values($rows);
-        });
+        // Prepare the isolated workspace before publishing the account in users.json.
+        // This prevents a failed workspace creation from ever becoming a valid registry
+        // generation (or JsonStore backup) that could later resurrect a ghost account.
+        $created = [
+            'id' => bin2hex(random_bytes(12)),
+            'name' => $name,
+            'email' => $email,
+            'password_hash' => $hash,
+            'role' => $role,
+            'active' => true,
+            'created_at' => gmdate('c'),
+            'updated_at' => gmdate('c'),
+            'last_login_at' => null,
+            'session_version' => 1,
+        ];
+        $createdId = (string)$created['id'];
+        UserWorkspace::ensure($createdId);
 
-        if (!is_array($created)) {
-            throw new RuntimeException('Korisnički račun nije izrađen.');
-        }
         try {
-            UserWorkspace::ensure((string)$created['id']);
+            $this->store->update(function (array $rows) use ($email, $created): array {
+                foreach ($rows as $row) {
+                    if (is_array($row) && hash_equals((string)($row['email'] ?? ''), $email)) {
+                        throw new RuntimeException('Korisnički račun s tom e-mail adresom već postoji.');
+                    }
+                }
+                $rows[] = $created;
+                return array_values($rows);
+            });
         } catch (\Throwable $e) {
-            // Keep account persistence and its isolated workspace transactional enough
-            // for shared hosting: a failed workspace must not leave a ghost account.
-            try {
-                $createdId = (string)$created['id'];
-                $this->store->update(static fn(array $rows): array => array_values(array_filter(
-                    $rows,
-                    static fn($row): bool => !is_array($row) || !hash_equals((string)($row['id'] ?? ''), $createdId)
-                )));
-                @rmdir(UserWorkspace::directory($createdId));
-            } catch (\Throwable) {
-                // Preserve the original storage failure; the admin can retry after fixing permissions.
-            }
+            // The workspace is still empty at this point because the caller cannot use
+            // the account until the registry write succeeds. Remove only that new path.
+            @rmdir(UserWorkspace::directory($createdId));
             throw $e;
         }
+
         return $this->publicUser($created);
     }
 

--- a/ByFTP WEB/tests/unit.php
+++ b/ByFTP WEB/tests/unit.php
@@ -21,6 +21,7 @@ require __DIR__ . '/../app/Security/HostGuard.php';
 require __DIR__ . '/../app/Storage/JsonStore.php';
 require __DIR__ . '/../app/Security/Crypto.php';
 require __DIR__ . '/../app/Storage/UserWorkspace.php';
+require __DIR__ . '/../app/Storage/UserStore.php';
 require __DIR__ . '/../app/Security/RateLimiter.php';
 require __DIR__ . '/../app/Storage/ProfileStore.php';
 
@@ -30,6 +31,7 @@ use ByFTP\Remote\RemoteClientInterface;
 use ByFTP\Security\HostGuard;
 use ByFTP\Security\RateLimiter;
 use ByFTP\Storage\ProfileStore;
+use ByFTP\Storage\UserStore;
 
 final class BatchRenameFakeClient implements RemoteClientInterface
 {
@@ -311,6 +313,28 @@ check(
     'non-SFTP profile strips SFTP-only state'
 );
 
+// Reproduce a shared-hosting workspace failure without relying on chmod semantics:
+// replace storage/users with a regular file so recursive user directory creation fails.
+$profileDir = BYFTP_STORAGE . '/users/profile-binding-test';
+foreach (glob($profileDir . '/*') ?: [] as $path) {
+    if (is_file($path)) {
+        @unlink($path);
+    }
+}
+@rmdir($profileDir);
+@rmdir(BYFTP_STORAGE . '/users');
+file_put_contents(BYFTP_STORAGE . '/users', 'workspace-blocker');
+$userStore = new UserStore();
+throws(
+    fn() => $userStore->create('Blocked User', 'blocked@example.com', 'strong-password-123', 'user'),
+    'user create fails before registry commit when workspace is unavailable'
+);
+check(
+    !is_file(BYFTP_STORAGE . '/users.json') && !is_file(BYFTP_STORAGE . '/users.json.bak'),
+    'failed user workspace leaves no registry or ghost backup generation'
+);
+@unlink(BYFTP_STORAGE . '/users');
+
 $renameClient = new BatchRenameFakeClient(['/a' => 'A', '/x-a' => 'B'], 4);
 $renameOps = new RemoteOperations($renameClient);
 throws(
@@ -350,7 +374,17 @@ try {
         }
     }
     @rmdir($profileDir);
+    if (is_file(BYFTP_STORAGE . '/users')) {
+        @unlink(BYFTP_STORAGE . '/users');
+    }
     @rmdir(BYFTP_STORAGE . '/users');
+    foreach ([
+        BYFTP_STORAGE . '/users.json',
+        BYFTP_STORAGE . '/users.json.bak',
+        BYFTP_STORAGE . '/users.json.lock',
+    ] as $path) {
+        @unlink($path);
+    }
     @rmdir(BYFTP_STORAGE);
 }
 


### PR DESCRIPTION
## Sažetak

- mijenja `UserStore::create()` tako da se izolirani korisnički workspace mora uspješno pripremiti prije upisa računa u `users.json`
- e-mail uniqueness i registry commit i dalje se izvršavaju atomskim `JsonStore::update()` pod lockom
- ako registry commit zakaže nakon pripreme workspacea, uklanja se samo novonastali prazni workspace
- uklanja stari rollback obrazac koji je nakon workspace greške radio drugi `JsonStore::update()` i time mogao spremiti ghost korisnika u `.bak` generaciju
- dodaje regresijski WEB unit test koji deterministički blokira `storage/users` i potvrđuje da ne nastaju ni `users.json` ni `users.json.bak`

## Problem

Dosadašnji redoslijed bio je `users.json commit -> UserWorkspace::ensure()`. Ako bi workspace izrada zakaže, rollback bi drugim `JsonStore::update()` uklonio račun iz primarne datoteke, ali bi prethodna generacija s novim korisnikom mogla završiti kao `users.json.bak`. U slučaju kasnijeg oporavka iz backupa takav ghost račun mogao bi se vratiti.

Novi redoslijed je `validate/hash -> generate id -> prepare empty workspace -> atomic registry commit`. Tako neuspjeli workspace nikada ne postaje valjana registry generacija.

## Regresijski test

Test privremeno postavlja `storage/users` kao običnu datoteku, zbog čega izrada `users/<id>` mora pasti. Nakon toga provjerava da `UserStore::create()` baca iznimku i da ne postoji ni primarna ni backup registry generacija.

## Opseg

Nema promjene verzije ni korisničkog sadržaja. Recovery/stability hardening za ByFTP WEB 1.7.1.