### PR TITLE
Make WEB authentication rate limits atomic

### DIFF
--- a/ByFTP WEB/app/Security/RateLimiter.php
+++ b/ByFTP WEB/app/Security/RateLimiter.php
@@ -24,6 +24,36 @@ final class RateLimiter
         return new JsonStore($this->path($key), false);
     }
 
+    /**
+     * Atomically reserve one authentication/registration attempt.
+     *
+     * Returns true while the caller is still within the configured limit and false once
+     * the limit was already exhausted. JsonStore::update() holds the exclusive store lock
+     * across both the threshold check and increment, so concurrent requests cannot all
+     * observe the same pre-increment count.
+     */
+    public function consume(string $key): bool
+    {
+        $allowed = false;
+        $now = time();
+        $this->store($key)->update(function (array $data) use (&$allowed, $now): array {
+            if ((int)($data['first'] ?? 0) + $this->window < $now) {
+                $data = ['first' => $now, 'count' => 0];
+            }
+            $data['first'] = (int)($data['first'] ?? $now);
+            $count = max(0, (int)($data['count'] ?? 0));
+            if ($count >= $this->maxAttempts) {
+                $allowed = false;
+                $data['count'] = $count;
+                return $data;
+            }
+            $data['count'] = $count + 1;
+            $allowed = true;
+            return $data;
+        }, ['first' => $now, 'count' => 0]);
+        return $allowed;
+    }
+
     public function blocked(string $key): bool
     {
         $data = $this->store($key)->read(['first' => time(), 'count' => 0]);

--- a/ByFTP WEB/login.php
+++ b/ByFTP WEB/login.php
@@ -47,78 +47,96 @@ $ipLimiter = new RateLimiter(12, 900);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = strtolower(trim((string)($_POST['email'] ?? '')));
+    $password = (string)($_POST['password'] ?? '');
     $accountKey = 'login-account:' . hash('sha256', byftp_truncate($email, 320));
     $ipKey = 'login-ip:' . byftp_client_ip();
+
     if (!byftp_verify_csrf(is_string($_POST['csrf'] ?? null) ? $_POST['csrf'] : null)) {
         $error = 'Sigurnosni token nije valjan.';
-    } elseif ($ipLimiter->blocked($ipKey) || $accountLimiter->blocked($accountKey)) {
-        $error = 'Previše neuspjelih pokušaja. Pokušaj ponovno kasnije.';
-        AppLogger::event('auth.blocked', ['email' => $email]);
-    } elseif ($legacy) {
-        $password = (string)($_POST['password'] ?? '');
-        if (strlen($password) > 4096 || !password_verify($password, (string)$config['password_hash'])) {
-            $accountLimiter->hit($accountKey);
-            $ipLimiter->hit($ipKey);
-            usleep(350000);
-            $error = 'Pogrešna administratorska lozinka.';
-        } else {
-            try {
-                $user = $users->create((string)($_POST['name'] ?? 'Administrator'), $email, $password, 'admin');
-                // Move legacy data before removing the old login marker. If migration fails,
-                // the newly created account can retry the migration on the next valid login.
-                UserWorkspace::migrateLegacy((string)$user['id']);
-                $next = $config;
-                unset($next['password_hash']);
-                $next['version'] = BYFTP_VERSION;
-                $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
-                byftp_write_config($next);
-                if (!Auth::attempt($email, $password)) {
-                    throw new RuntimeException('Račun je izrađen, ali automatska prijava nije dovršena. Pokušaj se ponovno prijaviti.');
-                }
-                byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
-                AppLogger::event('auth.legacy_migrated', ['user_id' => $user['id']]);
-                byftp_redirect('app');
-            } catch (Throwable $e) {
-                $error = $e->getMessage();
-            }
-        }
-    } elseif (Auth::attempt($email, (string)($_POST['password'] ?? ''))) {
-        $migrationFailed = false;
-
-        // Recovery path for an interrupted legacy -> multi-user migration: the account may
-        // already exist while the legacy password marker/data still remain. Only this actual
-        // migration transaction is allowed to invalidate an otherwise successful login.
-        if (!empty($config['password_hash']) && Auth::isAdmin()) {
-            try {
-                UserWorkspace::migrateLegacy(Auth::id());
-                $next = $config;
-                unset($next['password_hash']);
-                $next['version'] = BYFTP_VERSION;
-                $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
-                byftp_write_config($next);
-                AppLogger::event('auth.legacy_migration_recovered', ['user_id' => Auth::id()]);
-            } catch (Throwable $e) {
-                AppLogger::event('auth.legacy_migration_failed', [
-                    'user_id' => Auth::id(),
-                    'error' => byftp_truncate($e->getMessage(), 300),
-                ]);
-                Auth::logout();
-                $migrationFailed = true;
-                $error = 'Prijava je valjana, ali migracija starih ByFTP podataka nije dovršena. Provjeri dozvole storage direktorija i pokušaj ponovno.';
-            }
-        }
-
-        if (!$migrationFailed) {
-            byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
-            AppLogger::event('auth.login', ['email' => $email, 'user_id' => Auth::id()]);
-            byftp_redirect('app');
-        }
     } else {
-        $accountLimiter->hit($accountKey);
-        $ipLimiter->hit($ipKey);
-        usleep(350000);
-        $error = 'E-mail ili lozinka nisu točni.';
-        AppLogger::event('auth.failed', ['email' => $email]);
+        $rateLimitState = 'allowed';
+        try {
+            // Reserve both counters before any password verification. Each consume() is one
+            // locked check+increment transaction, preventing concurrent requests from all
+            // observing the same pre-increment count. Storage failure denies authentication.
+            $ipAllowed = $ipLimiter->consume($ipKey);
+            $accountAllowed = $accountLimiter->consume($accountKey);
+            if (!$ipAllowed || !$accountAllowed) {
+                $rateLimitState = 'blocked';
+            }
+        } catch (Throwable $e) {
+            $rateLimitState = 'error';
+            AppLogger::event('auth.rate_limit_consume_failed', [
+                'error' => byftp_truncate($e->getMessage(), 300),
+            ]);
+        }
+
+        if ($rateLimitState === 'error') {
+            $error = 'Sigurnosna zaštita prijave trenutačno nije dostupna. Pokušaj ponovno kasnije.';
+        } elseif ($rateLimitState === 'blocked') {
+            $error = 'Previše neuspjelih pokušaja. Pokušaj ponovno kasnije.';
+            AppLogger::event('auth.blocked', ['email' => $email]);
+        } elseif ($legacy) {
+            if (strlen($password) > 4096 || !password_verify($password, (string)$config['password_hash'])) {
+                usleep(350000);
+                $error = 'Pogrešna administratorska lozinka.';
+            } else {
+                try {
+                    $user = $users->create((string)($_POST['name'] ?? 'Administrator'), $email, $password, 'admin');
+                    // Move legacy data before removing the old login marker. If migration fails,
+                    // the newly created account can retry the migration on the next valid login.
+                    UserWorkspace::migrateLegacy((string)$user['id']);
+                    $next = $config;
+                    unset($next['password_hash']);
+                    $next['version'] = BYFTP_VERSION;
+                    $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
+                    byftp_write_config($next);
+                    if (!Auth::attempt($email, $password)) {
+                        throw new RuntimeException('Račun je izrađen, ali automatska prijava nije dovršena. Pokušaj se ponovno prijaviti.');
+                    }
+                    byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
+                    AppLogger::event('auth.legacy_migrated', ['user_id' => $user['id']]);
+                    byftp_redirect('app');
+                } catch (Throwable $e) {
+                    $error = $e->getMessage();
+                }
+            }
+        } elseif (Auth::attempt($email, $password)) {
+            $migrationFailed = false;
+
+            // Recovery path for an interrupted legacy -> multi-user migration: the account may
+            // already exist while the legacy password marker/data still remain. Only this actual
+            // migration transaction is allowed to invalidate an otherwise successful login.
+            if (!empty($config['password_hash']) && Auth::isAdmin()) {
+                try {
+                    UserWorkspace::migrateLegacy(Auth::id());
+                    $next = $config;
+                    unset($next['password_hash']);
+                    $next['version'] = BYFTP_VERSION;
+                    $next['allow_registration'] = (bool)($next['allow_registration'] ?? false);
+                    byftp_write_config($next);
+                    AppLogger::event('auth.legacy_migration_recovered', ['user_id' => Auth::id()]);
+                } catch (Throwable $e) {
+                    AppLogger::event('auth.legacy_migration_failed', [
+                        'user_id' => Auth::id(),
+                        'error' => byftp_truncate($e->getMessage(), 300),
+                    ]);
+                    Auth::logout();
+                    $migrationFailed = true;
+                    $error = 'Prijava je valjana, ali migracija starih ByFTP podataka nije dovršena. Provjeri dozvole storage direktorija i pokušaj ponovno.';
+                }
+            }
+
+            if (!$migrationFailed) {
+                byftp_clear_login_rate_limiters($accountLimiter, $accountKey, $ipLimiter, $ipKey);
+                AppLogger::event('auth.login', ['email' => $email, 'user_id' => Auth::id()]);
+                byftp_redirect('app');
+            }
+        } else {
+            usleep(350000);
+            $error = 'E-mail ili lozinka nisu točni.';
+            AppLogger::event('auth.failed', ['email' => $email]);
+        }
     }
 }
 $pageTitle = 'Prijava · ' . byftp_app_name();

