### PR TITLE
Short-circuit account limits for blocked login IPs

### DIFF
--- a/ByFTP WEB/app/Security/LoginRateLimitGate.php
+++ b/ByFTP WEB/app/Security/LoginRateLimitGate.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace ByFTP\Security;
+
+/**
+ * Applies login rate limits in abuse-resistant order.
+ *
+ * The IP budget is consumed first. Once that source is blocked, no account-specific
+ * limiter is touched, preventing an already-blocked client from exhausting arbitrary
+ * account budgets. The account budget is consumed only for requests admitted by IP.
+ */
+final class LoginRateLimitGate
+{
+    public static function consume(
+        RateLimiter $ipLimiter,
+        string $ipKey,
+        RateLimiter $accountLimiter,
+        string $accountKey
+    ): bool {
+        if (!$ipLimiter->consume($ipKey)) {
+            return false;
+        }
+        return $accountLimiter->consume($accountKey);
+    }
+}

--- a/ByFTP WEB/login.php
+++ b/ByFTP WEB/login.php
@@ -4,6 +4,7 @@ require __DIR__ . '/app/bootstrap.php';
 
 use ByFTP\Security\AppLogger;
 use ByFTP\Security\Auth;
+use ByFTP\Security\LoginRateLimitGate;
 use ByFTP\Security\RateLimiter;
 use ByFTP\Storage\UserStore;
 use ByFTP\Storage\UserWorkspace;
@@ -56,12 +57,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         $rateLimitState = 'allowed';
         try {
-            // Reserve both counters before any password verification. Each consume() is one
-            // locked check+increment transaction, preventing concurrent requests from all
-            // observing the same pre-increment count. Storage failure denies authentication.
-            $ipAllowed = $ipLimiter->consume($ipKey);
-            $accountAllowed = $accountLimiter->consume($accountKey);
-            if (!$ipAllowed || !$accountAllowed) {
+            // The IP budget is consumed first. A source that is already blocked must not
+            // be allowed to consume account-specific budgets for arbitrary e-mail addresses.
+            // Each individual consume remains an atomic check+increment transaction.
+            if (!LoginRateLimitGate::consume($ipLimiter, $ipKey, $accountLimiter, $accountKey)) {
                 $rateLimitState = 'blocked';
             }
         } catch (Throwable $e) {

--- a/ByFTP WEB/tests/rate-limiter.php
+++ b/ByFTP WEB/tests/rate-limiter.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use ByFTP\Security\LoginRateLimitGate;
 use ByFTP\Security\RateLimiter;
 
 $storage = sys_get_temp_dir() . '/byftp-rate-limit-' . bin2hex(random_bytes(6));
@@ -8,6 +9,7 @@ define('BYFTP_STORAGE', $storage);
 
 require __DIR__ . '/../app/Storage/JsonStore.php';
 require __DIR__ . '/../app/Security/RateLimiter.php';
+require __DIR__ . '/../app/Security/LoginRateLimitGate.php';
 
 $failed = false;
 
@@ -31,6 +33,11 @@ function limiter_throws(callable $callback, string $label): void
     }
 }
 
