### PR TITLE
Reject conflicting WEB ZIP extraction topology

### DIFF
--- a/ByFTP WEB/app/Operations/RemoteOperations.php
+++ b/ByFTP WEB/app/Operations/RemoteOperations.php
@@ -366,6 +366,27 @@ final class RemoteOperations
                     ];
                 }
 
+                $plannedTypes = [];
+                foreach ($plan as $row) {
+                    $remote = (string)$row['remote'];
+                    if (array_key_exists($remote, $plannedTypes)) {
+                        throw new RuntimeException('ZIP sadrži više stavki za isto odredište.');
+                    }
+                    $plannedTypes[$remote] = !empty($row['directory']) ? 'dir' : 'file';
+                }
+                foreach ($plannedTypes as $remote => $type) {
+                    $parent = PathGuard::parent($remote);
+                    while ($parent !== '/') {
+                        if (($plannedTypes[$parent] ?? null) === 'file') {
+                            throw new RuntimeException('ZIP sadrži konflikt datoteke i podređene putanje.');
+                        }
+                        if ($parent === $destination) break;
+                        $next = PathGuard::parent($parent);
+                        if ($next === $parent) break;
+                        $parent = $next;
+                    }
+                }
+
                 // Only a fully validated archive is allowed to mutate remote state.
                 foreach ($plan as $row) {
                     $remote = (string)$row['remote'];

--- a/ByFTP WEB/tests/zip-extraction-preflight.php
+++ b/ByFTP WEB/tests/zip-extraction-preflight.php
@@ -104,6 +104,8 @@ final class ZipPreflightFakeClient implements RemoteClientInterface
     }
 }
 
