### PR TITLE
Keep successful WEB logins independent of limiter cleanup

### DIFF
--- a/ByFTP WEB/login.php
+++ b/ByFTP WEB/login.php
@@ -8,6 +8,29 @@ use ByFTP\Security\RateLimiter;
 use ByFTP\Storage\UserStore;
 use ByFTP\Storage\UserWorkspace;
 
+function byftp_clear_login_rate_limiters(
+    RateLimiter $accountLimiter,
+    string $accountKey,
+    RateLimiter $ipLimiter,
+    string $ipKey
+): void {
+    foreach ([
+        ['scope' => 'account', 'limiter' => $accountLimiter, 'key' => $accountKey],
+        ['scope' => 'ip', 'limiter' => $ipLimiter, 'key' => $ipKey],
+    ] as $entry) {
+        try {
+            $entry['limiter']->clear($entry['key']);
+        } catch (Throwable $e) {
+            // Authentication has already succeeded. A best-effort limiter reset must not
+            // turn a valid login into a false legacy-migration failure or destroy the session.
+            AppLogger::event('auth.rate_limit_clear_failed', [
+                'scope' => $entry['scope'],
+                'error' => byftp_truncate($e->getMessage(), 300),
+            ]);
+        }
+    }
+}
+
 if (!byftp_is_configured()) {
     byftp_redirect('setup');
 }
@@ -49,9 +72,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $next['version'] = BYFTP_VERSION;
                 $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
                 byftp_write_config($next);
-                $accountLimiter->clear($accountKey);
-                $ipLimiter->clear($ipKey);
-                Auth::attempt($email, $password);
+                if (!Auth::attempt($email, $password)) {
+                    throw new RuntimeException('Račun je izrađen, ali automatska prijava nije dovršena. Pokušaj se ponovno prijaviti.');
+                }
+                byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
                 AppLogger::event('auth.legacy_migrated', ['user_id' => $user['id']]);
                 byftp_redirect('app');
             } catch (Throwable $e) {
@@ -59,10 +83,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     } elseif (Auth::attempt($email, (string)($_POST['password'] ?? ''))) {
-        try {
-            // Recovery path for an interrupted legacy -> multi-user migration: the account may
-            // already exist while the legacy password marker/data still remain.
-            if (!empty($config['password_hash']) && Auth::isAdmin()) {
+        $migrationFailed = false;
+
+        // Recovery path for an interrupted legacy -> multi-user migration: the account may
+        // already exist while the legacy password marker/data still remain. Only this actual
+        // migration transaction is allowed to invalidate an otherwise successful login.
+        if (!empty($config['password_hash']) && Auth::isAdmin()) {
+            try {
                 UserWorkspace::migrateLegacy(Auth::id());
                 $next = $config;
                 unset($next['password_hash']);
@@ -70,15 +97,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
                 byftp_write_config($next);
                 AppLogger::event('auth.legacy_migration_recovered', ['user_id' => Auth::id()]);
+            } catch (Throwable $e) {
+                AppLogger::event('auth.legacy_migration_failed', [
+                    'user_id' => Auth::id(),
+                    'error' => byftp_truncate($e->getMessage(), 300),
+                ]);
+                Auth::logout();
+                $migrationFailed = true;
+                $error = 'Prijava je valjana, ali migracija starih ByFTP podataka nije dovršena. Provjeri dozvole storage direktorija i pokušaj ponovno.';
             }
-            $accountLimiter->clear($accountKey);
-            $ipLimiter->clear($ipKey);
+        }
+
+        if (!$migrationFailed) {
+            byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
             AppLogger::event('auth.login', ['email' => $email, 'user_id' => Auth::id()]);
             byftp_redirect('app');
-        } catch (Throwable $e) {
-            AppLogger::event('auth.legacy_migration_failed', ['user_id' => Auth::id(), 'error' => byftp_truncate($e->getMessage(), 300)]);
-            Auth::logout();
-            $error = 'Prijava je valjana, ali migracija starih ByFTP podataka nije dovršena. Provjeri dozvole storage direktorija i pokušaj ponovno.';
         }
     } else {
         $accountLimiter->hit($accountKey);

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -203,6 +203,20 @@ def main() -> int:
         require(auth, marker, "ByFTP WEB/app/Security/Auth.php")
     require(read("ByFTP WEB/app/bootstrap.php"), "'samesite' => 'Strict'", "ByFTP WEB/app/bootstrap.php")
 
+    login = read("ByFTP WEB/login.php")
+    for marker in (
+        "function byftp_clear_login_rate_limiters(",
+        "auth.rate_limit_clear_failed",
+        "if (!Auth::attempt($email, $password))",
+        "$migrationFailed = false;",
+        "if (!$migrationFailed)",
+    ):
+        require(login, marker, "ByFTP WEB/login.php")
+    if "$accountLimiter->clear(" in login or "$ipLimiter->clear(" in login:
+        fail("login performs direct post-auth limiter cleanup outside the fail-soft helper")
+    if login.count("Auth::logout();") != 1:
+        fail("login must invalidate an authenticated session only for the actual legacy migration failure path")
+
     setup = read("ByFTP WEB/setup.php")
     rollback_match = re.search(r"\$rollbackArtifacts\s*=\s*\[(.*?)\];", setup, re.DOTALL)
     if rollback_match is None:
@@ -267,6 +281,7 @@ def main() -> int:
     print(f"WEB_JS_SYNTAX_FILES={js_count}")
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
+    print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")
     print("WEB_PWA_AUTHENTICATED_CACHE=BLOCKED")
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")


### PR DESCRIPTION
## Sažetak

- izdvaja post-auth rate-limit reset u `byftp_clear_login_rate_limiters()`
- failure pri čišćenju account/IP limiter storagea više ne odjavljuje već uspješno autenticiranog korisnika
- cleanup failure dobiva poseban `auth.rate_limit_clear_failed` audit događaj
- samo stvarni interrupted legacy migration failure smije pozvati `Auth::logout()`
- legacy upgrade sada provjerava rezultat `Auth::attempt()` umjesto da ga ignorira
- `audit_web.py` statički čuva novi error-scoping ugovor

## Problem

Normalni login je nakon uspješnog `Auth::attempt()` stavljao legacy recovery, `RateLimiter::clear()`, audit logging i redirect u isti široki `try/catch`. Ako bi samo limiter storage reset zakaže, catch je događaj pogrešno bilježio kao `auth.legacy_migration_failed`, odjavio korisnika i prikazao poruku da migracija starih podataka nije dovršena — čak i kada legacy migracije uopće nije bilo.

`RateLimiter::clear()` zapisuje JsonStore i legitimno može baciti storage grešku kod problema s dozvolama/diskom. Takav best-effort cleanup ne smije poništiti već potvrđenu autentikaciju.

## Novo ponašanje

- legacy migration ostaje fail-closed
- limiter cleanup je fail-soft nakon uspješne autentikacije
- svaka cleanup greška se logira bez credentiala i bez rušenja sesije
- oba limitera se pokušavaju očistiti neovisno
- normalni korisnik nastavlja u aplikaciju čak ako cleanup storage privremeno nije dostupan

## CI ugovor

WEB audit zahtijeva helper i `auth.rate_limit_clear_failed`, zabranjuje direktni `$accountLimiter->clear()` / `$ipLimiter->clear()` u login flowu te provjerava da je `Auth::logout()` ograničen na jedan stvarni migration-failure path.

Nema promjene verzije, dizajna ni korisničkog sadržaja.