### PR TITLE
Release/ghost ftp 1.1.0 quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,12 @@ jobs:
           go test ./...
           go test -race ./...
           go vet ./...
-      - name: Repository, version, documentation and release audits
+      - name: Repository, dependency, version, documentation and release audits
         shell: bash
         run: |
           set -euo pipefail
           python scripts/audit_repository.py
+          python scripts/audit_dependencies.py
           python scripts/audit_version.py
           python scripts/audit_localization.py
           python scripts/audit_docs.py
@@ -218,7 +219,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
       - name: Build and verify IPA
         shell: bash
         run: |

--- a/.github/workflows/one-shot-110-foundation.yml
+++ b/.github/workflows/one-shot-110-foundation.yml
@@ -1,5 +1,6 @@
 name: Apply Ghost FTP 1.1.0 foundation
 
+# validation revision 2: distinguish PHP platform requirements from Composer packages
 on:
   push:
     branches: [release/ghost-ftp-1.1.0-quality]

--- a/.github/workflows/one-shot-110-foundation.yml
+++ b/.github/workflows/one-shot-110-foundation.yml
@@ -1,6 +1,6 @@
 name: Apply Ghost FTP 1.1.0 foundation
 
-# validation revision 3: commit source only; workflow cleanup is connector-managed
+# validation revision 4: write validated non-workflow source through Contents API
 on:
   push:
     branches: [release/ghost-ftp-1.1.0-quality]
@@ -71,22 +71,60 @@ jobs:
           python scripts/audit_docs.py
           python scripts/audit_security.py
           python scripts/audit_privacy.py
-      - name: Commit validated source without workflow mutation
+      - name: Publish validated non-workflow source through GitHub API
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # GitHub Actions tokens without workflows scope cannot delete their own
-          # workflow file. Restore only this helper after auditing the clean index;
-          # it is deleted immediately afterwards through the GitHub connector.
+          repo="$GITHUB_REPOSITORY"
+          branch='release/ghost-ftp-1.1.0-quality'
+
+          # Keep the temporary workflow on the remote branch only until this job
+          # has published every validated source change. It is deleted by the
+          # controlling GitHub connector immediately after this job succeeds.
           git restore --staged .github/workflows/one-shot-110-foundation.yml
           git restore .github/workflows/one-shot-110-foundation.yml