--- a/ByFTP WEB/register.php
+++ b/ByFTP WEB/register.php
@@ -21,20 +21,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $confirm = (string)($_POST['confirm'] ?? '');
     if (!byftp_verify_csrf(is_string($_POST['csrf'] ?? null) ? $_POST['csrf'] : null)) {
         $error = 'Sigurnosni token nije valjan.';
-    } elseif ($limiter->blocked($key)) {
-        $error = 'Previše registracija s ove adrese. Pokušaj ponovno kasnije.';
     } elseif ($password !== $confirm) {
         $error = 'Lozinke se ne podudaraju.';
     } else {
+        $attemptAllowed = false;
         try {
-            // Count every accepted registration attempt, including validation/duplicate failures,
-            // so password hashing and account enumeration cannot be abused without limits.
-            $limiter->hit($key);
-            $user = (new UserStore())->create($name, $email, $password, 'user');
-            AppLogger::event('auth.register', ['user_id' => $user['id']]);
-            byftp_redirect('login', ['registered' => 1]);
+            // Reserve the attempt before validation/hash work. The limiter performs the
+            // threshold check and increment under one exclusive JsonStore lock.
+            $attemptAllowed = $limiter->consume($key);
         } catch (Throwable $e) {
-            $error = $e->getMessage();
+            AppLogger::event('auth.registration_rate_limit_consume_failed', [
+                'error' => byftp_truncate($e->getMessage(), 300),
+            ]);
+            $error = 'Sigurnosna zaštita registracije trenutačno nije dostupna. Pokušaj ponovno kasnije.';
+        }
+
+        if ($error === '' && !$attemptAllowed) {
+            $error = 'Previše registracija s ove adrese. Pokušaj ponovno kasnije.';
+            AppLogger::event('auth.registration_blocked');
+        } elseif ($error === '' && $attemptAllowed) {
+            try {
+                // The attempt was already atomically counted, so validation/duplicate
+                // failures cannot be retried without consuming the configured budget.
+                $user = (new UserStore())->create($name, $email, $password, 'user');
+                AppLogger::event('auth.register', ['user_id' => $user['id']]);
+                byftp_redirect('login', ['registered' => 1]);
+            } catch (Throwable $e) {
+                $error = $e->getMessage();
+            }
         }
     }
 }

