### PR TITLE
Run read-only Ghost FTP 1.0.5 source audit

### DIFF
--- a/.github/workflows/one-shot-105-audit.yml
+++ b/.github/workflows/one-shot-105-audit.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - name: Scan exception, write and client-interface paths
+      - name: Scan exception, write, interface and visible-brand paths
         shell: bash
         run: |
           set -euo pipefail
@@ -32,3 +32,7 @@ jobs:
           grep -RFn --include='*.php' 'function write(string $remotePath' 'GhostFTP WEB' || true
           echo '=== RUNTIME_EXCEPTION_DYNAMIC ==='
           grep -REn --include='*.php' 'new RuntimeException\([^;]*(\$[A-Za-z_][A-Za-z0-9_]*|getMessage\()' 'GhostFTP WEB' || true
+          echo '=== VISIBLE_GHOSTFTP_TOPLEVEL ==='
+          grep -Fn --include='*.php' 'GhostFTP' 'GhostFTP WEB'/*.php || true
+          echo '=== VISIBLE_GHOSTFTP_VIEWS ==='
+          grep -RFn --include='*.php' 'GhostFTP' 'GhostFTP WEB/app/Views' || true

--- a/.github/workflows/one-shot-105-audit.yml
+++ b/.github/workflows/one-shot-105-audit.yml
@@ -1,0 +1,34 @@
+name: Ghost FTP 1.0.5 read-only audit
+
+on:
+  push:
+    branches:
+      - audit/ghost-ftp-1.0.5
+    paths:
+      - .github/workflows/one-shot-105-audit.yml
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Scan exception, write and client-interface paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo '=== GET_MESSAGE ==='
+          grep -RFn --include='*.php' 'getMessage()' 'GhostFTP WEB' || true
+          echo '=== THROWABLE_CATCHES ==='
+          grep -RFn --include='*.php' 'catch (\Throwable' 'GhostFTP WEB' || true
+          echo '=== FILE_PUT_CONTENTS ==='
+          grep -RFn --include='*.php' 'file_put_contents' 'GhostFTP WEB' || true
+          echo '=== REMOTE_WRITE_CALLS ==='
+          grep -RFn --include='*.php' -- '->write(' 'GhostFTP WEB' || true
+          echo '=== REMOTE_WRITE_DECLARATIONS ==='
+          grep -RFn --include='*.php' 'function write(string $remotePath' 'GhostFTP WEB' || true
+          echo '=== RUNTIME_EXCEPTION_DYNAMIC ==='
+          grep -REn --include='*.php' 'new RuntimeException\([^;]*(\$[A-Za-z_][A-Za-z0-9_]*|getMessage\()' 'GhostFTP WEB' || true


### PR DESCRIPTION
## Authorization

- [ ] This source-code change was explicitly requested or authorized for Ghost FTP.
- [ ] I have read and will follow `LICENSE` and the contribution documentation.

> Ghost FTP is source-available software. Opening a pull request or fork does not itself grant rights beyond the repository license and applicable GitHub platform rights.

## Summary

Describe the change and why it is needed.

## Branding and compatibility

- [ ] New public UI, documentation and release assets use **Ghost FTP**.
- [ ] Any retained `GhostFTP`/`GhostFTP` identifier is required for backward compatibility, migration or installed-application identity and is not user-facing branding.

## Security and privacy

- [ ] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [ ] No automatic external API or hidden network destination was added.
- [ ] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [ ] SFTP host-key verification and pinning remain active.
- [ ] Local path-traversal, symlink, junction and reparse-point protections remain active.
- [ ] No external Go module was added without explicit architecture/security review.
- [ ] Tests, screenshots and fixtures contain no real credentials, production servers or customer data.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/audit_security.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] PHP syntax checks pass when web code changed.
- [ ] Native platform build checks pass for affected platforms.

## Regression coverage

Describe tests added or changed for connections, transfers, paths, profiles, installation/uninstallation, localization, release packaging or other affected behavior.
