### PR TITLE
Preserve .zip on long WEB archive download names

### DIFF
--- a/ByFTP WEB/app/helpers.php
+++ b/ByFTP WEB/app/helpers.php
@@ -128,6 +128,19 @@ function byftp_truncate(string $value, int $length): string
     return function_exists('mb_substr') ? mb_substr($value, 0, $length) : substr($value, 0, $length);
 }
 
+function byftp_archive_download_name(string $value): string
+{
+    $name = trim($value);
+    $name = preg_replace('/[^\pL\pN._ -]+/u', '-', $name) ?: 'byftp-download';
+    $base = preg_replace('/\.zip$/i', '', $name);
+    $base = is_string($base) ? $base : '';
+    $base = rtrim(byftp_truncate($base, 116), " .");
+    if ($base === '') {
+        $base = 'byftp-download';
+    }
+    return $base . '.zip';
+}
+
 function byftp_client_ip(): string
 {
     // REMOTE_ADDR is intentionally used directly. Forwarded headers are not trusted by default.

--- a/ByFTP WEB/download-archive.php
+++ b/ByFTP WEB/download-archive.php
@@ -32,12 +32,7 @@ if (!$profile) {
 }
 
 $paths = byftp_string_paths((string)($_POST['paths'] ?? '[]'), 200);
-$name = trim((string)($_POST['name'] ?? 'byftp-download.zip'));
-$name = preg_replace('/[^\pL\pN._ -]+/u', '-', $name) ?: 'byftp-download.zip';
-if (!str_ends_with(strtolower($name), '.zip')) {
-    $name .= '.zip';
-}
-$name = byftp_truncate($name, 120);
+$name = byftp_archive_download_name((string)($_POST['name'] ?? 'byftp-download.zip'));
 
 $tmp = tempnam(BYFTP_STORAGE . '/tmp', 'archive-');
 if ($tmp === false) {

--- a/ByFTP WEB/tests/archive-download-name.php
+++ b/ByFTP WEB/tests/archive-download-name.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../app/helpers.php';
+
+$passed = 0;
+$failed = 0;
+
+function check(bool $condition, string $label): void
+{
+    global $passed, $failed;
+    if ($condition) {
+        $passed++;
+        return;
+    }
+    $failed++;
+    fwrite(STDERR, "FAIL: {$label}\n");
+}
+
+$long = byftp_archive_download_name(str_repeat('a', 200) . '.zip');
+check(strlen($long) === 120, 'long archive name is capped at 120 ASCII bytes');
+check(str_ends_with($long, '.zip'), 'long archive name preserves zip extension after truncation');
+check(substr($long, 0, -4) === str_repeat('a', 116), 'long archive name truncates the base before appending extension');
+
+check(
+    byftp_archive_download_name('backup.ZIP') === 'backup.zip',
+    'existing ZIP extension is normalized without duplication'
+);
+check(
+    byftp_archive_download_name('backup') === 'backup.zip',
+    'missing ZIP extension is appended'
+);
+check(
+    byftp_archive_download_name('.zip') === 'byftp-download.zip',
+    'empty archive basename falls back to a stable filename'
+);
+check(
+    byftp_archive_download_name(" report\r\n2026?.zip ") === 'report-2026-.zip',
+    'unsafe archive filename characters are sanitized before header use'
+);
+check(
+    str_ends_with(byftp_archive_download_name(str_repeat('č', 200)), '.zip'),
+    'multibyte long archive name still preserves zip extension'
+);
+
+if ($failed > 0) {
+    fwrite(STDERR, "WEB_ARCHIVE_DOWNLOAD_NAME_TEST=FAIL passed={$passed} failed={$failed}\n");
+    exit(1);
+}
+
+echo "WEB_ARCHIVE_DOWNLOAD_NAME_TEST=PASS ({$passed})\n";

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -97,6 +97,10 @@ def run_runtime_checks() -> tuple[int, int]:
         label="ByFTP WEB ZIP creation error-path tests",
     )
     run_checked(
+        [php, str(WEB / "tests" / "archive-download-name.php")],
+        label="ByFTP WEB archive download filename tests",
+    )
+    run_checked(
         [php, str(WEB / "tests" / "user-registry.php")],
         label="ByFTP WEB user registry fail-closed tests",
     )
@@ -146,9 +150,9 @@ def main() -> int:
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
         "ByFTP WEB/tests/name-input.php", "ByFTP WEB/tests/zip-creation.php",
-        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
-        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/tests/profile-recovery.php",
-        "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/archive-download-name.php", "ByFTP WEB/tests/user-registry.php",
+        "ByFTP WEB/tests/config-security.php", "ByFTP WEB/tests/rate-limiter.php",
+        "ByFTP WEB/tests/profile-recovery.php", "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -249,8 +253,19 @@ def main() -> int:
         "if (isset($GLOBALS['byftp_config_error']))",
         "Konfiguracija aplikacije nema valjan encryption ključ",
         "unset($GLOBALS['byftp_config_error']);",
+        "function byftp_archive_download_name(string $value): string",
+        "return $base . '.zip';",
     ):
         require(helpers, marker, "ByFTP WEB/app/helpers.php")
