### PR TITLE
Reject noncanonical WEB name inputs

### DIFF
--- a/ByFTP WEB/api.php
+++ b/ByFTP WEB/api.php
@@ -112,21 +112,21 @@ try {
 
         case 'mkdir':
             $parent = PathGuard::normalizeRelative((string)($_POST['path'] ?? '/'));
-            $target = PathGuard::child($parent, PathGuard::basename((string)($_POST['name'] ?? '')));
+            $target = PathGuard::child($parent, PathGuard::segment((string)($_POST['name'] ?? '')));
             $client->makeDirectory($target);
             AppLogger::event('directory.create', ['profile_id'=>$profileId,'path'=>$target]);
             byftp_json(['ok'=>true,'path'=>$target]);
 
         case 'new_file':
             $parent = PathGuard::normalizeRelative((string)($_POST['path'] ?? '/'));
-            $target = PathGuard::child($parent, PathGuard::basename((string)($_POST['name'] ?? '')));
+            $target = PathGuard::child($parent, PathGuard::segment((string)($_POST['name'] ?? '')));
             $ops->createFile($target, (string)($_POST['content'] ?? ''));
             AppLogger::event('file.create', ['profile_id'=>$profileId,'path'=>$target]);
             byftp_json(['ok'=>true,'path'=>$target]);
 
         case 'rename':
             $from = PathGuard::ensureNotRoot((string)($_POST['from'] ?? ''));
-            $to = PathGuard::child(PathGuard::parent($from), PathGuard::basename((string)($_POST['name'] ?? '')));
+            $to = PathGuard::child(PathGuard::parent($from), PathGuard::segment((string)($_POST['name'] ?? '')));
             $client->rename($from, $to);
             AppLogger::event('item.rename', ['profile_id'=>$profileId,'from'=>$from,'to'=>$to]);
             byftp_json(['ok'=>true,'path'=>$to]);

--- a/ByFTP WEB/tests/name-input.php
+++ b/ByFTP WEB/tests/name-input.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../app/Remote/PathGuard.php';
+
+use ByFTP\Remote\PathGuard;
+
+$passed = 0;
+$failed = 0;
+
+function check_name_input(bool $condition, string $label): void
+{
+    global $passed, $failed;
+    if ($condition) {
+        $passed++;
+        return;
+    }
+    $failed++;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+function throws_name_input(callable $fn, string $label): void
+{
+    try {
+        $fn();
+        check_name_input(false, $label);
+    } catch (Throwable) {
+        check_name_input(true, $label);
+    }
+}
+
+throws_name_input(
+    fn() => PathGuard::segment('nested/file.txt'),
+    'single-name validator rejects slash-separated input'
+);
+throws_name_input(
+    fn() => PathGuard::segment('../file.txt'),
+    'single-name validator rejects traversal-shaped input'
+);
+
+$api = file_get_contents(__DIR__ . '/../api.php');
+if (!is_string($api)) {
+    fwrite(STDERR, "WEB_NAME_INPUT_TEST=FAIL unable to read api.php\n");
+    exit(1);
+}
+
+$strictName = "PathGuard::segment((string)(\$_POST['name'] ?? ''))";
+$legacyName = "PathGuard::basename((string)(\$_POST['name'] ?? ''))";
+check_name_input(
+    substr_count($api, $strictName) === 3,
+    'mkdir, new_file and rename all use strict single-name validation'
+);
+check_name_input(
+    !str_contains($api, $legacyName),
+    'API no longer silently canonicalizes explicit name fields with basename'
+);
+
+if ($failed > 0) {
+    fwrite(STDERR, "WEB_NAME_INPUT_TEST=FAIL passed={$passed} failed={$failed}\n");
+    exit(1);
+}
+
+echo "WEB_NAME_INPUT_TEST=PASS ({$passed})\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -89,6 +89,10 @@ def run_runtime_checks() -> tuple[int, int]:
         run_checked([php, "-l", str(path)], label=f"PHP syntax: {path.relative_to(ROOT)}")
     run_checked([php, str(WEB / "tests" / "unit.php")], label="ByFTP WEB unit tests")
     run_checked(
+        [php, str(WEB / "tests" / "name-input.php")],
+        label="ByFTP WEB strict name-input tests",
+    )
+    run_checked(
         [php, str(WEB / "tests" / "user-registry.php")],
         label="ByFTP WEB user registry fail-closed tests",
     )
@@ -137,9 +141,9 @@ def main() -> int:
         "ByFTP WEB/assets/js/pwa.js", "ByFTP WEB/assets/js/settings.js",
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
-        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
-        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/tests/profile-recovery.php",
-        "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/name-input.php", "ByFTP WEB/tests/user-registry.php",
+        "ByFTP WEB/tests/config-security.php", "ByFTP WEB/tests/rate-limiter.php",
+        "ByFTP WEB/tests/profile-recovery.php", "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -191,6 +195,12 @@ def main() -> int:
     )
     if zip_finalization is None:
         fail("WEB ZIP build does not fail closed when ZipArchive::close() fails")
+
+    api = read("ByFTP WEB/api.php")
+    strict_name = "PathGuard::segment((string)($_POST['name'] ?? ''))"
+    legacy_name = "PathGuard::basename((string)($_POST['name'] ?? ''))"
+    if api.count(strict_name) != 3 or legacy_name in api:
+        fail("mkdir/new_file/rename must reject noncanonical explicit name fields instead of basename-normalizing them")
 
     profile_store = read("ByFTP WEB/app/Storage/ProfileStore.php")
     for marker in (
@@ -325,6 +335,13 @@ def main() -> int:
     for marker in ("22junk", "profile traversal rejected", "host edge whitespace rejected", "credential protocol controls rejected"):
         require(tests, marker, "ByFTP WEB/tests/unit.php")
 
+    name_input_tests = read("ByFTP WEB/tests/name-input.php")
+    for marker in (
+        "single-name validator rejects slash-separated input",
+        "API no longer silently canonicalizes explicit name fields with basename",
+    ):
+        require(name_input_tests, marker, "ByFTP WEB/tests/name-input.php")
+
     registry_tests = read("ByFTP WEB/tests/user-registry.php")
     for marker in (
         "old-password-123",
@@ -391,6 +408,7 @@ def main() -> int:
     print(f"WEB_PHP_SYNTAX_FILES={php_count}")
     print(f"WEB_JS_SYNTAX_FILES={js_count}")
     print("WEB_UNIT_TESTS=PASS")
+    print("WEB_NAME_INPUTS=FAIL_CLOSED")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_PROFILE_CREDENTIAL_RECOVERY=FAIL_CLOSED")


### PR DESCRIPTION
## Summary
- use `PathGuard::segment()` for the explicit single-name fields used by `mkdir`, `new_file` and `rename`
- reject separator-shaped values such as `a/b` and traversal-shaped values instead of silently converting them to a basename
- preserve `PathGuard::basename()` for browser-supplied upload filenames, where basename normalization is intentional
- add a focused runtime/source regression test and enforce the invariant in `scripts/audit_web.py`

## Why
The three explicit `name` actions previously passed user input through `PathGuard::basename()`. This was not a directory-escape vulnerability, but a request such as `a/b` could be silently interpreted as `b`, causing the API to operate on a different name than the caller supplied. Explicit single-name fields should fail closed instead.

## Validation
- `ByFTP WEB/tests/name-input.php` verifies slash/traversal-shaped names are rejected and all three API call sites use strict segment validation
- the WEB audit runs the regression and reports `WEB_NAME_INPUTS=FAIL_CLOSED`
- no version change; this remains a focused 1.8.0 stability/input-validation fix