### PR TITLE
Make WEB audit subprocess decoding UTF-8 safe

### DIFF
--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -33,7 +33,11 @@ def require(text: str, marker: str, where: str) -> None:
 def tracked_web_files() -> list[str]:
     try:
         output = subprocess.check_output(
-            ["git", "ls-files", "--", "ByFTP WEB"], cwd=ROOT, text=True
+            ["git", "ls-files", "--", "ByFTP WEB"],
+            cwd=ROOT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         fail(f"git ls-files failed for ByFTP WEB: {exc}")
@@ -46,6 +50,8 @@ def run_checked(command: list[str], *, label: str, cwd: Path = ROOT) -> None:
             command,
             cwd=cwd,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=False,
@@ -282,6 +288,7 @@ def main() -> int:
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")
+    print("WEB_SUBPROCESS_TEXT_ENCODING=UTF8_REPLACE")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")
     print("WEB_PWA_AUTHENTICATED_CACHE=BLOCKED")
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
+import audit_web
 from verify_bundle import MANIFEST, required_members, verify_bundle
 
 VERSION = "9.8.7"
@@ -34,6 +37,36 @@ def write_bundle(path: Path, members: dict[str, bytes], *, manifest_override: st
         for name, data in members.items():
             zf.writestr(name, data)
         zf.writestr(MANIFEST, manifest.encode("ascii"))
+
+
+class AuditWebSubprocessTests(unittest.TestCase):
+    def test_run_checked_pins_utf8_decoding(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+            captured.update(kwargs)
+            return SimpleNamespace(returncode=0, stdout="Greška: čćžšđ")
+
+        with mock.patch.object(audit_web.subprocess, "run", side_effect=fake_run):
+            audit_web.run_checked(["fake-command"], label="UTF-8 regression")
+
+        self.assertEqual(captured.get("encoding"), "utf-8")
+        self.assertEqual(captured.get("errors"), "replace")
+        self.assertIs(captured.get("text"), True)
+
+    def test_tracked_files_pins_utf8_decoding(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_check_output(command: list[str], **kwargs: object) -> str:
+            captured.update(kwargs)
+            return "ByFTP WEB/README.md\n"
+
+        with mock.patch.object(audit_web.subprocess, "check_output", side_effect=fake_check_output):
+            self.assertEqual(audit_web.tracked_web_files(), ["ByFTP WEB/README.md"])
+
+        self.assertEqual(captured.get("encoding"), "utf-8")
+        self.assertEqual(captured.get("errors"), "replace")
+        self.assertIs(captured.get("text"), True)
 
 
 class VerifyBundleTests(unittest.TestCase):


### PR DESCRIPTION
## Sažetak

- `scripts/audit_web.py` više ne koristi platform-default text encoding za child procese
- `subprocess.run()` sada eksplicitno koristi `encoding="utf-8"` i `errors="replace"`
- `git ls-files` decoding također je eksplicitno UTF-8
- dodana su dva Python regression testa koja mockom provjeravaju oba subprocess ugovora

## Potvrđeni problem

Windows build u Checks #1094 nije pao zbog ByFTP produkcijskog koda nego zato što je Python 3.14 na Windows runneru `subprocess.run(..., text=True)` pokušao dekodirati UTF-8 hrvatski output kroz cp1252 i završio s `UnicodeDecodeError` prije nego što je WEB audit mogao prikazati stvarnu PHP poruku.

Audit alat ne smije ovisiti o lokalnom OS codepageu. ByFTP source i test output su UTF-8, pa se child-process output sada eksplicitno čita kao UTF-8. `errors="replace"` osigurava da čak ni nekonformni byte output ne sruši audit prije dijagnostike stvarnog command failurea.

## Regresijska pokrivenost

`test_release_tools.py` sada provjerava da:
- `audit_web.run_checked()` prosljeđuje `encoding="utf-8"`, `errors="replace"`, `text=True`
- `tracked_web_files()` koristi isti encoding ugovor za `git ls-files`

Nema promjene runtime ByFTP aplikacije, verzije, UI-a ni korisničkog sadržaja. Ovo je cross-platform CI/release stability hardening.