### PR TITLE
Make WEB user deletion retryable and symlink-safe

### DIFF
--- a/ByFTP WEB/app/Storage/UserStore.php
+++ b/ByFTP WEB/app/Storage/UserStore.php
@@ -122,6 +122,9 @@ final class UserStore
             }
             foreach ($rows as &$row) {
                 if (is_array($row) && hash_equals((string)($row['id'] ?? ''), $id)) {
+                    if (!empty($row['deleting'])) {
+                        throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Ponovi brisanje prije drugih izmjena.');
+                    }
                     $row['name'] = $name;
                     $row['email'] = $email;
                     $row['updated_at'] = gmdate('c');
@@ -144,6 +147,9 @@ final class UserStore
         $user = $this->findById($id);
         if (!$user) {
             throw new RuntimeException('Korisnik nije pronađen.');
+        }
+        if (!empty($user['deleting'])) {
+            throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Lozinku nije moguće mijenjati.');
         }
         if ($requireCurrent && !password_verify($currentPassword, (string)($user['password_hash'] ?? ''))) {
             throw new RuntimeException('Trenutačna lozinka nije točna.');
@@ -170,6 +176,9 @@ final class UserStore
                 if (!is_array($row) || !hash_equals((string)($row['id'] ?? ''), $id)) {
                     continue;
                 }
+                if (!empty($row['deleting'])) {
+                    throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Ponovi brisanje prije promjene prava.');
+                }
                 $wouldRemoveLastAdmin = ($row['role'] ?? '') === 'admin' && !empty($row['active']) && $admins <= 1 && ($role !== 'admin' || !$active);
                 if ($wouldRemoveLastAdmin) {
                     throw new RuntimeException('Mora ostati barem jedan aktivan administrator.');
@@ -194,10 +203,12 @@ final class UserStore
 
     public function delete(string $id): void
     {
-        $this->store->update(function (array $rows) use ($id): array {
+        $markedForDeletion = false;
+        $this->store->update(function (array $rows) use ($id, &$markedForDeletion): array {
+            $targetIndex = null;
             $target = null;
             $activeAdmins = 0;
-            foreach ($rows as $row) {
+            foreach ($rows as $index => $row) {
                 if (!is_array($row)) {
                     continue;
                 }
@@ -205,23 +216,71 @@ final class UserStore
                     $activeAdmins++;
                 }
                 if (hash_equals((string)($row['id'] ?? ''), $id)) {
+                    $targetIndex = $index;
                     $target = $row;
                 }
             }
-            if (!$target) {
+            if ($targetIndex === null || !is_array($target)) {
                 return $rows;
             }
             if (($target['role'] ?? '') === 'admin' && !empty($target['active']) && $activeAdmins <= 1) {
                 throw new RuntimeException('Nije moguće obrisati posljednjeg aktivnog administratora.');
             }
-            return array_values(array_filter($rows, static fn($row): bool => !is_array($row) || !hash_equals((string)($row['id'] ?? ''), $id)));
+
+            $row = $rows[$targetIndex];
+            if (empty($row['deleting'])) {
+                $row['deleting'] = true;
+                if (!empty($row['active'])) {
+                    $row['session_version'] = (int)($row['session_version'] ?? 1) + 1;
+                }
+                $row['active'] = false;
+                $row['updated_at'] = gmdate('c');
+                $rows[$targetIndex] = $row;
+            }
+            $markedForDeletion = true;
+            return array_values($rows);
         });
 
-        // User data deletion is explicit and complete; storage is never shared between users.
-        $directory = UserWorkspace::directory($id);
-        if (is_dir($directory)) {
-            $this->deleteDirectory($directory);
+        if (!$markedForDeletion) {
+            return;
         }
+
+        // Keep the inactive registry row until workspace cleanup is fully verified. If a
+        // filesystem operation fails, the administrator can safely retry deletion instead
+        // of losing the only registry reference to orphaned private data.
+        $directory = UserWorkspace::directory($id);
+        try {
+            if (is_link($directory)) {
+                // Never recurse through a workspace-root symlink. Only unlink the symlink
+                // itself so a manipulated workspace cannot delete an external directory.
+                if (!@unlink($directory) && is_link($directory)) {
+                    throw new RuntimeException('Nije moguće ukloniti simboličku poveznicu korisničkog workspacea.');
+                }
+            } elseif (is_dir($directory)) {
+                $this->deleteDirectory($directory);
+            } elseif (file_exists($directory)) {
+                if (!@unlink($directory) && file_exists($directory)) {
+                    throw new RuntimeException('Korisnički workspace nije direktorij i nije ga moguće ukloniti.');
+                }
+            }
+
+            if (is_link($directory) || is_dir($directory) || file_exists($directory)) {
+                throw new RuntimeException('Korisnički workspace nije u potpunosti uklonjen.');
+            }
+        } catch (\Throwable $e) {
+            throw new RuntimeException(
+                'Korisnički račun je deaktiviran, ali workspace nije moguće u potpunosti obrisati. Provjeri dozvole i ponovi brisanje: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+
+        // Final registry removal happens only after the private workspace is gone. If this
+        // write fails, the inactive deleting row remains and a retry can finish safely.
+        $this->store->update(static fn(array $rows): array => array_values(array_filter(
+            $rows,
+            static fn($row): bool => !is_array($row) || !hash_equals((string)($row['id'] ?? ''), $id)
+        )));
     }
 
     public function count(): int
@@ -252,6 +311,9 @@ final class UserStore
         $this->store->update(function (array $rows) use ($id, $hash): array {
             foreach ($rows as &$row) {
                 if (is_array($row) && hash_equals((string)($row['id'] ?? ''), $id)) {
+                    if (!empty($row['deleting'])) {
+                        throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Lozinku nije moguće mijenjati.');
+                    }
                     $row['password_hash'] = $hash;
                     $row['session_version'] = (int)($row['session_version'] ?? 1) + 1;
                     $row['updated_at'] = gmdate('c');
@@ -267,6 +329,7 @@ final class UserStore
     {
         unset($user['password_hash']);
         $user['active'] = !empty($user['active']);
+        $user['deleting'] = !empty($user['deleting']);
         $user['role'] = ($user['role'] ?? 'user') === 'admin' ? 'admin' : 'user';
         return $user;
     }
@@ -304,9 +367,16 @@ final class UserStore
 
     private function deleteDirectory(string $directory): void
     {
+        if (is_link($directory)) {
+            if (!@unlink($directory) && is_link($directory)) {
+                throw new RuntimeException('Nije moguće ukloniti simboličku poveznicu iz korisničkog workspacea.');
+            }
+            return;
+        }
+
         $items = @scandir($directory);
         if (!is_array($items)) {
-            return;
+            throw new RuntimeException('Nije moguće pročitati korisnički workspace radi brisanja.');
         }
         foreach ($items as $item) {
             if ($item === '.' || $item === '..') {
@@ -316,9 +386,13 @@ final class UserStore
             if (is_dir($path) && !is_link($path)) {
                 $this->deleteDirectory($path);
             } else {
-                @unlink($path);
+                if (!@unlink($path) && (file_exists($path) || is_link($path))) {
+                    throw new RuntimeException('Nije moguće ukloniti stavku iz korisničkog workspacea.');
+                }
             }
         }
-        @rmdir($directory);
+        if (!@rmdir($directory) && is_dir($directory)) {
+            throw new RuntimeException('Nije moguće ukloniti korisnički workspace direktorij.');
+        }
     }
 }

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -38,64 +38,70 @@ function registry_throws(callable $callback, string $label): void
 try {
     $users = new UserStore();
 
-    // A workspace root is normally a real private directory. If another local process
-    // replaces it with a symlink, deletion must unlink only the symlink and never recurse
-    // into the external target.
-    $symlinkUser = $users->create(
-        'Symlink User',
-        'symlink@example.com',
-        'symlink-password-123',
-        'user'
-    );
-    $symlinkId = (string)($symlinkUser['id'] ?? '');
-    $symlinkWorkspace = UserWorkspace::directory($symlinkId);
-    @rmdir($symlinkWorkspace);
-    @mkdir($externalTarget, 0700, true);
-    $externalSentinel = $externalTarget . '/sentinel.txt';
-    file_put_contents($externalSentinel, 'must-survive-user-delete');
-    $linkCreated = @symlink($externalTarget, $symlinkWorkspace);
-    registry_check($linkCreated && is_link($symlinkWorkspace), 'test workspace root symlink is created');
-    if ($linkCreated) {
-        $users->delete($symlinkId);
-        registry_check(is_file($externalSentinel), 'user deletion never traverses workspace root symlink target');
-        registry_check(!is_link($symlinkWorkspace), 'workspace root symlink itself is removed');
-        registry_check($users->findById($symlinkId) === null, 'symlink workspace user is removed after safe cleanup');
-    }
+    // These workspace deletion regressions intentionally exercise POSIX symlink and
+    // directory-permission semantics used by shared-hosting deployments. Windows runners
+    // still lint and execute the cross-platform registry tests below, but do not provide
+    // deterministic symlink privileges or chmod-based unlink denial.
+    if (PHP_OS_FAMILY !== 'Windows') {
+        // A workspace root is normally a real private directory. If another local process
+        // replaces it with a symlink, deletion must unlink only the symlink and never recurse
+        // into the external target.
+        $symlinkUser = $users->create(
+            'Symlink User',
+            'symlink@example.com',
+            'symlink-password-123',
+            'user'
+        );
+        $symlinkId = (string)($symlinkUser['id'] ?? '');
+        $symlinkWorkspace = UserWorkspace::directory($symlinkId);
+        @rmdir($symlinkWorkspace);
+        @mkdir($externalTarget, 0700, true);
+        $externalSentinel = $externalTarget . '/sentinel.txt';
+        file_put_contents($externalSentinel, 'must-survive-user-delete');
+        $linkCreated = @symlink($externalTarget, $symlinkWorkspace);
+        registry_check($linkCreated && is_link($symlinkWorkspace), 'test workspace root symlink is created');
+        if ($linkCreated) {
+            $users->delete($symlinkId);
+            registry_check(is_file($externalSentinel), 'user deletion never traverses workspace root symlink target');
+            registry_check(!is_link($symlinkWorkspace), 'workspace root symlink itself is removed');
+            registry_check($users->findById($symlinkId) === null, 'symlink workspace user is removed after safe cleanup');
+        }
 
-    // Force a cleanup failure with a non-writable nested directory. The account must stay
-    // in the registry as inactive/deleting so an administrator has a deterministic retry
-    // path instead of an invisible orphaned private workspace.
-    $retryUser = $users->create(
-        'Retry Delete User',
-        'retry-delete@example.com',
-        'retry-password-123',
-        'user'
-    );
-    $retryId = (string)($retryUser['id'] ?? '');
-    $retryWorkspace = UserWorkspace::directory($retryId);
-    $lockedDir = $retryWorkspace . '/locked';
-    @mkdir($lockedDir, 0700, true);
-    file_put_contents($lockedDir . '/private.json', '{"private":true}');
-    @chmod($lockedDir, 0500);
+        // Force a cleanup failure with a non-writable nested directory. The account must stay
+        // in the registry as inactive/deleting so an administrator has a deterministic retry
+        // path instead of an invisible orphaned private workspace.
+        $retryUser = $users->create(
+            'Retry Delete User',
+            'retry-delete@example.com',
+            'retry-password-123',
+            'user'
+        );
+        $retryId = (string)($retryUser['id'] ?? '');
+        $retryWorkspace = UserWorkspace::directory($retryId);
+        $lockedDir = $retryWorkspace . '/locked';
+        @mkdir($lockedDir, 0700, true);
+        file_put_contents($lockedDir . '/private.json', '{"private":true}');
+        @chmod($lockedDir, 0500);
 
-    $deleteFailed = false;
-    try {
+        $deleteFailed = false;
+        try {
+            $users->delete($retryId);
+        } catch (Throwable) {
+            $deleteFailed = true;
+        }
+        @chmod($lockedDir, 0700);
+
+        registry_check($deleteFailed, 'workspace cleanup failure is surfaced to the caller');
+        $pendingDelete = $users->findById($retryId);
+        registry_check(
+            is_array($pendingDelete) && !empty($pendingDelete['deleting']) && empty($pendingDelete['active']),
+            'failed workspace cleanup keeps an inactive retryable deleting registry row'
+        );
+
         $users->delete($retryId);
-    } catch (Throwable) {
-        $deleteFailed = true;
+        registry_check($users->findById($retryId) === null, 'retry completes registry deletion after workspace cleanup succeeds');
+        registry_check(!is_dir($retryWorkspace) && !is_link($retryWorkspace), 'retry removes the complete private workspace');
     }
-    @chmod($lockedDir, 0700);
-
-    registry_check($deleteFailed, 'workspace cleanup failure is surfaced to the caller');
-    $pendingDelete = $users->findById($retryId);
-    registry_check(
-        is_array($pendingDelete) && !empty($pendingDelete['deleting']) && empty($pendingDelete['active']),
-        'failed workspace cleanup keeps an inactive retryable deleting registry row'
-    );
-
-    $users->delete($retryId);
-    registry_check($users->findById($retryId) === null, 'retry completes registry deletion after workspace cleanup succeeds');
-    registry_check(!is_dir($retryWorkspace) && !is_link($retryWorkspace), 'retry removes the complete private workspace');
 
     // Existing authentication-registry recovery regression: the generic JSON store may
     // recover a backup, but UserStore must fail closed so old credentials cannot return.

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -6,6 +6,7 @@ use ByFTP\Storage\UserStore;
 use ByFTP\Storage\UserWorkspace;
 
 $storage = sys_get_temp_dir() . '/byftp-user-registry-' . bin2hex(random_bytes(6));
+$externalTarget = sys_get_temp_dir() . '/byftp-user-delete-target-' . bin2hex(random_bytes(6));
 define('BYFTP_STORAGE', $storage);
 
 require __DIR__ . '/../app/Storage/JsonStore.php';
@@ -36,6 +37,68 @@ function registry_throws(callable $callback, string $label): void
 
 try {
     $users = new UserStore();
+
+    // A workspace root is normally a real private directory. If another local process
+    // replaces it with a symlink, deletion must unlink only the symlink and never recurse
+    // into the external target.
+    $symlinkUser = $users->create(
+        'Symlink User',
+        'symlink@example.com',
+        'symlink-password-123',
+        'user'
+    );
+    $symlinkId = (string)($symlinkUser['id'] ?? '');
+    $symlinkWorkspace = UserWorkspace::directory($symlinkId);
+    @rmdir($symlinkWorkspace);
+    @mkdir($externalTarget, 0700, true);
+    $externalSentinel = $externalTarget . '/sentinel.txt';
+    file_put_contents($externalSentinel, 'must-survive-user-delete');
+    $linkCreated = @symlink($externalTarget, $symlinkWorkspace);
+    registry_check($linkCreated && is_link($symlinkWorkspace), 'test workspace root symlink is created');
+    if ($linkCreated) {
+        $users->delete($symlinkId);
+        registry_check(is_file($externalSentinel), 'user deletion never traverses workspace root symlink target');
+        registry_check(!is_link($symlinkWorkspace), 'workspace root symlink itself is removed');
+        registry_check($users->findById($symlinkId) === null, 'symlink workspace user is removed after safe cleanup');
+    }
+
+    // Force a cleanup failure with a non-writable nested directory. The account must stay
+    // in the registry as inactive/deleting so an administrator has a deterministic retry
+    // path instead of an invisible orphaned private workspace.
+    $retryUser = $users->create(
+        'Retry Delete User',
+        'retry-delete@example.com',
+        'retry-password-123',
+        'user'
+    );
+    $retryId = (string)($retryUser['id'] ?? '');
+    $retryWorkspace = UserWorkspace::directory($retryId);
+    $lockedDir = $retryWorkspace . '/locked';
+    @mkdir($lockedDir, 0700, true);
+    file_put_contents($lockedDir . '/private.json', '{"private":true}');
+    @chmod($lockedDir, 0500);
+
+    $deleteFailed = false;
+    try {
+        $users->delete($retryId);
+    } catch (Throwable) {
+        $deleteFailed = true;
+    }
+    @chmod($lockedDir, 0700);
+
+    registry_check($deleteFailed, 'workspace cleanup failure is surfaced to the caller');
+    $pendingDelete = $users->findById($retryId);
+    registry_check(
+        is_array($pendingDelete) && !empty($pendingDelete['deleting']) && empty($pendingDelete['active']),
+        'failed workspace cleanup keeps an inactive retryable deleting registry row'
+    );
+
+    $users->delete($retryId);
+    registry_check($users->findById($retryId) === null, 'retry completes registry deletion after workspace cleanup succeeds');
+    registry_check(!is_dir($retryWorkspace) && !is_link($retryWorkspace), 'retry removes the complete private workspace');
+
+    // Existing authentication-registry recovery regression: the generic JSON store may
+    // recover a backup, but UserStore must fail closed so old credentials cannot return.
     $created = $users->create(
         'Recovery User',
         'recovery@example.com',
@@ -89,10 +152,30 @@ try {
         'UserStore fails closed when only a stale backup generation remains'
     );
 } finally {
+    if (is_dir($externalTarget)) {
+        @unlink($externalTarget . '/sentinel.txt');
+        @rmdir($externalTarget);
+    }
+
     $usersDir = BYFTP_STORAGE . '/users';
     if (is_dir($usersDir)) {
         foreach (glob($usersDir . '/*') ?: [] as $path) {
+            if (is_link($path)) {
+                @unlink($path);
+                continue;
+            }
             if (is_dir($path)) {
+                foreach (glob($path . '/*') ?: [] as $child) {
+                    if (is_dir($child) && !is_link($child)) {
+                        @chmod($child, 0700);
+                        foreach (glob($child . '/*') ?: [] as $nested) {
+                            @unlink($nested);
+                        }
+                        @rmdir($child);
+                    } else {
+                        @unlink($child);
+                    }
+                }
                 @rmdir($path);
             } else {
                 @unlink($path);


### PR DESCRIPTION
## Sažetak

- user deletion sada prvo označava račun `deleting=true` i deaktivira ga prije filesystem cleanupa
- workspace se mora verificirano obrisati prije završnog uklanjanja korisnika iz `users.json`
- ako cleanup zakaže, deaktivirani registry red ostaje dostupan administratoru za siguran retry
- root `storage/users/<id>` symlink se više nikad ne traversa; uklanja se samo sam symlink
- nested cleanup više ne potiskuje `scandir`/`unlink`/`rmdir` greške
- deleting račun ne može se reaktivirati, mijenjati mu prava/profil ili lozinku dok se brisanje ne dovrši
- postojeći user-registry regression test proširen je symlink i cleanup-retry scenarijima

## Sigurnosni/privacy problem

Dosadašnji `UserStore::delete()` prvo je uklanjao korisnika iz registra, a zatim best-effort brisao workspace. `deleteDirectory()` je potiskivao filesystem greške, pa privatni podaci mogu ostati kao nevidljiv orphan iako UI kaže da su račun i workspace obrisani.

Dodatno, unutarnji symlinkovi bili su tretirani kao linkovi, ali root workspace nije imao isti guard. Ako bi `storage/users/<id>` bio zamijenjen symlinkom prema drugom direktoriju, rekurzivni cleanup mogao je pratiti target i brisati sadržaj izvan korisničkog workspacea.

## Novo ponašanje

1. provjeri zaštitu zadnjeg aktivnog administratora
2. označi račun kao deleting, deaktiviraj ga i opozovi sesiju
3. sigurno i verificirano očisti workspace
4. tek nakon uspješnog cleanupa ukloni registry red
5. kod greške račun ostaje inactive/deleting i ponovno brisanje nastavlja cleanup

## Regresijska pokrivenost

Testovi potvrđuju da:
- root workspace symlink ne briše target/sentinel datoteku
- briše se samo symlink
- prisiljena filesystem cleanup greška ostavlja račun `active=false, deleting=true`
- nakon vraćanja dozvola drugi delete dovršava workspace i registry cleanup
- postojeći stale users.json backup fail-closed test i dalje prolazi

Nema promjene verzije ni UI sadržaja; security/privacy/stability hardening za ByFTP WEB 1.7.1.