+$failures = [];
+
 $archivePath = $testStorage . '/malicious.zip';
 $zip = new ZipArchive();
 if ($zip->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
@@ -137,8 +139,6 @@ try {
 } catch (Throwable) {
     $threw = true;
 }
-
-$failures = [];
 if (!$threw) {
     $failures[] = 'unsafe ZIP traversal entry was not rejected';
 }
@@ -146,10 +146,41 @@ if ($client->mutations() !== []) {
     $failures[] = 'unsafe ZIP is rejected before any remote mutation';
 }
 
+$topologyPath = $testStorage . '/topology.zip';
+$zip = new ZipArchive();
+if ($zip->open($topologyPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    throw new RuntimeException('Unable to create ZIP topology regression fixture.');
+}
+if (!$zip->addFromString('safe.txt', 'safe')) {
+    throw new RuntimeException('Unable to add ZIP topology parent file.');
+}
+if (!$zip->addFromString('safe.txt/child.txt', 'child')) {
+    throw new RuntimeException('Unable to add ZIP topology child file.');
+}
+if (!$zip->close()) {
+    throw new RuntimeException('Unable to finalize ZIP topology regression fixture.');
+}
+
+$topologyClient = new ZipPreflightFakeClient($topologyPath);
+$topologyOps = new RemoteOperations($topologyClient);
+$topologyThrew = false;
+try {
+    $topologyOps->extractZip('/archive.zip', '/dest');
+} catch (Throwable) {
+    $topologyThrew = true;
+}
+if (!$topologyThrew) {
+    $failures[] = 'conflicting ZIP file/child topology was not rejected';
+}
+if ($topologyClient->mutations() !== []) {
+    $failures[] = 'conflicting ZIP topology is rejected before any remote mutation';
+}
+
 foreach (glob($testStorage . '/tmp/*') ?: [] as $path) {
     @unlink($path);
 }
 @unlink($archivePath);
+@unlink($topologyPath);
 @rmdir($testStorage . '/tmp');
 @rmdir($testStorage);
 

--- a/scripts/audit_web.py
+++ b/scripts/audit_web.py
@@ -232,16 +232,30 @@ def main() -> int:
         "$plan = [];",
         "// Validate the complete archive before creating directories or uploading files.",
         "$plan[] = [",
+        "$plannedTypes = [];",
+        "array_key_exists($remote, $plannedTypes)",
+        "($plannedTypes[$parent] ?? null) === 'file'",
+        "ZIP sadrži više stavki za isto odredište.",
+        "ZIP sadrži konflikt datoteke i podređene putanje.",
         "// Only a fully validated archive is allowed to mutate remote state.",
         "foreach ($plan as $row)",
     ):
         require(extract_zip, marker, "ByFTP WEB/app/Operations/RemoteOperations.php extractZip")
     plan_add = extract_zip.find("$plan[] = [")
-    execute_plan = extract_zip.find("foreach ($plan as $row)")
+    topology_types = extract_zip.find("$plannedTypes = [];")
+    topology_duplicate = extract_zip.find("array_key_exists($remote, $plannedTypes)", topology_types)
+    topology_parent = extract_zip.find("($plannedTypes[$parent] ?? null) === 'file'", topology_types)
+    execution_marker = extract_zip.find("// Only a fully validated archive is allowed to mutate remote state.")
+    execute_plan = extract_zip.find("foreach ($plan as $row)", execution_marker)
     ensure_directory = extract_zip.find("$this->ensureDirectory($remote);", execute_plan)
     upload_atomic = extract_zip.find("$this->uploadAtomic($entryTmp, $remote);", execute_plan)
-    if not (0 <= plan_add < execute_plan < ensure_directory and execute_plan < upload_atomic):
-        fail("WEB ZIP extraction can mutate remote state before complete archive preflight")
+    if not (
+        0 <= plan_add < topology_types < topology_duplicate < execution_marker
+        and topology_types < topology_parent < execution_marker
+        and execution_marker < execute_plan < ensure_directory
+        and execute_plan < upload_atomic
+    ):
+        fail("WEB ZIP extraction topology validation does not complete before remote mutation")
     if "$this->ensureDirectory($remote);" in extract_zip[:execute_plan] or "$this->uploadAtomic($entryTmp, $remote);" in extract_zip[:execute_plan]:
         fail("WEB ZIP extraction performs remote mutation during archive validation")
 
@@ -414,6 +428,9 @@ def main() -> int:
     for marker in (
         "../escape.txt",
         "unsafe ZIP is rejected before any remote mutation",
+        "safe.txt/child.txt",
+        "conflicting ZIP file/child topology was not rejected",
+        "conflicting ZIP topology is rejected before any remote mutation",
         "WEB_ZIP_EXTRACTION_PREFLIGHT_TEST=PASS",
     ):
         require(zip_extraction_tests, marker, "ByFTP WEB/tests/zip-extraction-preflight.php")
@@ -495,6 +512,7 @@ def main() -> int:
     print("WEB_NAME_INPUTS=FAIL_CLOSED")
     print("WEB_ARCHIVE_DOWNLOAD_NAME=PRESERVES_ZIP_EXTENSION")
     print("WEB_ZIP_EXTRACTION_PREFLIGHT=FAIL_CLOSED")
+    print("WEB_ZIP_EXTRACTION_TOPOLOGY=FAIL_CLOSED")
     print("WEB_USER_REGISTRY_RECOVERY=FAIL_CLOSED")
     print("WEB_CONFIG_SECURITY_POLICY_RECOVERY=FAIL_CLOSED")
     print("WEB_PROFILE_CREDENTIAL_RECOVERY=FAIL_CLOSED")


### PR DESCRIPTION
## Summary
- reject duplicate normalized ZIP extraction destinations during preflight
- reject any extraction plan where a planned file is an ancestor of another planned entry
- perform both topology checks before the execution loop can create directories or upload files
- extend the real `ZipArchive` regression with `safe.txt` plus `safe.txt/child.txt` and require zero remote mutations
- enforce the topology ordering and markers in `scripts/audit_web.py`

## Why
The existing extraction preflight validated individual paths before remote writes, but it did not validate conflicts between otherwise valid planned destinations. A ZIP containing a file such as `safe.txt` and a later entry `safe.txt/child.txt` could therefore write the parent file and only then fail when the child required that same path to be a directory. Duplicate normalized targets were similarly ambiguous. Both conditions must fail before any remote mutation.

## Regression coverage
- real `ZipArchive` fixture contains `safe.txt` and `safe.txt/child.txt`
- extraction must throw before the fake remote client records any mutation
- source audit requires duplicate-target and file-as-parent checks between plan construction and the execution marker
- existing traversal preflight regression remains active
- Windows without optional PHP ZIP continues to use the existing `SKIP_NO_ZIP` behavior while Ubuntu executes the real runtime fixtures

No version change; this remains a focused 1.8.0 WEB extraction-safety fix.