### PR TITLE
Fail closed on stale WEB profile backups

### DIFF
--- a/ByFTP WEB/app/Storage/ProfileStore.php
+++ b/ByFTP WEB/app/Storage/ProfileStore.php
@@ -15,7 +15,10 @@ final class ProfileStore
     public function __construct(string $userId)
     {
         UserWorkspace::ensure($userId);
-        $this->store = new JsonStore(UserWorkspace::file($userId, 'profiles.json'));
+        // Saved connection profiles contain encrypted passwords/private keys and explicit
+        // user deletion intent. Keep profiles.json.bak for manual recovery only; runtime
+        // reads must never resurrect a deleted credential generation automatically.
+        $this->store = new JsonStore(UserWorkspace::file($userId, 'profiles.json'), false);
         $this->crypto = new Crypto();
     }
 

--- a/ByFTP WEB/tests/profile-recovery.php
+++ b/ByFTP WEB/tests/profile-recovery.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+use ByFTP\Storage\JsonStore;
+use ByFTP\Storage\ProfileStore;
+use ByFTP\Storage\UserWorkspace;
+
+function byftp_truncate(string $value, int $length): string
+{
+    return substr($value, 0, $length);
+}
+
+function byftp_config(bool $fresh = false): array
+{
+    return ['secret_key' => base64_encode(str_repeat('P', 32))];
+}
+
+$storage = sys_get_temp_dir() . '/byftp-profile-recovery-' . bin2hex(random_bytes(6));
+define('BYFTP_STORAGE', $storage);
+
+require __DIR__ . '/../app/Remote/PathGuard.php';
+require __DIR__ . '/../app/Storage/JsonStore.php';
+require __DIR__ . '/../app/Security/Crypto.php';
+require __DIR__ . '/../app/Storage/UserWorkspace.php';
+require __DIR__ . '/../app/Storage/ProfileStore.php';
+
+$failed = false;
+
+function profile_recovery_check(bool $condition, string $label): void
+{
+    global $failed;
+    if ($condition) {
+        return;
+    }
+    $failed = true;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+function profile_recovery_throws(callable $callback, string $label): void
+{
+    try {
+        $callback();
+        profile_recovery_check(false, $label);
+    } catch (Throwable) {
+        profile_recovery_check(true, $label);
+    }
+}
+
+$userId = 'profile-recovery-user';
+$userDir = '';
+$profilePath = '';
+
+try {
+    $profiles = new ProfileStore($userId);
+    $userDir = UserWorkspace::directory($userId);
+    $profilePath = UserWorkspace::file($userId, 'profiles.json');
+
+    $deleted = $profiles->save([
+        'label' => 'Deleted FTP',
+        'protocol' => 'ftp',
+        'host' => 'deleted.example.com',
+        'port' => '21',
+        'base_path' => '/',
+        'username' => 'deleted-user',
+        'password' => 'deleted-secret-123',
+        'timeout' => '30',
+        'auth_method' => 'password',
+    ]);
+    $deletedId = (string)($deleted['id'] ?? '');
+    profile_recovery_check($deletedId !== '', 'deleted-profile regression fixture is created');
+
+    $kept = $profiles->save([
+        'label' => 'Kept FTP',
+        'protocol' => 'ftp',
+        'host' => 'kept.example.com',
+        'port' => '21',
+        'base_path' => '/',
+        'username' => 'kept-user',
+        'password' => 'kept-secret-456',
+        'timeout' => '30',
+        'auth_method' => 'password',
+    ]);
+    $keptId = (string)($kept['id'] ?? '');
+    profile_recovery_check($keptId !== '', 'kept-profile regression fixture is created');
+
+    $profiles->delete($deletedId);
+    profile_recovery_check($profiles->find($deletedId, true) === null, 'deleted profile is absent from valid primary generation');
+    profile_recovery_check($profiles->find($keptId, true) !== null, 'unrelated profile remains in valid primary generation');
+
+    $backupRaw = @file_get_contents($profilePath . '.bak');
+    $backupRows = is_string($backupRaw) ? json_decode($backupRaw, true) : null;
+    $backupContainsDeleted = false;
+    if (is_array($backupRows)) {
+        foreach ($backupRows as $row) {
+            if (is_array($row) && ($row['id'] ?? '') === $deletedId) {
+                $backupContainsDeleted = true;
+                break;
+            }
+        }
+    }
+    profile_recovery_check(
+        $backupContainsDeleted,
+        'backup intentionally contains the deleted encrypted profile used by the regression scenario'
+    );
+
+    file_put_contents($profilePath, '{corrupt-profile-primary');
+    profile_recovery_throws(
+        fn() => (new ProfileStore($userId))->find($deletedId, true),
+        'ProfileStore fails closed instead of resurrecting deleted credentials from stale backup'
+    );
+
+    $manualRows = (new JsonStore($profilePath))->read();
+    profile_recovery_check(
+        is_array($manualRows) && count($manualRows) >= 2,
+        'generic JsonStore still exposes profile backup for explicit operator recovery'
+    );
+
+    @unlink($profilePath);
+    profile_recovery_throws(
+        fn() => (new ProfileStore($userId))->all(true),
+        'ProfileStore fails closed when only stale profiles.json.bak remains'
+    );
+} finally {
+    if ($userDir !== '' && is_dir($userDir)) {
+        foreach (glob($userDir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($userDir);
+    }
+    @rmdir(BYFTP_STORAGE . '/users');
+    @rmdir(BYFTP_STORAGE);
+}
+
+if ($failed) {
+    fwrite(STDERR, "WEB_PROFILE_RECOVERY_TEST=FAIL\n");
+    exit(1);
+}
+
+echo "WEB_PROFILE_RECOVERY_TEST=PASS\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -100,6 +100,10 @@ def run_runtime_checks() -> tuple[int, int]:
         [php, str(WEB / "tests" / "rate-limiter.php")],
         label="ByFTP WEB atomic rate-limiter tests",
     )
+    run_checked(
+        [php, str(WEB / "tests" / "profile-recovery.php")],
+        label="ByFTP WEB deleted-profile recovery tests",
+    )
     for path in js_files:
         run_checked([node, "--check", str(path)], label=f"JavaScript syntax: {path.relative_to(ROOT)}")
     run_checked([node, "--check", str(WEB / "service-worker.js")], label="JavaScript syntax: ByFTP WEB/service-worker.js")
@@ -134,7 +138,8 @@ def main() -> int:
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
         "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
-        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/tests/profile-recovery.php",
+        "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -183,6 +188,7 @@ def main() -> int:
         "preg_match('/^[0-9]{1,5}$/', $rawPort)",
         "preg_match('/[\\r\\n\\x00]/', $username)",
         "PathGuard::normalizeRelative($basePath)",
+        "new JsonStore(UserWorkspace::file($userId, 'profiles.json'), false)",
     ):
         require(profile_store, marker, "ByFTP WEB/app/Storage/ProfileStore.php")
     if "trim((string)($input['host']" in profile_store:
@@ -339,6 +345,15 @@ def main() -> int:
     ):
         require(limiter_tests, marker, "ByFTP WEB/tests/rate-limiter.php")
 
