### PR TITLE
Fail closed on stale WEB rate-limit backups

### DIFF
--- a/ByFTP WEB/app/Security/RateLimiter.php
+++ b/ByFTP WEB/app/Security/RateLimiter.php
@@ -16,9 +16,17 @@ final class RateLimiter
         return BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
     }
 
+    private function store(string $key): JsonStore
+    {
+        // Login/registration attempt counters are security state. Never roll them back
+        // to an older .bak generation after primary corruption or loss because that can
+        // reduce the observed attempt count and weaken brute-force protection.
+        return new JsonStore($this->path($key), false);
+    }
+
     public function blocked(string $key): bool
     {
-        $data = (new JsonStore($this->path($key)))->read(['first' => time(), 'count' => 0]);
+        $data = $this->store($key)->read(['first' => time(), 'count' => 0]);
         if ((int)($data['first'] ?? 0) + $this->window < time()) {
             $this->clear($key);
             return false;
@@ -28,7 +36,7 @@ final class RateLimiter
 
     public function hit(string $key): void
     {
-        (new JsonStore($this->path($key)))->update(function (array $data): array {
+        $this->store($key)->update(function (array $data): array {
             if ((int)($data['first'] ?? 0) + $this->window < time()) {
                 $data = ['first' => time(), 'count' => 0];
             }
@@ -44,6 +52,6 @@ final class RateLimiter
         // JsonStore keeps a last-known-good .bak generation; deleting only the
         // primary would make the next read restore stale failed-login attempts.
         // Reusing the same lock file also preserves cross-request serialization.
-        (new JsonStore($this->path($key)))->write(['first' => time(), 'count' => 0]);
+        $this->store($key)->write(['first' => time(), 'count' => 0]);
     }
 }

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use ByFTP\Security\RateLimiter;
 use ByFTP\Storage\JsonStore;
 use ByFTP\Storage\UserStore;
 use ByFTP\Storage\UserWorkspace;
@@ -12,6 +13,7 @@ define('BYFTP_STORAGE', $storage);
 require __DIR__ . '/../app/Storage/JsonStore.php';
 require __DIR__ . '/../app/Storage/UserWorkspace.php';
 require __DIR__ . '/../app/Storage/UserStore.php';
+require __DIR__ . '/../app/Security/RateLimiter.php';
 
 $failed = false;
 
@@ -103,6 +105,33 @@ try {
         registry_check(!is_dir($retryWorkspace) && !is_link($retryWorkspace), 'retry removes the complete private workspace');
     }
 
+    // Rate-limit counters are security state too. Build a valid backup containing a lower
+    // attempt count, then corrupt/remove the primary. The limiter must never roll back to
+    // that older count because doing so would weaken brute-force protection.
+    $rateKey = 'login:203.0.113.50';
+    $limiter = new RateLimiter(3, 3600);
+    $limiter->hit($rateKey);
+    $limiter->hit($rateKey);
+    $ratePath = BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $rateKey) . '.json';
+    $rateBackup = $ratePath . '.bak';
+    $rateBackupRaw = @file_get_contents($rateBackup);
+    $rateBackupData = is_string($rateBackupRaw) ? json_decode($rateBackupRaw, true) : null;
+    registry_check(
+        is_array($rateBackupData) && (int)($rateBackupData['count'] ?? 0) === 1,
+        'rate-limit backup contains the prior lower attempt count used by the regression scenario'
+    );
+
+    file_put_contents($ratePath, '{corrupt-rate-limit-state');
+    registry_throws(
+        fn() => $limiter->blocked($rateKey),
+        'rate limiter fails closed instead of recovering a lower stale attempt count after primary corruption'
+    );
+    @unlink($ratePath);
+    registry_throws(
+        fn() => $limiter->blocked($rateKey),
+        'rate limiter fails closed when only an older backup attempt count remains'
+    );
+
     // Existing authentication-registry recovery regression: the generic JSON store may
     // recover a backup, but UserStore must fail closed so old credentials cannot return.
     $created = $users->create(
@@ -161,6 +190,14 @@ try {
     if (is_dir($externalTarget)) {
         @unlink($externalTarget . '/sentinel.txt');
         @rmdir($externalTarget);
+    }
+
+    $logsDir = BYFTP_STORAGE . '/logs';
+    if (is_dir($logsDir)) {
+        foreach (glob($logsDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        @rmdir($logsDir);
     }
 
     $usersDir = BYFTP_STORAGE . '/users';


### PR DESCRIPTION
## Sažetak

- `RateLimiter` sada koristi `JsonStore(..., false)` za sve attempt-counter operacije
- oštećen ili nestao primarni rate-limit JSON više ne vraća automatski stariji `.bak` s manjim brojem pokušaja
- `blocked()`, `hit()` i `clear()` koriste isti security-state store helper
- postojeći WEB security-state runtime test proširen je korupcija/backup-only scenarijem

## Sigurnosni problem

Rate-limit counter je autentikacijsko sigurnosno stanje. Dosadašnji generic `JsonStore` recovery mogao je nakon korupcije primarnog limiter JSON-a učitati prethodnu `.bak` generaciju. Budući da backup tipično sadrži jedan pokušaj manje, to može smanjiti efektivni broj zabilježenih neuspjelih prijava i oslabiti brute-force zaštitu.

## Regresijska pokrivenost

Test:
- napravi dva `hit()` poziva
- potvrđuje da backup namjerno sadrži prethodni `count=1`
- korumpira primarni limiter JSON i zahtijeva da `blocked()` baci storage grešku umjesto stale recoveryja
- uklanja primarni zapis i ponovno potvrđuje fail-closed kad ostane samo backup

Generic JsonStore backup recovery ostaje dostupan za nesigurnosne/ručne recovery tokove; promjena je ograničena na RateLimiter.

Nema promjene verzije, UI-a ni korisničkog sadržaja.