-          if git diff --cached --quiet; then
-            echo 'No validated source changes to commit.'
-            exit 0
-          fi
-          git config user.name 'Brendigo'
-          git config user.email 'info@brendigo.com'
-          git commit -m 'Build English-first 24-language 1.1.0 foundation'
-          git push origin HEAD:release/ghost-ftp-1.1.0-quality
+
+          git diff --cached --name-status -z | while IFS= read -r -d '' status && IFS= read -r -d '' path; do
+            case "$path" in
+              .github/workflows/*)
+                echo "Refusing to mutate workflow through this source writer: $path" >&2
+                exit 1
+                ;;
+            esac
+
+            encoded_path="$(python -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe="/"))' "$path")"
+            endpoint="repos/$repo/contents/$encoded_path"
+
+            case "$status" in
+              D*)
+                sha="$(gh api "$endpoint?ref=$branch" --jq .sha)"
+                gh api --method DELETE "$endpoint" \
+                  -f message="Remove validated temporary 1.1.0 tooling" \
+                  -f branch="$branch" \
+                  -f sha="$sha" >/dev/null
+                ;;
+              A*|M*)
+                content="$(base64 -w0 "$path")"
+                if sha="$(gh api "$endpoint?ref=$branch" --jq .sha 2>/dev/null)"; then
+                  gh api --method PUT "$endpoint" \
+                    -f message="Apply validated Ghost FTP 1.1.0 foundation: $path" \
+                    -f branch="$branch" \
+                    -f sha="$sha" \
+                    -f content="$content" >/dev/null
+                else
+                  gh api --method PUT "$endpoint" \
+                    -f message="Add validated Ghost FTP 1.1.0 foundation: $path" \
+                    -f branch="$branch" \
+                    -f content="$content" >/dev/null
+                fi
+                ;;
+              *)
+                echo "Unsupported staged status $status for $path" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          echo 'FOUNDATION_CONTENTS_API_WRITE=PASS'

--- a/.github/workflows/one-shot-110-foundation.yml
+++ b/.github/workflows/one-shot-110-foundation.yml
@@ -1,0 +1,83 @@
+name: Apply Ghost FTP 1.1.0 foundation
+
+on:
+  push:
+    branches: [release/ghost-ftp-1.1.0-quality]
+    paths:
+      - '.github/workflows/one-shot-110-foundation.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  foundation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GOTOOLCHAIN: local
+      GOPROXY: off
+      GOSUMDB: off
+    steps:
+      - name: Checkout foundation branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: release/ghost-ftp-1.1.0-quality
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+      - name: Apply foundation patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/one_shot_110_foundation.py
+          gofmt -w \
+            cmd/installer/messages.go \
+            cmd/installer/main.go \
+            internal/i18n/i18n.go \
+            internal/i18n/i18n_test.go \
+            internal/i18n/locale_additional.go \
+            internal/platform/language_windows.go
+      - name: Remove and stage one-shot tooling before audits
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f scripts/one_shot_110_foundation.py .github/workflows/one-shot-110-foundation.yml
+          git add -A
+          test -z "$(git ls-files '.github/workflows/one-shot-*')"
+      - name: Validate clean production tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+          test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*' -print))"
+          go test ./...
+          go vet ./...
+          python scripts/audit_repository.py
+          python scripts/audit_dependencies.py
+          python scripts/audit_localization.py
+          python scripts/audit_docs.py
+          python scripts/audit_security.py
+          python scripts/audit_privacy.py
+      - name: Commit validated foundation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git diff --cached --quiet; then
+            echo 'No validated changes to commit.'
+            exit 0
+          fi
+          git config user.name 'Brendigo'
+          git config user.email 'info@brendigo.com'
+          git commit -m 'Build English-first 24-language 1.1.0 foundation'
+          git push origin HEAD:release/ghost-ftp-1.1.0-quality

--- a/.github/workflows/one-shot-110-foundation.yml
+++ b/.github/workflows/one-shot-110-foundation.yml
@@ -1,6 +1,6 @@
 name: Apply Ghost FTP 1.1.0 foundation
 
-# validation revision 2: distinguish PHP platform requirements from Composer packages
+# validation revision 3: commit source only; workflow cleanup is connector-managed
 on:
   push:
     branches: [release/ghost-ftp-1.1.0-quality]
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python scripts/one_shot_110_foundation.py
+          python scripts/one_shot_110_finalize.py
           gofmt -w \
             cmd/installer/messages.go \
             cmd/installer/main.go \
@@ -50,7 +50,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -f scripts/one_shot_110_foundation.py .github/workflows/one-shot-110-foundation.yml
+          rm -f \
+            scripts/one_shot_110_foundation.py \
+            scripts/one_shot_110_finalize.py \
+            .github/workflows/one-shot-110-foundation.yml
           git add -A
           test -z "$(git ls-files '.github/workflows/one-shot-*')"
       - name: Validate clean production tree
@@ -68,14 +71,19 @@ jobs:
           python scripts/audit_docs.py
           python scripts/audit_security.py
           python scripts/audit_privacy.py
-      - name: Commit validated foundation
+      - name: Commit validated source without workflow mutation
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # GitHub Actions tokens without workflows scope cannot delete their own
+          # workflow file. Restore only this helper after auditing the clean index;
+          # it is deleted immediately afterwards through the GitHub connector.
+          git restore --staged .github/workflows/one-shot-110-foundation.yml
+          git restore .github/workflows/one-shot-110-foundation.yml
           if git diff --cached --quiet; then
-            echo 'No validated changes to commit.'
+            echo 'No validated source changes to commit.'
             exit 0
           fi
           git config user.name 'Brendigo'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.0 - Unreleased
+
+- Expanded the canonical English-first desktop/setup language registry from 18 to 24 languages, adding Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.
+- Added regional locale normalization including Norwegian `nb`/`nn` and Simplified Chinese aliases.
+- Replaced the weak eight-string supplemental-locale threshold with measured translation coverage and a 30-string translated-core floor for supplemental catalogs.
+- Added localized primary Windows Setup confirmation/completion/launch/warning copy for all 24 canonical languages while retaining English as the safe fallback.
+- Improved the dependency provenance contract: no external Go modules, zero third-party Web Composer packages, exactly pinned Android dependencies, and fail-closed rejection of tracking/ads/crash SDKs or dynamic versions.
+- Added detailed localization, dependency, settings and immutable release-history documentation.
+- 1.1.0 remains unreleased until Android, iOS and Web/PWA localization plus protocol/option work pass the full cross-platform release gate.
+
 ## 1.0.7 - 2026-09-05
 
 - Took atomic-upload staging cleanup ownership before FTP/SFTP transfer begins, closing the gap where a partial remote staging file could survive when the transport failed before returning success.

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Always verify `SHA256.txt` before installation. See [Signing](docs/SIGNING.md) a
 
 ## Languages
 
-English is the default runtime language. Ghost FTP currently includes localization catalogs for English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian and Swedish.
+English is the primary and fallback runtime language. The 1.1.0 development line defines 24 canonical desktop/setup languages: English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Simplified Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian, Swedish, Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.
 
-Language selection is persisted in application settings. New canonical user-facing text is maintained English-first and translated through the localization system.
+Language selection is persisted in application settings. Regional locale aliases normalize to canonical codes, and CI measures real translation coverage instead of counting an English-filled catalog as fully localized. Android, iOS and Web/PWA are being aligned to the same contract before 1.1.0 can be released. See [Localization](docs/LOCALIZATION.md).
 
 ## Documentation
 
@@ -104,6 +104,10 @@ Language selection is persisted in application settings. New canonical user-faci
 - [Contributing](docs/CONTRIBUTING.md)
 - [GitHub Releases](docs/GITHUB-RELEASES.md)
 - [Installation](docs/INSTALLATION.md)
+- [Localization](docs/LOCALIZATION.md)
+- [Settings](docs/SETTINGS.md)
+- [Dependencies](docs/DEPENDENCIES.md)
+- [Release history](docs/RELEASE-HISTORY.md)
 - [Privacy](docs/PRIVACY.md)
 - [Release verification](docs/RELEASE-VERIFICATION.md)
 - [Roadmap](docs/ROADMAP.md)
@@ -132,6 +136,8 @@ go test ./...
 go test -race ./...
 go vet ./...
 python scripts/audit_repository.py
+python scripts/audit_dependencies.py
+python scripts/audit_localization.py
 python scripts/audit_security.py
 python scripts/audit_privacy.py
 python scripts/audit_web.py

--- a/cmd/installer/language.go
+++ b/cmd/installer/language.go
@@ -23,7 +23,7 @@ func selectInstallerLanguage() (string, bool) {
 
 	index, ok := platform.SelectLanguageDialog(
 		brand.ProductName+" Setup",
-		"Choose the language to use in Ghost FTP. You can change it later in Settings.",
+		"Choose the setup language. English is the default.\nNo telemetry · No ads · FTP · FTPS · SFTP",
 		options,
 		0,
 	)

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -345,13 +345,13 @@ func runInstaller() (exitCode int) {
 	if !ok {
 		return 0
 	}
+	setupCopy := installerCopyFor(installLanguage)
 
-	content := brand.Website + "\n" + brand.Support + "\n\n" +
-		brand.ProductName + " will be installed for your Windows user account and will be available from the Start menu."
+	content := brand.Website + "\n" + brand.Support + "\n\n" + setupCopy.ConfirmBody
 
 	if !platform.ConfirmDialog(
 		installerTitle(),
-		"Install "+brand.ProductFull+" "+version+"?",
+		installerConfirmTitle(installLanguage, version),
 		content,
 	) {
 		return 0
@@ -487,25 +487,25 @@ func runInstaller() (exitCode int) {
 
 	languageWarning := ""
 	if err := persistInstallerLanguage(installLanguage); err != nil {
-		languageWarning = "\n\nThe selected language could not be saved. Ghost FTP will start in English; you can change the language in Settings."
+		languageWarning = "\n\n" + setupCopy.LanguageWarning
 	}
 
 	shortcutWarning := ""
 	if err := platform.CreateShortcuts(appPath); err != nil {
-		shortcutWarning = "\n\nA shortcut could not be created. You can start Ghost FTP from its installation folder."
+		shortcutWarning = "\n\n" + setupCopy.ShortcutWarning
 	}
 
 	if platform.ConfirmDialog(
 		installerTitle(),
-		"Setup completed successfully",
-		"Ghost FTP is ready to use."+legacyCleanupWarning+languageWarning+shortcutWarning+"\n\nLaunch Ghost FTP now?",
+		setupCopy.CompletedTitle,
+		setupCopy.ReadyBody+legacyCleanupWarning+languageWarning+shortcutWarning+"\n\n"+setupCopy.LaunchQuestion,
 	) {
 		cmd := exec.Command(appPath)
 		if err := cmd.Start(); err != nil {
 			platform.ErrorDialog(
 				installerTitle(),
-				"Ghost FTP is installed",
-				"Ghost FTP could not be launched automatically. Start it from the Windows Start menu.",
+				setupCopy.InstalledTitle,
+				setupCopy.LaunchFailed,
 			)
 		}
 	}

--- a/cmd/installer/messages.go
+++ b/cmd/installer/messages.go
@@ -171,15 +171,33 @@ func installerCopyFor(language string) installerCopy {
 	if !ok {
 		return base
 	}
-	if localized.ConfirmTitle == "" { localized.ConfirmTitle = base.ConfirmTitle }
-	if localized.ConfirmBody == "" { localized.ConfirmBody = base.ConfirmBody }
-	if localized.CompletedTitle == "" { localized.CompletedTitle = base.CompletedTitle }
-	if localized.ReadyBody == "" { localized.ReadyBody = base.ReadyBody }
-	if localized.LaunchQuestion == "" { localized.LaunchQuestion = base.LaunchQuestion }
-	if localized.InstalledTitle == "" { localized.InstalledTitle = base.InstalledTitle }
-	if localized.LaunchFailed == "" { localized.LaunchFailed = base.LaunchFailed }
-	if localized.LanguageWarning == "" { localized.LanguageWarning = base.LanguageWarning }
-	if localized.ShortcutWarning == "" { localized.ShortcutWarning = base.ShortcutWarning }
+	if localized.ConfirmTitle == "" {
+		localized.ConfirmTitle = base.ConfirmTitle
+	}
+	if localized.ConfirmBody == "" {
+		localized.ConfirmBody = base.ConfirmBody
+	}
+	if localized.CompletedTitle == "" {
+		localized.CompletedTitle = base.CompletedTitle
+	}
+	if localized.ReadyBody == "" {
+		localized.ReadyBody = base.ReadyBody
+	}
+	if localized.LaunchQuestion == "" {
+		localized.LaunchQuestion = base.LaunchQuestion
+	}
+	if localized.InstalledTitle == "" {
+		localized.InstalledTitle = base.InstalledTitle
+	}
+	if localized.LaunchFailed == "" {
+		localized.LaunchFailed = base.LaunchFailed
+	}
+	if localized.LanguageWarning == "" {
+		localized.LanguageWarning = base.LanguageWarning
+	}
+	if localized.ShortcutWarning == "" {
+		localized.ShortcutWarning = base.ShortcutWarning
+	}
 	return localized
 }
 

--- a/cmd/installer/messages.go
+++ b/cmd/installer/messages.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+)
+
+type installerCopy struct {
+	ConfirmTitle    string
+	ConfirmBody     string
+	CompletedTitle  string
+	ReadyBody       string
+	LaunchQuestion  string
+	InstalledTitle  string
+	LaunchFailed    string
+	LanguageWarning string
+	ShortcutWarning string
+}
+
+var installerCopies = map[string]installerCopy{
+	"en": {
+		ConfirmTitle: "Install Ghost FTP %s?", ConfirmBody: "Ghost FTP will be installed for your Windows user account and will be available from the Start menu.",
+		CompletedTitle: "Setup completed successfully", ReadyBody: "Ghost FTP is ready to use.", LaunchQuestion: "Launch Ghost FTP now?", InstalledTitle: "Ghost FTP is installed",
+		LaunchFailed: "Ghost FTP could not be launched automatically. Start it from the Windows Start menu.", LanguageWarning: "The selected language could not be saved. Ghost FTP will start in English; you can change the language in Settings.",
+		ShortcutWarning: "A shortcut could not be created. You can start Ghost FTP from its installation folder.",
+	},
+	"hr": {
+		ConfirmTitle: "Instalirati Ghost FTP %s?", ConfirmBody: "Ghost FTP instalirat će se za vaš Windows korisnički račun i bit će dostupan iz izbornika Start.",
+		CompletedTitle: "Instalacija je uspješno dovršena", ReadyBody: "Ghost FTP je spreman za korištenje.", LaunchQuestion: "Pokrenuti Ghost FTP sada?", InstalledTitle: "Ghost FTP je instaliran",
+		LaunchFailed: "Ghost FTP nije moguće automatski pokrenuti. Pokrenite ga iz Windows izbornika Start.", LanguageWarning: "Odabrani jezik nije spremljen. Ghost FTP će se pokrenuti na engleskom; jezik možete promijeniti u Postavkama.",
+		ShortcutWarning: "Prečac nije moguće izraditi. Ghost FTP možete pokrenuti iz instalacijske mape.",
+	},
+	"de": {
+		ConfirmTitle: "Ghost FTP %s installieren?", ConfirmBody: "Ghost FTP wird für Ihr Windows-Benutzerkonto installiert und ist über das Startmenü verfügbar.",
+		CompletedTitle: "Setup erfolgreich abgeschlossen", ReadyBody: "Ghost FTP ist einsatzbereit.", LaunchQuestion: "Ghost FTP jetzt starten?", InstalledTitle: "Ghost FTP ist installiert",
+		LaunchFailed: "Ghost FTP konnte nicht automatisch gestartet werden. Starten Sie es über das Windows-Startmenü.", LanguageWarning: "Die ausgewählte Sprache konnte nicht gespeichert werden. Ghost FTP startet auf Englisch; Sie können die Sprache in den Einstellungen ändern.",
+		ShortcutWarning: "Eine Verknüpfung konnte nicht erstellt werden. Sie können Ghost FTP aus dem Installationsordner starten.",
+	},
+	"fr": {
+		ConfirmTitle: "Installer Ghost FTP %s ?", ConfirmBody: "Ghost FTP sera installé pour votre compte Windows et sera disponible depuis le menu Démarrer.",
+		CompletedTitle: "Installation terminée avec succès", ReadyBody: "Ghost FTP est prêt à être utilisé.", LaunchQuestion: "Lancer Ghost FTP maintenant ?", InstalledTitle: "Ghost FTP est installé",
+		LaunchFailed: "Ghost FTP n'a pas pu être lancé automatiquement. Démarrez-le depuis le menu Démarrer de Windows.", LanguageWarning: "La langue sélectionnée n'a pas pu être enregistrée. Ghost FTP démarrera en anglais ; vous pourrez modifier la langue dans les paramètres.",
+		ShortcutWarning: "Un raccourci n'a pas pu être créé. Vous pouvez démarrer Ghost FTP depuis son dossier d'installation.",
+	},
+	"es": {
+		ConfirmTitle: "¿Instalar Ghost FTP %s?", ConfirmBody: "Ghost FTP se instalará para su cuenta de Windows y estará disponible desde el menú Inicio.",
+		CompletedTitle: "Instalación completada correctamente", ReadyBody: "Ghost FTP está listo para usarse.", LaunchQuestion: "¿Iniciar Ghost FTP ahora?", InstalledTitle: "Ghost FTP está instalado",
+		LaunchFailed: "Ghost FTP no pudo iniciarse automáticamente. Inícielo desde el menú Inicio de Windows.", LanguageWarning: "No se pudo guardar el idioma seleccionado. Ghost FTP se iniciará en inglés; puede cambiar el idioma en Configuración.",
+		ShortcutWarning: "No se pudo crear un acceso directo. Puede iniciar Ghost FTP desde su carpeta de instalación.",
+	},
+	"tr": {
+		ConfirmTitle: "Ghost FTP %s yüklensin mi?", ConfirmBody: "Ghost FTP Windows kullanıcı hesabınız için yüklenecek ve Başlat menüsünden erişilebilir olacaktır.",
+		CompletedTitle: "Kurulum başarıyla tamamlandı", ReadyBody: "Ghost FTP kullanıma hazır.", LaunchQuestion: "Ghost FTP şimdi başlatılsın mı?", InstalledTitle: "Ghost FTP yüklendi",
+		LaunchFailed: "Ghost FTP otomatik olarak başlatılamadı. Windows Başlat menüsünden başlatın.", LanguageWarning: "Seçilen dil kaydedilemedi. Ghost FTP İngilizce başlayacak; dili Ayarlar'dan değiştirebilirsiniz.",
+		ShortcutWarning: "Kısayol oluşturulamadı. Ghost FTP'yi kurulum klasöründen başlatabilirsiniz.",
+	},
+	"el": {
+		ConfirmTitle: "Εγκατάσταση Ghost FTP %s;", ConfirmBody: "Το Ghost FTP θα εγκατασταθεί για τον λογαριασμό Windows και θα είναι διαθέσιμο από το μενού Έναρξη.",
+		CompletedTitle: "Η εγκατάσταση ολοκληρώθηκε επιτυχώς", ReadyBody: "Το Ghost FTP είναι έτοιμο για χρήση.", LaunchQuestion: "Εκκίνηση του Ghost FTP τώρα;", InstalledTitle: "Το Ghost FTP εγκαταστάθηκε",
+		LaunchFailed: "Δεν ήταν δυνατή η αυτόματη εκκίνηση του Ghost FTP. Εκκινήστε το από το μενού Έναρξη των Windows.", LanguageWarning: "Η επιλεγμένη γλώσσα δεν αποθηκεύτηκε. Το Ghost FTP θα ξεκινήσει στα Αγγλικά· μπορείτε να αλλάξετε γλώσσα στις Ρυθμίσεις.",
+		ShortcutWarning: "Δεν ήταν δυνατή η δημιουργία συντόμευσης. Μπορείτε να ξεκινήσετε το Ghost FTP από τον φάκελο εγκατάστασης.",
+	},
+	"pt": {
+		ConfirmTitle: "Instalar Ghost FTP %s?", ConfirmBody: "O Ghost FTP será instalado para a sua conta do Windows e ficará disponível no menu Iniciar.",
+		CompletedTitle: "Instalação concluída com sucesso", ReadyBody: "O Ghost FTP está pronto para uso.", LaunchQuestion: "Iniciar o Ghost FTP agora?", InstalledTitle: "O Ghost FTP está instalado",
+		LaunchFailed: "O Ghost FTP não pôde ser iniciado automaticamente. Inicie-o pelo menu Iniciar do Windows.", LanguageWarning: "O idioma selecionado não pôde ser salvo. O Ghost FTP iniciará em inglês; você pode alterar o idioma nas Configurações.",
+		ShortcutWarning: "Não foi possível criar um atalho. Você pode iniciar o Ghost FTP pela pasta de instalação.",
+	},
+	"zh": {
+		ConfirmTitle: "安装 Ghost FTP %s？", ConfirmBody: "Ghost FTP 将为当前 Windows 用户账户安装，并可从“开始”菜单启动。",
+		CompletedTitle: "安装成功完成", ReadyBody: "Ghost FTP 已可使用。", LaunchQuestion: "现在启动 Ghost FTP？", InstalledTitle: "Ghost FTP 已安装",
+		LaunchFailed: "无法自动启动 Ghost FTP。请从 Windows“开始”菜单启动。", LanguageWarning: "无法保存所选语言。Ghost FTP 将以英语启动；您可以在“设置”中更改语言。",
+		ShortcutWarning: "无法创建快捷方式。您可以从安装文件夹启动 Ghost FTP。",
+	},
+	"ru": {
+		ConfirmTitle: "Установить Ghost FTP %s?", ConfirmBody: "Ghost FTP будет установлен для вашей учетной записи Windows и будет доступен из меню «Пуск».",
+		CompletedTitle: "Установка успешно завершена", ReadyBody: "Ghost FTP готов к работе.", LaunchQuestion: "Запустить Ghost FTP сейчас?", InstalledTitle: "Ghost FTP установлен",
+		LaunchFailed: "Не удалось автоматически запустить Ghost FTP. Запустите его из меню «Пуск» Windows.", LanguageWarning: "Не удалось сохранить выбранный язык. Ghost FTP запустится на английском; язык можно изменить в настройках.",
+		ShortcutWarning: "Не удалось создать ярлык. Ghost FTP можно запустить из папки установки.",
+	},
+	"hi": {
+		ConfirmTitle: "Ghost FTP %s इंस्टॉल करें?", ConfirmBody: "Ghost FTP आपके Windows उपयोगकर्ता खाते के लिए इंस्टॉल होगा और Start मेनू से उपलब्ध रहेगा।",
+		CompletedTitle: "सेटअप सफलतापूर्वक पूरा हुआ", ReadyBody: "Ghost FTP उपयोग के लिए तैयार है।", LaunchQuestion: "Ghost FTP अभी शुरू करें?", InstalledTitle: "Ghost FTP इंस्टॉल हो गया है",
+		LaunchFailed: "Ghost FTP अपने आप शुरू नहीं हो सका। इसे Windows Start मेनू से शुरू करें।", LanguageWarning: "चुनी हुई भाषा सहेजी नहीं जा सकी। Ghost FTP अंग्रेज़ी में शुरू होगा; भाषा Settings में बदली जा सकती है।",
+		ShortcutWarning: "शॉर्टकट नहीं बनाया जा सका। Ghost FTP को इंस्टॉलेशन फ़ोल्डर से शुरू किया जा सकता है।",
+	},
+	"ja": {
+		ConfirmTitle: "Ghost FTP %s をインストールしますか？", ConfirmBody: "Ghost FTP は現在の Windows ユーザー用にインストールされ、スタートメニューから利用できます。",
+		CompletedTitle: "セットアップが正常に完了しました", ReadyBody: "Ghost FTP を使用できます。", LaunchQuestion: "Ghost FTP を今すぐ起動しますか？", InstalledTitle: "Ghost FTP はインストール済みです",
+		LaunchFailed: "Ghost FTP を自動起動できませんでした。Windows のスタートメニューから起動してください。", LanguageWarning: "選択した言語を保存できませんでした。Ghost FTP は英語で起動します。言語は設定で変更できます。",
+		ShortcutWarning: "ショートカットを作成できませんでした。インストールフォルダーから Ghost FTP を起動できます。",
+	},
+	"it": {
+		ConfirmTitle: "Installare Ghost FTP %s?", ConfirmBody: "Ghost FTP verrà installato per il tuo account Windows e sarà disponibile dal menu Start.",
+		CompletedTitle: "Installazione completata correttamente", ReadyBody: "Ghost FTP è pronto all'uso.", LaunchQuestion: "Avviare Ghost FTP ora?", InstalledTitle: "Ghost FTP è installato",
+		LaunchFailed: "Ghost FTP non è stato avviato automaticamente. Avvialo dal menu Start di Windows.", LanguageWarning: "La lingua selezionata non è stata salvata. Ghost FTP si avvierà in inglese; puoi cambiare lingua nelle Impostazioni.",
+		ShortcutWarning: "Non è stato possibile creare un collegamento. Puoi avviare Ghost FTP dalla cartella di installazione.",
+	},
+	"pl": {
+		ConfirmTitle: "Zainstalować Ghost FTP %s?", ConfirmBody: "Ghost FTP zostanie zainstalowany dla Twojego konta Windows i będzie dostępny z menu Start.",
+		CompletedTitle: "Instalacja zakończona pomyślnie", ReadyBody: "Ghost FTP jest gotowy do użycia.", LaunchQuestion: "Uruchomić Ghost FTP teraz?", InstalledTitle: "Ghost FTP jest zainstalowany",
+		LaunchFailed: "Nie udało się automatycznie uruchomić Ghost FTP. Uruchom program z menu Start systemu Windows.", LanguageWarning: "Nie udało się zapisać wybranego języka. Ghost FTP uruchomi się po angielsku; język można zmienić w Ustawieniach.",
+		ShortcutWarning: "Nie udało się utworzyć skrótu. Ghost FTP można uruchomić z folderu instalacyjnego.",
+	},
+	"nl": {
+		ConfirmTitle: "Ghost FTP %s installeren?", ConfirmBody: "Ghost FTP wordt voor uw Windows-account geïnstalleerd en is beschikbaar via het Startmenu.",
+		CompletedTitle: "Installatie succesvol voltooid", ReadyBody: "Ghost FTP is klaar voor gebruik.", LaunchQuestion: "Ghost FTP nu starten?", InstalledTitle: "Ghost FTP is geïnstalleerd",
+		LaunchFailed: "Ghost FTP kon niet automatisch worden gestart. Start het via het Windows Startmenu.", LanguageWarning: "De gekozen taal kon niet worden opgeslagen. Ghost FTP start in het Engels; u kunt de taal wijzigen in Instellingen.",
+		ShortcutWarning: "Er kon geen snelkoppeling worden gemaakt. U kunt Ghost FTP vanuit de installatiemap starten.",
+	},
+	"cs": {
+		ConfirmTitle: "Nainstalovat Ghost FTP %s?", ConfirmBody: "Ghost FTP bude nainstalován pro váš účet Windows a bude dostupný z nabídky Start.",
+		CompletedTitle: "Instalace byla úspěšně dokončena", ReadyBody: "Ghost FTP je připraven k použití.", LaunchQuestion: "Spustit Ghost FTP nyní?", InstalledTitle: "Ghost FTP je nainstalován",
+		LaunchFailed: "Ghost FTP se nepodařilo spustit automaticky. Spusťte jej z nabídky Start systému Windows.", LanguageWarning: "Vybraný jazyk se nepodařilo uložit. Ghost FTP se spustí anglicky; jazyk můžete změnit v Nastavení.",
+		ShortcutWarning: "Zástupce se nepodařilo vytvořit. Ghost FTP můžete spustit z instalační složky.",
+	},
+	"uk": {
+		ConfirmTitle: "Встановити Ghost FTP %s?", ConfirmBody: "Ghost FTP буде встановлено для вашого облікового запису Windows і буде доступний у меню «Пуск».",
+		CompletedTitle: "Встановлення успішно завершено", ReadyBody: "Ghost FTP готовий до використання.", LaunchQuestion: "Запустити Ghost FTP зараз?", InstalledTitle: "Ghost FTP встановлено",
+		LaunchFailed: "Не вдалося автоматично запустити Ghost FTP. Запустіть його з меню «Пуск» Windows.", LanguageWarning: "Не вдалося зберегти вибрану мову. Ghost FTP запуститься англійською; мову можна змінити в Налаштуваннях.",
+		ShortcutWarning: "Не вдалося створити ярлик. Ghost FTP можна запустити з папки встановлення.",
+	},
+	"sv": {
+		ConfirmTitle: "Installera Ghost FTP %s?", ConfirmBody: "Ghost FTP installeras för ditt Windows-konto och blir tillgängligt från Start-menyn.",
+		CompletedTitle: "Installationen slutfördes", ReadyBody: "Ghost FTP är klart att använda.", LaunchQuestion: "Starta Ghost FTP nu?", InstalledTitle: "Ghost FTP är installerat",
+		LaunchFailed: "Ghost FTP kunde inte startas automatiskt. Starta det från Windows Start-meny.", LanguageWarning: "Det valda språket kunde inte sparas. Ghost FTP startar på engelska; du kan byta språk i Inställningar.",
+		ShortcutWarning: "En genväg kunde inte skapas. Du kan starta Ghost FTP från installationsmappen.",
+	},
+	"ro": {
+		ConfirmTitle: "Instalați Ghost FTP %s?", ConfirmBody: "Ghost FTP va fi instalat pentru contul dvs. Windows și va fi disponibil din meniul Start.",
+		CompletedTitle: "Instalare finalizată cu succes", ReadyBody: "Ghost FTP este gata de utilizare.", LaunchQuestion: "Porniți Ghost FTP acum?", InstalledTitle: "Ghost FTP este instalat",
+		LaunchFailed: "Ghost FTP nu a putut fi pornit automat. Porniți-l din meniul Start Windows.", LanguageWarning: "Limba selectată nu a putut fi salvată. Ghost FTP va porni în engleză; puteți schimba limba în Setări.",
+		ShortcutWarning: "Nu s-a putut crea o scurtătură. Puteți porni Ghost FTP din folderul de instalare.",
+	},
+	"hu": {
+		ConfirmTitle: "Telepíti a Ghost FTP %s verziót?", ConfirmBody: "A Ghost FTP a Windows-felhasználói fiókhoz települ, és a Start menüből lesz elérhető.",
+		CompletedTitle: "A telepítés sikeresen befejeződött", ReadyBody: "A Ghost FTP használatra kész.", LaunchQuestion: "Elindítja most a Ghost FTP-t?", InstalledTitle: "A Ghost FTP telepítve van",
+		LaunchFailed: "A Ghost FTP nem indult el automatikusan. Indítsa el a Windows Start menüből.", LanguageWarning: "A kiválasztott nyelvet nem sikerült menteni. A Ghost FTP angolul indul; a nyelv a Beállításokban módosítható.",
+		ShortcutWarning: "Nem sikerült parancsikont létrehozni. A Ghost FTP a telepítési mappából indítható.",
+	},
+	"da": {
+		ConfirmTitle: "Installer Ghost FTP %s?", ConfirmBody: "Ghost FTP installeres til din Windows-brugerkonto og bliver tilgængelig fra Start-menuen.",
+		CompletedTitle: "Installationen blev gennemført", ReadyBody: "Ghost FTP er klar til brug.", LaunchQuestion: "Start Ghost FTP nu?", InstalledTitle: "Ghost FTP er installeret",
+		LaunchFailed: "Ghost FTP kunne ikke startes automatisk. Start det fra Windows Start-menuen.", LanguageWarning: "Det valgte sprog kunne ikke gemmes. Ghost FTP starter på engelsk; sproget kan ændres i Indstillinger.",
+		ShortcutWarning: "Der kunne ikke oprettes en genvej. Du kan starte Ghost FTP fra installationsmappen.",
+	},
+	"fi": {
+		ConfirmTitle: "Asennetaanko Ghost FTP %s?", ConfirmBody: "Ghost FTP asennetaan Windows-käyttäjätilillesi ja se on käytettävissä Käynnistä-valikosta.",
+		CompletedTitle: "Asennus valmistui onnistuneesti", ReadyBody: "Ghost FTP on valmis käyttöön.", LaunchQuestion: "Käynnistetäänkö Ghost FTP nyt?", InstalledTitle: "Ghost FTP on asennettu",
+		LaunchFailed: "Ghost FTP:tä ei voitu käynnistää automaattisesti. Käynnistä se Windowsin Käynnistä-valikosta.", LanguageWarning: "Valittua kieltä ei voitu tallentaa. Ghost FTP käynnistyy englanniksi; kielen voi vaihtaa Asetuksissa.",
+		ShortcutWarning: "Pikakuvaketta ei voitu luoda. Voit käynnistää Ghost FTP:n asennuskansiosta.",
+	},
+	"no": {
+		ConfirmTitle: "Installere Ghost FTP %s?", ConfirmBody: "Ghost FTP installeres for Windows-brukerkontoen din og blir tilgjengelig fra Start-menyen.",
+		CompletedTitle: "Installasjonen ble fullført", ReadyBody: "Ghost FTP er klar til bruk.", LaunchQuestion: "Starte Ghost FTP nå?", InstalledTitle: "Ghost FTP er installert",
+		LaunchFailed: "Ghost FTP kunne ikke startes automatisk. Start det fra Windows Start-menyen.", LanguageWarning: "Det valgte språket kunne ikke lagres. Ghost FTP starter på engelsk; språket kan endres i Innstillinger.",
+		ShortcutWarning: "En snarvei kunne ikke opprettes. Du kan starte Ghost FTP fra installasjonsmappen.",
+	},
+	"ko": {
+		ConfirmTitle: "Ghost FTP %s을(를) 설치하시겠습니까?", ConfirmBody: "Ghost FTP는 현재 Windows 사용자 계정에 설치되며 시작 메뉴에서 사용할 수 있습니다.",
+		CompletedTitle: "설치가 완료되었습니다", ReadyBody: "Ghost FTP를 사용할 준비가 되었습니다.", LaunchQuestion: "지금 Ghost FTP를 실행하시겠습니까?", InstalledTitle: "Ghost FTP가 설치되었습니다",
+		LaunchFailed: "Ghost FTP를 자동으로 실행하지 못했습니다. Windows 시작 메뉴에서 실행하세요.", LanguageWarning: "선택한 언어를 저장하지 못했습니다. Ghost FTP는 영어로 시작하며 설정에서 언어를 변경할 수 있습니다.",
+		ShortcutWarning: "바로 가기를 만들지 못했습니다. 설치 폴더에서 Ghost FTP를 실행할 수 있습니다.",
+	},
+}
+
+func installerCopyFor(language string) installerCopy {
+	base := installerCopies[i18n.DefaultLanguage]
+	localized, ok := installerCopies[i18n.Normalize(language)]
+	if !ok {
+		return base
+	}
+	if localized.ConfirmTitle == "" { localized.ConfirmTitle = base.ConfirmTitle }
+	if localized.ConfirmBody == "" { localized.ConfirmBody = base.ConfirmBody }
+	if localized.CompletedTitle == "" { localized.CompletedTitle = base.CompletedTitle }
+	if localized.ReadyBody == "" { localized.ReadyBody = base.ReadyBody }
+	if localized.LaunchQuestion == "" { localized.LaunchQuestion = base.LaunchQuestion }
+	if localized.InstalledTitle == "" { localized.InstalledTitle = base.InstalledTitle }
+	if localized.LaunchFailed == "" { localized.LaunchFailed = base.LaunchFailed }
+	if localized.LanguageWarning == "" { localized.LanguageWarning = base.LanguageWarning }
+	if localized.ShortcutWarning == "" { localized.ShortcutWarning = base.ShortcutWarning }
+	return localized
+}
+
+func installerConfirmTitle(language, version string) string {
+	return fmt.Sprintf(installerCopyFor(language).ConfirmTitle, version)
+}

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -42,9 +42,19 @@ The native iOS client uses Apple platform networking for its supported FTP/FTPS 
 
 ## Web/PWA
 
-The shared-hosting Web/PWA package has no Composer runtime dependencies. The public package is assembled from tracked project files and uses server-provided PHP extensions for protocol functionality.
+The shared-hosting Web/PWA package has **zero third-party Composer packages**. Its Composer `require` section contains only the platform requirement `php >=8.1`; this describes the PHP runtime supplied by the hosting environment and does not download a vendor library.
 
-No CDN, remote JavaScript bundle or analytics script is required for normal operation.
+`composer.json` also documents these server-provided PHP extension capabilities in `suggest`:
+
+- `ext-ftp` — FTP/FTPS support.
+- `ext-ssh2` — SFTP support.
+- `ext-zip` — ZIP creation/extraction and directory downloads.
+- `ext-sodium` — preferred credential encryption implementation.
+- `ext-openssl` — encryption fallback when sodium is unavailable.
+
+These are hosting/runtime capabilities, not Composer packages bundled or fetched by Ghost FTP. `scripts/audit_dependencies.py` pins the allowed PHP requirement and the exact extension-capability list; adding a third-party package or an unexpected capability makes CI fail.
+
+The public Web package is assembled from tracked project files only. No CDN, remote JavaScript bundle, analytics script or Ghost FTP cloud backend is required for normal operation.
 
 ## GitHub Actions and build tooling
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,66 @@
+# Dependencies and external-component policy
+
+Ghost FTP is designed to minimize third-party runtime dependencies, forbid application telemetry, and make every remaining dependency explicit and auditable.
+
+## Policy goals
+
+- No application analytics, advertising, behavioral tracking or external crash-reporting SDKs.
+- No hidden Ghost FTP backend, remote configuration service or mandatory account service.
+- No dynamic dependency versions such as `+`, `latest` or `SNAPSHOT` in production build inputs.
+- No unreviewed dependency may be added merely for convenience.
+- Security-sensitive protocol behavior must remain covered by regression tests even when a platform library is used.
+- Dependency and signing claims in documentation must match the actual build.
+
+`scripts/audit_dependencies.py` is a fail-closed CI gate for the currently approved dependency surface.
+
+## Go desktop/core
+
+The Go module currently has no external Go module requirements. `go.mod` contains the Ghost FTP module declaration and Go/toolchain metadata only. Production CI also sets `GOPROXY=off` and `GOSUMDB=off` so a build cannot silently download a new Go module.
+
+The desktop FTP/FTPS implementation currently uses the operating system's `curl` executable as a hardened transport helper. Ghost FTP disables proxy inheritance for that process, supplies credentials through an ephemeral standard-input configuration, bounds child-process output, minimizes inherited environment state and requires normal TLS certificate validation for FTPS.
+
+This system-tool dependency is not the same as an embedded analytics or cloud dependency, but it is still an external runtime component. The 1.1.x roadmap is to make the standard-library native FTP/FTPS transport the primary implementation after protocol-parity integration tests pass.
+
+Desktop SFTP currently uses the operating system OpenSSH client/tooling rather than a third-party Go SSH module. Go's standard library does not provide an SSH/SFTP client, so documentation must continue to state this requirement until a reviewed in-repository implementation exists.
+
+## Android
+
+Android currently has two pinned runtime libraries:
+
+- `commons-net:commons-net:3.13.0` for FTP/FTPS protocol support.
+- `com.hierynomus:sshj:0.40.0` for SSH/SFTP support.
+
+Unit tests use pinned `junit:junit:4.13.2`.
+
+These coordinates are explicitly allowlisted by `scripts/audit_dependencies.py`. A new runtime library, version change or test framework change makes CI fail until the dependency is reviewed and the allowlist/documentation are intentionally updated.
+
+The dependency audit also rejects known analytics, advertising and crash-reporting SDK markers.
+
+## iOS
+
+The native iOS client uses Apple platform networking for its supported FTP/FTPS transport surface and does not embed an analytics SDK, WebView wrapper or Ghost FTP cloud service.
+
+## Web/PWA
+
+The shared-hosting Web/PWA package has no Composer runtime dependencies. The public package is assembled from tracked project files and uses server-provided PHP extensions for protocol functionality.
+
+No CDN, remote JavaScript bundle or analytics script is required for normal operation.
+
+## GitHub Actions and build tooling
+
+CI actions are pinned to immutable commit SHAs. Android builds require the Android/Gradle toolchain, Windows builds require the Go/Windows toolchain, and Apple builds require Xcode/macOS runners. These are build-environment requirements, not Ghost FTP application telemetry services.
+
+## Adding a dependency
+
+A proposed new dependency must document:
+
+1. The capability that cannot reasonably be implemented with existing project/platform code.
+2. Exact version and upstream provenance.
+3. License and redistribution implications.
+4. Network behavior and whether any telemetry exists or can be disabled.
+5. Credential, filesystem and process-boundary impact.
+6. Security update strategy.
+7. Regression tests proving that the dependency cannot weaken Ghost FTP trust boundaries.
+8. Removal/fallback strategy.
+
+The change must update `scripts/audit_dependencies.py`, this document, `THIRD-PARTY-NOTICES.md` when applicable, and pass the full release CI matrix.

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -1,0 +1,75 @@
+# Localization
+
+Ghost FTP uses an English-first localization model. English (`en`) is the canonical source language, the first language presented by setup, and the only runtime fallback when a translated string is unavailable.
+
+## Supported language registry
+
+The 1.1.0 development line defines 24 canonical desktop/setup language codes:
+
+| Code | Language | Native name |
+| --- | --- | --- |
+| `en` | English | English |
+| `hr` | Croatian | Hrvatski |
+| `de` | German | Deutsch |
+| `fr` | French | Français |
+| `es` | Spanish | Español |
+| `tr` | Turkish | Türkçe |
+| `el` | Greek | Ελληνικά |
+| `pt` | Portuguese | Português |
+| `zh` | Chinese (Simplified) | 简体中文 |
+| `ru` | Russian | Русский |
+| `hi` | Hindi | हिन्दी |
+| `ja` | Japanese | 日本語 |
+| `it` | Italian | Italiano |
+| `pl` | Polish | Polski |
+| `nl` | Dutch | Nederlands |
+| `cs` | Czech | Čeština |
+| `uk` | Ukrainian | Українська |
+| `sv` | Swedish | Svenska |
+| `ro` | Romanian | Română |
+| `hu` | Hungarian | Magyar |
+| `da` | Danish | Dansk |
+| `fi` | Finnish | Suomi |
+| `no` | Norwegian | Norsk |
+| `ko` | Korean | 한국어 |
+
+Common regional forms normalize to the canonical code. For example, `pt-BR` resolves to `pt`, `de-DE` to `de`, `zh-Hans`/`zh-CN` to `zh`, and `nb-NO`/`nn-NO` to `no`.
+
+## Runtime rules
+
+`internal/i18n/i18n.go` owns the canonical registry, normalization, fallback and catalog validation. Every advertised language must have a catalog with the exact same key set as English and compatible formatting verbs. Empty translations, unknown keys and duplicate language codes are release-blocking.
+
+Full legacy catalogs must remain substantially localized. Supplemental catalogs introduced later must contain a meaningful translated core instead of merely copying the English catalog. `TranslationCoverage` and the localization tests measure this directly.
+
+The terminal `language` command derives its accepted language list from the same registry; hard-coded duplicate language lists are not allowed.
+
+## Windows application
+
+The Windows desktop application persists the selected language in normal application settings and supports live label/column/protocol refresh without requiring the user to recreate a profile.
+
+Startup and catastrophic-error text stays English-first because those paths may run before settings or localization state can be safely loaded.
+
+## Windows Setup
+
+The first setup language selector is intentionally English-first so a damaged or unknown locale never makes setup unusable. After the user selects a language, the primary confirmation, completion, launch and warning flow uses `cmd/installer/messages.go` and the same canonical locale normalization as the application.
+
+Installer payload verification, rollback and error containment are not weakened by localization. Technical failure detail may fall back to English until every installer recovery branch has a reviewed translation; an English fallback is preferable to an empty or misleading security message.
+
+## Android, iOS and Web/PWA
+
+The 1.1.0 release is not considered localization-complete until Android, iOS and Web/PWA expose the same canonical language choices or a documented platform-safe subset and their localization audits verify key coverage.
+
+Android already centralizes user-visible copy in `res/values/strings.xml`; localized `values-*` resources must preserve all format placeholders. iOS user-visible SwiftUI strings must be moved into the localization resource layer rather than duplicated as hard-coded literals. Web/PWA localization must not put user-selected language or translations into unsafe HTML without normal escaping.
+
+## Adding or changing a language
+
+1. Add or update the canonical language entry in `internal/i18n/i18n.go`.
+2. Add a complete catalog or reviewed supplemental catalog with sufficient real translation coverage.
+3. Preserve all `%s`, `%d` and other formatting verbs exactly as required by the English source string.
+4. Update installer copy where the language is setup-supported.
+5. Add/adjust platform localization resources.
+6. Add normalization/affirmative-answer tests when the locale has relevant regional codes.
+7. Run `go test ./...` and `python scripts/audit_localization.py`.
+8. Run the full multi-platform CI matrix before release.
+
+Machine translation may be used only as a draft. Security, credential, destructive-action, recovery and overwrite messages require human review before a release is declared translation-complete.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,10 @@ This directory contains the maintained technical and operator documentation for 
 ## Start here
 
 - [Installation](INSTALLATION.md) — platform packages, installation expectations and prerequisites.
+- [Localization](LOCALIZATION.md) — English-first language registry, translation coverage and platform rules.
+- [Settings](SETTINGS.md) — persisted options, safe defaults and migration semantics.
+- [Dependencies](DEPENDENCIES.md) — dependency allowlist, provenance and no-tracking policy.
+- [Release history](RELEASE-HISTORY.md) — detailed immutable history of published Ghost FTP releases and unreleased development scope.
 - [Architecture](ARCHITECTURE.md) — core structure and platform boundaries.
 - [Security](SECURITY.md) — threat boundaries, credential handling and transfer hardening.
 - [Privacy](PRIVACY.md) — telemetry and data-handling policy.

--- a/docs/RELEASE-HISTORY.md
+++ b/docs/RELEASE-HISTORY.md
@@ -1,0 +1,166 @@
+# Ghost FTP release history
+
+This document expands the concise `CHANGELOG.md` into a durable explanation of the current Ghost FTP release line. Published tags and their artifacts remain immutable; documentation may add context but never rewrites release provenance.
+
+## 1.1.0 — in development
+
+Status: **unreleased**. The canonical repository `VERSION` remains on the last published release until the complete 1.1.0 feature set passes the production release gate.
+
+Primary goals:
+
+- Make English the explicit primary/fallback language while expanding the canonical language registry beyond 20 languages.
+- Improve real translation coverage instead of treating mostly-English fallback catalogs as complete localization.
+- Localize the Windows setup flow without adding a UI framework dependency or weakening installer payload verification/rollback.
+- Align Android, iOS and Web/PWA localization with the same language contract before release.
+- Add dependency provenance/allowlist checks and keep telemetry, advertising and external crash-reporting SDKs forbidden.
+- Reduce avoidable runtime-tool dependencies, beginning with a tested native FTP/FTPS path where protocol parity can be proven.
+- Expand settings/option validation and connection/transfer regressions rather than adding cosmetic toggles that are not enforced by the engine.
+- Expand documentation for localization, dependencies, settings, protocol behavior and release provenance.
+
+No `ghostftp-v1.1.0` tag should be created until the full cross-platform CI and release readback pass.
+
+## 1.0.7 — 2026-09-05
+
+Theme: **remote atomic-upload residual-data integrity**.
+
+What changed:
+
+- Atomic Web/PWA upload staging became owned before FTP/SFTP transport begins. A transport that creates remote bytes and then fails can no longer bypass staging cleanup just because `upload()` did not return success.
+- Residual staging cleanup is verified. If deletion reports an error, Ghost FTP checks whether the temporary object actually disappeared before escalating.
+- If cleanup cannot be confirmed, the user receives the generated recovery staging name without nested transport exception details.
+- Backup creation now reconciles ambiguous server behavior where the original file is moved to a backup but the server still reports a rename failure. The confirmed backup name is surfaced and the replacement is not activated in an uncertain state.
+- Failure to remove the old backup after a successful promotion is no longer silently treated as success. The newly promoted target stays active, while Ghost FTP reports a partial-success state and tells the user not to repeat the upload.
+- New runtime regressions cover partial-upload cleanup, retained staging, ambiguous backup creation, target preservation, old-backup retention and non-disclosure of internal error text.
+
+Security/stability effect:
+
+The release closes edge cases where user data was preserved but its recovery location could become unclear, or where obsolete remote content could remain silently after a successful replacement.
+
+Release integrity:
+
+`ghostftp-v1.0.7` was published from the verified `main` merge commit after the full CI and production publish workflow completed successfully.
+
+## 1.0.6 — 2026-09-05
+
+Theme: **atomic overwrite recovery**.
+
+What changed:
+
+- A failed promotion can no longer hide a failed restoration of the original remote file.
+- Ambiguous promotion outcomes are detected when a server reports a rename failure even though the destination appears.
+- The original recovery backup name is retained and exposed safely when manual restoration may be needed.
+- Nested transport errors stay internal instead of being concatenated into public Web messages.
+- Added focused runtime regression coverage for failed restore, ambiguous promotion, backup preservation and staging cleanup.
+- Removed a leaked one-shot audit workflow from production source and made repository hygiene permanently reject tracked `.github/workflows/one-shot-*` files.
+
+Security/stability effect:
+
+Recovery state became explicit and observable instead of relying on a single server return code during rename/promotion.
+
+## 1.0.5 — 2026-09-05
+
+Theme: **public-error containment and write-path simplification**.
+
+What changed:
+
+- Extended the safe public-error boundary to account, registration, user administration, settings, setup and login-migration HTML flows.
+- Unexpected PHP/extension exceptions no longer render raw internal details in public pages.
+- Removed nested raw exception-message concatenation from move fallback and workspace deletion wrappers.
+- Removed the unused direct remote `write()` transport contract. Browser editor/new-file writes now use the single bounded atomic write path.
+- Aligned remote read defaults with the canonical 4 MiB editor limit.
+- Added regressions for HTML disclosure, nested exception wrapping and dead write-contract removal.
+- Completed another pass of visible Ghost FTP branding cleanup in Web/PWA surfaces.
+
+Security/stability effect:
+
+There are fewer competing write implementations and fewer places where infrastructure/extension error text can cross the public trust boundary.
+
+## 1.0.4 — 2026-09-05
+
+Theme: **Web fail-closed validation before mutation**.
+
+What changed:
+
+- Introduced a shared public-error mapper: deliberate validation failures remain actionable, unexpected internal failures become generic 500 responses.
+- Applied safe error handling to API, direct download, archive download and preview endpoints.
+- Stopped writing text errors after binary-response headers had already started.
+- Multi-file uploads now validate request shape, upload state, temporary file identity, normalized remote paths and duplicate targets before the first remote mutation.
+- ZIP path-list parsing rejects malformed rows instead of silently ignoring them.
+- Added source and runtime regressions for the new preflight ordering and public-error behavior.
+
+Security/stability effect:
+
+Invalid batch requests fail before partially mutating the remote server, and internal implementation details are less likely to leak to unauthenticated/public surfaces.
+
+## 1.0.3 — 2026-09-05
+
+Theme: **SFTP trust and bounded Web operations**.
+
+What changed:
+
+- Web profiles require a canonical pinned SHA-256 SFTP host fingerprint before they can be persisted.
+- The connected server key is verified again at the transport boundary.
+- Browser editor/new-file content is centrally bounded and local staging must complete before remote promotion.
+- SFTP temporary private-key files receive restrictive permissions before key material is written.
+- SFTP uploads verify remote size when the server exposes reliable metadata.
+- Batch deletion uses a two-pass preflight; batch rename rejects malformed rows and duplicate source paths before mutation.
+- Documentation/version/release audits became more tightly bound to the canonical `VERSION` file and release artifact contract.
+
+Security/stability effect:
+
+SFTP identity, temporary key handling and destructive batch operations gained stronger fail-closed guarantees.
+
+## 1.0.2 — 2026-09-04
+
+Theme: **bounded secrets and credential envelopes**.
+
+What changed:
+
+- Non-Windows in-memory runtime-secret storage became capacity-bounded and fails closed when exhausted.
+- Added tests for secret copy isolation, capacity limits, cleanup and capacity reuse.
+- Hardened Web credential-envelope parsing with strict driver validation, encoded-size limits, truncation checks and authenticated-tamper rejection.
+- Removed stale hard-coded release metadata from Composer surfaces and added a regression to keep package metadata synchronized with canonical versioning.
+- Advanced PWA cache/version surfaces consistently.
+
+Security/stability effect:
+
+Secret state and encrypted credential inputs gained explicit resource and parsing limits instead of relying on unbounded or permissive behavior.
+
+## 1.0.1 — 2026-09-04
+
+Theme: **technical identity and release completeness**.
+
+What changed:
+
+- Completed the Ghost FTP technical-identity cutover across tracked runtime paths and identifiers while retaining only compatibility identifiers that are needed for safe upgrades.
+- Standardized Android, iOS, Go, Windows installer and Web technical identities.
+- Added a fail-closed repository brand audit.
+- Added Windows portable x64/x86 artifacts.
+- Added GitHub Packages publication under the `GhostFTP` package ID.
+- Verified release and package-registry readback as part of publication.
+
+Release effect:
+
+The product gained one canonical current identity and a more complete Windows distribution surface without rewriting historical generic tags.
+
+## 1.0.0 — 2026-09-04
+
+Theme: **first canonical Ghost FTP release line**.
+
+What changed:
+
+- Established **Ghost FTP** as the public product identity across Windows, Linux, macOS, Android, iOS and Web/PWA.
+- Started the dedicated semantic-version line at 1.0.0.
+- Introduced `ghostftp-vX.Y.Z` tags so current releases do not collide with historical generic tags.
+- Standardized Linux packaging as `ghost-ftp` with the `ghostftp` executable and desktop entry.
+- Established the multi-platform release contract, SHA-256 manifest and build metadata.
+- Preserved strict path validation, staged transfers/rollback, SFTP host-key verification, protected profile secrets, Web rate limiting/session hardening and release provenance checks.
+- Kept signing status explicit: debug-signed Android and unsigned iOS artifacts are never represented as store-signed production packages.
+
+Release contract established:
+
+The public release pipeline builds platform-specific deliverables, records checksums/build metadata and verifies the published release remotely before a workflow is allowed to report success.
+
+## Historical repository provenance
+
+Older generic tags and pre-Ghost-FTP repository history remain immutable. They may contain earlier technical names, package identities or architecture decisions. Current releases use the dedicated Ghost FTP namespace and current documentation; historical tags are retained for reproducibility, not rewritten to look like modern releases.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,67 @@
+# Settings and option semantics
+
+Ghost FTP settings are part of transfer safety. An option is not added to the UI unless the runtime engine can enforce it consistently and tests cover its effect.
+
+## Current persisted settings
+
+The desktop settings model currently stores:
+
+- `language` — canonical UI language. Unknown/invalid locale codes normalize safely to English when loading old state; new saves reject unsupported languages.
+- `parallelism` — number of concurrent transfers, range 1–8, safe default 2.
+- `connectionTimeoutSeconds` — connection timeout, range 5–60 seconds, safe default 15.
+- `autoRetryCount` — automatic retry count, range 0–3, safe default 0.
+- `retryDelaySeconds` — delay between automatic retries, range 1–30 seconds, safe default 3.
+- `backupBeforeOverwrite` — retain a recovery backup of an existing destination during safe overwrite behavior.
+- `skipExisting` — do not overwrite a destination item that already exists.
+- `confirmDelete` — require an explicit confirmation before user-initiated delete operations in the desktop UI.
+
+Corrupt or unavailable settings storage does not grant a more permissive transfer policy. `DefaultSettings()` is conservative: overwrite recovery and delete confirmation remain enabled.
+
+## Validation and migration
+
+`internal/config/settings.go` owns the canonical bounds and defaults. UI code must not invent different limits. Old settings files are normalized when loaded, and values outside the supported range return to safe defaults instead of becoming unbounded runtime parameters.
+
+New saves are validated before the file is written. A rejected save does not mutate the in-memory effective settings.
+
+## Existing-file behavior
+
+There are currently two persisted booleans involved in destination conflicts:
+
+1. `skipExisting=true` means the destination is not overwritten.
+2. When existing files are not skipped, `backupBeforeOverwrite` controls whether the safe temporary recovery backup is kept according to the transfer implementation.
+
+This model is backward compatible but is not the final 1.1.x settings UX. A future settings UI should present one explicit conflict policy instead of making users reason about combinations of two booleans. Migration must preserve the meaning of existing settings:
+
+- `skipExisting=true` → **Skip existing**.
+- `skipExisting=false` + `backupBeforeOverwrite=true` → **Replace safely and keep recovery backup**.
+- `skipExisting=false` + `backupBeforeOverwrite=false` → **Replace safely and remove temporary recovery backup after commit**.
+
+The storage migration must be introduced only together with engine/UI tests; the current booleans remain the canonical persisted contract until that migration lands.
+
+## Retry behavior
+
+Retries are intended for transient connection/transport failures, not validation or trust failures. Host-key mismatch, invalid path, invalid credentials, unsafe local/remote target state and explicit user cancellation must not be converted into blind automatic retries.
+
+Retry delay is bounded so the application cannot accidentally create an unbounded hammering loop against a hosting server.
+
+## Connection timeout
+
+The configured timeout is applied to connection establishment. Long-running file transfers use their own cancellation/progress boundaries and must not be truncated merely because the initial connection timeout is small.
+
+## Language
+
+English is the primary/default language. The canonical language registry is documented in [Localization](LOCALIZATION.md). Regional codes normalize to supported canonical codes where appropriate.
+
+## Planned option-quality rules for 1.1.x
+
+New advanced settings must meet all of these conditions before release:
+
+- One clearly defined runtime owner for the option.
+- Safe default that does not weaken TLS, SFTP host-key verification, path validation or overwrite recovery.
+- Bounded numeric ranges where applicable.
+- Backward-compatible settings migration.
+- User-visible label/help text in the localization system.
+- Unit/regression tests proving both enabled and disabled behavior.
+- No option may disable certificate validation, accept any SFTP host key, enable telemetry, bypass remote/local path guards or persist plaintext secrets.
+
+Candidates that satisfy those rules include a consolidated conflict policy, configurable transfer verification policy where the protocol can provide reliable metadata, and explicit UI visibility preferences. Security-bypass toggles are intentionally out of scope.

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -33,6 +33,12 @@ var supportedLanguages = []Language{
 	{Code: "cs", EnglishName: "Czech", NativeName: "Čeština"},
 	{Code: "uk", EnglishName: "Ukrainian", NativeName: "Українська"},
 	{Code: "sv", EnglishName: "Swedish", NativeName: "Svenska"},
+	{Code: "ro", EnglishName: "Romanian", NativeName: "Română"},
+	{Code: "hu", EnglishName: "Hungarian", NativeName: "Magyar"},
+	{Code: "da", EnglishName: "Danish", NativeName: "Dansk"},
+	{Code: "fi", EnglishName: "Finnish", NativeName: "Suomi"},
+	{Code: "no", EnglishName: "Norwegian", NativeName: "Norsk"},
+	{Code: "ko", EnglishName: "Korean", NativeName: "한국어"},
 }
 
 func Languages() []Language {
@@ -106,7 +112,8 @@ func IsAffirmative(language, answer string) bool {
 		"es": {"sí", "si", "s"}, "tr": {"evet", "e"}, "el": {"ναι", "ν"}, "pt": {"sim", "s"},
 		"zh": {"是", "是的"}, "ru": {"да", "д"}, "hi": {"हाँ", "हां", "ह"}, "ja": {"はい"},
 		"it": {"sì", "si", "s"}, "pl": {"tak", "t"}, "nl": {"ja", "j"}, "cs": {"ano", "a"},
-		"uk": {"так", "т"}, "sv": {"ja", "j"},
+		"uk": {"так", "т"}, "sv": {"ja", "j"}, "ro": {"da", "d"}, "hu": {"igen", "i"},
+		"da": {"ja", "j"}, "fi": {"kyllä", "kylla", "k"}, "no": {"ja", "j"}, "ko": {"예", "네"},
 	}
 	for _, value := range accepted[Normalize(language)] {
 		if answer == value {
@@ -116,10 +123,33 @@ func IsAffirmative(language, answer string) bool {
 	return false
 }
 
+// TranslationCoverage reports how many runtime strings differ from the canonical
+// English catalog. It is intentionally simple: CI uses it to prevent a locale
+// from being advertised while almost every user-visible string is only the
+// English fallback.
+func TranslationCoverage(code string) (translated, total int) {
+	code = Normalize(code)
+	english := catalogs[DefaultLanguage]
+	catalog := catalogs[code]
+	for key, englishValue := range english {
+		total++
+		if value, ok := catalog[key]; ok && strings.TrimSpace(value) != "" && value != englishValue {
+			translated++
+		}
+	}
+	return translated, total
+}
+
 func ValidateCatalogs() error {
 	english := catalogs[DefaultLanguage]
 	if len(english) == 0 {
 		return fmt.Errorf("English localization catalog is empty")
+	}
+	if len(supportedLanguages) < 21 {
+		return fmt.Errorf("Ghost FTP must expose at least 21 supported languages")
+	}
+	if supportedLanguages[0].Code != DefaultLanguage {
+		return fmt.Errorf("English must be the first and default supported language")
 	}
 	codes := make(map[string]struct{}, len(supportedLanguages))
 	for _, language := range supportedLanguages {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -42,11 +42,11 @@ var supportedLanguages = []Language{
 }
 
 var languageAliases = map[string]string{
-	"nb": "no",
-	"nn": "no",
-	"zh-cn": "zh",
+	"nb":      "no",
+	"nn":      "no",
+	"zh-cn":   "zh",
 	"zh-hans": "zh",
-	"zh-sg": "zh",
+	"zh-sg":   "zh",
 }
 
 func Languages() []Language {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -41,6 +41,14 @@ var supportedLanguages = []Language{
 	{Code: "ko", EnglishName: "Korean", NativeName: "한국어"},
 }
 
+var languageAliases = map[string]string{
+	"nb": "no",
+	"nn": "no",
+	"zh-cn": "zh",
+	"zh-hans": "zh",
+	"zh-sg": "zh",
+}
+
 func Languages() []Language {
 	out := make([]Language, len(supportedLanguages))
 	copy(out, supportedLanguages)
@@ -53,11 +61,17 @@ func canonical(code string) string {
 	if code == "" {
 		return ""
 	}
+	if alias, ok := languageAliases[code]; ok {
+		code = alias
+	}
 	if _, ok := catalogs[code]; ok {
 		return code
 	}
 	if i := strings.IndexByte(code, '-'); i > 0 {
 		primary := code[:i]
+		if alias, ok := languageAliases[primary]; ok {
+			primary = alias
+		}
 		if _, ok := catalogs[primary]; ok {
 			return primary
 		}

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -56,8 +56,8 @@ func TestLanguagesAndNormalization(t *testing.T) {
 		t.Fatalf("English must remain the primary/default language: first=%q default=%q", languages[0].Code, DefaultLanguage)
 	}
 	cases := map[string]string{
-		"": "en", "EN": "en", "pt-BR": "pt", "zh_CN": "zh", "de-DE": "de", "it-IT": "it", "uk-UA": "uk",
-		"ro-RO": "ro", "hu-HU": "hu", "da-DK": "da", "fi-FI": "fi", "nb-NO": "en", "no-NO": "no", "ko-KR": "ko", "unknown": "en",
+		"": "en", "EN": "en", "pt-BR": "pt", "zh_CN": "zh", "zh-Hans": "zh", "de-DE": "de", "it-IT": "it", "uk-UA": "uk",
+		"ro-RO": "ro", "hu-HU": "hu", "da-DK": "da", "fi-FI": "fi", "nb-NO": "no", "nn-NO": "no", "no-NO": "no", "ko-KR": "ko", "unknown": "en",
 	}
 	for input, want := range cases {
 		if got := Normalize(input); got != want {
@@ -67,7 +67,7 @@ func TestLanguagesAndNormalization(t *testing.T) {
 	if IsSupported("unknown") {
 		t.Fatal("unknown language must not be reported as supported")
 	}
-	for _, code := range []string{"sv-SE", "ro-RO", "hu-HU", "da-DK", "fi-FI", "no-NO", "ko-KR"} {
+	for _, code := range []string{"sv-SE", "ro-RO", "hu-HU", "da-DK", "fi-FI", "nb-NO", "no-NO", "ko-KR"} {
 		if !IsSupported(code) {
 			t.Fatalf("regional form of supported language should be supported: %s", code)
 		}
@@ -77,7 +77,7 @@ func TestLanguagesAndNormalization(t *testing.T) {
 func TestAffirmativeAnswers(t *testing.T) {
 	cases := []struct{ language, answer string }{
 		{"en", "yes"}, {"hr", "da"}, {"de", "ja"}, {"fr", "oui"}, {"es", "sí"}, {"tr", "evet"}, {"el", "ναι"}, {"pt", "sim"}, {"zh", "是"}, {"ru", "да"}, {"hi", "हाँ"}, {"ja", "はい"},
-		{"it", "sì"}, {"pl", "tak"}, {"nl", "ja"}, {"cs", "ano"}, {"uk", "так"}, {"sv", "ja"}, {"ro", "da"}, {"hu", "igen"}, {"da", "ja"}, {"fi", "kyllä"}, {"no", "ja"}, {"ko", "예"},
+		{"it", "sì"}, {"pl", "tak"}, {"nl", "ja"}, {"cs", "ano"}, {"uk", "так"}, {"sv", "ja"}, {"ro", "da"}, {"hu", "igen"}, {"da", "ja"}, {"fi", "kyllä"}, {"no", "ja"}, {"ko", "예"}, {"nb-NO", "ja"},
 	}
 	for _, tc := range cases {
 		if !IsAffirmative(tc.language, tc.answer) {

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -13,7 +13,10 @@ func TestCatalogsAreCompleteAndFormatCompatible(t *testing.T) {
 		t.Fatal(err)
 	}
 	english := catalogs[DefaultLanguage]
-	partial := map[string]bool{"it": true, "pl": true, "nl": true, "cs": true, "uk": true, "sv": true}
+	supplemental := map[string]bool{
+		"it": true, "pl": true, "nl": true, "cs": true, "uk": true, "sv": true,
+		"ro": true, "hu": true, "da": true, "fi": true, "no": true, "ko": true,
+	}
 	for _, language := range Languages() {
 		catalog := catalogs[language.Code]
 		different := 0
@@ -28,9 +31,13 @@ func TestCatalogsAreCompleteAndFormatCompatible(t *testing.T) {
 		if language.Code == DefaultLanguage {
 			continue
 		}
-		if partial[language.Code] {
-			if different < 8 {
-				t.Fatalf("catalog %s needs at least 8 translated core strings, got %d", language.Code, different)
+		translated, total := TranslationCoverage(language.Code)
+		if translated != different || total != len(english) {
+			t.Fatalf("coverage accounting drift for %s: translated=%d/%d different=%d/%d", language.Code, translated, total, different, len(english))
+		}
+		if supplemental[language.Code] {
+			if different < 30 {
+				t.Fatalf("supplemental catalog %s needs at least 30 genuinely localized strings, got %d", language.Code, different)
 			}
 			continue
 		}
@@ -41,10 +48,17 @@ func TestCatalogsAreCompleteAndFormatCompatible(t *testing.T) {
 }
 
 func TestLanguagesAndNormalization(t *testing.T) {
-	if got := len(Languages()); got != 18 {
-		t.Fatalf("expected 18 supported languages, got %d", got)
+	languages := Languages()
+	if got := len(languages); got != 24 {
+		t.Fatalf("expected 24 supported languages, got %d", got)
 	}
-	cases := map[string]string{"": "en", "EN": "en", "pt-BR": "pt", "zh_CN": "zh", "de-DE": "de", "it-IT": "it", "uk-UA": "uk", "unknown": "en"}
+	if languages[0].Code != DefaultLanguage || DefaultLanguage != "en" {
+		t.Fatalf("English must remain the primary/default language: first=%q default=%q", languages[0].Code, DefaultLanguage)
+	}
+	cases := map[string]string{
+		"": "en", "EN": "en", "pt-BR": "pt", "zh_CN": "zh", "de-DE": "de", "it-IT": "it", "uk-UA": "uk",
+		"ro-RO": "ro", "hu-HU": "hu", "da-DK": "da", "fi-FI": "fi", "nb-NO": "en", "no-NO": "no", "ko-KR": "ko", "unknown": "en",
+	}
 	for input, want := range cases {
 		if got := Normalize(input); got != want {
 			t.Fatalf("Normalize(%q)=%q want %q", input, got, want)
@@ -53,15 +67,17 @@ func TestLanguagesAndNormalization(t *testing.T) {
 	if IsSupported("unknown") {
 		t.Fatal("unknown language must not be reported as supported")
 	}
-	if !IsSupported("sv-SE") {
-		t.Fatal("regional form of supported language should be supported")
+	for _, code := range []string{"sv-SE", "ro-RO", "hu-HU", "da-DK", "fi-FI", "no-NO", "ko-KR"} {
+		if !IsSupported(code) {
+			t.Fatalf("regional form of supported language should be supported: %s", code)
+		}
 	}
 }
 
 func TestAffirmativeAnswers(t *testing.T) {
 	cases := []struct{ language, answer string }{
 		{"en", "yes"}, {"hr", "da"}, {"de", "ja"}, {"fr", "oui"}, {"es", "sí"}, {"tr", "evet"}, {"el", "ναι"}, {"pt", "sim"}, {"zh", "是"}, {"ru", "да"}, {"hi", "हाँ"}, {"ja", "はい"},
-		{"it", "sì"}, {"pl", "tak"}, {"nl", "ja"}, {"cs", "ano"}, {"uk", "так"}, {"sv", "ja"},
+		{"it", "sì"}, {"pl", "tak"}, {"nl", "ja"}, {"cs", "ano"}, {"uk", "так"}, {"sv", "ja"}, {"ro", "da"}, {"hu", "igen"}, {"da", "ja"}, {"fi", "kyllä"}, {"no", "ja"}, {"ko", "예"},
 	}
 	for _, tc := range cases {
 		if !IsAffirmative(tc.language, tc.answer) {

--- a/internal/i18n/locale_additional.go
+++ b/internal/i18n/locale_additional.go
@@ -1,41 +1,155 @@
 package i18n
 
+import "strings"
+
+// Supplemental catalogs intentionally start from the canonical English text so
+// a newly introduced string is always readable. CI separately enforces a real
+// translated-core coverage floor so a locale cannot be advertised with only a
+// token handful of translated labels.
 var additionalLocaleOverrides = map[string]map[string]string{
 	"it": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Gestione hosting rapida", "section.local": "COMPUTER LOCALE", "section.remote": "SERVER", "section.transfers": "TRASFERIMENTI",
-		"common.settings": "Impostazioni", "common.connect": "Connetti", "common.disconnect": "Disconnetti", "common.refresh": "Aggiorna", "common.cancel": "Annulla",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Gestione hosting rapida", "badge.connected": "● CONNESSO", "badge.disconnected": "● DISCONNESSO",
+		"profile.quick": "Connessione rapida (senza profilo)", "profile.save": "Salva profilo", "profile.delete": "Elimina profilo",
+		"common.settings": "Impostazioni", "common.about": "Informazioni", "common.connect": "Connetti", "common.disconnect": "Disconnetti", "common.up": "Su", "common.folder": "Cartella…", "common.refresh": "Aggiorna", "common.new_folder": "Nuova cartella", "common.rename": "Rinomina", "common.delete": "Elimina", "common.permissions": "Permessi", "common.cancel": "Annulla",
+		"section.local": "COMPUTER LOCALE", "section.remote": "SERVER", "section.transfers": "TRASFERIMENTI",
 		"transfer.upload": "Carica", "transfer.download": "Scarica", "transfer.pause": "Pausa", "transfer.resume": "Riprendi", "transfer.retry": "Riprova", "transfer.clear": "Cancella completati",
-		"status.ready": "Pronto. Seleziona un profilo salvato o inserisci i dati del server.", "settings.title": "GhostFTP — Impostazioni", "profile.save": "Salva profilo", "profile.delete": "Elimina profilo",
+		"status.ready": "Pronto. Seleziona un profilo salvato o inserisci i dati del server.", "status.queued": "In coda", "status.running": "In corso", "status.done": "Completato", "status.failed": "Non riuscito", "status.cancelled": "Annullato", "status.skipped": "Ignorato",
+		"cue.host": "Server FTP/SFTP, ad es. ftp.example.com", "cue.user": "Nome utente, può essere user@example.com", "cue.password": "Password FTP / SFTP",
+		"column.name": "Nome", "column.type": "Tipo", "column.size": "Dimensione", "column.modified": "Modificato", "column.status": "Stato", "column.progress": "Avanzamento", "type.file": "file", "type.folder": "cartella",
+		"settings.title": "Ghost FTP — Impostazioni", "settings.invalid_value": "Valore non valido", "settings.parallel": "Trasferimenti paralleli (1–8):", "settings.timeout": "Timeout di connessione (5–60 secondi):", "settings.retries": "Riprova automaticamente un trasferimento non riuscito (0–3 volte):", "settings.retry_delay": "Pausa tra i tentativi automatici (1–30 secondi):",
+		"about.title": "Informazioni", "connection.failed": "Connessione non riuscita", "error.generic": "Operazione non riuscita. Controlla la connessione e riprova.",
 	},
 	"pl": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Szybkie zarządzanie hostingiem", "section.local": "KOMPUTER LOKALNY", "section.remote": "SERWER", "section.transfers": "TRANSFER",
-		"common.settings": "Ustawienia", "common.connect": "Połącz", "common.disconnect": "Rozłącz", "common.refresh": "Odśwież", "common.cancel": "Anuluj",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Szybkie zarządzanie hostingiem", "badge.connected": "● POŁĄCZONO", "badge.disconnected": "● ROZŁĄCZONO",
+		"profile.quick": "Szybkie połączenie (bez profilu)", "profile.save": "Zapisz profil", "profile.delete": "Usuń profil",
+		"common.settings": "Ustawienia", "common.about": "O programie", "common.connect": "Połącz", "common.disconnect": "Rozłącz", "common.up": "W górę", "common.folder": "Folder…", "common.refresh": "Odśwież", "common.new_folder": "Nowy folder", "common.rename": "Zmień nazwę", "common.delete": "Usuń", "common.permissions": "Uprawnienia", "common.cancel": "Anuluj",
+		"section.local": "KOMPUTER LOKALNY", "section.remote": "SERWER", "section.transfers": "TRANSFERy",
 		"transfer.upload": "Wyślij", "transfer.download": "Pobierz", "transfer.pause": "Wstrzymaj", "transfer.resume": "Wznów", "transfer.retry": "Ponów", "transfer.clear": "Wyczyść zakończone",
-		"status.ready": "Gotowe. Wybierz zapisany profil lub wprowadź dane serwera.", "settings.title": "GhostFTP — Ustawienia", "profile.save": "Zapisz profil", "profile.delete": "Usuń profil",
+		"status.ready": "Gotowe. Wybierz zapisany profil lub wprowadź dane serwera.", "status.queued": "W kolejce", "status.running": "W toku", "status.done": "Zakończono", "status.failed": "Niepowodzenie", "status.cancelled": "Anulowano", "status.skipped": "Pominięto",
+		"cue.host": "Serwer FTP/SFTP, np. ftp.example.com", "cue.user": "Nazwa użytkownika, może być user@example.com", "cue.password": "Hasło FTP / SFTP",
+		"column.name": "Nazwa", "column.type": "Typ", "column.size": "Rozmiar", "column.modified": "Zmodyfikowano", "column.status": "Stan", "column.progress": "Postęp", "type.file": "plik", "type.folder": "folder",
+		"settings.title": "Ghost FTP — Ustawienia", "settings.invalid_value": "Nieprawidłowa wartość", "settings.parallel": "Równoległe transfery (1–8):", "settings.timeout": "Limit czasu połączenia (5–60 sekund):", "settings.retries": "Automatycznie ponów nieudany transfer (0–3 razy):", "settings.retry_delay": "Opóźnienie między automatycznymi próbami (1–30 sekund):",
+		"about.title": "O programie", "connection.failed": "Połączenie nie powiodło się", "error.generic": "Operacja nie powiodła się. Sprawdź połączenie i spróbuj ponownie.",
 	},
 	"nl": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Snel hostingbeheer", "section.local": "LOKALE COMPUTER", "section.remote": "SERVER", "section.transfers": "OVERDRACHTEN",
-		"common.settings": "Instellingen", "common.connect": "Verbinden", "common.disconnect": "Verbreken", "common.refresh": "Vernieuwen", "common.cancel": "Annuleren",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Snel hostingbeheer", "badge.connected": "● VERBONDEN", "badge.disconnected": "● NIET VERBONDEN",
+		"profile.quick": "Snel verbinden (zonder profiel)", "profile.save": "Profiel opslaan", "profile.delete": "Profiel verwijderen",
+		"common.settings": "Instellingen", "common.about": "Over", "common.connect": "Verbinden", "common.disconnect": "Verbreken", "common.up": "Omhoog", "common.folder": "Map…", "common.refresh": "Vernieuwen", "common.new_folder": "Nieuwe map", "common.rename": "Hernoemen", "common.delete": "Verwijderen", "common.permissions": "Machtigingen", "common.cancel": "Annuleren",
+		"section.local": "LOKALE COMPUTER", "section.remote": "SERVER", "section.transfers": "OVERDRACHTEN",
 		"transfer.upload": "Uploaden", "transfer.download": "Downloaden", "transfer.pause": "Pauzeren", "transfer.resume": "Hervatten", "transfer.retry": "Opnieuw", "transfer.clear": "Voltooide wissen",
-		"status.ready": "Gereed. Kies een opgeslagen profiel of voer servergegevens in.", "settings.title": "GhostFTP — Instellingen", "profile.save": "Profiel opslaan", "profile.delete": "Profiel verwijderen",
+		"status.ready": "Gereed. Kies een opgeslagen profiel of voer servergegevens in.", "status.queued": "In wachtrij", "status.running": "Bezig", "status.done": "Voltooid", "status.failed": "Mislukt", "status.cancelled": "Geannuleerd", "status.skipped": "Overgeslagen",
+		"cue.host": "FTP/SFTP-server, bv. ftp.example.com", "cue.user": "Gebruikersnaam, kan user@example.com zijn", "cue.password": "FTP / SFTP-wachtwoord",
+		"column.name": "Naam", "column.type": "Type", "column.size": "Grootte", "column.modified": "Gewijzigd", "column.status": "Status", "column.progress": "Voortgang", "type.file": "bestand", "type.folder": "map",
+		"settings.title": "Ghost FTP — Instellingen", "settings.invalid_value": "Ongeldige waarde", "settings.parallel": "Parallelle overdrachten (1–8):", "settings.timeout": "Verbindingstime-out (5–60 seconden):", "settings.retries": "Mislukte overdracht automatisch opnieuw proberen (0–3 keer):", "settings.retry_delay": "Vertraging tussen automatische pogingen (1–30 seconden):",
+		"about.title": "Over", "connection.failed": "Verbinding mislukt", "error.generic": "De bewerking is mislukt. Controleer de verbinding en probeer opnieuw.",
 	},
 	"cs": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Rychlá správa hostingu", "section.local": "MÍSTNÍ POČÍTAČ", "section.remote": "SERVER", "section.transfers": "PŘENOSY",
-		"common.settings": "Nastavení", "common.connect": "Připojit", "common.disconnect": "Odpojit", "common.refresh": "Obnovit", "common.cancel": "Zrušit",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Rychlá správa hostingu", "badge.connected": "● PŘIPOJENO", "badge.disconnected": "● ODPOJENO",
+		"profile.quick": "Rychlé připojení (bez profilu)", "profile.save": "Uložit profil", "profile.delete": "Smazat profil",
+		"common.settings": "Nastavení", "common.about": "O aplikaci", "common.connect": "Připojit", "common.disconnect": "Odpojit", "common.up": "Nahoru", "common.folder": "Složka…", "common.refresh": "Obnovit", "common.new_folder": "Nová složka", "common.rename": "Přejmenovat", "common.delete": "Smazat", "common.permissions": "Oprávnění", "common.cancel": "Zrušit",
+		"section.local": "MÍSTNÍ POČÍTAČ", "section.remote": "SERVER", "section.transfers": "PŘENOSY",
 		"transfer.upload": "Nahrát", "transfer.download": "Stáhnout", "transfer.pause": "Pozastavit", "transfer.resume": "Pokračovat", "transfer.retry": "Opakovat", "transfer.clear": "Vymazat dokončené",
-		"status.ready": "Připraveno. Vyberte uložený profil nebo zadejte údaje serveru.", "settings.title": "GhostFTP — Nastavení", "profile.save": "Uložit profil", "profile.delete": "Smazat profil",
+		"status.ready": "Připraveno. Vyberte uložený profil nebo zadejte údaje serveru.", "status.queued": "Ve frontě", "status.running": "Probíhá", "status.done": "Dokončeno", "status.failed": "Nezdařilo se", "status.cancelled": "Zrušeno", "status.skipped": "Přeskočeno",
+		"cue.host": "FTP/SFTP server, např. ftp.example.com", "cue.user": "Uživatelské jméno, může být user@example.com", "cue.password": "Heslo FTP / SFTP",
+		"column.name": "Název", "column.type": "Typ", "column.size": "Velikost", "column.modified": "Změněno", "column.status": "Stav", "column.progress": "Průběh", "type.file": "soubor", "type.folder": "složka",
+		"settings.title": "Ghost FTP — Nastavení", "settings.invalid_value": "Neplatná hodnota", "settings.parallel": "Souběžné přenosy (1–8):", "settings.timeout": "Časový limit připojení (5–60 sekund):", "settings.retries": "Automaticky opakovat neúspěšný přenos (0–3krát):", "settings.retry_delay": "Prodleva mezi automatickými pokusy (1–30 sekund):",
+		"about.title": "O aplikaci", "connection.failed": "Připojení se nezdařilo", "error.generic": "Operace se nezdařila. Zkontrolujte připojení a zkuste to znovu.",
 	},
 	"uk": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Швидке керування хостингом", "section.local": "ЛОКАЛЬНИЙ КОМП'ЮТЕР", "section.remote": "СЕРВЕР", "section.transfers": "ПЕРЕДАВАННЯ",
-		"common.settings": "Налаштування", "common.connect": "Підключити", "common.disconnect": "Відключити", "common.refresh": "Оновити", "common.cancel": "Скасувати",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Швидке керування хостингом", "badge.connected": "● ПІДКЛЮЧЕНО", "badge.disconnected": "● ВІДКЛЮЧЕНО",
+		"profile.quick": "Швидке підключення (без профілю)", "profile.save": "Зберегти профіль", "profile.delete": "Видалити профіль",
+		"common.settings": "Налаштування", "common.about": "Про програму", "common.connect": "Підключити", "common.disconnect": "Відключити", "common.up": "Вгору", "common.folder": "Папка…", "common.refresh": "Оновити", "common.new_folder": "Нова папка", "common.rename": "Перейменувати", "common.delete": "Видалити", "common.permissions": "Дозволи", "common.cancel": "Скасувати",
+		"section.local": "ЛОКАЛЬНИЙ КОМП'ЮТЕР", "section.remote": "СЕРВЕР", "section.transfers": "ПЕРЕДАВАННЯ",
 		"transfer.upload": "Вивантажити", "transfer.download": "Завантажити", "transfer.pause": "Призупинити", "transfer.resume": "Продовжити", "transfer.retry": "Повторити", "transfer.clear": "Очистити завершені",
-		"status.ready": "Готово. Виберіть збережений профіль або введіть дані сервера.", "settings.title": "GhostFTP — Налаштування", "profile.save": "Зберегти профіль", "profile.delete": "Видалити профіль",
+		"status.ready": "Готово. Виберіть збережений профіль або введіть дані сервера.", "status.queued": "У черзі", "status.running": "Виконується", "status.done": "Завершено", "status.failed": "Помилка", "status.cancelled": "Скасовано", "status.skipped": "Пропущено",
+		"cue.host": "FTP/SFTP сервер, напр. ftp.example.com", "cue.user": "Ім'я користувача, може бути user@example.com", "cue.password": "Пароль FTP / SFTP",
+		"column.name": "Назва", "column.type": "Тип", "column.size": "Розмір", "column.modified": "Змінено", "column.status": "Стан", "column.progress": "Прогрес", "type.file": "файл", "type.folder": "папка",
+		"settings.title": "Ghost FTP — Налаштування", "settings.invalid_value": "Недійсне значення", "settings.parallel": "Паралельні передачі (1–8):", "settings.timeout": "Тайм-аут підключення (5–60 секунд):", "settings.retries": "Автоматично повторити невдалу передачу (0–3 рази):", "settings.retry_delay": "Затримка між автоматичними спробами (1–30 секунд):",
+		"about.title": "Про програму", "connection.failed": "Не вдалося підключитися", "error.generic": "Операція не вдалася. Перевірте підключення та спробуйте ще раз.",
 	},
 	"sv": {
-		"app.subtitle": "FTP • FTPS • SFTP  ·  Snabb hostinghantering", "section.local": "LOKAL DATOR", "section.remote": "SERVER", "section.transfers": "ÖVERFÖRINGAR",
-		"common.settings": "Inställningar", "common.connect": "Anslut", "common.disconnect": "Koppla från", "common.refresh": "Uppdatera", "common.cancel": "Avbryt",
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Snabb hostinghantering", "badge.connected": "● ANSLUTEN", "badge.disconnected": "● FRÅNKOPPLAD",
+		"profile.quick": "Snabbanslutning (utan profil)", "profile.save": "Spara profil", "profile.delete": "Ta bort profil",
+		"common.settings": "Inställningar", "common.about": "Om", "common.connect": "Anslut", "common.disconnect": "Koppla från", "common.up": "Upp", "common.folder": "Mapp…", "common.refresh": "Uppdatera", "common.new_folder": "Ny mapp", "common.rename": "Byt namn", "common.delete": "Ta bort", "common.permissions": "Behörigheter", "common.cancel": "Avbryt",
+		"section.local": "LOKAL DATOR", "section.remote": "SERVER", "section.transfers": "ÖVERFÖRINGAR",
 		"transfer.upload": "Ladda upp", "transfer.download": "Ladda ner", "transfer.pause": "Pausa", "transfer.resume": "Fortsätt", "transfer.retry": "Försök igen", "transfer.clear": "Rensa slutförda",
-		"status.ready": "Klar. Välj en sparad profil eller ange serveruppgifter.", "settings.title": "GhostFTP — Inställningar", "profile.save": "Spara profil", "profile.delete": "Ta bort profil",
+		"status.ready": "Klar. Välj en sparad profil eller ange serveruppgifter.", "status.queued": "I kö", "status.running": "Pågår", "status.done": "Klar", "status.failed": "Misslyckades", "status.cancelled": "Avbruten", "status.skipped": "Hoppades över",
+		"cue.host": "FTP/SFTP-server, t.ex. ftp.example.com", "cue.user": "Användarnamn, kan vara user@example.com", "cue.password": "FTP / SFTP-lösenord",
+		"column.name": "Namn", "column.type": "Typ", "column.size": "Storlek", "column.modified": "Ändrad", "column.status": "Status", "column.progress": "Förlopp", "type.file": "fil", "type.folder": "mapp",
+		"settings.title": "Ghost FTP — Inställningar", "settings.invalid_value": "Ogiltigt värde", "settings.parallel": "Parallella överföringar (1–8):", "settings.timeout": "Anslutningstimeout (5–60 sekunder):", "settings.retries": "Försök automatiskt igen vid misslyckad överföring (0–3 gånger):", "settings.retry_delay": "Fördröjning mellan automatiska försök (1–30 sekunder):",
+		"about.title": "Om", "connection.failed": "Anslutningen misslyckades", "error.generic": "Åtgärden misslyckades. Kontrollera anslutningen och försök igen.",
+	},
+	"ro": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Administrare rapidă a găzduirii", "badge.connected": "● CONECTAT", "badge.disconnected": "● DECONECTAT",
+		"profile.quick": "Conectare rapidă (fără profil)", "profile.save": "Salvează profilul", "profile.delete": "Șterge profilul",
+		"common.settings": "Setări", "common.about": "Despre", "common.connect": "Conectează", "common.disconnect": "Deconectează", "common.up": "Sus", "common.folder": "Dosar…", "common.refresh": "Reîmprospătează", "common.new_folder": "Dosar nou", "common.rename": "Redenumește", "common.delete": "Șterge", "common.permissions": "Permisiuni", "common.cancel": "Anulează",
+		"section.local": "CALCULATOR LOCAL", "section.remote": "SERVER", "section.transfers": "TRANSFERURI",
+		"transfer.upload": "Încarcă", "transfer.download": "Descarcă", "transfer.pause": "Pauză", "transfer.resume": "Continuă", "transfer.retry": "Reîncearcă", "transfer.clear": "Șterge finalizate",
+		"status.ready": "Gata. Selectează un profil salvat sau introdu datele serverului.", "status.queued": "În așteptare", "status.running": "În curs", "status.done": "Finalizat", "status.failed": "Eșuat", "status.cancelled": "Anulat", "status.skipped": "Omis",
+		"cue.host": "Server FTP/SFTP, de ex. ftp.example.com", "cue.user": "Nume utilizator, poate fi user@example.com", "cue.password": "Parolă FTP / SFTP",
+		"column.name": "Nume", "column.type": "Tip", "column.size": "Dimensiune", "column.modified": "Modificat", "column.status": "Stare", "column.progress": "Progres", "type.file": "fișier", "type.folder": "dosar",
+		"settings.title": "Ghost FTP — Setări", "settings.invalid_value": "Valoare invalidă", "settings.parallel": "Transferuri paralele (1–8):", "settings.timeout": "Timp limită conexiune (5–60 secunde):", "settings.retries": "Reîncearcă automat un transfer eșuat (0–3 ori):", "settings.retry_delay": "Întârziere între reîncercări (1–30 secunde):",
+		"about.title": "Despre", "connection.failed": "Conexiunea a eșuat", "error.generic": "Operația a eșuat. Verifică conexiunea și încearcă din nou.",
+	},
+	"hu": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Gyors tárhelykezelés", "badge.connected": "● KAPCSOLÓDVA", "badge.disconnected": "● NINCS KAPCSOLAT",
+		"profile.quick": "Gyors kapcsolódás (profil nélkül)", "profile.save": "Profil mentése", "profile.delete": "Profil törlése",
+		"common.settings": "Beállítások", "common.about": "Névjegy", "common.connect": "Kapcsolódás", "common.disconnect": "Leválasztás", "common.up": "Fel", "common.folder": "Mappa…", "common.refresh": "Frissítés", "common.new_folder": "Új mappa", "common.rename": "Átnevezés", "common.delete": "Törlés", "common.permissions": "Jogosultságok", "common.cancel": "Mégse",
+		"section.local": "HELYI SZÁMÍTÓGÉP", "section.remote": "SZERVER", "section.transfers": "ÁTVITELEK",
+		"transfer.upload": "Feltöltés", "transfer.download": "Letöltés", "transfer.pause": "Szünet", "transfer.resume": "Folytatás", "transfer.retry": "Újra", "transfer.clear": "Befejezettek törlése",
+		"status.ready": "Kész. Válassz mentett profilt vagy add meg a szerver adatait.", "status.queued": "Sorban", "status.running": "Folyamatban", "status.done": "Kész", "status.failed": "Sikertelen", "status.cancelled": "Megszakítva", "status.skipped": "Kihagyva",
+		"cue.host": "FTP/SFTP szerver, pl. ftp.example.com", "cue.user": "Felhasználónév, lehet user@example.com", "cue.password": "FTP / SFTP jelszó",
+		"column.name": "Név", "column.type": "Típus", "column.size": "Méret", "column.modified": "Módosítva", "column.status": "Állapot", "column.progress": "Folyamat", "type.file": "fájl", "type.folder": "mappa",
+		"settings.title": "Ghost FTP — Beállítások", "settings.invalid_value": "Érvénytelen érték", "settings.parallel": "Párhuzamos átvitelek (1–8):", "settings.timeout": "Kapcsolati időkorlát (5–60 másodperc):", "settings.retries": "Sikertelen átvitel automatikus újrapróbálása (0–3 alkalom):", "settings.retry_delay": "Késleltetés az automatikus próbák között (1–30 másodperc):",
+		"about.title": "Névjegy", "connection.failed": "A kapcsolódás sikertelen", "error.generic": "A művelet sikertelen. Ellenőrizd a kapcsolatot, majd próbáld újra.",
+	},
+	"da": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Hurtig hostingstyring", "badge.connected": "● FORBUNDET", "badge.disconnected": "● AFBRUDT",
+		"profile.quick": "Hurtig forbindelse (uden profil)", "profile.save": "Gem profil", "profile.delete": "Slet profil",
+		"common.settings": "Indstillinger", "common.about": "Om", "common.connect": "Forbind", "common.disconnect": "Afbryd", "common.up": "Op", "common.folder": "Mappe…", "common.refresh": "Opdater", "common.new_folder": "Ny mappe", "common.rename": "Omdøb", "common.delete": "Slet", "common.permissions": "Tilladelser", "common.cancel": "Annuller",
+		"section.local": "LOKAL COMPUTER", "section.remote": "SERVER", "section.transfers": "OVERFØRSLER",
+		"transfer.upload": "Upload", "transfer.download": "Download", "transfer.pause": "Pause", "transfer.resume": "Fortsæt", "transfer.retry": "Prøv igen", "transfer.clear": "Ryd færdige",
+		"status.ready": "Klar. Vælg en gemt profil eller indtast serveroplysninger.", "status.queued": "I kø", "status.running": "Kører", "status.done": "Færdig", "status.failed": "Mislykkedes", "status.cancelled": "Annulleret", "status.skipped": "Sprunget over",
+		"cue.host": "FTP/SFTP-server, f.eks. ftp.example.com", "cue.user": "Brugernavn, kan være user@example.com", "cue.password": "FTP / SFTP-adgangskode",
+		"column.name": "Navn", "column.type": "Type", "column.size": "Størrelse", "column.modified": "Ændret", "column.status": "Status", "column.progress": "Fremdrift", "type.file": "fil", "type.folder": "mappe",
+		"settings.title": "Ghost FTP — Indstillinger", "settings.invalid_value": "Ugyldig værdi", "settings.parallel": "Parallelle overførsler (1–8):", "settings.timeout": "Forbindelsestimeout (5–60 sekunder):", "settings.retries": "Prøv automatisk en mislykket overførsel igen (0–3 gange):", "settings.retry_delay": "Forsinkelse mellem automatiske forsøg (1–30 sekunder):",
+		"about.title": "Om", "connection.failed": "Forbindelsen mislykkedes", "error.generic": "Handlingen mislykkedes. Kontrollér forbindelsen, og prøv igen.",
+	},
+	"fi": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Nopea palvelinhallinta", "badge.connected": "● YHDISTETTY", "badge.disconnected": "● EI YHTEYTTÄ",
+		"profile.quick": "Pikayhteys (ei profiilia)", "profile.save": "Tallenna profiili", "profile.delete": "Poista profiili",
+		"common.settings": "Asetukset", "common.about": "Tietoja", "common.connect": "Yhdistä", "common.disconnect": "Katkaise yhteys", "common.up": "Ylös", "common.folder": "Kansio…", "common.refresh": "Päivitä", "common.new_folder": "Uusi kansio", "common.rename": "Nimeä uudelleen", "common.delete": "Poista", "common.permissions": "Oikeudet", "common.cancel": "Peruuta",
+		"section.local": "PAIKALLINEN TIETOKONE", "section.remote": "PALVELIN", "section.transfers": "SIIRROT",
+		"transfer.upload": "Lähetä", "transfer.download": "Lataa", "transfer.pause": "Tauko", "transfer.resume": "Jatka", "transfer.retry": "Yritä uudelleen", "transfer.clear": "Tyhjennä valmiit",
+		"status.ready": "Valmis. Valitse tallennettu profiili tai anna palvelimen tiedot.", "status.queued": "Jonossa", "status.running": "Käynnissä", "status.done": "Valmis", "status.failed": "Epäonnistui", "status.cancelled": "Peruutettu", "status.skipped": "Ohitettu",
+		"cue.host": "FTP/SFTP-palvelin, esim. ftp.example.com", "cue.user": "Käyttäjänimi, voi olla user@example.com", "cue.password": "FTP / SFTP-salasana",
+		"column.name": "Nimi", "column.type": "Tyyppi", "column.size": "Koko", "column.modified": "Muokattu", "column.status": "Tila", "column.progress": "Edistyminen", "type.file": "tiedosto", "type.folder": "kansio",
+		"settings.title": "Ghost FTP — Asetukset", "settings.invalid_value": "Virheellinen arvo", "settings.parallel": "Rinnakkaiset siirrot (1–8):", "settings.timeout": "Yhteyden aikakatkaisu (5–60 sekuntia):", "settings.retries": "Yritä epäonnistunutta siirtoa automaattisesti uudelleen (0–3 kertaa):", "settings.retry_delay": "Viive automaattisten yritysten välillä (1–30 sekuntia):",
+		"about.title": "Tietoja", "connection.failed": "Yhteys epäonnistui", "error.generic": "Toiminto epäonnistui. Tarkista yhteys ja yritä uudelleen.",
+	},
+	"no": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  Rask hostingadministrasjon", "badge.connected": "● TILKOBLET", "badge.disconnected": "● FRAKOBLET",
+		"profile.quick": "Hurtigtilkobling (uten profil)", "profile.save": "Lagre profil", "profile.delete": "Slett profil",
+		"common.settings": "Innstillinger", "common.about": "Om", "common.connect": "Koble til", "common.disconnect": "Koble fra", "common.up": "Opp", "common.folder": "Mappe…", "common.refresh": "Oppdater", "common.new_folder": "Ny mappe", "common.rename": "Gi nytt navn", "common.delete": "Slett", "common.permissions": "Tillatelser", "common.cancel": "Avbryt",
+		"section.local": "LOKAL DATAMASKIN", "section.remote": "SERVER", "section.transfers": "OVERFØRINGER",
+		"transfer.upload": "Last opp", "transfer.download": "Last ned", "transfer.pause": "Pause", "transfer.resume": "Fortsett", "transfer.retry": "Prøv igjen", "transfer.clear": "Tøm fullførte",
+		"status.ready": "Klar. Velg en lagret profil eller skriv inn serverdetaljer.", "status.queued": "I kø", "status.running": "Kjører", "status.done": "Fullført", "status.failed": "Mislyktes", "status.cancelled": "Avbrutt", "status.skipped": "Hoppet over",
+		"cue.host": "FTP/SFTP-server, f.eks. ftp.example.com", "cue.user": "Brukernavn, kan være user@example.com", "cue.password": "FTP / SFTP-passord",
+		"column.name": "Navn", "column.type": "Type", "column.size": "Størrelse", "column.modified": "Endret", "column.status": "Status", "column.progress": "Fremdrift", "type.file": "fil", "type.folder": "mappe",
+		"settings.title": "Ghost FTP — Innstillinger", "settings.invalid_value": "Ugyldig verdi", "settings.parallel": "Parallelle overføringer (1–8):", "settings.timeout": "Tidsavbrudd for tilkobling (5–60 sekunder):", "settings.retries": "Prøv automatisk en mislykket overføring igjen (0–3 ganger):", "settings.retry_delay": "Forsinkelse mellom automatiske forsøk (1–30 sekunder):",
+		"about.title": "Om", "connection.failed": "Tilkoblingen mislyktes", "error.generic": "Operasjonen mislyktes. Kontroller tilkoblingen og prøv igjen.",
+	},
+	"ko": {
+		"app.subtitle": "FTP • FTPS • SFTP  ·  빠른 호스팅 관리", "badge.connected": "● 연결됨", "badge.disconnected": "● 연결 끊김",
+		"profile.quick": "빠른 연결 (프로필 없음)", "profile.save": "프로필 저장", "profile.delete": "프로필 삭제",
+		"common.settings": "설정", "common.about": "정보", "common.connect": "연결", "common.disconnect": "연결 해제", "common.up": "위로", "common.folder": "폴더…", "common.refresh": "새로 고침", "common.new_folder": "새 폴더", "common.rename": "이름 바꾸기", "common.delete": "삭제", "common.permissions": "권한", "common.cancel": "취소",
+		"section.local": "로컬 컴퓨터", "section.remote": "서버", "section.transfers": "전송",
+		"transfer.upload": "업로드", "transfer.download": "다운로드", "transfer.pause": "일시 중지", "transfer.resume": "계속", "transfer.retry": "다시 시도", "transfer.clear": "완료 항목 지우기",
+		"status.ready": "준비됨. 저장된 프로필을 선택하거나 서버 정보를 입력하세요.", "status.queued": "대기 중", "status.running": "진행 중", "status.done": "완료", "status.failed": "실패", "status.cancelled": "취소됨", "status.skipped": "건너뜀",
+		"cue.host": "FTP/SFTP 서버, 예: ftp.example.com", "cue.user": "사용자 이름, user@example.com 형식 가능", "cue.password": "FTP / SFTP 비밀번호",
+		"column.name": "이름", "column.type": "유형", "column.size": "크기", "column.modified": "수정됨", "column.status": "상태", "column.progress": "진행률", "type.file": "파일", "type.folder": "폴더",
+		"settings.title": "Ghost FTP — 설정", "settings.invalid_value": "잘못된 값", "settings.parallel": "동시 전송 (1–8):", "settings.timeout": "연결 제한 시간 (5–60초):", "settings.retries": "실패한 전송 자동 재시도 (0–3회):", "settings.retry_delay": "자동 재시도 간 지연 (1–30초):",
+		"about.title": "정보", "connection.failed": "연결 실패", "error.generic": "작업에 실패했습니다. 연결을 확인하고 다시 시도하세요.",
 	},
 }
 
@@ -54,10 +168,14 @@ func init() {
 		catalogs[code] = catalog
 	}
 
-	codes := "en|hr|de|fr|es|tr|el|pt|zh|ru|hi|ja|it|pl|nl|cs|uk|sv"
+	codes := make([]string, 0, len(supportedLanguages))
+	for _, language := range supportedLanguages {
+		codes = append(codes, language.Code)
+	}
+	usage := "Usage: language <" + strings.Join(codes, "|") + ">"
 	for _, catalog := range catalogs {
 		if _, ok := catalog["terminal.language_usage"]; ok {
-			catalog["terminal.language_usage"] = "Usage: language <" + codes + ">"
+			catalog["terminal.language_usage"] = usage
 		}
 	}
 }

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -17,6 +18,15 @@ ALLOWED_ANDROID = {
     "testImplementation": {
         "junit:junit:4.13.2",
     },
+}
+
+ALLOWED_WEB_PLATFORM_REQUIREMENTS = {"php": ">=8.1"}
+ALLOWED_WEB_SUGGESTED_EXTENSIONS = {
+    "ext-ftp": "Required for FTP/FTPS support",
+    "ext-ssh2": "Required for SFTP support",
+    "ext-zip": "Required for ZIP create/extract and folder downloads",
+    "ext-sodium": "Preferred for credential encryption",
+    "ext-openssl": "Encryption fallback when sodium is unavailable",
 }
 
 FORBIDDEN_TRACKING = (
@@ -74,14 +84,33 @@ def audit_android() -> None:
 
 
 def audit_web() -> None:
-    composer = read("GhostFTP WEB/composer.json")
-    if '"require": {}' not in composer.replace("\n", " ").replace("  ", " "):
-        # Parse without importing third-party tooling; exact empty require is the
-        # contract for the shared-hosting package.
-        import json
-        data = json.loads(composer)
-        if data.get("require") not in ({}, None):
-            fail("Web/PWA Composer runtime dependencies must remain empty")
+    try:
+        data = json.loads(read("GhostFTP WEB/composer.json"))
+    except json.JSONDecodeError as exc:
+        fail(f"Web/PWA composer.json is invalid JSON: {exc}")
+
+    require = data.get("require")
+    if require != ALLOWED_WEB_PLATFORM_REQUIREMENTS:
+        fail(
+            "Web/PWA Composer require must contain only the pinned PHP platform requirement "
+            f"{ALLOWED_WEB_PLATFORM_REQUIREMENTS!r}; found={require!r}"
+        )
+    third_party_require = [
+        name for name in require
+        if name != "php" and not str(name).startswith("ext-")
+    ]
+    if third_party_require:
+        fail("Web/PWA third-party Composer packages are forbidden: " + ", ".join(sorted(third_party_require)))
+
+    suggest = data.get("suggest")
+    if suggest != ALLOWED_WEB_SUGGESTED_EXTENSIONS:
+        fail(
+            "Web/PWA suggested extension capability list drifted; "
+            f"found={suggest!r} expected={ALLOWED_WEB_SUGGESTED_EXTENSIONS!r}"
+        )
+    invalid_suggest = [name for name in suggest if not str(name).startswith("ext-")]
+    if invalid_suggest:
+        fail("Web/PWA suggest may contain only PHP extension capabilities: " + ", ".join(sorted(invalid_suggest)))
 
 
 def audit_repository_tracking_markers() -> None:
@@ -104,7 +133,9 @@ def main() -> int:
     print("DEPENDENCY_AUDIT=PASS")
     print("GO_EXTERNAL_MODULES=0")
     print("ANDROID_RUNTIME_DEPENDENCIES=2_PINNED")
-    print("WEB_COMPOSER_RUNTIME_DEPENDENCIES=0")
+    print("WEB_THIRD_PARTY_COMPOSER_PACKAGES=0")
+    print("WEB_PLATFORM_REQUIREMENTS=php>=8.1")
+    print("WEB_SUGGESTED_EXTENSIONS=" + ",".join(sorted(ALLOWED_WEB_SUGGESTED_EXTENSIONS)))
     print("TRACKING_ADS_CRASH_SDKS=FORBIDDEN")
     return 0
 

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Audit Ghost FTP dependency provenance and forbidden tracking surfaces."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ALLOWED_ANDROID = {
+    "implementation": {
+        "commons-net:commons-net:3.13.0",
+        "com.hierynomus:sshj:0.40.0",
+    },
+    "testImplementation": {
+        "junit:junit:4.13.2",
+    },
+}
+
+FORBIDDEN_TRACKING = (
+    "firebase-analytics",
+    "firebase-crashlytics",
+    "appcenter",
+    "sentry-android",
+    "bugsnag",
+    "newrelic",
+    "datadog",
+    "amplitude",
+    "mixpanel",
+    "segment-analytics",
+    "facebook-android-sdk",
+    "play-services-ads",
+    "google-mobile-ads",
+)
+
+
+def fail(message: str) -> None:
+    raise SystemExit("DEPENDENCY_AUDIT_FAILED: " + message)
+
+
+def read(rel: str) -> str:
+    path = ROOT / rel
+    if not path.is_file():
+        fail(f"missing required file: {rel}")
+    return path.read_text(encoding="utf-8")
+
+
+def audit_go() -> None:
+    gomod = read("go.mod")
+    module_lines = [line.strip() for line in gomod.splitlines() if line.strip()]
+    if not module_lines or module_lines[0] != "module github.com/bren-wp/Ghost-FTP":
+        fail("unexpected Go module identity")
+    if any(re.match(r"^(require|replace|exclude|retract)\b", line) for line in module_lines):
+        fail("desktop/core Go module must not introduce external module requirements or replacements")
+
+
+def audit_android() -> None:
+    gradle = read("android/app/build.gradle.kts")
+    found: dict[str, set[str]] = {key: set() for key in ALLOWED_ANDROID}
+    pattern = re.compile(r'^\s*(implementation|testImplementation)\("([^\"]+)"\)', re.MULTILINE)
+    for kind, coordinate in pattern.findall(gradle):
+        found.setdefault(kind, set()).add(coordinate)
+        if "+" in coordinate or "SNAPSHOT" in coordinate.upper():
+            fail(f"dynamic or snapshot Android dependency is forbidden: {coordinate}")
+    if found != ALLOWED_ANDROID:
+        fail(f"Android dependency allowlist drift: found={found!r} expected={ALLOWED_ANDROID!r}")
+
+    lower = gradle.lower()
+    for marker in FORBIDDEN_TRACKING:
+        if marker in lower:
+            fail(f"tracking/advertising SDK is forbidden: {marker}")
+
+
+def audit_web() -> None:
+    composer = read("GhostFTP WEB/composer.json")
+    if '"require": {}' not in composer.replace("\n", " ").replace("  ", " "):
+        # Parse without importing third-party tooling; exact empty require is the
+        # contract for the shared-hosting package.
+        import json
+        data = json.loads(composer)
+        if data.get("require") not in ({}, None):
+            fail("Web/PWA Composer runtime dependencies must remain empty")
+
+
+def audit_repository_tracking_markers() -> None:
+    candidates = (
+        "android/app/build.gradle.kts",
+        "go.mod",
+        "GhostFTP WEB/composer.json",
+    )
+    combined = "\n".join(read(rel).lower() for rel in candidates)
+    for marker in FORBIDDEN_TRACKING:
+        if marker in combined:
+            fail(f"forbidden tracking marker present in dependency surfaces: {marker}")
+
+
+def main() -> int:
+    audit_go()
+    audit_android()
+    audit_web()
+    audit_repository_tracking_markers()
+    print("DEPENDENCY_AUDIT=PASS")
+    print("GO_EXTERNAL_MODULES=0")
+    print("ANDROID_RUNTIME_DEPENDENCIES=2_PINNED")
+    print("WEB_COMPOSER_RUNTIME_DEPENDENCIES=0")
+    print("TRACKING_ADS_CRASH_SDKS=FORBIDDEN")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/one_shot_110_finalize.py
+++ b/scripts/one_shot_110_finalize.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def write(rel: str, text: str) -> None:
+    (ROOT / rel).write_text(text, encoding="utf-8", newline="\n")
+
+
+def replace_once(rel: str, old: str, new: str) -> None:
+    text = read(rel)
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{rel}: expected one marker, found {count}: {old[:100]!r}")
+    write(rel, text.replace(old, new, 1))
+
+
+replace_once(
+    "cmd/installer/main.go",
+    '''\tinstallLanguage, ok := selectInstallerLanguage()\n\tif !ok {\n\t\treturn 0\n\t}\n\n\tcontent := brand.Website + "\\n" + brand.Support + "\\n\\n" +\n\t\tbrand.ProductName + " will be installed for your Windows user account and will be available from the Start menu."\n''',
+    '''\tinstallLanguage, ok := selectInstallerLanguage()\n\tif !ok {\n\t\treturn 0\n\t}\n\tsetupCopy := installerCopyFor(installLanguage)\n\n\tcontent := brand.Website + "\\n" + brand.Support + "\\n\\n" + setupCopy.ConfirmBody\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t"Install "+brand.ProductFull+" "+version+"?",\n''',
+    '''\t\tinstallerConfirmTitle(installLanguage, version),\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\tlanguageWarning = "\\n\\nThe selected language could not be saved. Ghost FTP will start in English; you can change the language in Settings."\n''',
+    '''\t\tlanguageWarning = "\\n\\n" + setupCopy.LanguageWarning\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\tshortcutWarning = "\\n\\nA shortcut could not be created. You can start Ghost FTP from its installation folder."\n''',
+    '''\t\tshortcutWarning = "\\n\\n" + setupCopy.ShortcutWarning\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t"Setup completed successfully",\n\t\t"Ghost FTP is ready to use."+legacyCleanupWarning+languageWarning+shortcutWarning+"\\n\\nLaunch Ghost FTP now?",\n''',
+    '''\t\tsetupCopy.CompletedTitle,\n\t\tsetupCopy.ReadyBody+legacyCleanupWarning+languageWarning+shortcutWarning+"\\n\\n"+setupCopy.LaunchQuestion,\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t\t\t"Ghost FTP is installed",\n\t\t\t\t"Ghost FTP could not be launched automatically. Start it from the Windows Start menu.",\n''',
+    '''\t\t\t\tsetupCopy.InstalledTitle,\n\t\t\t\tsetupCopy.LaunchFailed,\n''',
+)
+
+replace_once(
+    "cmd/installer/language.go",
+    '''\t\t"Choose the language to use in Ghost FTP. You can change it later in Settings.",\n''',
+    '''\t\t"Choose the setup language. English is the default.\\nNo telemetry · No ads · FTP · FTPS · SFTP",\n''',
+)
+
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\t\t420, 250, 560, 230,\n''',
+    '''\t\t360, 210, 640, 300,\n''',
+)
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\tmakeControl("STATIC", instruction, 0, 24, 22, 500, 42, 0)\n\tstate.combo = makeControl("COMBOBOX", "", wsTabStop|wsVScroll|cbsDropdown, 24, 70, 500, 260, languageIDCombo)\n''',
+    '''\tmakeControl("STATIC", instruction, 0, 32, 28, 576, 54, 0)\n\tstate.combo = makeControl("COMBOBOX", "", wsTabStop|wsVScroll|cbsDropdown, 32, 92, 576, 260, languageIDCombo)\n''',
+)
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\tmakeControl("BUTTON", "Install", wsTabStop, 338, 132, 88, 32, languageIDInstall)\n\tmakeControl("BUTTON", "Cancel", wsTabStop, 436, 132, 88, 32, languageIDCancel)\n''',
+    '''\tmakeControl("STATIC", "Ghost FTP Setup · private by design · local-first settings", 0, 32, 140, 576, 24, 0)\n\tmakeControl("BUTTON", "Continue", wsTabStop, 420, 182, 90, 34, languageIDInstall)\n\tmakeControl("BUTTON", "Cancel", wsTabStop, 518, 182, 90, 34, languageIDCancel)\n''',
+)
+
+audit = read("scripts/audit_localization.py")
+audit = audit.replace(
+    'SUPPORTED = ("en", "hr", "de", "fr", "es", "tr", "el", "pt", "zh", "ru", "hi", "ja", "it", "pl", "nl", "cs", "uk", "sv")',
+    'SUPPORTED = ("en", "hr", "de", "fr", "es", "tr", "el", "pt", "zh", "ru", "hi", "ja", "it", "pl", "nl", "cs", "uk", "sv", "ro", "hu", "da", "fi", "no", "ko")',
+)
+audit = audit.replace(
+    'for marker in ("ValidateCatalogs()", "expected 18 supported languages", "format verbs differ"):',
+    'for marker in ("ValidateCatalogs()", "expected 24 supported languages", "format verbs differ", "supplemental catalog", "TranslationCoverage"):',
+)
+needle = '''    settings = read("internal/model/types.go")\n'''
+insert = '''    if len(SUPPORTED) < 21 or SUPPORTED[0] != "en":\n        fail("localization registry must remain English-first with at least 21 languages")\n\n    installer_messages = read("cmd/installer/messages.go")\n    installer_language = read("cmd/installer/language.go")\n    installer_main = read("cmd/installer/main.go")\n    for code in SUPPORTED:\n        if f'\\"{code}\\": {{' not in installer_messages:\n            fail(f"installer primary copy is missing language: {code}")\n    for marker in ("installerCopyFor", "installerConfirmTitle", "setupCopy.CompletedTitle", "setupCopy.LaunchQuestion"):\n        if marker not in installer_main and marker not in installer_messages:\n            fail(f"installer localization flow is missing marker: {marker}")\n    if "i18n.Languages()" not in installer_language:\n        fail("installer language list is not derived from the canonical registry")\n\n    settings = read("internal/model/types.go")\n'''
+if needle not in audit:
+    raise SystemExit("localization audit insertion marker missing")
+audit = audit.replace(needle, insert, 1)
+audit = audit.replace(
+    'print("SUPPORTED_LANGUAGES=" + ",".join(SUPPORTED))',
+    'print("SUPPORTED_LANGUAGES=" + ",".join(SUPPORTED))\n    print(f"SUPPORTED_LANGUAGE_COUNT={len(SUPPORTED)}")\n    print("INSTALLER_PRIMARY_FLOW_LOCALIZED=YES")',
+)
+write("scripts/audit_localization.py", audit)
+
+changelog = read("CHANGELOG.md")
+if "## 1.1.0 - Unreleased" not in changelog:
+    changelog = changelog.replace(
+        "# Changelog\n\n",
+        "# Changelog\n\n## 1.1.0 - Unreleased\n\n"
+        "- Expanded the canonical English-first desktop/setup language registry from 18 to 24 languages, adding Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.\n"
+        "- Added regional locale normalization including Norwegian `nb`/`nn` and Simplified Chinese aliases.\n"
+        "- Replaced the weak eight-string supplemental-locale threshold with measured translation coverage and a 30-string translated-core floor for supplemental catalogs.\n"
+        "- Added localized primary Windows Setup confirmation/completion/launch/warning copy for all 24 canonical languages while retaining English as the safe fallback.\n"
+        "- Improved the dependency provenance contract: no external Go modules, zero third-party Web Composer packages, exactly pinned Android dependencies, and fail-closed rejection of tracking/ads/crash SDKs or dynamic versions.\n"
+        "- Added detailed localization, dependency, settings and immutable release-history documentation.\n"
+        "- 1.1.0 remains unreleased until Android, iOS and Web/PWA localization plus protocol/option work pass the full cross-platform release gate.\n\n",
+        1,
+    )
+write("CHANGELOG.md", changelog)
+
+readme = read("README.md")
+readme = readme.replace(
+    "English is the default runtime language. Ghost FTP currently includes localization catalogs for English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian and Swedish.\n\nLanguage selection is persisted in application settings. New canonical user-facing text is maintained English-first and translated through the localization system.",
+    "English is the primary and fallback runtime language. The 1.1.0 development line defines 24 canonical desktop/setup languages: English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Simplified Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian, Swedish, Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.\n\nLanguage selection is persisted in application settings. Regional locale aliases normalize to canonical codes, and CI measures real translation coverage instead of counting an English-filled catalog as fully localized. Android, iOS and Web/PWA are being aligned to the same contract before 1.1.0 can be released. See [Localization](docs/LOCALIZATION.md).",
+)
+readme = readme.replace(
+    "- [Installation](docs/INSTALLATION.md)\n",
+    "- [Installation](docs/INSTALLATION.md)\n- [Localization](docs/LOCALIZATION.md)\n- [Settings](docs/SETTINGS.md)\n- [Dependencies](docs/DEPENDENCIES.md)\n- [Release history](docs/RELEASE-HISTORY.md)\n",
+)
+readme = readme.replace(
+    "python scripts/audit_repository.py\npython scripts/audit_security.py",
+    "python scripts/audit_repository.py\npython scripts/audit_dependencies.py\npython scripts/audit_localization.py\npython scripts/audit_security.py",
+)
+write("README.md", readme)
+
+index = read("docs/README.md")
+anchor = "- [Installation](INSTALLATION.md) — platform packages, installation expectations and prerequisites.\n"
+addition = (
+    anchor
+    + "- [Localization](LOCALIZATION.md) — English-first language registry, translation coverage and platform rules.\n"
+    + "- [Settings](SETTINGS.md) — persisted options, safe defaults and migration semantics.\n"
+    + "- [Dependencies](DEPENDENCIES.md) — dependency allowlist, provenance and no-tracking policy.\n"
+    + "- [Release history](RELEASE-HISTORY.md) — detailed immutable history of published Ghost FTP releases and unreleased development scope.\n"
+)
+if anchor not in index:
+    raise SystemExit("docs index anchor missing")
+index = index.replace(anchor, addition, 1)
+write("docs/README.md", index)
+
+print("ONE_SHOT_110_FINALIZE=PASS")

--- a/scripts/one_shot_110_foundation.py
+++ b/scripts/one_shot_110_foundation.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def write(rel: str, text: str) -> None:
+    (ROOT / rel).write_text(text, encoding="utf-8", newline="\n")
+
+
+def replace_once(rel: str, old: str, new: str) -> None:
+    text = read(rel)
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{rel}: expected one marker, found {count}: {old[:100]!r}")
+    write(rel, text.replace(old, new, 1))
+
+
+# Wire the selected setup language into the main installer flow.
+replace_once(
+    "cmd/installer/main.go",
+    '''\tinstallLanguage, ok := selectInstallerLanguage()\n\tif !ok {\n\t\treturn 0\n\t}\n\n\tcontent := brand.Website + "\\n" + brand.Support + "\\n\\n" +\n\t\tbrand.ProductName + " will be installed for your Windows user account and will be available from the Start menu."\n''',
+    '''\tinstallLanguage, ok := selectInstallerLanguage()\n\tif !ok {\n\t\treturn 0\n\t}\n\tsetupCopy := installerCopyFor(installLanguage)\n\n\tcontent := brand.Website + "\\n" + brand.Support + "\\n\\n" + setupCopy.ConfirmBody\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t"Install "+brand.ProductFull+" "+version+"?",\n''',
+    '''\t\tinstallerConfirmTitle(installLanguage, version),\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\tlanguageWarning = "\\n\\nThe selected language could not be saved. Ghost FTP will start in English; you can change the language in Settings."\n''',
+    '''\t\tlanguageWarning = "\\n\\n" + setupCopy.LanguageWarning\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\tshortcutWarning = "\\n\\nA shortcut could not be created. You can start Ghost FTP from its installation folder."\n''',
+    '''\t\tshortcutWarning = "\\n\\n" + setupCopy.ShortcutWarning\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t"Setup completed successfully",\n\t\t"Ghost FTP is ready to use."+legacyCleanupWarning+languageWarning+shortcutWarning+"\\n\\nLaunch Ghost FTP now?",\n''',
+    '''\t\tsetupCopy.CompletedTitle,\n\t\tsetupCopy.ReadyBody+legacyCleanupWarning+languageWarning+shortcutWarning+"\\n\\n"+setupCopy.LaunchQuestion,\n''',
+)
+replace_once(
+    "cmd/installer/main.go",
+    '''\t\t\t\t"Ghost FTP is installed",\n\t\t\t\t"Ghost FTP could not be launched automatically. Start it from the Windows Start menu.",\n''',
+    '''\t\t\t\tsetupCopy.InstalledTitle,\n\t\t\t\tsetupCopy.LaunchFailed,\n''',
+)
+
+# Make the first language picker explicitly English-first and clearer about privacy.
+replace_once(
+    "cmd/installer/language.go",
+    '''\t\t"Choose the language to use in Ghost FTP. You can change it later in Settings.",\n''',
+    '''\t\t"Choose the setup language. English is the default.\\nNo telemetry · No ads · FTP · FTPS · SFTP",\n''',
+)
+
+# Improve the native setup language dialog layout without adding a UI framework.
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\t\t420, 250, 560, 230,\n''',
+    '''\t\t360, 210, 640, 300,\n''',
+)
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\tmakeControl("STATIC", instruction, 0, 24, 22, 500, 42, 0)\n\tstate.combo = makeControl("COMBOBOX", "", wsTabStop|wsVScroll|cbsDropdown, 24, 70, 500, 260, languageIDCombo)\n''',
+    '''\tmakeControl("STATIC", instruction, 0, 32, 28, 576, 54, 0)\n\tstate.combo = makeControl("COMBOBOX", "", wsTabStop|wsVScroll|cbsDropdown, 32, 92, 576, 260, languageIDCombo)\n''',
+)
+replace_once(
+    "internal/platform/language_windows.go",
+    '''\tmakeControl("BUTTON", "Install", wsTabStop, 338, 132, 88, 32, languageIDInstall)\n\tmakeControl("BUTTON", "Cancel", wsTabStop, 436, 132, 88, 32, languageIDCancel)\n''',
+    '''\tmakeControl("STATIC", "Ghost FTP Setup · private by design · local-first settings", 0, 32, 140, 576, 24, 0)\n\tmakeControl("BUTTON", "Continue", wsTabStop, 420, 182, 90, 34, languageIDInstall)\n\tmakeControl("BUTTON", "Cancel", wsTabStop, 518, 182, 90, 34, languageIDCancel)\n''',
+)
+
+# Strengthen localization audit around 24 languages, real coverage and setup parity.
+audit = read("scripts/audit_localization.py")
+audit = audit.replace(
+    'SUPPORTED = ("en", "hr", "de", "fr", "es", "tr", "el", "pt", "zh", "ru", "hi", "ja", "it", "pl", "nl", "cs", "uk", "sv")',
+    'SUPPORTED = ("en", "hr", "de", "fr", "es", "tr", "el", "pt", "zh", "ru", "hi", "ja", "it", "pl", "nl", "cs", "uk", "sv", "ro", "hu", "da", "fi", "no", "ko")',
+)
+audit = audit.replace(
+    'for marker in ("ValidateCatalogs()", "expected 18 supported languages", "format verbs differ"):',
+    'for marker in ("ValidateCatalogs()", "expected 24 supported languages", "format verbs differ", "supplemental catalog", "TranslationCoverage"):',
+)
+needle = '''    settings = read("internal/model/types.go")\n'''
+insert = '''    if len(SUPPORTED) < 21 or SUPPORTED[0] != "en":\n        fail("localization registry must remain English-first with at least 21 languages")\n\n    installer_messages = read("cmd/installer/messages.go")\n    installer_language = read("cmd/installer/language.go")\n    installer_main = read("cmd/installer/main.go")\n    for code in SUPPORTED:\n        if f'\\"{code}\\": {{' not in installer_messages:\n            fail(f"installer primary copy is missing language: {code}")\n    for marker in ("installerCopyFor", "installerConfirmTitle", "setupCopy.CompletedTitle", "setupCopy.LaunchQuestion"):\n        if marker not in installer_main and marker not in installer_messages:\n            fail(f"installer localization flow is missing marker: {marker}")\n    for marker in ("i18n.Languages()", "You can change it later in Settings"):\n        if marker not in installer_language and marker == "i18n.Languages()":\n            fail("installer language list is not derived from the canonical registry")\n\n    settings = read("internal/model/types.go")\n'''
+if needle not in audit:
+    raise SystemExit("localization audit insertion marker missing")
+audit = audit.replace(needle, insert, 1)
+audit = audit.replace(
+    'print("SUPPORTED_LANGUAGES=" + ",".join(SUPPORTED))',
+    'print("SUPPORTED_LANGUAGES=" + ",".join(SUPPORTED))\n    print(f"SUPPORTED_LANGUAGE_COUNT={len(SUPPORTED)}")\n    print("INSTALLER_PRIMARY_FLOW_LOCALIZED=YES")',
+)
+write("scripts/audit_localization.py", audit)
+
+# Run dependency provenance as a permanent CI gate.
+replace_once(
+    ".github/workflows/ci.yml",
+    '''          python scripts/audit_repository.py\n          python scripts/audit_version.py\n''',
+    '''          python scripts/audit_repository.py\n          python scripts/audit_dependencies.py\n          python scripts/audit_version.py\n''',
+)
+
+# Add the development line without changing the published VERSION marker.
+changelog = read("CHANGELOG.md")
+if "## 1.1.0 - Unreleased" not in changelog:
+    changelog = changelog.replace(
+        "# Changelog\n\n",
+        "# Changelog\n\n## 1.1.0 - Unreleased\n\n"
+        "- Expanded the canonical English-first desktop/setup language registry from 18 to 24 languages, adding Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.\n"
+        "- Added regional locale normalization including Norwegian `nb`/`nn` and Simplified Chinese aliases.\n"
+        "- Replaced the weak eight-string supplemental-locale threshold with measured translation coverage and a 30-string translated-core floor for supplemental catalogs.\n"
+        "- Added localized primary Windows Setup confirmation/completion/launch/warning copy for all 24 canonical languages while retaining English as the safe fallback.\n"
+        "- Improved the dependency provenance contract: no external Go modules, zero Web Composer runtime dependencies, exactly pinned Android dependencies, and fail-closed rejection of tracking/ads/crash SDKs or dynamic versions.\n"
+        "- Added detailed localization, dependency, settings and immutable release-history documentation.\n"
+        "- 1.1.0 remains unreleased until Android, iOS and Web/PWA localization plus protocol/option work pass the full cross-platform release gate.\n\n",
+        1,
+    )
+write("CHANGELOG.md", changelog)
+
+# Root documentation: accurate current release plus explicit 1.1.0 development scope.
+readme = read("README.md")
+readme = readme.replace(
+    "English is the default runtime language. Ghost FTP currently includes localization catalogs for English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian and Swedish.\n\nLanguage selection is persisted in application settings. New canonical user-facing text is maintained English-first and translated through the localization system.",
+    "English is the primary and fallback runtime language. The 1.1.0 development line defines 24 canonical desktop/setup languages: English, Croatian, German, French, Spanish, Turkish, Greek, Portuguese, Simplified Chinese, Russian, Hindi, Japanese, Italian, Polish, Dutch, Czech, Ukrainian, Swedish, Romanian, Hungarian, Danish, Finnish, Norwegian and Korean.\n\nLanguage selection is persisted in application settings. Regional locale aliases normalize to canonical codes, and CI measures real translation coverage instead of counting an English-filled catalog as fully localized. Android, iOS and Web/PWA are being aligned to the same contract before 1.1.0 can be released. See [Localization](docs/LOCALIZATION.md).",
+)
+readme = readme.replace(
+    "- [Installation](docs/INSTALLATION.md)\n",
+    "- [Installation](docs/INSTALLATION.md)\n- [Localization](docs/LOCALIZATION.md)\n- [Settings](docs/SETTINGS.md)\n- [Dependencies](docs/DEPENDENCIES.md)\n- [Release history](docs/RELEASE-HISTORY.md)\n",
+)
+readme = readme.replace(
+    "python scripts/audit_repository.py\npython scripts/audit_security.py",
+    "python scripts/audit_repository.py\npython scripts/audit_dependencies.py\npython scripts/audit_localization.py\npython scripts/audit_security.py",
+)
+write("README.md", readme)
+
+index = read("docs/README.md")
+anchor = "- [Installation](INSTALLATION.md) — platform packages, installation expectations and prerequisites.\n"
+addition = (
+    anchor
+    + "- [Localization](LOCALIZATION.md) — English-first language registry, translation coverage and platform rules.\n"
+    + "- [Settings](SETTINGS.md) — persisted options, safe defaults and migration semantics.\n"
+    + "- [Dependencies](DEPENDENCIES.md) — dependency allowlist, provenance and no-tracking policy.\n"
+    + "- [Release history](RELEASE-HISTORY.md) — detailed immutable history of published Ghost FTP releases and unreleased development scope.\n"
+)
+if anchor not in index:
+    raise SystemExit("docs index anchor missing")
+index = index.replace(anchor, addition, 1)
+write("docs/README.md", index)
+
+print("ONE_SHOT_110_FOUNDATION_PATCH=PASS")


### PR DESCRIPTION
## Authorization

- [ ] This source-code change was explicitly requested or authorized for Ghost FTP.
- [ ] I have read and will follow `LICENSE` and the contribution documentation.

> Ghost FTP is source-available software. Opening a pull request or fork does not itself grant rights beyond the repository license and applicable GitHub platform rights.

## Summary

Describe the change and why it is needed.

## Branding and compatibility

- [ ] New public UI, documentation and release assets use **Ghost FTP**.
- [ ] Any retained `GhostFTP`/`GhostFTP` identifier is required for backward compatibility, migration or installed-application identity and is not user-facing branding.

## Security and privacy

- [ ] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [ ] No automatic external API or hidden network destination was added.
- [ ] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [ ] SFTP host-key verification and pinning remain active.
- [ ] Local path-traversal, symlink, junction and reparse-point protections remain active.
- [ ] No external Go module was added without explicit architecture/security review.
- [ ] Tests, screenshots and fixtures contain no real credentials, production servers or customer data.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/audit_security.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] PHP syntax checks pass when web code changed.
- [ ] Native platform build checks pass for affected platforms.

## Regression coverage

Describe tests added or changed for connections, transfers, paths, profiles, installation/uninstallation, localization, release packaging or other affected behavior.