--- a/ByFTP WEB/tests/rate-limiter.php
+++ b/ByFTP WEB/tests/rate-limiter.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+use ByFTP\Security\RateLimiter;
+
+$storage = sys_get_temp_dir() . '/byftp-rate-limit-' . bin2hex(random_bytes(6));
+define('BYFTP_STORAGE', $storage);
+
+require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/Security/RateLimiter.php';
+
+$failed = false;
+
+function limiter_check(bool $condition, string $label): void
+{
+    global $failed;
+    if ($condition) {
+        return;
+    }
+    $failed = true;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+function limiter_throws(callable $callback, string $label): void
+{
+    try {
+        $callback();
+        limiter_check(false, $label);
+    } catch (Throwable) {
+        limiter_check(true, $label);
+    }
+}
+
+try {
+    $key = 'login-account:atomic-test';
+    $limiter = new RateLimiter(2, 3600);
+
+    limiter_check($limiter->consume($key), 'first attempt is atomically admitted');
+    limiter_check($limiter->consume($key), 'second attempt is atomically admitted at configured budget');
+    limiter_check(!$limiter->consume($key), 'attempt after configured budget is atomically rejected');
+    limiter_check($limiter->blocked($key), 'blocked state agrees with consumed attempt budget');
+
+    $path = BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
+    $raw = @file_get_contents($path);
+    $state = is_string($raw) ? json_decode($raw, true) : null;
+    limiter_check(
+        is_array($state) && (int)($state['count'] ?? -1) === 2,
+        'rejected consume does not inflate persisted attempt count beyond configured threshold'
+    );
+
+    $limiter->clear($key);
+    limiter_check(!$limiter->blocked($key), 'clear resets the consumed attempt budget');
+    limiter_check($limiter->consume($key), 'attempt is admitted again after explicit reset');
+
+    // Create a valid backup generation, then corrupt the primary. Security-state recovery
+    // must fail closed instead of consuming from an older counter generation.
+    $limiter->consume($key);
+    limiter_check(is_file($path . '.bak'), 'rate limiter keeps a backup for explicit diagnostics/recovery');
+    file_put_contents($path, '{corrupt-rate-limit-primary');
+    limiter_throws(
+        fn() => $limiter->consume($key),
+        'atomic consume fails closed when primary rate-limit state is corrupt'
+    );
+} finally {
+    $logs = BYFTP_STORAGE . '/logs';
+    if (is_dir($logs)) {
+        foreach (glob($logs . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($logs);
+    }
+    @rmdir(BYFTP_STORAGE);
+}
+
+if ($failed) {
+    fwrite(STDERR, "WEB_RATE_LIMITER_TEST=FAIL\n");
+    exit(1);
+}
+
+echo "WEB_RATE_LIMITER_TEST=PASS\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -96,6 +96,10 @@ def run_runtime_checks() -> tuple[int, int]:
         [php, str(WEB / "tests" / "config-security.php")],
         label="ByFTP WEB config fail-closed tests",
     )
+    run_checked(
+        [php, str(WEB / "tests" / "rate-limiter.php")],
+        label="ByFTP WEB atomic rate-limiter tests",
+    )
     for path in js_files:
         run_checked([node, "--check", str(path)], label=f"JavaScript syntax: {path.relative_to(ROOT)}")
     run_checked([node, "--check", str(WEB / "service-worker.js")], label="JavaScript syntax: ByFTP WEB/service-worker.js")
@@ -121,6 +125,7 @@ def main() -> int:
         "ByFTP WEB/app/Remote/FtpClient.php", "ByFTP WEB/app/Remote/SftpClient.php",
         "ByFTP WEB/app/Remote/PathGuard.php", "ByFTP WEB/app/Security/HostGuard.php",
         "ByFTP WEB/app/Security/Auth.php", "ByFTP WEB/app/Security/Crypto.php",
+        "ByFTP WEB/app/Security/RateLimiter.php",
         "ByFTP WEB/app/Storage/JsonStore.php", "ByFTP WEB/app/Storage/ProfileStore.php",
         "ByFTP WEB/app/Storage/UserStore.php", "ByFTP WEB/app/Storage/UserWorkspace.php",
         "ByFTP WEB/assets/css/app.css", "ByFTP WEB/assets/css/brendigo.css",
@@ -129,7 +134,7 @@ def main() -> int:
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
         "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
-        "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -203,6 +208,15 @@ def main() -> int:
     ):
         require(helpers, marker, "ByFTP WEB/app/helpers.php")
 
+    rate_limiter = read("ByFTP WEB/app/Security/RateLimiter.php")
+    for marker in (
+        "public function consume(string $key): bool",
+        "$this->store($key)->update(function (array $data)",
+        "if ($count >= $this->maxAttempts)",
+        "$data['count'] = $count + 1;",
+    ):
+        require(rate_limiter, marker, "ByFTP WEB/app/Security/RateLimiter.php")
+
     host_guard = read("ByFTP WEB/app/Security/HostGuard.php")
     for marker in ("connectionTargets", "FILTER_FLAG_NO_PRIV_RANGE", "FILTER_FLAG_NO_RES_RANGE", "localhost", "dns_get_record"):
         require(host_guard, marker, "ByFTP WEB/app/Security/HostGuard.php")
@@ -227,6 +241,9 @@ def main() -> int:
     for marker in (
         "function byftp_clear_login_rate_limiters(",
         "auth.rate_limit_clear_failed",
+        "$ipLimiter->consume($ipKey)",
+        "$accountLimiter->consume($accountKey)",
+        "auth.rate_limit_consume_failed",
         "if (!Auth::attempt($email, $password))",
         "$migrationFailed = false;",
         "if (!$migrationFailed)",
@@ -234,8 +251,20 @@ def main() -> int:
         require(login, marker, "ByFTP WEB/login.php")
     if "$accountLimiter->clear(" in login or "$ipLimiter->clear(" in login:
         fail("login performs direct post-auth limiter cleanup outside the fail-soft helper")
+    if "->blocked(" in login or "->hit(" in login:
+        fail("login uses split rate-limit check/hit operations instead of atomic pre-auth consume")
     if login.count("Auth::logout();") != 1:
         fail("login must invalidate an authenticated session only for the actual legacy migration failure path")
+
+    register = read("ByFTP WEB/register.php")
+    for marker in (
+        "$limiter->consume($key)",
+        "auth.registration_rate_limit_consume_failed",
+        "auth.registration_blocked",
+    ):
+        require(register, marker, "ByFTP WEB/register.php")
+    if "->blocked(" in register or "->hit(" in register:
+        fail("registration uses split rate-limit check/hit operations instead of atomic consume")
 
     setup = read("ByFTP WEB/setup.php")
     for marker in (
@@ -291,6 +320,15 @@ def main() -> int:
     ):
         require(config_tests, marker, "ByFTP WEB/tests/config-security.php")
 
+    limiter_tests = read("ByFTP WEB/tests/rate-limiter.php")
+    for marker in (
+        "first attempt is atomically admitted",
+        "attempt after configured budget is atomically rejected",
+        "rejected consume does not inflate persisted attempt count",
+        "atomic consume fails closed when primary rate-limit state is corrupt",
+    ):
+        require(limiter_tests, marker, "ByFTP WEB/tests/rate-limiter.php")
+
     allowed_storage = {
         "ByFTP WEB/storage/.htaccess",
         "ByFTP WEB/storage/logs/.gitkeep",
@@ -320,6 +358,7 @@ def main() -> int:
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
+    print("WEB_LOGIN_RATE_LIMIT_ATTEMPTS=ATOMIC_PRE_AUTH")
     print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")
     print("WEB_SUBPROCESS_TEXT_ENCODING=UTF8_REPLACE")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")


### PR DESCRIPTION
## Sažetak

- novi `RateLimiter::consume()` atomarno radi provjeru praga i increment unutar jednog `JsonStore::update()` ekskluzivnog locka
- login prije bilo kakve provjere lozinke rezervira i account i IP pokušaj
- greška rate-limit storagea fail-closed zaustavlja autentikaciju i zapisuje zaseban audit događaj
- uspješna prijava i dalje best-effort briše oba limitera kroz postojeći fail-soft cleanup helper
- legacy login i normalni login više ne koriste odvojeni `blocked()` + `hit()` obrazac
- registracija također rezervira pokušaj prije UserStore create/validacije
- dodan je runtime `rate-limiter.php` regression i CI statičke invarijante

## Sigurnosni problem

Dosadašnji login radio je odvojeno `blocked()` pa tek nakon neuspjele provjere `hit()`. Svaka operacija je pojedinačno zaključana, ali zajedno nisu transakcija. Više paralelnih zahtjeva zato može svi proći `blocked()` na istom starom countu prije nego što prvi `hit()` poveća brojač, što omogućuje burst pokušaje iznad konfiguriranog praga.

## Novo ponašanje

- `consume()` pod jednim lockom čita aktualni brojač, resetira istekli window, provjerava prag i povećava count
- prvih `maxAttempts` pokušaja dobivaju dopuštenje; sljedeći je odbijen bez daljnjeg povećavanja brojača
- login provodi CSRF prije limiter rezervacije, ali password verification/Auth::attempt dolaze tek nakon uspješnog consumea oba limita
- ako limiter storage nije čitljiv/zapisiv, autentikacija se ne izvršava
- uspješna prijava čisti rezervirani pokušaj kao i ranije

## Regresijska pokrivenost

Novi runtime test potvrđuje:
- prvi i drugi pokušaj prolaze za limit 2
- treći se atomarno odbija
- persisted count ostaje točno 2 nakon odbijenog consumea
- clear vraća budget
- nakon corrupt-primary rate-limit JSON-a consume fail-closed baca storage grešku

WEB audit dodatno zabranjuje `blocked()`/`hit()` u login i registration tokovima i zahtijeva pre-auth `consume()` pozive.

Nema promjene verzije ni drugih platformskih funkcija.