### PR TITLE
Fail closed on stale WEB user registry backups

### DIFF
--- a/ByFTP WEB/app/Storage/JsonStore.php
+++ b/ByFTP WEB/app/Storage/JsonStore.php
@@ -11,11 +11,14 @@ use RuntimeException;
  * - adjacent flock file coordinates readers/writers
  * - temp + rename prevents partial primary writes
  * - one last-known-good .bak generation improves recovery from external corruption
+ * - security-sensitive stores may disable automatic backup recovery and fail closed
  */
 final class JsonStore
 {
-    public function __construct(private readonly string $path)
-    {
+    public function __construct(
+        private readonly string $path,
+        private readonly bool $recoverFromBackup = true
+    ) {
     }
 
     public function read(array $fallback = []): array
@@ -88,6 +91,9 @@ final class JsonStore
     {
         if (!is_file($this->path)) {
             if (is_file($this->backupPath())) {
+                if (!$this->recoverFromBackup) {
+                    throw new RuntimeException('Primarna JSON datoteka nedostaje. Automatski oporavak iz sigurnosne kopije nije dopušten za ove podatke.');
+                }
                 return [$this->decodeFile($this->backupPath()), true];
             }
             return [$fallback, false];
@@ -96,7 +102,7 @@ final class JsonStore
         try {
             return [$this->decodeFile($this->path), false];
         } catch (RuntimeException $primaryError) {
-            if (!is_file($this->backupPath())) {
+            if (!$this->recoverFromBackup || !is_file($this->backupPath())) {
                 throw $primaryError;
             }
             try {

--- a/ByFTP WEB/app/Storage/UserStore.php
+++ b/ByFTP WEB/app/Storage/UserStore.php
@@ -11,7 +11,10 @@ final class UserStore
 
     public function __construct()
     {
-        $this->store = new JsonStore(BYFTP_STORAGE . '/users.json');
+        // Authentication/authorization state must never silently roll back to the
+        // previous generation after primary corruption. Keep users.json.bak for
+        // explicit operator recovery, but fail closed for runtime reads/updates.
+        $this->store = new JsonStore(BYFTP_STORAGE . '/users.json', false);
     }
 
     public function all(): array

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+use ByFTP\Storage\JsonStore;
+use ByFTP\Storage\UserStore;
+use ByFTP\Storage\UserWorkspace;
+
+$storage = sys_get_temp_dir() . '/byftp-user-registry-' . bin2hex(random_bytes(6));
+define('BYFTP_STORAGE', $storage);
+
+require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/Storage/UserWorkspace.php';
+require __DIR__ . '/../app/Storage/UserStore.php';
+
+$failed = false;
+
+function registry_check(bool $condition, string $label): void
+{
+    global $failed;
+    if ($condition) {
+        return;
+    }
+    $failed = true;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+function registry_throws(callable $callback, string $label): void
+{
+    try {
+        $callback();
+        registry_check(false, $label);
+    } catch (Throwable) {
+        registry_check(true, $label);
+    }
+}
+
+try {
+    $users = new UserStore();
+    $created = $users->create(
+        'Recovery User',
+        'recovery@example.com',
+        'old-password-123',
+        'user'
+    );
+    $userId = (string)($created['id'] ?? '');
+    registry_check($userId !== '', 'test user is created');
+
+    $users->changePassword(
+        $userId,
+        'old-password-123',
+        'new-password-456',
+        true
+    );
+
+    $backupPath = BYFTP_STORAGE . '/users.json.bak';
+    $backupRaw = @file_get_contents($backupPath);
+    $backupRows = is_string($backupRaw) ? json_decode($backupRaw, true) : null;
+    $backupHash = '';
+    if (is_array($backupRows)) {
+        foreach ($backupRows as $row) {
+            if (is_array($row) && ($row['id'] ?? '') === $userId) {
+                $backupHash = (string)($row['password_hash'] ?? '');
+                break;
+            }
+        }
+    }
+    registry_check(
+        $backupHash !== '' && password_verify('old-password-123', $backupHash),
+        'backup contains the prior password generation used by the regression scenario'
+    );
+
+    $primaryPath = BYFTP_STORAGE . '/users.json';
+    file_put_contents($primaryPath, '{corrupt-user-registry');
+
+    registry_throws(
+        fn() => (new UserStore())->authenticate('recovery@example.com', 'old-password-123'),
+        'UserStore fails closed instead of authenticating from stale backup after primary corruption'
+    );
+
+    $recoverableRows = (new JsonStore($primaryPath))->read();
+    registry_check(
+        is_array($recoverableRows) && count($recoverableRows) === 1,
+        'generic JsonStore recovery remains available for explicit/manual recovery paths'
+    );
+
+    @unlink($primaryPath);
+    registry_throws(
+        fn() => (new UserStore())->findByEmail('recovery@example.com'),
+        'UserStore fails closed when only a stale backup generation remains'
+    );
+} finally {
+    $usersDir = BYFTP_STORAGE . '/users';
+    if (is_dir($usersDir)) {
+        foreach (glob($usersDir . '/*') ?: [] as $path) {
+            if (is_dir($path)) {
+                @rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($usersDir);
+    }
+    foreach ([
+        BYFTP_STORAGE . '/users.json',
+        BYFTP_STORAGE . '/users.json.bak',
+        BYFTP_STORAGE . '/users.json.lock',
+    ] as $path) {
+        @unlink($path);
+    }
+    @rmdir(BYFTP_STORAGE);
+}
+
+if ($failed) {
+    fwrite(STDERR, "WEB_USER_REGISTRY_TEST=FAIL\n");
+    exit(1);
+}
+
+echo "WEB_USER_REGISTRY_TEST=PASS\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -82,6 +82,10 @@ def run_runtime_checks() -> tuple[int, int]:
     for path in php_files:
         run_checked([php, "-l", str(path)], label=f"PHP syntax: {path.relative_to(ROOT)}")
     run_checked([php, str(WEB / "tests" / "unit.php")], label="ByFTP WEB unit tests")
+    run_checked(
+        [php, str(WEB / "tests" / "user-registry.php")],
+        label="ByFTP WEB user registry fail-closed tests",
+    )
     for path in js_files:
         run_checked([node, "--check", str(path)], label=f"JavaScript syntax: {path.relative_to(ROOT)}")
     run_checked([node, "--check", str(WEB / "service-worker.js")], label="JavaScript syntax: ByFTP WEB/service-worker.js")
@@ -114,7 +118,7 @@ def main() -> int:
         "ByFTP WEB/assets/js/pwa.js", "ByFTP WEB/assets/js/settings.js",
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
-        "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -168,6 +172,17 @@ def main() -> int:
     if "trim((string)($input['host']" in profile_store:
         fail("profile host is normalized before fail-closed validation")
 
+    json_store = read("ByFTP WEB/app/Storage/JsonStore.php")
+    require(json_store, "private readonly bool $recoverFromBackup = true", "ByFTP WEB/app/Storage/JsonStore.php")
+    require(json_store, "if (!$this->recoverFromBackup)", "ByFTP WEB/app/Storage/JsonStore.php")
+
+    user_store = read("ByFTP WEB/app/Storage/UserStore.php")
+    require(
+        user_store,
+        "new JsonStore(BYFTP_STORAGE . '/users.json', false)",
+        "ByFTP WEB/app/Storage/UserStore.php",
+    )
+
     host_guard = read("ByFTP WEB/app/Security/HostGuard.php")
     for marker in ("connectionTargets", "FILTER_FLAG_NO_PRIV_RANGE", "FILTER_FLAG_NO_RES_RANGE", "localhost", "dns_get_record"):
         require(host_guard, marker, "ByFTP WEB/app/Security/HostGuard.php")
@@ -215,6 +230,15 @@ def main() -> int:
     for marker in ("22junk", "profile traversal rejected", "host edge whitespace rejected", "credential protocol controls rejected"):
         require(tests, marker, "ByFTP WEB/tests/unit.php")
 
+    registry_tests = read("ByFTP WEB/tests/user-registry.php")
+    for marker in (
+        "old-password-123",
+        "{corrupt-user-registry",
+        "fails closed instead of authenticating from stale backup",
+        "generic JsonStore recovery remains available",
+    ):
+        require(registry_tests, marker, "ByFTP WEB/tests/user-registry.php")
+
     allowed_storage = {
         "ByFTP WEB/storage/.htaccess",
         "ByFTP WEB/storage/logs/.gitkeep",
@@ -242,6 +266,7 @@ def main() -> int:
     print(f"WEB_PHP_SYNTAX_FILES={php_count}")
     print(f"WEB_JS_SYNTAX_FILES={js_count}")
     print("WEB_UNIT_TESTS=PASS")
+    print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")
     print("WEB_PWA_AUTHENTICATED_CACHE=BLOCKED")
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")


### PR DESCRIPTION
## Sažetak

- uvodi opciju `JsonStore` recovery politike uz kompatibilni default recovery način
- `UserStore` eksplicitno koristi fail-closed način za `users.json`
- oštećen ili nedostajući primarni auth registry više se ne zamjenjuje automatski starom `.bak` generacijom tijekom login/auth operacija
- `.bak` ostaje dostupan generic `JsonStore` recoveryju za ručni/namjerni oporavak
- dodaje zaseban funkcionalni WEB regression test koji stvara backup sa starom lozinkom, promijeni lozinku, ošteti primarni registry i potvrđuje da se stara lozinka ne može vratiti
- `audit_web.py` pokreće novi test i statički zahtijeva fail-closed `UserStore` konfiguraciju

## Sigurnosni problem

`JsonStore` je namjerno dizajniran da automatski koristi posljednju valjanu `.bak` generaciju ako primarna JSON datoteka nedostaje ili je oštećena. To je korisno za profile i druge podatke, ali je opasno za `users.json`: backup može sadržavati staru lozinku, staru `active` vrijednost, staru rolu ili staru `session_version`.

Ako bi se primarni `users.json` oštetio nakon sigurnosne promjene, automatski recovery mogao bi vratiti starije autentikacijsko stanje. Ovaj PR zato zadržava backup, ali authentication registry čita isključivo primarnu generaciju i fail-closed odbija operaciju ako ona nije valjana.

## Regresijska pokrivenost

Novi test potvrđuje:
- backup stvarno sadrži prethodnu lozinku
- nakon korupcije primarnog registra `UserStore::authenticate()` baca storage grešku umjesto korištenja stale backupa
- ako ostane samo `.bak`, `UserStore` i dalje fail-closed odbija čitanje
- generic `JsonStore` i dalje može čitati backup kada se recovery eksplicitno želi

## Opseg

Nema promjene verzije, UI-a ni korisničkog sadržaja. Security/recovery hardening za ByFTP WEB 1.7.1.