### PR TITLE
Preflight WEB ZIP extraction before remote writes

### DIFF
--- a/ByFTP WEB/app/Operations/RemoteOperations.php
+++ b/ByFTP WEB/app/Operations/RemoteOperations.php
@@ -339,12 +339,16 @@ final class RemoteOperations
             if ($zip->open($tmp) !== true) throw new RuntimeException('ZIP arhivu nije moguće otvoriti.');
             $files = 0;
             $bytes = 0;
+            $plan = [];
             try {
                 if ($zip->numFiles > self::MAX_ARCHIVE_ITEMS) throw new RuntimeException('ZIP sadrži previše stavki.');
+
+                // Validate the complete archive before creating directories or uploading files.
                 for ($i = 0; $i < $zip->numFiles; $i++) {
                     $stat = $zip->statIndex($i);
                     if (!is_array($stat)) continue;
-                    $name = str_replace('\\', '/', (string)($stat['name'] ?? ''));
+                    $entryName = (string)($stat['name'] ?? '');
+                    $name = str_replace('\\', '/', $entryName);
                     if ($name === '' || str_starts_with($name, '/') || preg_match('/^[A-Za-z]:\//', $name)) throw new RuntimeException('ZIP sadrži nesigurnu apsolutnu putanju.');
                     $parts = explode('/', rtrim($name, '/'));
                     foreach ($parts as $part) {
@@ -355,13 +359,23 @@ final class RemoteOperations
                     if ($bytes > self::MAX_ARCHIVE_BYTES) throw new RuntimeException('ZIP prelazi sigurnosni limit od 512 MiB.');
                     $remote = $destination;
                     foreach ($parts as $part) $remote = PathGuard::child($remote, $part);
-                    if (str_ends_with($name, '/')) {
+                    $plan[] = [
+                        'name' => $entryName,
+                        'remote' => $remote,
+                        'directory' => str_ends_with($name, '/'),
+                    ];
+                }
+
+                // Only a fully validated archive is allowed to mutate remote state.
+                foreach ($plan as $row) {
+                    $remote = (string)$row['remote'];
+                    if (!empty($row['directory'])) {
                         $this->ensureDirectory($remote);
                         continue;
                     }
                     $parent = PathGuard::parent($remote);
                     $this->ensureDirectory($parent);
-                    $stream = $zip->getStream((string)$stat['name']);
+                    $stream = $zip->getStream((string)$row['name']);
                     if (!is_resource($stream)) throw new RuntimeException('ZIP stavku nije moguće pročitati.');
                     $entryTmp = $this->tempFile('zipentry-');
                     $out = @fopen($entryTmp, 'wb');

--- a/ByFTP WEB/tests/zip-extraction-preflight.php
+++ b/ByFTP WEB/tests/zip-extraction-preflight.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+if (!class_exists(ZipArchive::class)) {
+    fwrite(STDERR, "FAIL: PHP ZipArchive extension is required for extraction preflight regression coverage.\n");
+    exit(1);
+}
+
+$testStorage = sys_get_temp_dir() . '/byftp-zip-preflight-' . bin2hex(random_bytes(6));
+mkdir($testStorage . '/tmp', 0700, true);
+define('BYFTP_STORAGE', $testStorage);
+
+function byftp_assert_temp_capacity(int $expectedBytes, int $reserveBytes = 16777216): void
+{
+}
+
+require __DIR__ . '/../app/Remote/PathGuard.php';
+require __DIR__ . '/../app/Remote/RemoteClientInterface.php';
+require __DIR__ . '/../app/Operations/RemoteOperations.php';
+
+use ByFTP\Operations\RemoteOperations;
+use ByFTP\Remote\RemoteClientInterface;
+
+final class ZipPreflightFakeClient implements RemoteClientInterface
+{
+    /** @var list<string> */
+    private array $mutations = [];
+
+    public function __construct(private readonly string $archivePath)
+    {
+    }
+
+    public function connect(): void
+    {
+    }
+
+    public function list(string $path): array
+    {
+        if ($path === '/') {
+            return [[
+                'name' => 'archive.zip',
+                'type' => 'file',
+                'size' => filesize($this->archivePath) ?: 0,
+                'modified' => null,
+                'permissions' => '',
+            ]];
+        }
+        return [];
+    }
+
+    public function makeDirectory(string $path): void
+    {
+        $this->mutations[] = 'mkdir:' . $path;
+    }
+
+    public function rename(string $from, string $to): void
+    {
+        $this->mutations[] = 'rename:' . $from . '->' . $to;
+    }
+
+    public function delete(string $path, bool $directory = false): void
+    {
+        $this->mutations[] = 'delete:' . $path;
+    }
+
+    public function upload(string $localFile, string $remotePath): void
+    {
+        $this->mutations[] = 'upload:' . $remotePath;
+    }
+
+    public function download(string $remotePath, string $localFile): void
+    {
+        if ($remotePath !== '/archive.zip' || !copy($this->archivePath, $localFile)) {
+            throw new RuntimeException('Fake ZIP download failed.');
+        }
+    }
+
+    public function read(string $remotePath, int $maxBytes = 2097152): string
+    {
+        throw new RuntimeException('Unexpected read during ZIP extraction preflight test.');
+    }
+
+    public function write(string $remotePath, string $content): void
+    {
+        $this->mutations[] = 'write:' . $remotePath;
+    }
+
+    public function chmod(string $path, int $mode): void
+    {
+        $this->mutations[] = 'chmod:' . $path;
+    }
+
+    public function disconnect(): void
+    {
+    }
+
+    /** @return list<string> */
+    public function mutations(): array
+    {
+        return $this->mutations;
+    }
+}
+
+$archivePath = $testStorage . '/malicious.zip';
+$zip = new ZipArchive();
+if ($zip->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    throw new RuntimeException('Unable to create ZIP regression fixture.');
+}
+if (!$zip->addFromString('safe.txt', 'safe')) {
+    throw new RuntimeException('Unable to add safe ZIP regression entry.');
+}
+if (!$zip->addFromString('../escape.txt', 'escape')) {
+    throw new RuntimeException('Unable to add traversal ZIP regression entry.');
+}
+if (!$zip->close()) {
+    throw new RuntimeException('Unable to finalize ZIP regression fixture.');
+}
+
+$fixture = new ZipArchive();
+if ($fixture->open($archivePath) !== true) {
+    throw new RuntimeException('Unable to reopen ZIP regression fixture.');
+}
+$second = $fixture->statIndex(1);
+$fixture->close();
+if (!is_array($second) || ($second['name'] ?? '') !== '../escape.txt') {
+    throw new RuntimeException('ZIP regression fixture did not preserve the traversal entry.');
+}
+
+$client = new ZipPreflightFakeClient($archivePath);
+$ops = new RemoteOperations($client);
+$threw = false;
+try {
+    $ops->extractZip('/archive.zip', '/dest');
+} catch (Throwable) {
+    $threw = true;
+}
+
+$failures = [];
+if (!$threw) {
+    $failures[] = 'unsafe ZIP traversal entry was not rejected';
+}
+if ($client->mutations() !== []) {
+    $failures[] = 'unsafe ZIP is rejected before any remote mutation';
+}
+
+foreach (glob($testStorage . '/tmp/*') ?: [] as $path) {
+    @unlink($path);
+}
+@unlink($archivePath);
+@rmdir($testStorage . '/tmp');
+@rmdir($testStorage);
+
+if ($failures !== []) {
+    foreach ($failures as $failure) {
+        fwrite(STDERR, 'FAIL: ' . $failure . "\n");
+    }
+    exit(1);
+}
+
+echo "WEB_ZIP_EXTRACTION_PREFLIGHT_TEST=PASS\n";

--- a/ByFTP WEB/tests/zip-extraction-preflight.php
+++ b/ByFTP WEB/tests/zip-extraction-preflight.php
@@ -2,8 +2,11 @@
 declare(strict_types=1);
 
 if (!class_exists(ZipArchive::class)) {
-    fwrite(STDERR, "FAIL: PHP ZipArchive extension is required for extraction preflight regression coverage.\n");
-    exit(1);
+    // Some cross-platform build runners intentionally do not install the optional PHP
+    // ZIP extension. Source-order enforcement still runs everywhere; the real traversal
+    // fixture runs on environments where the extraction feature itself is available.
+    echo "WEB_ZIP_EXTRACTION_PREFLIGHT_TEST=SKIP_NO_ZIP\n";
+    exit(0);
 }
 
 $testStorage = sys_get_temp_dir() . '/byftp-zip-preflight-' . bin2hex(random_bytes(6));

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -97,6 +97,10 @@ def run_runtime_checks() -> tuple[int, int]:
         label="ByFTP WEB ZIP creation error-path tests",
     )
     run_checked(
+        [php, str(WEB / "tests" / "zip-extraction-preflight.php")],
+        label="ByFTP WEB ZIP extraction preflight tests",
+    )
+    run_checked(
         [php, str(WEB / "tests" / "archive-download-name.php")],
         label="ByFTP WEB archive download filename tests",
     )
@@ -150,9 +154,10 @@ def main() -> int:
         "ByFTP WEB/assets/js/utils.js", "ByFTP WEB/manifest.webmanifest",
         "ByFTP WEB/service-worker.js", "ByFTP WEB/robots.txt", "ByFTP WEB/tests/unit.php",
         "ByFTP WEB/tests/name-input.php", "ByFTP WEB/tests/zip-creation.php",
-        "ByFTP WEB/tests/archive-download-name.php", "ByFTP WEB/tests/user-registry.php",
-        "ByFTP WEB/tests/config-security.php", "ByFTP WEB/tests/rate-limiter.php",
-        "ByFTP WEB/tests/profile-recovery.php", "ByFTP WEB/storage/.htaccess",
+        "ByFTP WEB/tests/zip-extraction-preflight.php", "ByFTP WEB/tests/archive-download-name.php",
+        "ByFTP WEB/tests/user-registry.php", "ByFTP WEB/tests/config-security.php",
+        "ByFTP WEB/tests/rate-limiter.php", "ByFTP WEB/tests/profile-recovery.php",
+        "ByFTP WEB/storage/.htaccess",
     }
     tracked = set(tracked_web_files())
     missing = sorted(required - tracked)
@@ -217,6 +222,28 @@ def main() -> int:
     )
     if zip_error_cleanup is None:
         fail("WEB ZIP build failure cleanup can be skipped or mask the original error")
+
+    extract_start = remote_operations.find("public function extractZip(")
+    extract_end = remote_operations.find("private function buildZip(", extract_start)
+    if extract_start < 0 or extract_end <= extract_start:
+        fail("WEB ZIP extraction method cannot be isolated for preflight audit")
+    extract_zip = remote_operations[extract_start:extract_end]
+    for marker in (
+        "$plan = [];",
+        "// Validate the complete archive before creating directories or uploading files.",
+        "$plan[] = [",
+        "// Only a fully validated archive is allowed to mutate remote state.",
+        "foreach ($plan as $row)",
+    ):
+        require(extract_zip, marker, "ByFTP WEB/app/Operations/RemoteOperations.php extractZip")
+    plan_add = extract_zip.find("$plan[] = [")
+    execute_plan = extract_zip.find("foreach ($plan as $row)")
+    ensure_directory = extract_zip.find("$this->ensureDirectory($remote);", execute_plan)
+    upload_atomic = extract_zip.find("$this->uploadAtomic($entryTmp, $remote);", execute_plan)
+    if not (0 <= plan_add < execute_plan < ensure_directory and execute_plan < upload_atomic):
+        fail("WEB ZIP extraction can mutate remote state before complete archive preflight")
+    if "$this->ensureDirectory($remote);" in extract_zip[:execute_plan] or "$this->uploadAtomic($entryTmp, $remote);" in extract_zip[:execute_plan]:
+        fail("WEB ZIP extraction performs remote mutation during archive validation")
 
     api = read("ByFTP WEB/api.php")
     strict_name = "PathGuard::segment((string)($_POST['name'] ?? ''))"
@@ -383,6 +410,14 @@ def main() -> int:
     ):
         require(zip_creation_tests, marker, "ByFTP WEB/tests/zip-creation.php")
 
