### PR TITLE
Make WEB password writes generation-safe

### DIFF
--- a/ByFTP WEB/app/Storage/UserStore.php
+++ b/ByFTP WEB/app/Storage/UserStore.php
@@ -102,7 +102,14 @@ final class UserStore
             return null;
         }
         if (password_needs_rehash((string)$user['password_hash'], self::passwordAlgorithm())) {
-            $this->replacePasswordHash((string)$user['id'], password_hash($password, self::passwordAlgorithm()));
+            // Rehash is still a password write. Bind it to the exact hash that was just
+            // verified so a concurrent password change cannot be overwritten by a login
+            // that authenticated against the previous generation.
+            $this->replacePasswordHash(
+                (string)$user['id'],
+                password_hash($password, self::passwordAlgorithm()),
+                (string)$user['password_hash']
+            );
         }
         $this->touchLogin((string)$user['id']);
         $fresh = $this->findById((string)$user['id']);
@@ -151,14 +158,19 @@ final class UserStore
         if (!empty($user['deleting'])) {
             throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Lozinku nije moguće mijenjati.');
         }
-        if ($requireCurrent && !password_verify($currentPassword, (string)($user['password_hash'] ?? ''))) {
+        $expectedCurrentHash = (string)($user['password_hash'] ?? '');
+        if ($requireCurrent && !password_verify($currentPassword, $expectedCurrentHash)) {
             throw new RuntimeException('Trenutačna lozinka nije točna.');
         }
         $hash = password_hash($newPassword, self::passwordAlgorithm());
         if (!is_string($hash)) {
             throw new RuntimeException('Nije moguće sigurno spremiti novu lozinku.');
         }
-        $this->replacePasswordHash($id, $hash);
+
+        // Current-password verification happens outside the file lock because Argon2/bcrypt
+        // can be intentionally expensive. The write itself is compare-and-swap bound to the
+        // exact verified hash, so a concurrent password change invalidates this request.
+        $this->replacePasswordHash($id, $hash, $requireCurrent ? $expectedCurrentHash : null);
     }
 
     public function updateAdminFields(string $id, string $role, bool $active): array
@@ -303,16 +315,20 @@ final class UserStore
         });
     }
 