+
+    archive_download = read("ByFTP WEB/download-archive.php")
+    require(
+        archive_download,
+        "$name = byftp_archive_download_name((string)($_POST['name'] ?? 'byftp-download.zip'));",
+        "ByFTP WEB/download-archive.php",
+    )
+    if "byftp_truncate($name, 120)" in archive_download:
+        fail("archive download truncates the full filename after adding .zip")
 
     rate_limiter = read("ByFTP WEB/app/Security/RateLimiter.php")
     for marker in (
@@ -368,6 +383,14 @@ def main() -> int:
     ):
         require(zip_creation_tests, marker, "ByFTP WEB/tests/zip-creation.php")
 
+    archive_name_tests = read("ByFTP WEB/tests/archive-download-name.php")
+    for marker in (
+        "long archive name preserves zip extension after truncation",
+        "existing ZIP extension is normalized without duplication",
+        "unsafe archive filename characters are sanitized before header use",
+    ):
+        require(archive_name_tests, marker, "ByFTP WEB/tests/archive-download-name.php")
+
     registry_tests = read("ByFTP WEB/tests/user-registry.php")
     for marker in (
         "old-password-123",
@@ -435,6 +458,7 @@ def main() -> int:
     print(f"WEB_JS_SYNTAX_FILES={js_count}")
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_NAME_INPUTS=FAIL_CLOSED")
+    print("WEB_ARCHIVE_DOWNLOAD_NAME=PRESERVES_ZIP_EXTENSION")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_PROFILE_CREDENTIAL_RECOVERY=FAIL_CLOSED")


### PR DESCRIPTION
## Summary
- add a central `byftp_archive_download_name()` helper for ZIP attachment names
- sanitize the requested name, normalize any existing `.ZIP` suffix, truncate only the basename, then append `.zip`
- replace duplicated filename logic in `download-archive.php` with the helper
- add a focused runtime regression test and WEB audit enforcement

## Why
`download-archive.php` previously appended `.zip` and then truncated the complete filename to 120 characters. A sufficiently long requested name could therefore lose the `.zip` suffix in `Content-Disposition`, producing a misleading extensionless download even though the payload is a ZIP archive.

## Regression coverage
- long 200-character names remain capped while preserving `.zip`
- an existing `.ZIP` suffix is normalized without duplication
- missing suffixes are appended
- an empty basename falls back to `byftp-download.zip`
- CR/LF and unsupported filename characters are sanitized
- the WEB audit executes the regression and reports `WEB_ARCHIVE_DOWNLOAD_NAME=PRESERVES_ZIP_EXTENSION`

No version change; this is a focused 1.8.0 WEB download-contract fix.