### PR TITLE
Fail closed when WEB ZIP finalization fails

### DIFF
--- a/ByFTP WEB/app/Operations/RemoteOperations.php
+++ b/ByFTP WEB/app/Operations/RemoteOperations.php
@@ -405,8 +405,18 @@ final class RemoteOperations
             @unlink($tmp);
             throw $e;
         }
-        $zip->close();
-        foreach ($temps as $temp) @unlink($temp);
+        try {
+            $closed = $zip->close();
+        } catch (\Throwable $e) {
+            @unlink($tmp);
+            throw new RuntimeException('Nije moguće dovršiti ZIP arhivu.', 0, $e);
+        } finally {
+            foreach ($temps as $temp) @unlink($temp);
+        }
+        if (!$closed) {
+            @unlink($tmp);
+            throw new RuntimeException('Nije moguće dovršiti ZIP arhivu.');
+        }
         return $tmp;
     }
 

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -182,6 +182,16 @@ def main() -> int:
     if "str_replace('\\\\', '/', $path)" in path_guard:
         fail("web path guard rewrites unsafe backslashes instead of rejecting them")
 
+    remote_operations = read("ByFTP WEB/app/Operations/RemoteOperations.php")
+    zip_finalization = re.search(
+        r"\$closed = \$zip->close\(\);.*?finally\s*\{\s*foreach \(\$temps as \$temp\) @unlink\(\$temp\);\s*\}\s*"
+        r"if \(!\$closed\)\s*\{\s*@unlink\(\$tmp\);\s*throw new RuntimeException\('Nije moguće dovršiti ZIP arhivu\.'\);",
+        remote_operations,
+        re.DOTALL,
+    )
+    if zip_finalization is None:
+        fail("WEB ZIP build does not fail closed when ZipArchive::close() fails")
+
     profile_store = read("ByFTP WEB/app/Storage/ProfileStore.php")
     for marker in (
         "$rawHost !== trim($rawHost)",
@@ -391,6 +401,7 @@ def main() -> int:
     print("WEB_VERSION_SOURCE=ROOT_AND_WEB_VERSION_MATCH")
     print("WEB_PWA_AUTHENTICATED_CACHE=BLOCKED")
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")
+    print("WEB_ZIP_FINALIZATION=FAIL_CLOSED")
     print("WEB_PRIVATE_HOSTS=BLOCKED_BY_DEFAULT")
     print("WEB_CREDENTIAL_LIFETIME=POST_AUTH_CLEARED")
     print("WEB_SETUP_FAILED_TRANSACTION_ARTIFACTS=CLEANED")


### PR DESCRIPTION
## Summary
- check the return value of `ZipArchive::close()` before a generated WEB archive can be returned or uploaded
- clean staged source temp files even if ZIP finalization throws
- delete an incomplete ZIP and fail closed when finalization returns `false` or throws
- extend the WEB audit so unchecked ZIP finalization cannot regress silently

## Why
`buildZip()` previously validated every `addFile()` call but ignored the final `ZipArchive::close()` result. Disk quota or I/O failures during central-directory finalization could therefore be reported as a successful ZIP build, allowing an incomplete archive to be downloaded or uploaded.

## Scope
No version change. This is a focused WEB stability fix on top of 1.8.0.