### PR TITLE
Improve privacy-safe connection diagnostics

### DIFF
--- a/internal/desktop/connection_diagnostics_windows_test.go
+++ b/internal/desktop/connection_diagnostics_windows_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/remote"
 )
 
+type windowsClassifiedDiagnosticError struct {
+	kind string
+	raw  string
+}
+
+func (e windowsClassifiedDiagnosticError) Error() string         { return e.raw }
+func (e windowsClassifiedDiagnosticError) UserErrorKind() string { return e.kind }
+
 func TestConnectionDiagnosticStatusUsesActiveEnglishLocale(t *testing.T) {
 	a := &app{settings: model.Settings{Language: "en"}}
 	host := "example.test"
@@ -54,6 +62,21 @@ func TestConnectionDiagnosticStatusDoesNotMixTransportDiagnosticsIntoConciseStat
 	for name, got := range statuses {
 		if got != want {
 			t.Fatalf("%s status = %q, want concise localized status %q", name, got, want)
+		}
+	}
+}
+
+func TestWindowsUserMessageUsesStructuredTransportDiagnosticWithoutRawLeak(t *testing.T) {
+	raw := `OpenSSH child detail C:\Users\Person\.ssh\id_ed25519 secret-token-should-not-leak`
+	for _, language := range []string{"en", "hr"} {
+		a := &app{settings: model.Settings{Language: language}}
+		got := a.userMessage(windowsClassifiedDiagnosticError{kind: "sftp_settings", raw: raw}, "connection.failed_body")
+		want := i18n.T(language, "sftp.failed_body")
+		if got != want {
+			t.Fatalf("%s Windows structured diagnostic = %q, want %q", language, got, want)
+		}
+		if got == raw {
+			t.Fatalf("%s Windows diagnostic leaked raw child-process detail", language)
 		}
 	}
 }