+    profile_recovery_tests = read("ByFTP WEB/tests/profile-recovery.php")
+    for marker in (
+        "backup intentionally contains the deleted encrypted profile",
+        "fails closed instead of resurrecting deleted credentials from stale backup",
+        "generic JsonStore still exposes profile backup for explicit operator recovery",
+        "fails closed when only stale profiles.json.bak remains",
+    ):
+        require(profile_recovery_tests, marker, "ByFTP WEB/tests/profile-recovery.php")
+
     allowed_storage = {
         "ByFTP WEB/storage/.htaccess",
         "ByFTP WEB/storage/logs/.gitkeep",
@@ -368,6 +383,7 @@ def main() -> int:
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
+    print("WEB_PROFILE_CREDENTIAL_RECOVERY=FAIL_CLOSED")
     print("WEB_LOGIN_RATE_LIMIT_ATTEMPTS=ATOMIC_PRE_AUTH")
     print("WEB_LOGIN_RATE_LIMIT_ORDER=IP_THEN_ACCOUNT_SHORT_CIRCUIT")
     print("WEB_POST_AUTH_LIMITER_RESET=FAIL_SOFT")


### PR DESCRIPTION
## Sažetak

- `ProfileStore` sada koristi `JsonStore(..., false)` za `profiles.json`
- oštećen ili nestao primarni profil registry više ne vraća automatski stariji `.bak`
- backup ostaje na disku za eksplicitni operator recovery, ali ga runtime ne koristi za silent rollback
- dodan je runtime `profile-recovery.php` regression
- `audit_web.py` izvršava novi test i zahtijeva fail-closed ProfileStore konfiguraciju

## Privacy/security problem

`profiles.json` sadrži šifrirane FTP/SFTP korisničke podatke, lozinke, privatne ključeve i key passphrase vrijednosti. Nakon brisanja profila prethodna `.bak` generacija još može sadržavati taj profil. Ako se primarni `profiles.json` kasnije ošteti ili nestane, generic JsonStore recovery mogao je automatski vratiti stariji backup i time ponovno aktivirati već obrisani profil i njegove vjerodajnice.

## Novo ponašanje

- profile registry je security/privacy state i ne radi automatski backup rollback
- corrupt-primary i backup-only stanje fail-closed prekidaju runtime čitanje
- `.bak` nije izbrisan i ostaje dostupan administratoru za namjerni recovery
- generic JsonStore recovery ostaje dostupan drugim nesenzitivnim/manual recovery slučajevima

## Regresijska pokrivenost

Test:
- sprema dva profila s testnim vjerodajnicama
- briše prvi profil i potvrđuje da ga primary više nema
- potvrđuje da `.bak` još sadrži ID obrisanog profila
- korumpira primary i zahtijeva da `ProfileStore` baci grešku umjesto vraćanja stale backupa
- potvrđuje da generic JsonStore i dalje može eksplicitno pročitati backup
- provjerava i backup-only fail-closed stanje

Nema promjene verzije ni drugih platformskih funkcija.