### PR TITLE
Fail closed on stale WEB app config backups

### DIFF
--- a/ByFTP WEB/app/helpers.php
+++ b/ByFTP WEB/app/helpers.php
@@ -40,9 +40,13 @@ function byftp_config(bool $fresh = false): array
         $path = byftp_config_path();
         if (!is_file($path) && !is_file($path . '.bak')) {
             $GLOBALS['byftp_config_cache'] = [];
+            unset($GLOBALS['byftp_config_error']);
         } else {
             try {
-                $GLOBALS['byftp_config_cache'] = (new ByFTP\Storage\JsonStore($path))->read([]);
+                // app.json contains the encryption key and runtime security policy.
+                // Keep the adjacent .bak for explicit operator recovery, but never
+                // silently roll security settings back to an older generation.
+                $GLOBALS['byftp_config_cache'] = (new ByFTP\Storage\JsonStore($path, false))->read([]);
                 unset($GLOBALS['byftp_config_error']);
             } catch (Throwable $e) {
                 // Fail closed into recovery/setup instead of crashing every request.
@@ -59,11 +63,20 @@ function byftp_write_config(array $data): void
     $store = new ByFTP\Storage\JsonStore(byftp_config_path());
     $store->write($data);
     $GLOBALS['byftp_config_cache'] = $data;
+    unset($GLOBALS['byftp_config_error']);
 }
 
 function byftp_update_config(array $changes): array
 {
-    $next = array_replace(byftp_config(true), $changes);
+    $current = byftp_config(true);
+    if (isset($GLOBALS['byftp_config_error'])) {
+        throw new RuntimeException('Konfiguracija aplikacije nije čitljiva. Vrati storage/app.json iz provjerene sigurnosne kopije prije spremanja postavki.');
+    }
+    $key = base64_decode((string)($current['secret_key'] ?? ''), true);
+    if (!is_string($key) || strlen($key) !== 32) {
+        throw new RuntimeException('Konfiguracija aplikacije nema valjan encryption ključ. Postavke nisu spremljene.');
+    }
+    $next = array_replace($current, $changes);
     byftp_write_config($next);
     return $next;
 }
@@ -259,7 +272,6 @@ function byftp_upload_error_message(int $code, string $name = ''): string
     };
 }
 
