### PR TITLE
Harden WEB ZIP creation error paths

### DIFF
--- a/ByFTP WEB/app/Operations/RemoteOperations.php
+++ b/ByFTP WEB/app/Operations/RemoteOperations.php
@@ -400,9 +400,14 @@ final class RemoteOperations
             }
             if ($count === 0) throw new RuntimeException('Nema dostupnih stavki za ZIP.');
         } catch (\Throwable $e) {
-            $zip->close();
-            foreach ($temps as $temp) @unlink($temp);
-            @unlink($tmp);
+            try {
+                $zip->close();
+            } catch (\Throwable) {
+                // Preserve the original build error; cleanup still must run.
+            } finally {
+                foreach ($temps as $temp) @unlink($temp);
+                @unlink($tmp);
+            }
             throw $e;
         }
         try {
@@ -428,7 +433,7 @@ final class RemoteOperations
         $count++;
         if ($count > self::MAX_ARCHIVE_ITEMS) throw new RuntimeException('Odabir prelazi sigurnosni limit ZIP stavki.');
         if (($item['type'] ?? 'file') === 'dir') {
-            $zip->addEmptyDir(rtrim($archivePath, '/'));
+            if (!$zip->addEmptyDir(rtrim($archivePath, '/'))) throw new RuntimeException('Nije moguće dodati direktorij u ZIP.');
             foreach ($this->client->list($remote) as $child) {
                 $name = PathGuard::segment((string)$child['name']);
                 $this->addZipNode($zip, PathGuard::child($remote, $name), rtrim($archivePath,'/').'/'.$name, $count, $bytes, $temps, $depth + 1);

--- a/ByFTP WEB/tests/zip-creation.php
+++ b/ByFTP WEB/tests/zip-creation.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+$source = file_get_contents(__DIR__ . '/../app/Operations/RemoteOperations.php');
+if (!is_string($source)) {
+    fwrite(STDERR, "WEB_ZIP_CREATION_TEST=FAIL unable to read RemoteOperations.php\n");
+    exit(1);
+}
+
+$passed = 0;
+$failed = 0;
+
+function check_zip_creation(bool $condition, string $label): void
+{
+    global $passed, $failed;
+    if ($condition) {
+        $passed++;
+        return;
+    }
+    $failed++;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+$directoryGuard = <<<'PHP'
+if (!$zip->addEmptyDir(rtrim($archivePath, '/'))) throw new RuntimeException('Nije moguće dodati direktorij u ZIP.');
+PHP;
+$preserveOriginalError = <<<'PHP'
+// Preserve the original build error; cleanup still must run.
+PHP;
+$errorCleanup = <<<'PHP'
+} finally {
+                foreach ($temps as $temp) @unlink($temp);
+                @unlink($tmp);
+            }
+            throw $e;
+PHP;
+
+check_zip_creation(
+    str_contains($source, $directoryGuard),
+    'ZIP directory insertion failure is checked explicitly'
+);
+check_zip_creation(
+    str_contains($source, $preserveOriginalError),
+    'ZIP cleanup preserves the original build failure'
+);
+check_zip_creation(
+    str_contains($source, $errorCleanup),
+    'ZIP build failure always cleans staged files and incomplete output'
+);
+
+if ($failed > 0) {
+    fwrite(STDERR, "WEB_ZIP_CREATION_TEST=FAIL passed={$passed} failed={$failed}\n");
+    exit(1);
+}
+
+echo "WEB_ZIP_CREATION_TEST=PASS ({$passed})\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -93,6 +93,10 @@ def run_runtime_checks() -> tuple[int, int]:
         label="ByFTP WEB strict name-input tests",
     )
     run_checked(
+        [php, str(WEB / "tests" / "zip-creation.php")],
+        label="ByFTP WEB ZIP creation error-path tests",
+    )
+    run_checked(
         [php, str(WEB / "tests" / "user-registry.php")],
         label="ByFTP WEB user registry fail-closed tests",
     )
@@ -141,9 +145,10 @@ def main() -> int:
         "ByFTP WEB/assets/js/pwa.js", "ByFTP WEB/assets/js/settings.js",
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
-        "ByFTP WEB/tests/name-input.php", "ByFTP WEB/tests/user-registry.php",
-        "ByFTP WEB/tests/config-security.php", "ByFTP WEB/tests/rate-limiter.php",
-        "ByFTP WEB/tests/profile-recovery.php", "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/name-input.php", "ByFTP WEB/tests/zip-creation.php",
+        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
+        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/tests/profile-recovery.php",
+        "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -195,6 +200,19 @@ def main() -> int:
     )
     if zip_finalization is None:
         fail("WEB ZIP build does not fail closed when ZipArchive::close() fails")
+    for marker in (
+        "if (!$zip->addEmptyDir(rtrim($archivePath, '/'))) throw new RuntimeException('Nije moguće dodati direktorij u ZIP.');",
+        "// Preserve the original build error; cleanup still must run.",
+    ):
+        require(marker=marker, text=remote_operations, where="ByFTP WEB/app/Operations/RemoteOperations.php")
+    zip_error_cleanup = re.search(
+        r"catch \(\\Throwable\)\s*\{.*?\}\s*finally\s*\{\s*"
+        r"foreach \(\$temps as \$temp\) @unlink\(\$temp\);\s*@unlink\(\$tmp\);\s*\}\s*throw \$e;",
+        remote_operations,
+        re.DOTALL,
+    )
+    if zip_error_cleanup is None:
+        fail("WEB ZIP build failure cleanup can be skipped or mask the original error")
 
     api = read("ByFTP WEB/api.php")
     strict_name = "PathGuard::segment((string)($_POST['name'] ?? ''))"
@@ -342,6 +360,14 @@ def main() -> int:
     ):
         require(name_input_tests, marker, "ByFTP WEB/tests/name-input.php")
 
