### PR TITLE
Add truthful transfer progress, speed and ETA

### DIFF
--- a/internal/desktop/localization_windows.go
+++ b/internal/desktop/localization_windows.go
@@ -354,19 +354,10 @@ func (a *app) fillTransferList(list uintptr, jobs []model.TransferJob) {
 		if job.Status == "running" && job.Attempts > 1 {
 			status += fmt.Sprintf(" · #%d", job.Attempts)
 		}
+		status += transferRuntimeSuffix(job)
 		if job.Error != "" {
 			status += ": " + job.Error
 		}
-		progress := job.Progress
-		if progress > 0 && progress <= 1 {
-			progress *= 100
-		}
-		if progress < 0 {
-			progress = 0
-		}
-		if progress > 100 {
-			progress = 100
-		}
-		insertListRow(list, index, []string{direction, job.LocalPath, job.RemotePath, status, fmt.Sprintf("%.0f%%", progress)})
+		insertListRow(list, index, []string{direction, job.LocalPath, job.RemotePath, status, transferProgressText(job)})
 	}
 }

--- a/internal/desktop/transfer_metrics.go
+++ b/internal/desktop/transfer_metrics.go
@@ -9,17 +9,22 @@ import (
 )
 
 func transferProgressText(job model.TransferJob) string {
-	progress := job.Progress
 	if job.BytesTotal > 0 {
-		progress = float64(job.BytesTransferred) * 100 / float64(job.BytesTotal)
+		progress := float64(job.BytesTransferred) * 100 / float64(job.BytesTotal)
+		progress = math.Max(0, math.Min(100, progress))
+		return fmt.Sprintf("%.0f%% · %s", progress, formatTransferBytes(job.BytesTransferred))
 	}
-	if progress > 0 && progress <= 1 && job.BytesTotal == 0 {
+	if job.BytesTransferred > 0 {
+		// A server that cannot provide reliable size metadata still gives us
+		// truthful staged bytes. Do not render a fabricated 0% percentage when
+		// the denominator is unknown.
+		return formatTransferBytes(job.BytesTransferred)
+	}
+	progress := job.Progress
+	if progress > 0 && progress <= 1 {
 		progress *= 100
 	}
 	progress = math.Max(0, math.Min(100, progress))
-	if job.BytesTransferred > 0 || job.BytesTotal > 0 {
-		return fmt.Sprintf("%.0f%% · %s", progress, formatTransferBytes(job.BytesTransferred))
-	}
 	return fmt.Sprintf("%.0f%%", progress)
 }
 

--- a/internal/desktop/transfer_metrics.go
+++ b/internal/desktop/transfer_metrics.go
@@ -1,0 +1,74 @@
+package desktop
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func transferProgressText(job model.TransferJob) string {
+	progress := job.Progress
+	if job.BytesTotal > 0 {
+		progress = float64(job.BytesTransferred) * 100 / float64(job.BytesTotal)
+	}
+	if progress > 0 && progress <= 1 && job.BytesTotal == 0 {
+		progress *= 100
+	}
+	progress = math.Max(0, math.Min(100, progress))
+	if job.BytesTransferred > 0 || job.BytesTotal > 0 {
+		return fmt.Sprintf("%.0f%% · %s", progress, formatTransferBytes(job.BytesTransferred))
+	}
+	return fmt.Sprintf("%.0f%%", progress)
+}
+
+func transferRuntimeSuffix(job model.TransferJob) string {
+	if job.BytesPerSecond <= 0 || (job.Status != "running" && job.Status != "done") {
+		return ""
+	}
+	text := " · " + formatTransferBytes(int64(job.BytesPerSecond)) + "/s"
+	if job.Status == "running" && job.ETASeconds > 0 {
+		text += " · " + formatTransferETA(job.ETASeconds)
+	}
+	return text
+}
+
+func formatTransferBytes(bytes int64) string {
+	if bytes < 0 {
+		bytes = 0
+	}
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	value := float64(bytes)
+	units := []string{"KB", "MB", "GB", "TB"}
+	for _, suffix := range units {
+		value /= unit
+		if value < unit || suffix == units[len(units)-1] {
+			if value >= 100 {
+				return fmt.Sprintf("%.0f %s", value, suffix)
+			}
+			if value >= 10 {
+				return fmt.Sprintf("%.1f %s", value, suffix)
+			}
+			return fmt.Sprintf("%.2f %s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%d B", bytes)
+}
+
+func formatTransferETA(seconds int64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	d := time.Duration(seconds) * time.Second
+	hours := int64(d / time.Hour)
+	minutes := int64((d % time.Hour) / time.Minute)
+	secs := int64((d % time.Minute) / time.Second)
+	if hours > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, secs)
+	}
+	return fmt.Sprintf("%02d:%02d", minutes, secs)
+}

--- a/internal/desktop/transfer_metrics_test.go
+++ b/internal/desktop/transfer_metrics_test.go
@@ -1,0 +1,37 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestTransferProgressTextUsesRuntimeBytes(t *testing.T) {
+	job := model.TransferJob{Progress: 3, BytesTransferred: 5 * 1024 * 1024, BytesTotal: 10 * 1024 * 1024}
+	if got := transferProgressText(job); got != "50% · 5.00 MB" {
+		t.Fatalf("transferProgressText()=%q", got)
+	}
+}
+
+func TestTransferRuntimeSuffixShowsSpeedAndETAOnlyWhileUseful(t *testing.T) {
+	running := model.TransferJob{Status: "running", BytesPerSecond: 2 * 1024 * 1024, ETASeconds: 65}
+	if got := transferRuntimeSuffix(running); got != " · 2.00 MB/s · 01:05" {
+		t.Fatalf("running suffix=%q", got)
+	}
+	done := running
+	done.Status = "done"
+	if got := transferRuntimeSuffix(done); got != " · 2.00 MB/s" {
+		t.Fatalf("done suffix=%q", got)
+	}
+	failed := running
+	failed.Status = "failed"
+	if got := transferRuntimeSuffix(failed); got != "" {
+		t.Fatalf("failed suffix=%q", got)
+	}
+}
+
+func TestFormatTransferETAHours(t *testing.T) {
+	if got := formatTransferETA(3661); got != "1:01:01" {
+		t.Fatalf("formatTransferETA()=%q", got)
+	}
+}

--- a/internal/desktop/transfer_metrics_test.go
+++ b/internal/desktop/transfer_metrics_test.go
@@ -44,6 +44,25 @@ func TestTransferRuntimeSuffixShowsSpeedAndETAOnlyWhileUseful(t *testing.T) {
 	}
 }
 