-    private function replacePasswordHash(string $id, string|false $hash): void
+    private function replacePasswordHash(string $id, string|false $hash, ?string $expectedCurrentHash = null): void
     {
         if (!is_string($hash) || $hash === '') {
             throw new RuntimeException('Nije moguće sigurno hashirati lozinku.');
         }
-        $this->store->update(function (array $rows) use ($id, $hash): array {
+        $this->store->update(function (array $rows) use ($id, $hash, $expectedCurrentHash): array {
             foreach ($rows as &$row) {
                 if (is_array($row) && hash_equals((string)($row['id'] ?? ''), $id)) {
                     if (!empty($row['deleting'])) {
                         throw new RuntimeException('Brisanje korisničkog računa nije dovršeno. Lozinku nije moguće mijenjati.');
+                    }
+                    if ($expectedCurrentHash !== null
+                        && !hash_equals($expectedCurrentHash, (string)($row['password_hash'] ?? ''))) {
+                        throw new RuntimeException('Lozinka je u međuvremenu promijenjena. Ponovi radnju s aktualnom lozinkom.');
                     }
                     $row['password_hash'] = $hash;
                     $row['session_version'] = (int)($row['session_version'] ?? 1) + 1;

--- a/ByFTP WEB/app/Storage/UserStore.php
+++ b/ByFTP WEB/app/Storage/UserStore.php
@@ -98,22 +98,25 @@ final class UserStore
     public function authenticate(string $email, string $password): ?array
     {
         $user = $this->findByEmail($email);
-        if (!$user || empty($user['active']) || !password_verify($password, (string)($user['password_hash'] ?? ''))) {
+        $verifiedHash = is_array($user) ? (string)($user['password_hash'] ?? '') : '';
+        if (!$user || empty($user['active']) || !password_verify($password, $verifiedHash)) {
             return null;
         }
-        if (password_needs_rehash((string)$user['password_hash'], self::passwordAlgorithm())) {
-            // Rehash is still a password write. Bind it to the exact hash that was just
-            // verified so a concurrent password change cannot be overwritten by a login
-            // that authenticated against the previous generation.
-            $this->replacePasswordHash(
-                (string)$user['id'],
-                password_hash($password, self::passwordAlgorithm()),
-                (string)$user['password_hash']
-            );
+
+        $rehash = null;
+        if (password_needs_rehash($verifiedHash, self::passwordAlgorithm())) {
+            $candidate = password_hash($password, self::passwordAlgorithm());
+            if (!is_string($candidate) || $candidate === '') {
+                throw new RuntimeException('Nije moguće sigurno obnoviti hash lozinke.');
+            }
+            $rehash = $candidate;
         }
-        $this->touchLogin((string)$user['id']);
-        $fresh = $this->findById((string)$user['id']);
-        return $fresh ? $this->publicUser($fresh) : null;
+
+        // Verification and session publication are two separate CPU/storage phases. Before
+        // returning an authenticated user, atomically prove the verified password generation
+        // is still current. This prevents an old password from winning a race with a reset.
+        $fresh = $this->completeAuthentication((string)$user['id'], $verifiedHash, $rehash);
+        return $this->publicUser($fresh);
     }
 
     public function updateProfile(string $id, string $name, string $email): array
@@ -300,19 +303,39 @@ final class UserStore
         return count(array_filter($this->store->read(), 'is_array'));
     }
 
-    private function touchLogin(string $id): void
+    private function completeAuthentication(string $id, string $verifiedHash, ?string $rehash): array
     {
-        $this->store->update(function (array $rows) use ($id): array {
+        $authenticated = null;
+        $this->store->update(function (array $rows) use ($id, $verifiedHash, $rehash, &$authenticated): array {
             foreach ($rows as &$row) {
-                if (is_array($row) && hash_equals((string)($row['id'] ?? ''), $id)) {
-                    $row['last_login_at'] = gmdate('c');
-                    $row['updated_at'] = gmdate('c');
-                    break;
+                if (!is_array($row) || !hash_equals((string)($row['id'] ?? ''), $id)) {
+                    continue;
                 }
+                if (empty($row['active']) || !empty($row['deleting'])) {
+                    throw new RuntimeException('Korisnički račun više nije aktivan.');
+                }
+                if (!hash_equals($verifiedHash, (string)($row['password_hash'] ?? ''))) {
+                    throw new RuntimeException('Lozinka je promijenjena tijekom prijave. Ponovi prijavu s aktualnom lozinkom.');
+                }
+                if ($rehash !== null) {
+                    if ($rehash === '') {
+                        throw new RuntimeException('Nije moguće sigurno obnoviti hash lozinke.');
+                    }
+                    $row['password_hash'] = $rehash;
+                    $row['session_version'] = (int)($row['session_version'] ?? 1) + 1;
+                }
+                $row['last_login_at'] = gmdate('c');
+                $row['updated_at'] = gmdate('c');
+                $authenticated = $row;
+                return $rows;
             }
             unset($row);
-            return $rows;
+            throw new RuntimeException('Korisnik nije pronađen.');
         });
+        if (!is_array($authenticated)) {
+            throw new RuntimeException('Prijava nije dovršena.');
+        }
+        return $authenticated;
     }
 
     private function replacePasswordHash(string $id, string|false $hash, ?string $expectedCurrentHash = null): void

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -40,6 +40,45 @@ function registry_throws(callable $callback, string $label): void
 try {
     $users = new UserStore();
 
+    // Password writes use compare-and-swap against the hash generation that was actually
+    // verified. This deterministic regression models two requests that both verified the
+    // same old password before either write: only the first may commit.
+    $casUser = $users->create(
+        'Password CAS User',
+        'password-cas@example.com',
+        'password-cas-old-123',
+        'user'
+    );
+    $casId = (string)($casUser['id'] ?? '');
+    $casBefore = $users->findById($casId);
+    $casOldHash = is_array($casBefore) ? (string)($casBefore['password_hash'] ?? '') : '';
+    $casVersion = is_array($casBefore) ? (int)($casBefore['session_version'] ?? 1) : 0;
+    $casHashA = password_hash('password-cas-new-a-456', PASSWORD_DEFAULT);
+    $casHashB = password_hash('password-cas-new-b-789', PASSWORD_DEFAULT);
+    registry_check(
+        $casOldHash !== '' && is_string($casHashA) && is_string($casHashB),
+        'password CAS regression fixture has valid hash generations'
+    );
+
+    $replacePasswordHash = (new ReflectionClass(UserStore::class))->getMethod('replacePasswordHash');
+    $replacePasswordHash->setAccessible(true);
+    $replacePasswordHash->invoke($users, $casId, $casHashA, $casOldHash);
+    registry_throws(
+        fn() => $replacePasswordHash->invoke($users, $casId, $casHashB, $casOldHash),
+        'stale verified password hash cannot overwrite a newer committed password generation'
+    );
+    $casAfter = $users->findById($casId);
+    registry_check(
+        is_array($casAfter)
+            && password_verify('password-cas-new-a-456', (string)($casAfter['password_hash'] ?? ''))
+            && !password_verify('password-cas-new-b-789', (string)($casAfter['password_hash'] ?? '')),
+        'failed stale CAS leaves the first committed password intact'
+    );
+    registry_check(
+        is_array($casAfter) && (int)($casAfter['session_version'] ?? 0) === $casVersion + 1,
+        'failed stale CAS does not increment session version a second time'
+    );
+
     // These workspace deletion regressions intentionally exercise POSIX symlink and
     // directory-permission semantics used by shared-hosting deployments. Windows runners
     // still lint and execute the cross-platform registry tests below, but do not provide
@@ -177,7 +216,7 @@ try {
 
     $recoverableRows = (new JsonStore($primaryPath))->read();
     registry_check(
-        is_array($recoverableRows) && count($recoverableRows) === 1,
+        is_array($recoverableRows) && count($recoverableRows) >= 1,
         'generic JsonStore recovery remains available for explicit/manual recovery paths'
     );
 

--- a/ByFTP WEB/tests/user-registry.php
+++ b/ByFTP WEB/tests/user-registry.php
@@ -79,6 +79,33 @@ try {
         'failed stale CAS does not increment session version a second time'
     );
 
+    // Authentication must be bound to the same generation too. A request that verified the
+    // old hash before the password change may not publish a session after the new hash wins.
+    $completeAuthentication = (new ReflectionClass(UserStore::class))->getMethod('completeAuthentication');
+    $completeAuthentication->setAccessible(true);
+    registry_throws(
+        fn() => $completeAuthentication->invoke($users, $casId, $casOldHash, null),
+        'authentication completion rejects a password hash generation changed after verification'
+    );
+    $afterStaleAuth = $users->findById($casId);
+    registry_check(
+        is_array($afterStaleAuth) && ($afterStaleAuth['last_login_at'] ?? null) === null,
+        'stale authentication generation is not published as a successful login'
+    );
+
+    $currentHash = is_array($afterStaleAuth) ? (string)($afterStaleAuth['password_hash'] ?? '') : '';
+    $authenticatedCurrent = $completeAuthentication->invoke($users, $casId, $currentHash, null);
+    registry_check(
+        is_array($authenticatedCurrent) && !empty($authenticatedCurrent['last_login_at']),
+        'current password generation can complete authentication'
+    );
+    $afterCurrentAuth = $users->findById($casId);
+    registry_check(
+        is_array($afterCurrentAuth)
+            && (int)($afterCurrentAuth['session_version'] ?? 0) === $casVersion + 1,
+        'authentication without rehash does not change the session generation'
+    );
+
     // These workspace deletion regressions intentionally exercise POSIX symlink and
     // directory-permission semantics used by shared-hosting deployments. Windows runners
     // still lint and execute the cross-platform registry tests below, but do not provide


### PR DESCRIPTION
## Sažetak

- promjena lozinke sada compare-and-swap veže zapis uz točan password hash koji je upravo provjeren
- dva paralelna zahtjeva koja su oba provjerila istu staru lozinku više ne mogu oba spremiti novu lozinku
- završetak autentikacije sada atomarno potvrđuje da je verificirana hash generacija još uvijek aktualna prije objave uspješne prijave
- automatski password rehash tijekom prijave također se izvršava unutar iste generation-safe authentication transakcije
- admin reset bez `requireCurrent` ostaje eksplicitni administrativni overwrite
- postojeći obavezni user-registry test proširen je determinističkim password-write i authentication-generation regressionima

## Security problem

`UserStore::changePassword()` je trenutačnu lozinku provjeravao izvan zaključanog JSON updatea, a zatim bez uvjeta zamjenjivao hash. Dva paralelna zahtjeva s istom starom lozinkom mogla su oba proći provjeru prije prvog zapisa; zadnji zapis bi tada pobijedio iako stara lozinka nakon prvog commita više nije smjela biti valjana.

Postojao je i zaseban login TOCTOU: zahtjev je mogao verificirati staru lozinku, zatim paralelni reset promijeniti hash i `session_version`, a login bi nakon toga `touchLogin()` + `findById()` pročitao novu generaciju i objavio sesiju s novim `session_version` iako je autentikacija zapravo izvedena opozvanom starom lozinkom.

## Novo ponašanje

- skupi `password_verify()` ostaje izvan file-locka
- password write dobiva `expectedCurrentHash` i commitira samo ako je aktualni registry hash još identičan verificiranoj generaciji
- `authenticate()` nakon provjere lozinke ulazi u atomarni `completeAuthentication()` koji pod istim `JsonStore::update()` lockom ponovno uspoređuje verificirani hash
- ako se hash, active/deleting stanje ili account generation u međuvremenu promijenio, autentikacija fail-closed završava bez `last_login_at` i bez objave sesije
- password rehash, kada je potreban, događa se samo ako je verificirana generacija još aktualna; tada se povećava `session_version`
- običan uspješan login bez rehasha ne mijenja `session_version`

## Regresijska pokrivenost

Test modelira dva zahtjeva koji su oba pročitali isti stari hash:
- prvi CAS zapis sprema novu lozinku
- drugi pokušaj s istim očekivanim starim hashom mora biti odbijen
- konačni hash prihvaća samo prvu novu lozinku
- `session_version` se povećava samo jednom
- `completeAuthentication()` sa stale starim hashom mora biti odbijen i ne smije postaviti `last_login_at`
- ista metoda s aktualnim hashom mora uspješno završiti autentikaciju
- uspješna autentikacija bez rehasha ne smije dodatno povećati `session_version`

Nema promjene verzije ni drugih platformskih funkcija.