+    zip_creation_tests = read("ByFTP WEB/tests/zip-creation.php")
+    for marker in (
+        "ZIP directory insertion failure is checked explicitly",
+        "ZIP cleanup preserves the original build failure",
+        "ZIP build failure always cleans staged files and incomplete output",
+    ):
+        require(zip_creation_tests, marker, "ByFTP WEB/tests/zip-creation.php")
+
     registry_tests = read("ByFTP WEB/tests/user-registry.php")
     for marker in (
         "old-password-123",
@@ -420,6 +446,7 @@ def main() -> int:
     print("WEB_PWA_AUTHENTICATED_CACHE=BLOCKED")
     print("WEB_REMOTE_PATHS=FAIL_CLOSED")
     print("WEB_ZIP_FINALIZATION=FAIL_CLOSED")
+    print("WEB_ZIP_CREATION_ERROR_PATHS=FAIL_CLOSED")
     print("WEB_PRIVATE_HOSTS=BLOCKED_BY_DEFAULT")
     print("WEB_CREDENTIAL_LIFETIME=POST_AUTH_CLEARED")
     print("WEB_SETUP_FAILED_TRANSACTION_ARTIFACTS=CLEANED")


### PR DESCRIPTION
## Summary
- check `ZipArchive::addEmptyDir()` and fail immediately if a directory entry cannot be added
- preserve the original ZIP build exception if the best-effort cleanup `close()` also throws
- always remove staged source temp files and incomplete ZIP output through `finally`
- add `ByFTP WEB/tests/zip-creation.php` and WEB audit enforcement for both error paths

## Why
ZIP creation already checked file insertion and final `close()`, but two error paths remained weak: directory insertion ignored the boolean result of `addEmptyDir()`, and a secondary exception from `close()` inside the build-error handler could mask the original failure and skip cleanup. Both conditions now fail closed without leaving incomplete temporary output.

## Validation
- new ZIP creation regression contract is executed by `scripts/audit_web.py`
- audit enforces checked directory insertion, preserved original errors, unconditional error cleanup and the existing finalization contract
- no version change; this is a focused 1.8.0 WEB reliability fix