--- a/internal/remote/tool_diagnostics.go
+++ b/internal/remote/tool_diagnostics.go
@@ -1,0 +1,109 @@
+package remote
+
+import "strings"
+
+// UserErrorKind exposes only a stable, non-secret semantic category to the UI
+// error mapper. Raw child-process output remains inside the remote package and
+// must never be rendered directly to users.
+func (e *toolError) UserErrorKind() string {
+	if e == nil {
+		return ""
+	}
+	s := strings.ToLower(strings.Join(strings.Fields(e.message), " "))
+
+	switch strings.ToLower(strings.TrimSpace(e.tool)) {
+	case "curl":
+		// Protocol replies are more specific than curl's process exit code and
+		// should win when both are available.
+		switch {
+		case containsDiagnosticMarker(s, "421 too many connections", "421 service not available", "421 connection", "too many connections"):
+			return "ftp_limit"
+		case containsDiagnosticMarker(s, "425 can't open data connection", "425 cannot open data connection", "425 failed to establish connection", "426 connection closed", "426 transfer aborted"):
+			return "ftp_data"
+		case containsDiagnosticMarker(s, "530 login", "530 user", "530 not logged", "login denied", "login incorrect", "authentication rejected"):
+			return "auth"
+		case containsDiagnosticMarker(s, "552 quota", "552 disk", "quota exceeded", "no space left", "disk full"):
+			return "disk"
+		case containsDiagnosticMarker(s, "connection refused", "actively refused"):
+			return "refused"
+		case containsDiagnosticMarker(s, "could not resolve host", "name or service not known", "temporary failure in name resolution", "no such host", "host not found"):
+			return "resolve"
+		case containsDiagnosticMarker(s, "timed out", "timeout", "operation timed out"):
+			return "timeout"
+		case containsDiagnosticMarker(s, "certificate", "ssl certificate", "tls", "schannel"):
+			return "tls"
+		}
+
+		switch e.code {
+		case 6:
+			return "resolve"
+		case 9:
+			return "permission"
+		case 18, 52, 55, 56:
+			return "connection_lost"
+		case 28:
+			return "timeout"
+		case 35, 51, 58, 59, 60, 64, 66, 77, 80, 82, 83, 90, 91:
+			return "tls"
+		case 67:
+			return "auth"
+		case 78:
+			return "not_found"
+		}
+
+	case "sftp":
+		switch {
+		case containsDiagnosticMarker(s,
+			"remote host identification has changed",
+			"host key verification failed",
+			"sftp host-key fingerprint changed",
+			"fingerprint se promijenio",
+			"otisak sftp host ključa se promijenio",
+		):
+			return "hostkey_changed"
+		case containsDiagnosticMarker(s, "could not resolve hostname", "name or service not known", "temporary failure in name resolution", "no such host", "host not found"):
+			return "resolve"
+		case containsDiagnosticMarker(s, "connection refused", "actively refused"):
+			return "refused"
+		case containsDiagnosticMarker(s, "connection timed out", "operation timed out", "timed out"):
+			return "timeout"
+		case containsDiagnosticMarker(s, "connection reset", "connection closed", "broken pipe", "connection aborted", "network is unreachable", "no route to host"):
+			return "connection_lost"
+		case containsDiagnosticMarker(s, "no such file", "not found", "couldn't stat remote file", "could not stat remote file"):
+			return "not_found"
+		case containsDiagnosticMarker(s,
+			"incorrect passphrase",
+			"bad passphrase",
+			"error in libcrypto",
+			"unprotected private key file",
+			"bad permissions: ignore key",
+		) || (strings.Contains(s, "load key") && strings.Contains(s, "invalid format")):
+			// Existing localized SFTP copy is intentionally used here rather than
+			// exposing the OpenSSH key path, parser details or passphrase prompt.
+			return "sftp_settings"
+		case containsDiagnosticMarker(s,
+			"authentication failed",
+			"authentication rejected",
+			"permission denied (publickey",
+			"permission denied (password",
+			"permission denied (keyboard-interactive",
+			"permission denied, please try again",
+			"too many authentication failures",
+		):
+			return "auth"
+		case containsDiagnosticMarker(s, "permission denied", "access denied"):
+			return "permission"
+		}
+	}
+
+	return ""
+}
+
+func containsDiagnosticMarker(s string, markers ...string) bool {
+	for _, marker := range markers {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/remote/tool_diagnostics_test.go
+++ b/internal/remote/tool_diagnostics_test.go
@@ -1,0 +1,71 @@
+package remote
+
+import "testing"
+
+func TestCurlToolErrorUserErrorKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    int
+		message string
+		want    string
+	}{
+		{name: "resolve code", code: 6, message: "opaque curl failure", want: "resolve"},
+		{name: "timeout code", code: 28, message: "opaque curl failure", want: "timeout"},
+		{name: "tls verification code", code: 60, message: "opaque curl failure", want: "tls"},
+		{name: "login code", code: 67, message: "opaque curl failure", want: "auth"},
+		{name: "remote missing code", code: 78, message: "opaque curl failure", want: "not_found"},
+		{name: "partial transfer code", code: 18, message: "opaque curl failure", want: "connection_lost"},
+		{name: "ftp limit reply wins", code: 7, message: "421 Too many connections from this IP", want: "ftp_limit"},
+		{name: "ftp data reply wins", code: 7, message: "425 Can't open data connection", want: "ftp_data"},
+		{name: "ftp login reply wins", code: 7, message: "530 Login incorrect", want: "auth"},
+		{name: "refused message", code: 7, message: "Failed to connect: Connection refused", want: "refused"},
+		{name: "unknown code stays unclassified", code: 99, message: "opaque curl failure", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &toolError{tool: "curl", code: tc.code, message: tc.message}
+			if got := err.UserErrorKind(); got != tc.want {
+				t.Fatalf("UserErrorKind()=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSFTPToolErrorUserErrorKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "host key changed", message: "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!", want: "hostkey_changed"},
+		{name: "host key verification", message: "Host key verification failed.", want: "hostkey_changed"},
+		{name: "resolve", message: "ssh: Could not resolve hostname server.invalid: Name or service not known", want: "resolve"},
+		{name: "refused", message: "ssh: connect to host example port 22: Connection refused", want: "refused"},
+		{name: "timeout", message: "ssh: connect to host example port 22: Connection timed out", want: "timeout"},
+		{name: "connection lost", message: "Connection reset by peer", want: "connection_lost"},
+		{name: "missing remote file", message: "stat remote: No such file or directory", want: "not_found"},
+		{name: "public key auth", message: "Permission denied (publickey,password).", want: "auth"},
+		{name: "keyboard interactive auth", message: "Permission denied (keyboard-interactive).", want: "auth"},
+		{name: "bad passphrase", message: "Load key C:/secret/key: incorrect passphrase supplied to decrypt private key", want: "sftp_settings"},
+		{name: "invalid key format", message: "Load key C:/secret/key: invalid format", want: "sftp_settings"},
+		{name: "libcrypto key failure", message: "Load key /home/user/key: error in libcrypto", want: "sftp_settings"},
+		{name: "private key permissions", message: "WARNING: UNPROTECTED PRIVATE KEY FILE! Bad permissions: ignore key", want: "sftp_settings"},
+		{name: "generic permission", message: "remote open: Permission denied", want: "permission"},
+		{name: "unknown output stays unclassified", message: "opaque sftp failure", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &toolError{tool: "sftp", code: 255, message: tc.message}
+			if got := err.UserErrorKind(); got != tc.want {
+				t.Fatalf("UserErrorKind()=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToolErrorUnknownToolHasNoUserClassification(t *testing.T) {
+	err := &toolError{tool: "other", code: 6, message: "Could not resolve host"}
+	if got := err.UserErrorKind(); got != "" {
+		t.Fatalf("UserErrorKind()=%q", got)
+	}
+}

--- a/internal/usererror/message.go
+++ b/internal/usererror/message.go
@@ -38,24 +38,31 @@ func MessageFor(language string, err error, fallback string) string {
 		return i18n.T(language, "error.timeout")
 	}
 
+	// Remote transport errors can expose a stable semantic category without
+	// exposing their raw curl/OpenSSH output. Use a strict whitelist so an
+	// arbitrary wrapped error cannot select an unexpected localization key.
+	if key := classifiedMessageKey(err); key != "" {
+		return i18n.T(language, key)
+	}
+
 	switch {
-	case containsAny(s, "otisak sftp host ključa se promijenio", "fingerprint se promijenio", "host key verification failed", "sftp host-key fingerprint changed"):
+	case containsAny(s, "otisak sftp host ključa se promijenio", "fingerprint se promijenio", "remote host identification has changed", "host key verification failed", "sftp host-key fingerprint changed"):
 		return i18n.T(language, "error.hostkey_changed")
 	case containsAny(s, "sftp podrška nije dostupna u sustavu windows", "sftp komponenta nije pronađena", "openssh client nije instaliran", "nedostaje sftp.exe", "nedostaje ssh-keyscan.exe", "nedostaje ssh-keygen.exe", "sftp support is unavailable", "openssh client is not installed", "missing sftp.exe", "missing ssh-keyscan.exe", "missing ssh-keygen.exe"):
 		return i18n.T(language, "error.sftp_unavailable")
 	case containsAny(s, "nije moguće dohvatiti sftp host ključ", "poslužitelj nije vratio ssh host ključ", "could not retrieve sftp host key", "server did not return an ssh host key"):
 		return i18n.T(language, "error.sftp_hostkey_missing")
-	case containsAny(s, "authentication failed", "permission denied (publickey", "permission denied (password", "permission denied, please try again", "login incorrect", "access denied", "530 login", "530 user", "530 not logged", "authentication rejected"):
+	case containsAny(s, "authentication failed", "permission denied (publickey", "permission denied (password", "permission denied (keyboard-interactive", "permission denied, please try again", "login incorrect", "access denied", "530 login", "530 user", "530 not logged", "authentication rejected"):
 		return i18n.T(language, "error.auth")
 	case containsAny(s, "421 too many connections", "421 service not available", "421 connection", "too many connections"):
 		return i18n.T(language, "error.ftp_limit")
 	case containsAny(s, "425 can't open data connection", "425 cannot open data connection", "425 failed to establish connection", "426 connection closed", "426 transfer aborted"):
 		return i18n.T(language, "error.ftp_data")
-	case containsAny(s, "could not resolve host", "name or service not known", "temporary failure in name resolution", "no such host", "host not found"):
+	case containsAny(s, "could not resolve host", "could not resolve hostname", "name or service not known", "temporary failure in name resolution", "no such host", "host not found"):
 		return i18n.T(language, "error.resolve")
 	case containsAny(s, "connection refused", "actively refused"):
 		return i18n.T(language, "error.refused")
-	case containsAny(s, "timed out", "timeout", "operation timed out"):
+	case containsAny(s, "timed out", "timeout", "operation timed out", "connection timed out"):
 		return i18n.T(language, "error.timeout")
 	case containsAny(s, "connection reset", "connection closed", "broken pipe", "connection aborted", "network is unreachable", "no route to host"):
 		return i18n.T(language, "error.connection_lost")
@@ -90,6 +97,47 @@ func MessageFor(language string, err error, fallback string) string {
 		fallback = i18n.T(language, "error.generic")
 	}
 	return fallback
+}
+
+func classifiedMessageKey(err error) string {
+	var classified interface{ UserErrorKind() string }
+	if !errors.As(err, &classified) {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(classified.UserErrorKind())) {
+	case "hostkey_changed":
+		return "error.hostkey_changed"
+	case "sftp_unavailable":
+		return "error.sftp_unavailable"
+	case "sftp_hostkey_missing":
+		return "error.sftp_hostkey_missing"
+	case "sftp_settings":
+		return "sftp.failed_body"
+	case "auth":
+		return "error.auth"
+	case "ftp_limit":
+		return "error.ftp_limit"
+	case "ftp_data":
+		return "error.ftp_data"
+	case "resolve":
+		return "error.resolve"
+	case "refused":
+		return "error.refused"
+	case "timeout":
+		return "error.timeout"
+	case "connection_lost":
+		return "error.connection_lost"
+	case "tls":
+		return "error.tls"
+	case "disk":
+		return "error.disk"
+	case "permission":
+		return "error.permission"
+	case "not_found":
+		return "error.not_found"
+	default:
+		return ""
+	}
 }
 
 func containsAny(s string, values ...string) bool {

--- a/internal/usererror/message_test.go
+++ b/internal/usererror/message_test.go
@@ -3,10 +3,19 @@ package usererror
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bren-wp/Ghost-FTP/internal/i18n"
 )
+
+type classifiedTestError struct {
+	kind string
+	raw  string
+}
+
+func (e classifiedTestError) Error() string         { return e.raw }
+func (e classifiedTestError) UserErrorKind() string { return e.kind }
 
 func TestMessageDefaultsToEnglishAndHidesToolDetails(t *testing.T) {
 	lowLevel := `curl: (67) Login denied; server said: 530 Login incorrect`
@@ -28,6 +37,63 @@ func TestMessageForLocalizesKnownErrors(t *testing.T) {
 		if got != want {
 			t.Fatalf("%s: got %q want %q", language.Code, got, want)
 		}
+	}
+}
+
+func TestMessageUsesStructuredTransportClassificationWithoutLeakingRawDetail(t *testing.T) {
+	raw := `opaque child-process output C:\Users\Person\.ssh\id_ed25519 secret-token-should-not-leak`
+	err := classifiedTestError{kind: "sftp_settings", raw: raw}
+	for _, language := range i18n.Languages() {
+		got := MessageFor(language.Code, err, "fallback")
+		want := i18n.T(language.Code, "sftp.failed_body")
+		if got != want {
+			t.Fatalf("%s: got %q want %q", language.Code, got, want)
+		}
+		if strings.Contains(got, "secret-token-should-not-leak") || strings.Contains(got, "id_ed25519") {
+			t.Fatalf("%s: structured diagnostic leaked raw detail: %q", language.Code, got)
+		}
+	}
+}
+
+func TestMessageStructuredKindWhitelist(t *testing.T) {
+	err := classifiedTestError{kind: "error.arbitrary_key", raw: "opaque-internal-tool-error"}
+	if got := MessageFor("en", err, "Safe fallback"); got != "Safe fallback" {
+		t.Fatalf("unapproved kind selected a message: %q", got)
+	}
+}
+
+func TestMessageContextDeadlineWinsStructuredClassification(t *testing.T) {
+	err := errors.Join(context.DeadlineExceeded, classifiedTestError{kind: "auth", raw: "opaque auth failure"})
+	if got, want := MessageFor("hr", err, "x"), i18n.T("hr", "error.timeout"); got != want {
+		t.Fatalf("deadline should win structured kind: got %q want %q", got, want)
+	}
+}
+
+func TestMessageStructuredKindsMapToExpectedCatalogKeys(t *testing.T) {
+	tests := map[string]string{
+		"hostkey_changed":      "error.hostkey_changed",
+		"sftp_unavailable":     "error.sftp_unavailable",
+		"sftp_hostkey_missing": "error.sftp_hostkey_missing",
+		"sftp_settings":        "sftp.failed_body",
+		"auth":                 "error.auth",
+		"ftp_limit":            "error.ftp_limit",
+		"ftp_data":             "error.ftp_data",
+		"resolve":              "error.resolve",
+		"refused":              "error.refused",
+		"timeout":              "error.timeout",
+		"connection_lost":      "error.connection_lost",
+		"tls":                  "error.tls",
+		"disk":                 "error.disk",
+		"permission":           "error.permission",
+		"not_found":            "error.not_found",
+	}
+	for kind, key := range tests {
+		t.Run(kind, func(t *testing.T) {
+			err := classifiedTestError{kind: kind, raw: "opaque"}
+			if got, want := MessageFor("en", err, "fallback"), i18n.T("en", key); got != want {
+				t.Fatalf("got %q want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -91,6 +157,26 @@ func TestMessageSFTPHostKeyScanFailure(t *testing.T) {
 	got := MessageFor("en", errors.New("could not retrieve sftp host key"), "x")
 	if want := i18n.T("en", "error.sftp_hostkey_missing"); got != want {
 		t.Fatalf("unexpected SFTP host-key scan message: %q", got)
+	}
+}
+
+func TestMessageOpenSSHFallbackMarkers(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		key  string
+	}{
+		{name: "changed host key", err: "REMOTE HOST IDENTIFICATION HAS CHANGED", key: "error.hostkey_changed"},
+		{name: "hostname resolution", err: "Could not resolve hostname example.invalid", key: "error.resolve"},
+		{name: "keyboard interactive auth", err: "Permission denied (keyboard-interactive)", key: "error.auth"},
+		{name: "connection timeout", err: "Connection timed out", key: "error.timeout"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := MessageFor("en", errors.New(tc.err), "fallback"), i18n.T("en", tc.key); got != want {
+				t.Fatalf("got %q want %q", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Ghost FTP 0.2.x connection diagnostics

This PR makes FTP/FTPS/SFTP failures more actionable while preserving Ghost FTP's no-telemetry/no-secret-leak boundary.

### Structured transport diagnostics
- curl and OpenSSH child-process failures now expose only a stable semantic `UserErrorKind()` category to the frontend error mapper;
- raw tool output, command details, key paths, certificate text, server banners and credentials are never returned directly to users;
- user-facing mapping uses a strict whitelist of existing localized messages rather than trusting arbitrary error-provided localization keys.

### FTP / FTPS
- distinguishes DNS resolution, timeout, refused connections, interrupted data flow, TLS/certificate failures, login rejection, remote access denial, missing remote files, FTP session limits and 425/426 data-channel failures;
- explicit FTP reply semantics take precedence over generic curl exit codes when both are available.

### SFTP
- distinguishes host-key changes, DNS, refused/timeout/lost connections, authentication rejection, remote path/permission failures and private-key/passphrase/configuration failures;
- private-key parser/passphrase failures reuse existing localized SFTP settings guidance instead of exposing OpenSSH key paths or parser output;
- host-key trust remains fail-closed.

### Shared Windows/Linux behavior
- the existing `usererror.MessageFor` path remains the single localized user-facing mapper, so Windows dialogs/status and Linux terminal flows receive the same classification;
- connection lifecycle and context cancellation/deadline states still win over lower-level transport classifications.

### Regression coverage
- curl exit-code and FTP-reply precedence;
- OpenSSH host-key/auth/key-format/passphrase/network/path classifications;
- localization for structured kinds;
- explicit whitelist behavior;
- joined timeout precedence;
- proof that raw key paths/secret-like child-process details are not leaked.

`VERSION` remains 0.2.1. Merge is blocked on the full CI/build/security/documentation gate and current-head authentic Windows UI capture.