### PR TITLE
Fail closed on stale WEB legacy migration backups

### DIFF
--- a/ByFTP WEB/app/Storage/UserWorkspace.php
+++ b/ByFTP WEB/app/Storage/UserWorkspace.php
@@ -41,9 +41,10 @@ final class UserWorkspace
                 continue;
             }
 
-            // Read through JsonStore so a valid legacy .bak can recover a corrupt or
-            // missing primary file. Write through JsonStore to preserve atomicity.
-            $data = (new JsonStore($source))->read([]);
+            // Legacy profiles/preferences contain credential/privacy state and deletion intent.
+            // Keep .bak available for explicit operator recovery, but never migrate from an
+            // older generation automatically when the primary file is corrupt or missing.
+            $data = (new JsonStore($source, false))->read([]);
             (new JsonStore($target))->write($data);
 
             foreach ([$source, $source . '.bak'] as $legacyPath) {

--- a/ByFTP WEB/tests/profile-recovery.php
+++ b/ByFTP WEB/tests/profile-recovery.php
@@ -52,6 +52,10 @@ $userId = 'profile-recovery-user';
 $userDir = '';
 $profilePath = '';
 $preferencePath = '';
+$legacyUserId = 'legacy-recovery-user';
+$legacyUserDir = '';
+$legacySource = '';
+$legacyTarget = '';
 
 try {
     $profiles = new ProfileStore($userId);
@@ -178,12 +182,65 @@ try {
         fn() => (new PreferenceStore($userId))->clientState(),
         'PreferenceStore fails closed when only stale preferences.json.bak remains'
     );
+
+    // Legacy upgrade must not make a different recovery decision than the normal runtime.
+    // A stale root backup can contain a profile deleted before the upgrade started.
+    $legacyUserDir = UserWorkspace::directory($legacyUserId);
+    $legacySource = BYFTP_STORAGE . '/profiles.json';
+    $legacyTarget = UserWorkspace::file($legacyUserId, 'profiles.json');
+    $legacyStore = new JsonStore($legacySource);
+    $legacyStore->write([[
+        'id' => 'stale-deleted-profile',
+        'label' => 'Stale deleted legacy profile',
+        'protocol' => 'ftp',
+        'host' => 'legacy.example.com',
+        'port' => 21,
+        'base_path' => '/',
+        'username_enc' => 'stale-encrypted-username',
+        'password_enc' => 'stale-encrypted-password',
+    ]]);
+    $legacyStore->write([]);
+
+    $legacyBackupRaw = @file_get_contents($legacySource . '.bak');
+    $legacyBackup = is_string($legacyBackupRaw) ? json_decode($legacyBackupRaw, true) : null;
+    profile_recovery_check(
+        is_array($legacyBackup)
+            && (($legacyBackup[0]['id'] ?? '') === 'stale-deleted-profile'),
+        'legacy backup intentionally contains a deleted credential generation for the migration regression'
+    );
+
+    file_put_contents($legacySource, '{corrupt-legacy-profile-primary');
+    profile_recovery_throws(
+        fn() => UserWorkspace::migrateLegacy($legacyUserId),
+        'legacy migration fails closed instead of restoring stale profile credentials from backup'
+    );
+    profile_recovery_check(
+        !is_file($legacyTarget) && !is_file($legacyTarget . '.bak'),
+        'failed legacy recovery does not create a migrated profile registry'
+    );
+
+    @unlink($legacySource);
+    profile_recovery_throws(
+        fn() => UserWorkspace::migrateLegacy($legacyUserId),
+        'legacy migration fails closed when only stale root profiles.json.bak remains'
+    );
+    profile_recovery_check(
+        !is_file($legacyTarget) && !is_file($legacyTarget . '.bak'),
+        'backup-only legacy recovery still leaves the target profile registry absent'
+    );
 } finally {
-    if ($userDir !== '' && is_dir($userDir)) {
-        foreach (glob($userDir . '/*') ?: [] as $file) {
-            @unlink($file);
+    foreach ([$legacySource, $legacySource . '.bak', $legacySource . '.lock'] as $legacyPath) {
+        if ($legacyPath !== '') {
+            @unlink($legacyPath);
         }
-        @rmdir($userDir);
+    }
+    foreach ([$userDir, $legacyUserDir] as $directory) {
+        if ($directory !== '' && is_dir($directory)) {
+            foreach (glob($directory . '/*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($directory);
+        }
     }
     @rmdir(BYFTP_STORAGE . '/users');
     @rmdir(BYFTP_STORAGE);


### PR DESCRIPTION
## Sažetak

- `UserWorkspace::migrateLegacy()` sada čita root legacy `profiles.json`/`preferences.json` kroz `JsonStore(..., false)`
- corrupt-primary ili backup-only legacy state više se ne migrira automatski iz starijeg `.bak`
- backup ostaje dostupan za eksplicitni operator recovery
- postojeći obavezni storage recovery test proširen je legacy migration regresijom

## Security/privacy problem

Legacy upgrade je prethodno namjerno dopuštao generic `.bak` recovery za root `profiles.json` i `preferences.json`. Ako je korisnik prije upgradea izbrisao profil, vjerodajnicu ili remote path history, prethodna `.bak` generacija je mogla sadržavati obrisani state. Korupcija ili gubitak primarnog legacy fajla tijekom upgradea mogla je zato ponovno uvesti taj stari state u novi korisnički workspace.

## Novo ponašanje

- legacy migration koristi samo valjani primary source
- corrupt-primary i backup-only source zaustavljaju migraciju
- target korisnički `profiles.json`/`preferences.json` se ne stvara iz stale backupa
- operator može ručno vratiti željenu backup generaciju u primary pa ponovno pokrenuti migraciju
- uspješna migracija valjanog primary statea ostaje nepromijenjena

## Regresijska pokrivenost

Obavezni WEB recovery test sada:
- stvara stale root `profiles.json.bak` s markerom obrisanog credential statea
- sprema noviju praznu primary generaciju
- korumpira primary i zahtijeva da migracija baci grešku
- potvrđuje da target profile registry nije stvoren
- uklanja primary i ponavlja backup-only slučaj
- potvrđuje da ni tada stale backup nije migriran

Nema promjene verzije ni drugih platformskih funkcija.