### PR TITLE
Require pinned host key for SFTP connections

### DIFF
--- a/ByFTP WEB/app/Remote/ClientFactory.php
+++ b/ByFTP WEB/app/Remote/ClientFactory.php
@@ -9,9 +9,18 @@ final class ClientFactory
 {
     public static function make(array $profile): RemoteClientInterface
     {
-        return match ((string)($profile['protocol'] ?? 'ftp')) {
+        $protocol = (string)($profile['protocol'] ?? 'ftp');
+        if ($protocol === 'sftp') {
+            // PHP ssh2 does not provide an OpenSSH known_hosts trust decision for us.
+            // Never allow password/key authentication before ByFTP has a pinned server key.
+            if ((string)($profile['host_fingerprint'] ?? '') === '') {
+                throw new RuntimeException('SFTP zahtijeva SHA-256 host fingerprint prije povezivanja. Provjeri fingerprint servera iz pouzdanog izvora i spremi ga u profil.');
+            }
+            return new SftpClient($profile);
+        }
+
+        return match ($protocol) {
             'ftp', 'ftps' => new FtpClient($profile),
-            'sftp' => new SftpClient($profile),
             default => throw new RuntimeException('Nepodržani protokol.'),
         };
     }

--- a/ByFTP WEB/tests/profile-recovery.php
+++ b/ByFTP WEB/tests/profile-recovery.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use ByFTP\Remote\ClientFactory;
+use ByFTP\Remote\SftpClient;
 use ByFTP\Storage\JsonStore;
 use ByFTP\Storage\PreferenceStore;
 use ByFTP\Storage\ProfileStore;
@@ -20,6 +22,9 @@ $storage = sys_get_temp_dir() . '/byftp-profile-recovery-' . bin2hex(random_byte
 define('BYFTP_STORAGE', $storage);
 
 require __DIR__ . '/../app/Remote/PathGuard.php';
+require __DIR__ . '/../app/Remote/RemoteClientInterface.php';
+require __DIR__ . '/../app/Remote/SftpClient.php';
+require __DIR__ . '/../app/Remote/ClientFactory.php';
 require __DIR__ . '/../app/Storage/JsonStore.php';
 require __DIR__ . '/../app/Security/Crypto.php';
 require __DIR__ . '/../app/Storage/UserWorkspace.php';
@@ -58,6 +63,21 @@ $legacySource = '';
 $legacyTarget = '';
 
 try {
+    // PHP ssh2 does not supply a known_hosts trust decision. The central client factory
+    // must therefore reject SFTP before authentication whenever no pinned host key exists.
+    profile_recovery_throws(
+        fn() => ClientFactory::make(['protocol' => 'sftp', 'host_fingerprint' => '']),
+        'SFTP client creation fails closed when no host fingerprint is pinned'
+    );
+    $pinnedSftp = ClientFactory::make([
+        'protocol' => 'sftp',
+        'host_fingerprint' => str_repeat('A', 64),
+    ]);
+    profile_recovery_check(
+        $pinnedSftp instanceof SftpClient,
+        'SFTP client creation remains available when a host fingerprint is pinned'
+    );
+
     $profiles = new ProfileStore($userId);
     $userDir = UserWorkspace::directory($userId);
     $profilePath = UserWorkspace::file($userId, 'profiles.json');


### PR DESCRIPTION
## Sažetak

- `ClientFactory` sada fail-closed odbija svaki SFTP profil bez spremljenog SHA-256 host fingerprinta
- zaštita vrijedi i za stare postojeće profile koji su ranije mogli imati prazno fingerprint polje
- password/key autentikacija ne može ni doći do `SftpClient` povezivanja bez pina identiteta servera
- postojeći obavezni WEB storage/security test proširen je SFTP host-key regressionom bez stvarne mrežne veze

## Security problem

PHP ssh2 ne provodi OpenSSH `known_hosts` trust odluku za ByFTP. `SftpClient` je provjeravao fingerprint samo kada je `host_fingerprint` bio popunjen, dok je `ProfileStore` dopuštao prazno polje. Takav profil mogao je koristiti SFTP lozinku ili privatni ključ bez provjere identiteta udaljenog servera, što ostavlja MITM rizik.

## Novo ponašanje

- SFTP uvijek zahtijeva pinned host fingerprint prije kreiranja klijenta
- prazni fingerprint baca jasnu sigurnosnu grešku prije mrežne veze/autentikacije
- profil s fingerprintom nastavlja u postojeći `SftpClient`, gdje se stvarni server key uspoređuje s pinom
- FTP/FTPS ponašanje nije promijenjeno

## Regresijska pokrivenost

Obavezni WEB test potvrđuje:
- `ClientFactory::make()` odbija SFTP bez fingerprinta
- SFTP s pinom i dalje kreira `SftpClient`
- test ne zahtijeva ssh2 ekstenziju ni vanjski server jer ne otvara mrežnu vezu

Nema promjene verzije ni drugih platformskih funkcija.