+function limiter_path(string $key): string
+{
+    return BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
+}
+
 try {
     $key = 'login-account:atomic-test';
     $limiter = new RateLimiter(2, 3600);
@@ -40,7 +47,7 @@ try {
     limiter_check(!$limiter->consume($key), 'attempt after configured budget is atomically rejected');
     limiter_check($limiter->blocked($key), 'blocked state agrees with consumed attempt budget');
 
-    $path = BYFTP_STORAGE . '/logs/rl-' . hash('sha256', $key) . '.json';
+    $path = limiter_path($key);
     $raw = @file_get_contents($path);
     $state = is_string($raw) ? json_decode($raw, true) : null;
     limiter_check(
@@ -51,6 +58,34 @@ try {
     $limiter->clear($key);
     limiter_check(!$limiter->blocked($key), 'clear resets the consumed attempt budget');
     limiter_check($limiter->consume($key), 'attempt is admitted again after explicit reset');
+
+    // A source that already exhausted its IP budget must not be able to spend arbitrary
+    // per-account budgets by continuing to submit different e-mail addresses.
+    $ipKey = 'login-ip:198.51.100.20';
+    $accountKey = 'login-account:target@example.test';
+    $ipLimiter = new RateLimiter(1, 3600);
+    $accountLimiter = new RateLimiter(5, 3600);
+    limiter_check($ipLimiter->consume($ipKey), 'IP setup attempt consumes its only budget slot');
+    limiter_check(
+        !LoginRateLimitGate::consume($ipLimiter, $ipKey, $accountLimiter, $accountKey),
+        'blocked IP is rejected by ordered login gate'
+    );
+    limiter_check(
+        !is_file(limiter_path($accountKey)),
+        'blocked IP does not create or consume an account-specific rate-limit state'
+    );
+
+    $ipLimiter->clear($ipKey);
+    limiter_check(
+        LoginRateLimitGate::consume($ipLimiter, $ipKey, $accountLimiter, $accountKey),
+        'admitted IP consumes the account budget after IP reset'
+    );
+    $accountRaw = @file_get_contents(limiter_path($accountKey));
+    $accountState = is_string($accountRaw) ? json_decode($accountRaw, true) : null;
+    limiter_check(
+        is_array($accountState) && (int)($accountState['count'] ?? -1) === 1,
+        'ordered login gate consumes account budget exactly once for admitted IP'
+    );
 
     // Create a valid backup generation, then corrupt the primary. Security-state recovery
     // must fail closed instead of consuming from an older counter generation.

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -125,7 +125,7 @@ def main() -> int:
         "ByFTP WEB/app/Remote/FtpClient.php", "ByFTP WEB/app/Remote/SftpClient.php",
         "ByFTP WEB/app/Remote/PathGuard.php", "ByFTP WEB/app/Security/HostGuard.php",
         "ByFTP WEB/app/Security/Auth.php", "ByFTP WEB/app/Security/Crypto.php",
-        "ByFTP WEB/app/Security/RateLimiter.php",
+        "ByFTP WEB/app/Security/RateLimiter.php", "ByFTP WEB/app/Security/LoginRateLimitGate.php",
         "ByFTP WEB/app/Storage/JsonStore.php", "ByFTP WEB/app/Storage/ProfileStore.php",
         "ByFTP WEB/app/Storage/UserStore.php", "ByFTP WEB/app/Storage/UserWorkspace.php",
         "ByFTP WEB/assets/css/app.css", "ByFTP WEB/assets/css/brendigo.css",
@@ -217,6 +217,13 @@ def main() -> int:
     ):
         require(rate_limiter, marker, "ByFTP WEB/app/Security/RateLimiter.php")
 
+    login_gate = read("ByFTP WEB/app/Security/LoginRateLimitGate.php")
+    for marker in (
+        "if (!$ipLimiter->consume($ipKey))",
+        "return $accountLimiter->consume($accountKey);",
+    ):
+        require(login_gate, marker, "ByFTP WEB/app/Security/LoginRateLimitGate.php")
+
     host_guard = read("ByFTP WEB/app/Security/HostGuard.php")
     for marker in ("connectionTargets", "FILTER_FLAG_NO_PRIV_RANGE", "FILTER_FLAG_NO_RES_RANGE", "localhost", "dns_get_record"):
         require(host_guard, marker, "ByFTP WEB/app/Security/HostGuard.php")
@@ -241,8 +248,7 @@ def main() -> int:
     for marker in (
         "function byftp_clear_login_rate_limiters(",
         "auth.rate_limit_clear_failed",
-        "$ipLimiter->consume($ipKey)",
-        "$accountLimiter->consume($accountKey)",
+        "LoginRateLimitGate::consume($ipLimiter, $ipKey, $accountLimiter, $accountKey)",
         "auth.rate_limit_consume_failed",
         "if (!Auth::attempt($email, $password))",
         "$migrationFailed = false;",
@@ -251,6 +257,8 @@ def main() -> int:
         require(login, marker, "ByFTP WEB/login.php")
     if "$accountLimiter->clear(" in login or "$ipLimiter->clear(" in login:
         fail("login performs direct post-auth limiter cleanup outside the fail-soft helper")
+    if "$ipLimiter->consume(" in login or "$accountLimiter->consume(" in login:
+        fail("login bypasses the ordered IP-first rate-limit gate")
     if "->blocked(" in login or "->hit(" in login:
         fail("login uses split rate-limit check/hit operations instead of atomic pre-auth consume")
     if login.count("Auth::logout();") != 1:
@@ -325,6 +333,8 @@ def main() -> int:
         "first attempt is atomically admitted",
         "attempt after configured budget is atomically rejected",
         "rejected consume does not inflate persisted attempt count",
+        "blocked IP does not create or consume an account-specific rate-limit state",
+        "ordered login gate consumes account budget exactly once for admitted IP",
         "atomic consume fails closed when primary rate-limit state is corrupt",
     ):
         require(limiter_tests, marker, "ByFTP WEB/tests/rate-limiter.php")
@@ -359,6 +369,7 @@ def main() -> int:
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_LOGIN_RATE_LIMIT_ATTEMPTS=ATOMIC_PRE_AUTH")
+    print("WEB_LOGIN_RATE_LIMIT_ORDER=IP_THEN_ACCOUNT_SHORT_CIRCUIT")
     print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")
     print("WEB_SUBPROCESS_TEXT_ENCODING=UTF8_REPLACE")
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")


### PR DESCRIPTION
## Sažetak

- dodan je `LoginRateLimitGate` koji primjenjuje login limitere redoslijedom IP → account
- ako je IP budget već iscrpljen, account-specific limiter se uopće ne dira
- account budget se troši samo za pokušaje koje je IP limiter prihvatio
- login više ne upravlja tim redoslijedom ručno nego koristi testabilni security gate
- runtime rate-limiter test proširen je blocked-IP/account-state regresijom
- WEB audit zahtijeva gate i zabranjuje direktne account/IP `consume()` pozive u login toku

## Problem

Nakon atomarnog pre-auth limitera iz PR #93 oba su limitera bila trošena redom bez short-circuita. Ako je IP već bio blokiran, zahtjev je ipak trošio account limiter za poslani e-mail. Time bi već blokirani izvor mogao nastaviti slati različite ili ciljane e-mail adrese i iscrpljivati njihove account budžete, stvarajući nepotreban account-lockout/DoS vektor.

## Novo ponašanje

`LoginRateLimitGate::consume()` prvo atomarno troši IP budget. Ako IP nije dopušten, odmah vraća `false`. Tek dopušten IP može trošiti account budget. Storage greške se i dalje propagiraju login toku koji ih fail-closed obrađuje bez autentikacije.

## Regresijska pokrivenost

Test:
- iscrpi IP limiter s limitom 1
- pozove gate s novim account ključem
- potvrđuje da je zahtjev odbijen
- potvrđuje da account limiter datoteka nije ni nastala
- resetira IP i potvrđuje da dopušten pokušaj troši account budget točno jednom

Nema promjene verzije ni drugih platformskih funkcija.