+func TestFormatTransferBytesBoundaries(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{bytes: 0, want: "0 B"},
+		{bytes: 1023, want: "1023 B"},
+		{bytes: 1024, want: "1.00 KB"},
+		{bytes: 10 * 1024, want: "10.0 KB"},
+		{bytes: 100 * 1024, want: "100 KB"},
+		{bytes: 1024 * 1024, want: "1.00 MB"},
+	}
+	for _, tc := range tests {
+		if got := formatTransferBytes(tc.bytes); got != tc.want {
+			t.Fatalf("formatTransferBytes(%d)=%q want %q", tc.bytes, got, tc.want)
+		}
+	}
+}
+
 func TestFormatTransferETAHours(t *testing.T) {
 	if got := formatTransferETA(3661); got != "1:01:01" {
 		t.Fatalf("formatTransferETA()=%q", got)

--- a/internal/desktop/transfer_metrics_test.go
+++ b/internal/desktop/transfer_metrics_test.go
@@ -13,6 +13,20 @@ func TestTransferProgressTextUsesRuntimeBytes(t *testing.T) {
 	}
 }
 
+func TestTransferProgressTextDoesNotInventPercentWithoutTotal(t *testing.T) {
+	job := model.TransferJob{Status: "running", BytesTransferred: 5 * 1024 * 1024}
+	if got := transferProgressText(job); got != "5.00 MB" {
+		t.Fatalf("transferProgressText()=%q", got)
+	}
+}
+
+func TestTransferProgressTextKeepsLegacyFractionCompatibility(t *testing.T) {
+	job := model.TransferJob{Progress: 0.42}
+	if got := transferProgressText(job); got != "42%" {
+		t.Fatalf("transferProgressText()=%q", got)
+	}
+}
+
 func TestTransferRuntimeSuffixShowsSpeedAndETAOnlyWhileUseful(t *testing.T) {
 	running := model.TransferJob{Status: "running", BytesPerSecond: 2 * 1024 * 1024, ETASeconds: 65}
 	if got := transferRuntimeSuffix(running); got != " · 2.00 MB/s · 01:05" {

--- a/internal/model/transfer_job_test.go
+++ b/internal/model/transfer_job_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTransferJobRuntimeClockIsNotSerialized(t *testing.T) {
+	job := TransferJob{
+		ID:               "job",
+		Status:           "running",
+		Progress:         50,
+		BytesTransferred: 512,
+		BytesTotal:       1024,
+		BytesPerSecond:   256,
+		ETASeconds:       2,
+		StartedAt:        "2026-09-06T19:00:00Z",
+	}
+	data, err := json.Marshal(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := string(data)
+	if strings.Contains(encoded, "startedAt") || strings.Contains(encoded, job.StartedAt) {
+		t.Fatalf("runtime clock leaked into transfer JSON: %s", encoded)
+	}
+	for _, field := range []string{"bytesTransferred", "bytesTotal", "bytesPerSecond", "etaSeconds"} {
+		if !strings.Contains(encoded, `"`+field+`"`) {
+			t.Fatalf("runtime metric %q missing from transfer JSON: %s", field, encoded)
+		}
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -99,7 +99,7 @@ type TransferJob struct {
 	BytesTotal       int64   `json:"bytesTotal,omitempty"`
 	BytesPerSecond   float64 `json:"bytesPerSecond,omitempty"`
 	ETASeconds       int64   `json:"etaSeconds,omitempty"`
-	StartedAt        string  `json:"startedAt,omitempty"`
+	StartedAt        string  `json:"-"`
 	Attempts         int     `json:"attempts,omitempty"`
 	Error            string  `json:"error,omitempty"`
 	CreatedAt        string  `json:"createdAt"`

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -88,14 +88,19 @@ type ConnectionConfig struct {
 }
 
 type TransferJob struct {
-	ID         string  `json:"id"`
-	Direction  string  `json:"direction"`
-	LocalPath  string  `json:"localPath"`
-	RemotePath string  `json:"remotePath"`
-	LocalRoot  string  `json:"-"`
-	Status     string  `json:"status"`
-	Progress   float64 `json:"progress"`
-	Attempts   int     `json:"attempts,omitempty"`
-	Error      string  `json:"error,omitempty"`
-	CreatedAt  string  `json:"createdAt"`
+	ID               string  `json:"id"`
+	Direction        string  `json:"direction"`
+	LocalPath        string  `json:"localPath"`
+	RemotePath       string  `json:"remotePath"`
+	LocalRoot        string  `json:"-"`
+	Status           string  `json:"status"`
+	Progress         float64 `json:"progress"`
+	BytesTransferred int64   `json:"bytesTransferred,omitempty"`
+	BytesTotal       int64   `json:"bytesTotal,omitempty"`
+	BytesPerSecond   float64 `json:"bytesPerSecond,omitempty"`
+	ETASeconds       int64   `json:"etaSeconds,omitempty"`
+	StartedAt        string  `json:"startedAt,omitempty"`
+	Attempts         int     `json:"attempts,omitempty"`
+	Error            string  `json:"error,omitempty"`
+	CreatedAt        string  `json:"createdAt"`
 }

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -438,11 +438,14 @@ func (c *CurlFTP) Upload(ctx context.Context, local, remotePath string, options 
 		return err
 	}
 	defer source.Close()
+	total := source.Size()
+	reportTransferProgress(options.Progress, 0, total)
 	tempPath := remoteJoin(dir, tempName)
 	lines := []string{"url = " + cfgQuote(c.baseURL(tempPath)), "upload-file = " + cfgQuote(source.Path()), "speed-time = 30", "speed-limit = 1"}
 	if _, err = c.run(ctx, lines); err != nil {
 		return cleanupFailure(err, dir, tempName, c.Delete)
 	}
+	reportTransferProgress(options.Progress, total, total)
 	if err = source.Verify(); err != nil {
 		return cleanupFailure(err, dir, tempName, c.Delete)
 	}
@@ -467,6 +470,7 @@ func (c *CurlFTP) Download(ctx context.Context, remotePath, local string, option
 			return err
 		}
 	}
+	total := bestEffortRemoteFileSize(ctx, remotePath, c.List)
 	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
 		return err
 	}
@@ -474,10 +478,13 @@ func (c *CurlFTP) Download(ctx context.Context, remotePath, local string, option
 	if err != nil {
 		return err
 	}
+	stopProgress := startLocalFileProgressMonitor(ctx, part, total, options.Progress)
 	lines := []string{"url = " + cfgQuote(c.baseURL(remotePath)), "output = " + cfgQuote(part), "speed-time = 30", "speed-limit = 1"}
-	if _, err := c.run(ctx, lines); err != nil {
+	_, runErr := c.run(ctx, lines)
+	stopProgress()
+	if runErr != nil {
 		_ = os.Remove(part)
-		return err
+		return runErr
 	}
 	if err := validateDownloadedPart(part); err != nil {
 		_ = os.Remove(part)

--- a/internal/remote/progress.go
+++ b/internal/remote/progress.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
 )
 
 type TransferProgressFunc func(transferred, total int64)
@@ -65,8 +66,11 @@ func startLocalFileProgressMonitor(ctx context.Context, file string, total int64
 		ticker := time.NewTicker(transferProgressInterval)
 		defer ticker.Stop()
 		reportCurrent := func() {
-			st, err := os.Stat(file)
-			if err != nil || !st.Mode().IsRegular() {
+			// The progress sampler is read-only, but it still must not follow a path
+			// that was replaced by a symlink/junction while the child transfer tool
+			// is running. Report bytes only for the expected regular staging file.
+			st, err := os.Lstat(file)
+			if err != nil || !st.Mode().IsRegular() || st.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(file) {
 				return
 			}
 			reportTransferProgress(report, st.Size(), total)

--- a/internal/remote/progress.go
+++ b/internal/remote/progress.go
@@ -1,0 +1,96 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"path"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+type TransferProgressFunc func(transferred, total int64)
+
+const transferProgressInterval = 500 * time.Millisecond
+
+func reportTransferProgress(report TransferProgressFunc, transferred, total int64) {
+	if report == nil {
+		return
+	}
+	if transferred < 0 {
+		transferred = 0
+	}
+	if total < 0 {
+		total = 0
+	}
+	if total > 0 && transferred > total {
+		transferred = total
+	}
+	report(transferred, total)
+}
+
+func bestEffortRemoteFileSize(ctx context.Context, remotePath string, list func(context.Context, string) ([]model.Item, error)) int64 {
+	if list == nil {
+		return 0
+	}
+	cleaned := path.Clean(remotePath)
+	dir, base := path.Split(cleaned)
+	if base == "" || base == "." || base == ".." {
+		return 0
+	}
+	if dir == "" {
+		dir = "."
+	}
+	dir = path.Clean(dir)
+	items, err := list(ctx, dir)
+	if err != nil {
+		return 0
+	}
+	item, ok := remoteEntry(items, base)
+	if !ok || item.IsDirectory || item.IsSymlink || item.Size < 0 {
+		return 0
+	}
+	return item.Size
+}
+
+func startLocalFileProgressMonitor(ctx context.Context, file string, total int64, report TransferProgressFunc) func() {
+	if report == nil {
+		return func() {}
+	}
+	reportTransferProgress(report, 0, total)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(transferProgressInterval)
+		defer ticker.Stop()
+		reportCurrent := func() {
+			st, err := os.Stat(file)
+			if err != nil || !st.Mode().IsRegular() {
+				return
+			}
+			reportTransferProgress(report, st.Size(), total)
+		}
+		for {
+			select {
+			case <-ticker.C:
+				reportCurrent()
+			case <-done:
+				reportCurrent()
+				return
+			case <-ctx.Done():
+				reportCurrent()
+				return
+			}
+		}
+	}()
+	return func() {
+		select {
+		case <-stopped:
+			return
+		default:
+		}
+		close(done)
+		<-stopped
+	}
+}

--- a/internal/remote/progress_test.go
+++ b/internal/remote/progress_test.go
@@ -1,0 +1,48 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestBestEffortRemoteFileSize(t *testing.T) {
+	got := bestEffortRemoteFileSize(context.Background(), "/public/file.bin", func(_ context.Context, dir string) ([]model.Item, error) {
+		if dir != "/public" {
+			t.Fatalf("dir=%q", dir)
+		}
+		return []model.Item{{Name: "file.bin", Size: 8192}, {Name: "folder", IsDirectory: true}}, nil
+	})
+	if got != 8192 {
+		t.Fatalf("size=%d", got)
+	}
+}
+
+func TestProgressMonitorReportsActualStagingBytes(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "part")
+	type sample struct{ transferred, total int64 }
+	samples := make(chan sample, 8)
+	stop := startLocalFileProgressMonitor(context.Background(), part, 10, func(transferred, total int64) {
+		samples <- sample{transferred, total}
+	})
+	if err := os.WriteFile(part, []byte("12345"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(transferProgressInterval + 100*time.Millisecond)
+	stop()
+	close(samples)
+	found := false
+	for s := range samples {
+		if s.transferred == 5 && s.total == 10 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("monitor never reported actual staging size")
+	}
+}

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -121,8 +121,6 @@ func cleanupStaleSFTPArtifacts(dir string) {
 			_ = os.Remove(filepath.Join(dir, name))
 		}
 	}
-	// 2.8 and older used one persistent generic SSH config. It contains no
-	// credential, but it is obsolete once every session receives its own config.
 	_ = os.Remove(filepath.Join(dir, "ssh-client.conf"))
 }
 
@@ -163,9 +161,6 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if err != nil {
 		return "", "", "", err
 	}
-
-	// Keep the user-entered host out of both the process command line and disk.
-	// OpenSSH ssh-keyscan accepts -f - to read targets directly from stdin.
 	scanCtx, scanCancel := context.WithTimeout(ctx, 12*time.Second)
 	defer scanCancel()
 	cmd := exec.CommandContext(scanCtx, scan, "-T", "8", "-t", "ed25519,ecdsa,rsa", "-p", strconv.Itoa(port), "-f", "-")
@@ -199,7 +194,6 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if len(lines) == 0 {
 		return "", "", "", errors.New("poslužitelj nije vratio SSH host ključ")
 	}
-
 	selected := lines[0]
 	rank := func(line string) int {
 		switch alg := scanKeyAlgorithm(line); {
@@ -222,7 +216,6 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if algorithm == "" {
 		return "", "", "", errors.New("poslužitelj je vratio nepodržan SSH host ključ")
 	}
-
 	name, err := writePrivateTempFile(tempDir, "GhostFTP-key-*.known_hosts", []byte(selected+"\n"))
 	if err != nil {
 		return "", "", "", err
@@ -290,9 +283,6 @@ func validatePrivateKeyPath(keyPath string) error {
 	return nil
 }
 
-// snapshotPrivateKey closes the check-then-open window around a user-selected
-// key. OpenSSH only sees a private 0600 copy made from one verified stable file
-// handle, never the original path that can be swapped after validation.
 func snapshotPrivateKey(dir, keyPath string) (string, error) {
 	if keyPath == "" {
 		return "", nil
@@ -640,7 +630,6 @@ func (s *SFTP) Upload(ctx context.Context, local, remotePath string, options Tra
 	} else if st.IsDir() {
 		return errors.New("upload očekuje datoteku")
 	}
-
 	dir, base, tempName, savedName, err := remoteTransferNames(remotePath)
 	if err != nil {
 		return err
@@ -662,10 +651,13 @@ func (s *SFTP) Upload(ctx context.Context, local, remotePath string, options Tra
 		return err
 	}
 	defer source.Close()
+	total := source.Size()
+	reportTransferProgress(options.Progress, 0, total)
 	tempPath := remoteJoin(dir, tempName)
 	if _, err = s.run(ctx, "put "+sftpQuote(source.Path())+" "+sftpQuote(tempPath)); err != nil {
 		return cleanupFailure(err, dir, tempName, s.Delete)
 	}
+	reportTransferProgress(options.Progress, total, total)
 	if err = source.Verify(); err != nil {
 		return cleanupFailure(err, dir, tempName, s.Delete)
 	}
@@ -693,6 +685,7 @@ func (s *SFTP) Download(ctx context.Context, remotePath, local string, options T
 			return err
 		}
 	}
+	total := bestEffortRemoteFileSize(ctx, remotePath, s.List)
 	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
 		return err
 	}
@@ -700,9 +693,12 @@ func (s *SFTP) Download(ctx context.Context, remotePath, local string, options T
 	if err != nil {
 		return err
 	}
-	if _, err := s.run(ctx, "get "+sftpQuote(remotePath)+" "+sftpQuote(part)); err != nil {
+	stopProgress := startLocalFileProgressMonitor(ctx, part, total, options.Progress)
+	_, runErr := s.run(ctx, "get "+sftpQuote(remotePath)+" "+sftpQuote(part))
+	stopProgress()
+	if runErr != nil {
 		_ = os.Remove(part)
-		return err
+		return runErr
 	}
 	if err := validateDownloadedPart(part); err != nil {
 		_ = os.Remove(part)

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -121,6 +121,8 @@ func cleanupStaleSFTPArtifacts(dir string) {
 			_ = os.Remove(filepath.Join(dir, name))
 		}
 	}
+	// 2.8 and older used one persistent generic SSH config. It contains no
+	// credential, but it is obsolete once every session receives its own config.
 	_ = os.Remove(filepath.Join(dir, "ssh-client.conf"))
 }
 
@@ -161,6 +163,9 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if err != nil {
 		return "", "", "", err
 	}
+
+	// Keep the user-entered host out of both the process command line and disk.
+	// OpenSSH ssh-keyscan accepts -f - to read targets directly from stdin.
 	scanCtx, scanCancel := context.WithTimeout(ctx, 12*time.Second)
 	defer scanCancel()
 	cmd := exec.CommandContext(scanCtx, scan, "-T", "8", "-t", "ed25519,ecdsa,rsa", "-p", strconv.Itoa(port), "-f", "-")
@@ -194,6 +199,7 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if len(lines) == 0 {
 		return "", "", "", errors.New("poslužitelj nije vratio SSH host ključ")
 	}
+
 	selected := lines[0]
 	rank := func(line string) int {
 		switch alg := scanKeyAlgorithm(line); {
@@ -216,6 +222,7 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if algorithm == "" {
 		return "", "", "", errors.New("poslužitelj je vratio nepodržan SSH host ključ")
 	}
+
 	name, err := writePrivateTempFile(tempDir, "GhostFTP-key-*.known_hosts", []byte(selected+"\n"))
 	if err != nil {
 		return "", "", "", err
@@ -283,6 +290,9 @@ func validatePrivateKeyPath(keyPath string) error {
 	return nil
 }
 
+// snapshotPrivateKey closes the check-then-open window around a user-selected
+// key. OpenSSH only sees a private 0600 copy made from one verified stable file
+// handle, never the original path that can be swapped after validation.
 func snapshotPrivateKey(dir, keyPath string) (string, error) {
 	if keyPath == "" {
 		return "", nil
@@ -630,6 +640,7 @@ func (s *SFTP) Upload(ctx context.Context, local, remotePath string, options Tra
 	} else if st.IsDir() {
 		return errors.New("upload očekuje datoteku")
 	}
+
 	dir, base, tempName, savedName, err := remoteTransferNames(remotePath)
 	if err != nil {
 		return err

--- a/internal/remote/types.go
+++ b/internal/remote/types.go
@@ -11,6 +11,7 @@ var ErrSkipped = errors.New("prijenos je preskočen jer odredišna datoteka već
 type TransferOptions struct {
 	KeepBackup   bool
 	SkipExisting bool
+	Progress     TransferProgressFunc
 }
 
 type Session interface {

--- a/internal/remote/upload_source_progress.go
+++ b/internal/remote/upload_source_progress.go
@@ -1,0 +1,12 @@
+package remote
+
+func (s *uploadSourceSnapshot) Size() int64 {
+	if s == nil || s.initial == nil {
+		return 0
+	}
+	size := s.initial.Size()
+	if size < 0 {
+		return 0
+	}
+	return size
+}

--- a/internal/transfer/manager.go
+++ b/internal/transfer/manager.go
@@ -467,7 +467,7 @@ func (m *Manager) RetryBatch(ids []string) error {
 	for _, i := range indices {
 		m.jobs[i].Status = "queued"
 		m.jobs[i].Error = ""
-		m.jobs[i].Progress = 0
+		resetTransferMetrics(&m.jobs[i], false)
 		m.jobs[i].Attempts = 0
 		j := m.jobs[i]
 		m.emitLocked(Event{Type: "job", Job: &j})
@@ -515,7 +515,7 @@ func (m *Manager) pump() {
 			return
 		}
 		m.jobs[idx].Status = "running"
-		m.jobs[idx].Progress = 0
+		resetTransferMetrics(&m.jobs[idx], true)
 		j := m.jobs[idx]
 		m.running++
 		ctx, cancel := context.WithCancel(context.Background())
@@ -571,15 +571,22 @@ func (m *Manager) finishJob(ctx context.Context, id string, err error) {
 		} else if errors.Is(err, remote.ErrSkipped) {
 			m.jobs[i].Status = "skipped"
 			m.jobs[i].Progress = 100
+			m.jobs[i].ETASeconds = 0
 			m.jobs[i].Error = "Datoteka već postoji"
 		} else if err == nil {
 			m.jobs[i].Status = "done"
 			m.jobs[i].Progress = 100
+			m.jobs[i].ETASeconds = 0
+			if m.jobs[i].BytesTotal > 0 {
+				m.jobs[i].BytesTransferred = m.jobs[i].BytesTotal
+			}
 		} else if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 			m.jobs[i].Status = "cancelled"
+			m.jobs[i].ETASeconds = 0
 			m.jobs[i].Error = "Otkazano"
 		} else {
 			m.jobs[i].Status = "failed"
+			m.jobs[i].ETASeconds = 0
 			m.jobs[i].Error = usererror.Message(err, "Prijenos nije uspio. Provjerite vezu i pokušajte ponovno.")
 		}
 		j := m.jobs[i]
@@ -600,6 +607,9 @@ func (m *Manager) setAttempt(id string, attempt int) {
 			continue
 		}
 		m.jobs[i].Attempts = attempt
+		if attempt > 1 {
+			resetTransferMetrics(&m.jobs[i], true)
+		}
 		j := m.jobs[i]
 		m.emitLocked(Event{Type: "job", Job: &j})
 		return
@@ -631,7 +641,13 @@ func (m *Manager) runAttempt(ctx context.Context, job model.TransferJob, setting
 		return err
 	}
 	defer release()
-	options := remote.TransferOptions{KeepBackup: settings.BackupBeforeOverwrite, SkipExisting: settings.SkipExisting}
+	options := remote.TransferOptions{
+		KeepBackup:   settings.BackupBeforeOverwrite,
+		SkipExisting: settings.SkipExisting,
+		Progress: func(transferred, total int64) {
+			m.updateProgress(job.ID, transferred, total)
+		},
+	}
 	if job.Direction == "upload" {
 		return sess.Upload(opCtx, job.LocalPath, job.RemotePath, options)
 	}

--- a/internal/transfer/progress.go
+++ b/internal/transfer/progress.go
@@ -1,0 +1,69 @@
+package transfer
+
+import (
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func resetTransferMetrics(job *model.TransferJob, started bool) {
+	if job == nil {
+		return
+	}
+	job.Progress = 0
+	job.BytesTransferred = 0
+	job.BytesTotal = 0
+	job.BytesPerSecond = 0
+	job.ETASeconds = 0
+	job.StartedAt = ""
+	if started {
+		job.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+}
+
+func (m *Manager) updateProgress(id string, transferred, total int64) {
+	if transferred < 0 {
+		transferred = 0
+	}
+	if total < 0 {
+		total = 0
+	}
+	if total > 0 && transferred > total {
+		transferred = total
+	}
+	now := time.Now().UTC()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.jobs {
+		job := &m.jobs[i]
+		if job.ID != id || job.Status != "running" {
+			continue
+		}
+		if job.StartedAt == "" {
+			job.StartedAt = now.Format(time.RFC3339Nano)
+		}
+		job.BytesTransferred = transferred
+		job.BytesTotal = total
+		if total > 0 {
+			job.Progress = float64(transferred) * 100 / float64(total)
+			if job.Progress > 100 {
+				job.Progress = 100
+			}
+		}
+		started, err := time.Parse(time.RFC3339Nano, job.StartedAt)
+		if err == nil {
+			elapsed := now.Sub(started).Seconds()
+			if elapsed >= 0.25 && transferred > 0 {
+				job.BytesPerSecond = float64(transferred) / elapsed
+				if total > transferred && job.BytesPerSecond > 0 {
+					job.ETASeconds = int64(float64(total-transferred)/job.BytesPerSecond + 0.5)
+				} else {
+					job.ETASeconds = 0
+				}
+			}
+		}
+		copy := *job
+		m.emitLocked(Event{Type: "job", Job: &copy})
+		return
+	}
+}

--- a/internal/transfer/progress.go
+++ b/internal/transfer/progress.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 )
 
-func resetTransferMetrics(job *model.TransferJob, started bool) {
+func resetTransferMetrics(job *model.TransferJob, _ bool) {
 	if job == nil {
 		return
 	}
@@ -15,10 +15,10 @@ func resetTransferMetrics(job *model.TransferJob, started bool) {
 	job.BytesTotal = 0
 	job.BytesPerSecond = 0
 	job.ETASeconds = 0
+	// Start the throughput clock on the first real transport progress sample,
+	// not when a worker is merely scheduled. This excludes destination checks,
+	// upload snapshot creation and other pre-transfer setup from speed/ETA.
 	job.StartedAt = ""
-	if started {
-		job.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
-	}
 }
 
 func (m *Manager) updateProgress(id string, transferred, total int64) {

--- a/internal/transfer/progress_test.go
+++ b/internal/transfer/progress_test.go
@@ -29,6 +29,37 @@ func TestUpdateProgressCalculatesRuntimeMetrics(t *testing.T) {
 	}
 }
 
+func TestResetTransferMetricsDefersClockUntilFirstProgressSample(t *testing.T) {
+	job := model.TransferJob{
+		Status:           "running",
+		Progress:         75,
+		BytesTransferred: 75,
+		BytesTotal:       100,
+		BytesPerSecond:   25,
+		ETASeconds:       1,
+		StartedAt:        time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}
+	resetTransferMetrics(&job, true)
+	if job.StartedAt != "" || job.Progress != 0 || job.BytesTransferred != 0 || job.BytesTotal != 0 || job.BytesPerSecond != 0 || job.ETASeconds != 0 {
+		t.Fatalf("metrics were not fully reset: %+v", job)
+	}
+
+	job.ID = "job"
+	m := &Manager{jobs: []model.TransferJob{job}}
+	before := time.Now().UTC().Add(-time.Second)
+	m.updateProgress("job", 0, 1024)
+	started, err := time.Parse(time.RFC3339Nano, m.jobs[0].StartedAt)
+	if err != nil {
+		t.Fatalf("StartedAt parse: %v", err)
+	}
+	if started.Before(before) || started.After(time.Now().UTC().Add(time.Second)) {
+		t.Fatalf("StartedAt=%v was not set by first progress sample", started)
+	}
+	if m.jobs[0].BytesPerSecond != 0 || m.jobs[0].ETASeconds != 0 {
+		t.Fatalf("first zero-byte sample should not invent speed/ETA: %+v", m.jobs[0])
+	}
+}
+
 func TestUpdateProgressClampsReportedBytes(t *testing.T) {
 	started := time.Now().UTC().Add(-time.Second).Format(time.RFC3339Nano)
 	m := &Manager{jobs: []model.TransferJob{{ID: "job", Status: "running", StartedAt: started}}}

--- a/internal/transfer/progress_test.go
+++ b/internal/transfer/progress_test.go
@@ -1,0 +1,48 @@
+package transfer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestUpdateProgressCalculatesRuntimeMetrics(t *testing.T) {
+	started := time.Now().UTC().Add(-2 * time.Second).Format(time.RFC3339Nano)
+	m := &Manager{jobs: []model.TransferJob{{ID: "job", Status: "running", StartedAt: started}}}
+	m.updateProgress("job", 512, 1024)
+	job := m.jobs[0]
+	if job.BytesTransferred != 512 || job.BytesTotal != 1024 {
+		t.Fatalf("bytes=%d/%d", job.BytesTransferred, job.BytesTotal)
+	}
+	if job.Progress < 49.9 || job.Progress > 50.1 {
+		t.Fatalf("progress=%f", job.Progress)
+	}
+	if job.BytesPerSecond <= 0 {
+		t.Fatalf("speed=%f", job.BytesPerSecond)
+	}
+	if job.ETASeconds < 1 || job.ETASeconds > 3 {
+		t.Fatalf("eta=%d", job.ETASeconds)
+	}
+	if len(m.events) != 1 || m.events[0].Job == nil {
+		t.Fatalf("expected one progress event, got %#v", m.events)
+	}
+}
+
+func TestUpdateProgressClampsReportedBytes(t *testing.T) {
+	started := time.Now().UTC().Add(-time.Second).Format(time.RFC3339Nano)
+	m := &Manager{jobs: []model.TransferJob{{ID: "job", Status: "running", StartedAt: started}}}
+	m.updateProgress("job", 4096, 1024)
+	job := m.jobs[0]
+	if job.BytesTransferred != 1024 || job.Progress != 100 || job.ETASeconds != 0 {
+		t.Fatalf("clamped job=%+v", job)
+	}
+}
+
+func TestUpdateProgressIgnoresFinishedJob(t *testing.T) {
+	m := &Manager{jobs: []model.TransferJob{{ID: "job", Status: "done", Progress: 100}}}
+	m.updateProgress("job", 1, 2)
+	if m.jobs[0].BytesTransferred != 0 || len(m.events) != 0 {
+		t.Fatalf("finished job mutated: %+v events=%d", m.jobs[0], len(m.events))
+	}
+}


### PR DESCRIPTION
## Ghost FTP 0.2.x transfer queue refinement

This PR improves transfer progress without introducing telemetry, persistent tracking, or fabricated metrics.

### Runtime metrics
- extends in-memory transfer jobs with transferred bytes, total bytes, average bytes/second and ETA;
- keeps the internal throughput start timestamp process-only (`json:"-"`) so it never expands the queue/API data surface;
- starts timing on the first real transport progress sample, excluding destination checks, upload snapshot creation and other pre-transfer setup from throughput/ETA;
- resets metrics on retry and emits updates through the existing bounded transfer event stream.

### FTP/FTPS/SFTP behavior
- downloads measure actual bytes written to Ghost FTP's existing private/random local staging file every 500 ms;
- the staging sampler uses no-follow filesystem metadata and refuses symlink/reparse replacements;
- remote total size is best-effort from existing directory-listing metadata; inability to obtain a reliable total never blocks the transfer and the UI shows transferred bytes without inventing a 0% percentage;
- uploads use the already verified private upload snapshot size for the real total, report start/final bytes, and deliberately do not invent intermediate percentages that curl/OpenSSH cannot reliably expose in the current child-process architecture;
- all existing snapshot, symlink/reparse, staging, atomic-replace and remote-temp commit protections remain in place.

### Windows queue UX
- keeps the existing five-column layout instead of adding clutter;
- Progress becomes compact factual output such as `42% · 8.2 MB`; when the total is unknown it shows only factual transferred bytes;
- Status adds runtime throughput/ETA such as `Running · 2.1 MB/s · 00:05` and retains retry/error state;
- completed jobs can retain their measured average throughput while failed/cancelled jobs do not display stale speed as if still active.

### Validation
- adds regressions for staging-byte monitoring, remote total-size lookup, no fabricated percent without a denominator, throughput clock boundaries, manager progress/ETA calculations, clamping, finished-job immutability, runtime timestamp JSON privacy and Windows byte/ETA formatting;
- unrelated SFTP comments/formatting were restored so the transport diff remains scoped to progress behavior;
- `VERSION` remains 0.2.1 and no release is triggered by this PR;
- merge remains blocked on full CI, Windows x64/x86 production builds and authentic current-head UI capture.