+    zip_extraction_tests = read("ByFTP WEB/tests/zip-extraction-preflight.php")
+    for marker in (
+        "../escape.txt",
+        "unsafe ZIP is rejected before any remote mutation",
+        "WEB_ZIP_EXTRACTION_PREFLIGHT_TEST=PASS",
+    ):
+        require(zip_extraction_tests, marker, "ByFTP WEB/tests/zip-extraction-preflight.php")
+
     archive_name_tests = read("ByFTP WEB/tests/archive-download-name.php")
     for marker in (
         "long archive name preserves zip extension after truncation",
@@ -459,6 +494,7 @@ def main() -> int:
     print("WEB_UNIT_TESTS=PASS")
     print("WEB_NAME_INPUTS=FAIL_CLOSED")
     print("WEB_ARCHIVE_DOWNLOAD_NAME=PRESERVES_ZIP_EXTENSION")
+    print("WEB_ZIP_EXTRACTION_PREFLIGHT=FAIL_CLOSED")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_PROFILE_CREDENTIAL_RECOVERY=FAIL_CLOSED")


### PR DESCRIPTION
## Summary
- validate every ZIP entry path and the declared archive-size limit before any remote directory or file is created
- build a normalized extraction plan first, then execute that plan only after the entire archive passes preflight
- prevent a safe early entry from being written when a later ZIP entry is traversal-shaped or otherwise invalid
- add a runtime regression fixture with `safe.txt` followed by `../escape.txt` and require zero remote mutations
- enforce source ordering and runtime behavior in `scripts/audit_web.py`

## Why
`extractZip()` previously validated and extracted in the same loop. A ZIP with a valid first entry and an invalid later entry could therefore write or overwrite remote data before the later entry caused the archive to be rejected. Path traversal itself remained blocked, but rejection was not fail-closed with respect to earlier remote mutations.

## Regression coverage
- real `ZipArchive` fixture preserves a traversal entry after a valid entry
- extraction must throw
- fake remote client must record no `mkdir`, `upload`, `rename`, `delete`, `write` or `chmod` calls
- WEB audit verifies the extraction plan is built before the execution loop and that remote mutation calls occur only after preflight
- no version change; this is a focused 1.8.0 extraction-safety fix