### PR TITLE
Cover existing remote ZIP topology conflicts

### DIFF
--- a/ByFTP WEB/tests/zip-extraction-preflight.php
+++ b/ByFTP WEB/tests/zip-extraction-preflight.php
@@ -1,10 +1,45 @@
 <?php
 declare(strict_types=1);
 
+$remoteOperationsSource = file_get_contents(__DIR__ . '/../app/Operations/RemoteOperations.php');
+if (!is_string($remoteOperationsSource)) {
+    fwrite(STDERR, "FAIL: unable to inspect RemoteOperations ZIP extraction source.\n");
+    exit(1);
+}
+$extractStart = strpos($remoteOperationsSource, 'public function extractZip(');
+$extractEnd = $extractStart !== false ? strpos($remoteOperationsSource, 'private function buildZip(', $extractStart) : false;
+if ($extractStart === false || $extractEnd === false || $extractEnd <= $extractStart) {
+    fwrite(STDERR, "FAIL: unable to isolate ZIP extraction source.\n");
+    exit(1);
+}
+$extractSource = substr($remoteOperationsSource, $extractStart, $extractEnd - $extractStart);
+$requiredTypesPos = strpos($extractSource, '$requiredTypes = $plannedTypes;');
+$remoteStatePos = strpos($extractSource, "$remoteState = ['/'=>'dir'];");
+$listingCachePos = strpos($extractSource, '$listingCache = [];');
+$existingFileConflictPos = strpos($extractSource, 'ZIP odredište blokira postojeća datoteka.');
+$existingDirectoryConflictPos = strpos($extractSource, 'ZIP datoteka ne može prepisati postojeći direktorij.');
+$executionPos = strpos($extractSource, '// Only a fully validated archive is allowed to mutate remote state.');
+if (
+    $requiredTypesPos === false
+    || $remoteStatePos === false
+    || $listingCachePos === false
+    || $existingFileConflictPos === false
+    || $existingDirectoryConflictPos === false
+    || $executionPos === false
+    || !($requiredTypesPos < $remoteStatePos
+        && $remoteStatePos <= $listingCachePos
+        && $listingCachePos < $existingFileConflictPos
+        && $existingFileConflictPos < $executionPos
+        && $existingDirectoryConflictPos < $executionPos)
+) {
+    fwrite(STDERR, "FAIL: existing remote ZIP topology is not fully preflighted before execution.\n");
+    exit(1);
+}
+
 if (!class_exists(ZipArchive::class)) {
     // Some cross-platform build runners intentionally do not install the optional PHP
-    // ZIP extension. Source-order enforcement still runs everywhere; the real traversal
-    // fixture runs on environments where the extraction feature itself is available.
+    // ZIP extension. Source-order enforcement above still runs everywhere; the real
+    // archive fixtures run where the extraction feature itself is available.
     echo "WEB_ZIP_EXTRACTION_PREFLIGHT_TEST=SKIP_NO_ZIP\n";
     exit(0);
 }

--- a/ByFTP WEB/tests/zip-extraction-preflight.php
+++ b/ByFTP WEB/tests/zip-extraction-preflight.php
@@ -29,8 +29,11 @@ final class ZipPreflightFakeClient implements RemoteClientInterface
     /** @var list<string> */
     private array $mutations = [];
 
-    public function __construct(private readonly string $archivePath)
-    {
+    /** @param array<string, list<array<string, mixed>>> $listings */
+    public function __construct(
+        private readonly string $archivePath,
+        private readonly array $listings = [],
+    ) {
     }
 
     public function connect(): void
@@ -39,16 +42,17 @@ final class ZipPreflightFakeClient implements RemoteClientInterface
 
     public function list(string $path): array
     {
+        $items = $this->listings[$path] ?? [];
         if ($path === '/') {
-            return [[
+            array_unshift($items, [
                 'name' => 'archive.zip',
                 'type' => 'file',
                 'size' => filesize($this->archivePath) ?: 0,
                 'modified' => null,
                 'permissions' => '',
-            ]];
+            ]);
         }
-        return [];
+        return $items;
     }
 
     public function makeDirectory(string $path): void
@@ -176,11 +180,57 @@ if ($topologyClient->mutations() !== []) {
     $failures[] = 'conflicting ZIP topology is rejected before any remote mutation';
 }
 
+$remoteTopologyPath = $testStorage . '/remote-topology.zip';
+$zip = new ZipArchive();
+if ($zip->open($remoteTopologyPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    throw new RuntimeException('Unable to create existing remote topology fixture.');
+}
+if (!$zip->addFromString('first.txt', 'first')) {
+    throw new RuntimeException('Unable to add early safe ZIP entry.');
+}
+if (!$zip->addFromString('blocked/child.txt', 'child')) {
+    throw new RuntimeException('Unable to add remote-topology child entry.');
+}
+if (!$zip->close()) {
+    throw new RuntimeException('Unable to finalize existing remote topology fixture.');
+}
+
+$remoteTopologyClient = new ZipPreflightFakeClient($remoteTopologyPath, [
+    '/' => [[
+        'name' => 'dest',
+        'type' => 'dir',
+        'size' => 0,
+        'modified' => null,
+        'permissions' => '',
+    ]],
+    '/dest' => [[
+        'name' => 'blocked',
+        'type' => 'file',
+        'size' => 7,
+        'modified' => null,
+        'permissions' => '',
+    ]],
+]);
+$remoteTopologyOps = new RemoteOperations($remoteTopologyClient);
+$remoteTopologyThrew = false;
+try {
+    $remoteTopologyOps->extractZip('/archive.zip', '/dest');
+} catch (Throwable) {
+    $remoteTopologyThrew = true;
+}
+if (!$remoteTopologyThrew) {
+    $failures[] = 'existing remote file blocking a required ZIP directory was not rejected';
+}
+if ($remoteTopologyClient->mutations() !== []) {
+    $failures[] = 'existing remote ZIP topology conflict is rejected before any remote mutation';
+}
+
 foreach (glob($testStorage . '/tmp/*') ?: [] as $path) {
     @unlink($path);
 }
 @unlink($archivePath);
 @unlink($topologyPath);
+@unlink($remoteTopologyPath);
 @rmdir($testStorage . '/tmp');
 @rmdir($testStorage);
 


### PR DESCRIPTION
## Summary
- add permanent regression coverage for the existing-remote topology preflight merged in #107
- simulate `/dest/blocked` as an existing remote file while the archive contains `first.txt` followed by `blocked/child.txt`
- require the archive to be rejected before any remote mkdir/upload/rename/delete/write/chmod mutation occurs
- run source-order checks before the optional ZipArchive capability check, so Windows runners without PHP ZIP still verify the preflight contract
- keep the real ZipArchive fixture active on runners where extraction is available

## Security and stability
The production fix in #107 prevents an otherwise-valid ZIP from partially modifying remote state before a conflict with existing remote files/directories is discovered. This PR makes that behavior non-regressible across the CI matrix.

## Regression coverage
- existing remote file blocks a required ZIP directory
- an earlier safe archive entry must not be written first
- `$requiredTypes`, remote-state/listing-cache checks, and both existing file/directory conflict checks must occur before the extraction execution marker
- existing traversal and internal file/child topology fixtures remain active

No version change; this is regression hardening before the next cross-platform release.