-
 function byftp_assert_temp_capacity(int $expectedBytes, int $reserveBytes = 16777216): void
 {
     if ($expectedBytes <= 0) {
@@ -305,7 +317,6 @@ function byftp_cleanup_stale_temp_files(int $maxAgeSeconds = 86400, int $maxFile
     }
     return $removed;
 }
-
 
 function byftp_session_limits(?array $config = null): array
 {

--- a/ByFTP WEB/setup.php
+++ b/ByFTP WEB/setup.php
@@ -43,10 +43,13 @@ $hasStoredData = static function (): bool {
     }
     return false;
 };
-$existingDataDetected = $hasStoredData();
-$error = $existingDataDetected
-    ? 'Pronađeni su postojeći ByFTP korisnički podaci, ali nedostaje konfiguracija s encryption ključem. Vrati storage/app.json ili storage/app.json.bak iz sigurnosne kopije prije nastavka.'
-    : '';
+$configRecoveryRequired = isset($GLOBALS['byftp_config_error']);
+$existingDataDetected = $configRecoveryRequired || $hasStoredData();
+$error = $configRecoveryRequired
+    ? 'Konfiguracija aplikacije nije čitljiva. Automatski povratak na stariji app.json.bak je blokiran radi sigurnosti. Vrati provjereni storage/app.json prije nastavka.'
+    : ($existingDataDetected
+        ? 'Pronađeni su postojeći ByFTP korisnički podaci, ali nedostaje konfiguracija s encryption ključem. Vrati storage/app.json ili storage/app.json.bak iz sigurnosne kopije prije nastavka.'
+        : '');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $appName = trim((string)($_POST['app_name'] ?? 'ByFTP')) ?: 'ByFTP';
@@ -57,8 +60,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $allowRegistration = !empty($_POST['allow_registration']);
 
     if ($existingDataDetected) {
-        // Never rotate the encryption key while encrypted user/profile data still exists.
-        $error = 'Postavljanje je zaključano radi zaštite postojećih podataka. Vrati storage/app.json ili storage/app.json.bak iz sigurnosne kopije.';
+        // Never rotate the encryption key while encrypted user/profile data still exists
+        // or while the primary configuration requires explicit operator recovery.
+        $error = 'Postavljanje je zaključano radi zaštite postojećih podataka i sigurnosnih postavki. Vrati provjereni storage/app.json prije nastavka.';
     } elseif (!byftp_verify_csrf(is_string($_POST['csrf'] ?? null) ? $_POST['csrf'] : null)) {
         $error = 'Sigurnosni token nije valjan. Osvježi stranicu.';
     } elseif ($password !== $confirm) {
@@ -76,13 +80,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $error = 'Nije moguće zaključati instalaciju. Provjeri dozvole storage direktorija i pokušaj ponovno.';
         } else {
             @chmod(BYFTP_STORAGE . '/setup.lock', 0600);
+            $setupTransactionStarted = false;
             try {
                 // Re-check under an exclusive lock so two simultaneous first-run requests
                 // cannot create different encryption keys or competing administrator accounts.
                 if (byftp_is_configured()) {
                     byftp_redirect('login');
                 }
+                if (isset($GLOBALS['byftp_config_error'])) {
+                    throw new RuntimeException('Konfiguracija aplikacije zahtijeva ručni oporavak. Novi setup nije pokrenut.');
+                }
 
+                $setupTransactionStarted = true;
                 $config = [
                     'app_name' => byftp_truncate($appName, 80),
                     'secret_key' => base64_encode(random_bytes(32)),
@@ -98,24 +107,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 AppLogger::event('install.complete', ['email' => strtolower($email)]);
                 byftp_redirect('login', ['installed' => 1]);
             } catch (Throwable $e) {
-                // existingDataDetected was false before this setup transaction. Therefore
-                // these config/user JSON generations and lock files can only be empty
-                // pre-existing scaffolding or artifacts created by this failed attempt.
-                // Remove the complete JsonStore generations so a stale users.json.bak
-                // cannot be mistaken for recoverable production data on the next request.
-                $rollbackArtifacts = [
-                    byftp_config_path(),
-                    byftp_config_path() . '.bak',
-                    byftp_config_path() . '.lock',
-                    BYFTP_STORAGE . '/users.json',
-                    BYFTP_STORAGE . '/users.json.bak',
-                    BYFTP_STORAGE . '/users.json.lock',
-                ];
-                foreach ($rollbackArtifacts as $artifact) {
-                    @unlink($artifact);
+                // Only a transaction that passed the recovery guards may remove setup
+                // artifacts. A pre-existing corrupt/missing primary config must be left
+                // untouched so an operator can restore it from a verified backup.
+                if ($setupTransactionStarted) {
+                    $rollbackArtifacts = [
+                        byftp_config_path(),
+                        byftp_config_path() . '.bak',
+                        byftp_config_path() . '.lock',
+                        BYFTP_STORAGE . '/users.json',
+                        BYFTP_STORAGE . '/users.json.bak',
+                        BYFTP_STORAGE . '/users.json.lock',
+                    ];
+                    foreach ($rollbackArtifacts as $artifact) {
+                        @unlink($artifact);
+                    }
+                    $GLOBALS['byftp_config_cache'] = [];
+                    unset($GLOBALS['byftp_config_error']);
                 }
-                $GLOBALS['byftp_config_cache'] = [];
-                unset($GLOBALS['byftp_config_error']);
                 $error = $e->getMessage();
             } finally {
                 flock($setupLock, LOCK_UN);
@@ -140,7 +149,7 @@ $pageTitle = 'Postavljanje ByFTP';
     <?php if ($error): ?><div class="alert error" role="alert"><?= byftp_e($error) ?></div><?php endif; ?>
     <?php if ($existingDataDetected): ?>
         <div class="stack">
-            <p class="muted">Novi setup bi izradio novi encryption ključ i postojeće spremljene FTP/SFTP vjerodajnice više se ne bi mogle dešifrirati. Ne briši <code>storage/users/</code> niti postojeće JSON datoteke dok ne vratiš konfiguraciju.</p>
+            <p class="muted">Novi setup bi mogao izraditi novi encryption ključ ili vratiti stariju sigurnosnu politiku. Ne briši <code>storage/users/</code> niti postojeće JSON datoteke. Vrati provjereni <code>storage/app.json</code> prije nastavka.</p>
         </div>
     <?php else: ?>
     <form method="post" class="stack auth-form" autocomplete="off">

--- a/ByFTP WEB/tests/config-security.php
+++ b/ByFTP WEB/tests/config-security.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+use ByFTP\Storage\JsonStore;
+
+$storage = sys_get_temp_dir() . '/byftp-config-security-' . bin2hex(random_bytes(6));
+define('BYFTP_STORAGE', $storage);
+
+require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/helpers.php';
+
+$failed = false;
+
+function config_check(bool $condition, string $label): void
+{
+    global $failed;
+    if ($condition) {
+        return;
+    }
+    $failed = true;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+function config_throws(callable $callback, string $label): void
+{
+    try {
+        $callback();
+        config_check(false, $label);
+    } catch (Throwable) {
+        config_check(true, $label);
+    }
+}
+
+try {
+    @mkdir(BYFTP_STORAGE, 0700, true);
+    $path = byftp_config_path();
+    $key = base64_encode(str_repeat('C', 32));
+
+    $oldConfig = [
+        'app_name' => 'ByFTP',
+        'secret_key' => $key,
+        'allow_registration' => true,
+        'allow_private_hosts' => true,
+        'session_idle_minutes' => 240,
+        'session_max_hours' => 48,
+        'version' => '1.7.1',
+    ];
+    $currentConfig = [
+        'app_name' => 'ByFTP',
+        'secret_key' => $key,
+        'allow_registration' => false,
+        'allow_private_hosts' => false,
+        'session_idle_minutes' => 60,
+        'session_max_hours' => 8,
+        'version' => '1.7.1',
+    ];
+
+    $store = new JsonStore($path);
+    $store->write($oldConfig);
+    $store->write($currentConfig);
+
+    $backupRaw = @file_get_contents($path . '.bak');
+    $backup = is_string($backupRaw) ? json_decode($backupRaw, true) : null;
+    config_check(
+        is_array($backup)
+            && !empty($backup['allow_registration'])
+            && !empty($backup['allow_private_hosts'])
+            && (int)($backup['session_idle_minutes'] ?? 0) === 240,
+        'backup contains the older, less restrictive security policy used by the regression scenario'
+    );
+
+    file_put_contents($path, '{corrupt-app-config');
+    $config = byftp_config(true);
+    config_check($config === [], 'runtime config does not recover stale app.json backup automatically');
+    config_check(isset($GLOBALS['byftp_config_error']), 'runtime config exposes recovery-required state');
+    config_check(!byftp_registration_enabled(), 'registration fails closed while config recovery is required');
+    config_check(!byftp_private_hosts_allowed(), 'private host access fails closed while config recovery is required');
+
+    $corruptPrimary = (string)@file_get_contents($path);
+    config_throws(
+        fn() => byftp_update_config(['allow_registration' => true]),
+        'config update is blocked while the primary config is corrupt'
+    );
+    config_check(
+        (string)@file_get_contents($path) === $corruptPrimary,
+        'blocked config update does not replace the corrupt primary or encryption state'
+    );
+
+    $manualRecovery = (new JsonStore($path))->read();
+    config_check(
+        !empty($manualRecovery['allow_registration']) && !empty($manualRecovery['allow_private_hosts']),
+        'generic JsonStore still exposes backup data for explicit operator recovery'
+    );
+
+    @unlink($path);
+    $backupOnly = byftp_config(true);
+    config_check($backupOnly === [], 'runtime config fails closed when only app.json.bak remains');
+    config_check(isset($GLOBALS['byftp_config_error']), 'backup-only config remains marked for manual recovery');
+    config_check(!byftp_is_configured(), 'backup-only stale config does not silently configure the application');
+} finally {
+    foreach ([
+        BYFTP_STORAGE . '/app.json',
+        BYFTP_STORAGE . '/app.json.bak',
+        BYFTP_STORAGE . '/app.json.lock',
+    ] as $file) {
+        @unlink($file);
+    }
+    @rmdir(BYFTP_STORAGE);
+}
+
+if ($failed) {
+    fwrite(STDERR, "WEB_CONFIG_SECURITY_TEST=FAIL\n");
+    exit(1);
+}
+
+echo "WEB_CONFIG_SECURITY_TEST=PASS\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -92,6 +92,10 @@ def run_runtime_checks() -> tuple[int, int]:
         [php, str(WEB / "tests" / "user-registry.php")],
         label="ByFTP WEB user registry fail-closed tests",
     )
+    run_checked(
+        [php, str(WEB / "tests" / "config-security.php")],
+        label="ByFTP WEB config fail-closed tests",
+    )
     for path in js_files:
         run_checked([node, "--check", str(path)], label=f"JavaScript syntax: {path.relative_to(ROOT)}")
     run_checked([node, "--check", str(WEB / "service-worker.js")], label="JavaScript syntax: ByFTP WEB/service-worker.js")
@@ -124,7 +128,8 @@ def main() -> int:
         "ByFTP WEB/assets/js/pwa.js", "ByFTP WEB/assets/js/settings.js",
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
-        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
+        "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -189,6 +194,15 @@ def main() -> int:
         "ByFTP WEB/app/Storage/UserStore.php",
     )
 
+    helpers = read("ByFTP WEB/app/helpers.php")
+    for marker in (
+        "new ByFTP\\Storage\\JsonStore($path, false)",
+        "if (isset($GLOBALS['byftp_config_error']))",
+        "Konfiguracija aplikacije nema valjan encryption ključ",
+        "unset($GLOBALS['byftp_config_error']);",
+    ):
+        require(helpers, marker, "ByFTP WEB/app/helpers.php")
+
     host_guard = read("ByFTP WEB/app/Security/HostGuard.php")
     for marker in ("connectionTargets", "FILTER_FLAG_NO_PRIV_RANGE", "FILTER_FLAG_NO_RES_RANGE", "localhost", "dns_get_record"):
         require(host_guard, marker, "ByFTP WEB/app/Security/HostGuard.php")
@@ -224,6 +238,14 @@ def main() -> int:
         fail("login must invalidate an authenticated session only for the actual legacy migration failure path")
 
     setup = read("ByFTP WEB/setup.php")
+    for marker in (
+        "$configRecoveryRequired = isset($GLOBALS['byftp_config_error']);",
+        "$existingDataDetected = $configRecoveryRequired || $hasStoredData();",
+        "$setupTransactionStarted = false;",
+        "if (isset($GLOBALS['byftp_config_error']))",
+        "if ($setupTransactionStarted)",
+    ):
+        require(setup, marker, "ByFTP WEB/setup.php")
     rollback_match = re.search(r"\$rollbackArtifacts\s*=\s*\[(.*?)\];", setup, re.DOTALL)
     if rollback_match is None:
         fail("ByFTP WEB/setup.php has no explicit failed-setup artifact rollback list")
@@ -259,6 +281,16 @@ def main() -> int:
     ):
         require(registry_tests, marker, "ByFTP WEB/tests/user-registry.php")
 
+    config_tests = read("ByFTP WEB/tests/config-security.php")
+    for marker in (
+        "{corrupt-app-config",
+        "runtime config does not recover stale app.json backup automatically",
+        "config update is blocked while the primary config is corrupt",
+        "generic JsonStore still exposes backup data for explicit operator recovery",
+        "backup-only stale config does not silently configure the application",
+    ):
+        require(config_tests, marker, "ByFTP WEB/tests/config-security.php")
+
     allowed_storage = {
         "ByFTP WEB/storage/.htaccess",
         "ByFTP WEB/storage/logs/.gitkeep",
@@ -287,6 +319,7 @@ def main() -> int:
     print(f"WEB_JS_SYNTAX_FILES={js_count}")
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
+    print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")
     print("WEB_SUBPROCESS_TEXT_ENCODING=UTF8_REPLACE")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")


### PR DESCRIPTION
## Sažetak

- `byftp_config()` sada koristi `JsonStore($path, false)` jer `app.json` sadrži encryption key i runtime sigurnosnu politiku
- oštećen ili nestao primarni `app.json` više ne vraća automatski stariji `.bak`
- `byftp_update_config()` odbija spremanje dok je config u recovery/error stanju i dodatno provjerava valjani 32-byte encryption ključ
- `byftp_write_config()` nakon uspješnog zapisa čisti eventualni stari config error state
- setup se zaključava ako je konfiguracija nečitljiva, čak i kada nema `users.json`/profilnih podataka
- late recovery error nakon setup locka ne smije pokrenuti rollback koji bi izbrisao postojeći corrupt config/backup
- dodan je runtime `config-security.php` regression i uključen u obavezni WEB audit

## Sigurnosni problem

`app.json` sadrži `secret_key`, `allow_registration`, `allow_private_hosts`, session limite i druge runtime postavke. Generic JsonStore fallback mogao je nakon korupcije primarnog configa učitati prethodnu `.bak` generaciju i time vratiti stariju sigurnosnu politiku, npr. ponovno omogućiti registraciju ili privatne hostove.

Još gore, aktivna administratorska sesija mogla je nakon config read failurea pozvati `byftp_update_config()`: prethodno se error pretvarao u prazan config, pa bi settings write mogao spremiti nepotpun `app.json` bez izvornog `secret_key`.

## Novo ponašanje

- `.bak` ostaje na disku za eksplicitni operator recovery
- runtime ne radi silent rollback sigurnosne politike
- registration/private-host policy fail-closed dok config nije ručno vraćen
- admin settings write ne može zamijeniti nečitljivi config
- setup ne može rotirati encryption key preko recovery-required instalacije

## Regresijska pokrivenost

Test namjerno:
- napravi stariji backup s `allow_registration=true`, `allow_private_hosts=true` i duljim session limitima
- spremi noviju restriktivnu primarnu generaciju
- korumpira primarni `app.json`
- potvrđuje da runtime vraća prazan/fail-closed config umjesto stale backupa
- potvrđuje da admin config update baca grešku i ne mijenja corrupt primary
- potvrđuje da generic JsonStore i dalje može pročitati backup za eksplicitni ručni recovery
- uklanja primary i potvrđuje da backup-only stanje ne konfigurira aplikaciju automatski

Nema promjene verzije ni drugih platformi.