### PR TITLE
Ghost FTP 1.0.0 Stable — optional Authenticode without generated production keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or (go telemetry).Trim() -ne 'off') {
             throw 'Go telemetry is not disabled.'
           }
-      - name: Prepare protected Authenticode identity
+      - name: Prepare optional protected Authenticode identity
         id: signing
         shell: pwsh
         env:
@@ -112,6 +112,7 @@ jobs:
             }
             "state=unsigned" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             Write-Host 'WINDOWS_RELEASE_SIGNING=UNSIGNED'
+            Write-Host 'No production signing identity is configured; artifacts will remain explicitly unsigned.'
             exit 0
           }
           if ([string]::IsNullOrWhiteSpace($env:PFX_PASSWORD)) {
@@ -248,12 +249,15 @@ jobs:
           else
             release_channel='stable'
             release_title="Ghost FTP $version"
-            test "$WINDOWS_SIGNING_STATE" = 'signed' || { echo 'Stable Windows releases require a configured trusted Authenticode identity.' >&2; exit 1; }
           fi
           case "$WINDOWS_SIGNING_STATE" in
             signed|unsigned) ;;
             *) echo "Invalid Windows signing state: $WINDOWS_SIGNING_STATE" >&2; exit 1 ;;
           esac
+          if [[ "$release_channel" = 'stable' && "$WINDOWS_SIGNING_STATE" = 'unsigned' ]]; then
+            echo '::warning::Publishing Stable with explicitly unsigned Windows artifacts. BUILD-METADATA.txt records WINDOWS_AUTHENTICODE=unsigned.'
+            printf '### Windows signing\nStable release is being published with **unsigned** Windows artifacts. Integrity remains bound to the exact release commit and SHA256.txt.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "VERSION=$version" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=ghostftp-v$version" >> "$GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Promoted the maintained Windows/Linux product line from the 0.x Beta channel to **Ghost FTP 1.0.0 Stable**.
 - Stable GitHub Releases are normal releases (`prerelease=false`) using the immutable `ghostftp-v1.0.0` tag contract.
-- Stable Windows publication remains fail-closed unless the protected trusted Authenticode signing identity is configured and produced binaries verify successfully.
+- Production Authenticode is optional: configured trusted certificates are verified fail-closed, while releases without a production certificate remain explicitly unsigned in `BUILD-METADATA.txt` rather than generating or pretending to use a trusted publisher key.
 
 ### Stability and transfer correctness
 
@@ -73,7 +73,8 @@ The 1.0.0 release candidate must pass the exact production gate before publicati
 - Python regression suite;
 - Windows x64/x86 production Setup + Portable build;
 - Linux amd64/arm64/i386 production package build;
-- stable Authenticode gate;
+- Authenticode verification when a production certificate is configured;
+- explicit `WINDOWS_AUTHENTICODE=unsigned` metadata when no production certificate is configured;
 - GitHub Package push/read-back;
 - GitHub Release asset/prerelease read-back.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Ghost-FTP-1.0.0-Portable-x86.exe
 
 Setup installs per user, registers integrated maintenance/uninstall information and uses a transaction/rollback path for replacement. Portable runs without installation registration and keeps its portable data boundary separate.
 
-Stable Windows publication remains gated on a configured trusted Authenticode identity in the protected release environment.
+Production Authenticode signing is optional. When a trusted certificate is configured in protected Actions secrets, Windows artifacts are signed and verified; when it is absent, the official release remains explicitly unsigned and records that state in `BUILD-METADATA.txt`. Ghost FTP never generates a self-signed certificate and presents it as a trusted production publisher identity.
 
 See [Installation](docs/INSTALLATION.md) and [Signing](docs/SIGNING.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,7 +97,7 @@ Platform transfer capabilities are explicit system-runtime dependencies and are 
 
 Windows uses native Win32 surfaces and controls. The release pipeline produces x64 and x86 Setup/Portable packages; the x32 Setup name is a byte-identical compatibility alias of x86.
 
-Stable release publication requires the protected trusted Authenticode identity. Signing key material is never stored in the repository.
+Production Authenticode is an optional hardening layer. If a protected trusted certificate is configured, the release pipeline signs and verifies the Windows artifacts. If it is absent, the release remains explicitly unsigned and records that state in `BUILD-METADATA.txt`. The production workflow never creates a self-signed publisher identity as a substitute for a real trusted certificate.
 
 ## Linux architecture
 
@@ -111,7 +111,7 @@ The release workflow runs a complete quality gate before artifact publication:
 2. repository, platform, dependency, security, privacy, localization and documentation audits;
 3. Python regression suites;
 4. Windows and Linux production builds;
-5. signing/metadata checks;
+5. signing-state/metadata checks, plus Authenticode verification when configured;
 6. explicit release allow-list assembly;
 7. SHA-256 manifest generation;
 8. GitHub Release publication and read-back;

--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -61,9 +61,15 @@ Before publication, the workflow queries the current `main` SHA and requires it 
 
 If `ghostftp-v1.0.0` already exists, it must resolve to the exact release commit. The workflow refuses to rewrite an existing version tag to different source.
 
-## Stable Windows signing rule
+## Windows signing state
 
-A stable Release is blocked unless the protected release environment reports the Windows artifacts as signed using the configured trusted Authenticode identity. Private signing material is supplied only via protected Actions secrets, written temporarily on the runner and removed after use.
+Authenticode signing is optional for stable publication. If protected production signing secrets are configured, the Windows Setup/Portable artifacts are signed and each produced signature must verify successfully. If no production certificate is configured, Windows artifacts are published unsigned and `BUILD-METADATA.txt` explicitly records:
+
+```text
+WINDOWS_AUTHENTICODE=unsigned
+```
+
+The workflow never generates a self-signed production publisher identity and never labels an unsigned artifact as signed. Private signing material, when used, is supplied only via protected Actions secrets, written temporarily on the runner and removed after use.
 
 ## Artifact allow-list
 
@@ -105,6 +111,6 @@ See [Packages](PACKAGES.md).
 
 ## Failure behavior
 
-A failed quality gate, production build, signing check, package push, tag validation, Release upload or read-back check causes the workflow to fail. A failed workflow is not represented as a completed stable release contract.
+A failed quality gate, production build, configured-signing verification, package push, tag validation, Release upload or read-back check causes the workflow to fail. Absence of a production Authenticode certificate alone does not fail publication; that state is preserved as `unsigned` metadata.
 
 See [Release verification](RELEASE-VERIFICATION.md), [Signing](SIGNING.md) and [Versioning](VERSIONING.md).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -25,9 +25,23 @@ Ghost-FTP-1.0.0-Portable-x86.exe
 
 Portable mode does not create the normal Setup registration and keeps its portable state boundary beside the application as documented by the product. Do not mix an installed data directory and portable data directory manually.
 
-### Stable signing
+### Windows signing state
 
-Stable Windows publication is blocked unless the protected release environment supplies the configured trusted Authenticode identity. Verify the Windows digital signature and `SHA256.txt` before deployment.
+Production Authenticode signing is optional. Read `BUILD-METADATA.txt` from the same official release:
+
+```text
+WINDOWS_AUTHENTICODE=signed
+```
+
+means the release workflow used a configured trusted production certificate and verified the produced signatures.
+
+```text
+WINDOWS_AUTHENTICODE=unsigned
+```
+
+means the official Windows artifacts are intentionally unsigned. The workflow does not generate a self-signed production identity merely to make the files appear signed.
+
+In both cases verify `SHA256.txt`. For a signed release, also verify the Authenticode publisher. Unsigned builds may trigger Windows SmartScreen/publisher warnings depending on local policy.
 
 ## Linux
 
@@ -49,7 +63,7 @@ Install the package matching the machine architecture with the system package ma
 
 ## Upgrade to 1.0.0
 
-Ghost FTP 1.0.0 is the first stable release. Existing 0.2.x local settings/profiles are intended to remain compatible. Before upgrading critical systems, keep a copy of local configuration and verify the stable package checksum/signature.
+Ghost FTP 1.0.0 is the first stable release. Existing 0.2.x local settings/profiles are intended to remain compatible. Before upgrading critical systems, keep a copy of local configuration and verify the stable package checksum and, when present, its signing state.
 
 Windows Setup performs a staged replacement and rollback-oriented transaction. Linux upgrades use the standard package manager semantics of the DEB package.
 
@@ -87,9 +101,11 @@ Remove the `ghost-ftp` package with the distribution package manager. User-local
 
 ## Troubleshooting
 
-### Windows signature validation fails
+### Windows shows an unknown-publisher or SmartScreen warning
 
-Do not bypass stable signature verification. Re-download from the official Release, verify `SHA256.txt`, and confirm that the release itself is the expected `ghostftp-v1.0.0` tag.
+First inspect `BUILD-METADATA.txt`. If it says `WINDOWS_AUTHENTICODE=unsigned`, the missing trusted signature is expected for that release. Verify the official release tag and `SHA256.txt`, and follow your Windows/organization security policy rather than disabling protections globally.
+
+If metadata says `WINDOWS_AUTHENTICODE=signed` but signature validation fails, re-download from the official Release and treat the mismatch as a verification failure.
 
 ### Linux package architecture mismatch
 
@@ -108,7 +124,7 @@ Use the privacy-safe connection diagnostics in Ghost FTP. Verify protocol, host,
 1. download from the official stable GitHub Release;
 2. verify release tag/version;
 3. verify `SHA256.txt`;
-4. verify Windows Authenticode when installing on Windows;
+4. inspect `WINDOWS_AUTHENTICODE` and verify Authenticode when the release is signed;
 5. choose the correct architecture;
 6. preserve needed local configuration before upgrade;
 7. test the target server using its intended FTP/FTPS/SFTP mode;

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,8 @@ This directory contains the maintained engineering, operations, privacy, securit
 - [`INSTALLATION.md`](INSTALLATION.md) — Windows Setup/Portable and Linux DEB installation/upgrade guidance.
 - [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) — canonical GitHub Release structure and release-channel rules.
 - [`PACKAGES.md`](PACKAGES.md) — stable GHCR distribution bundle published through GitHub Packages.
-- [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) — artifact, metadata, SHA-256, signing and package verification.
-- [`SIGNING.md`](SIGNING.md) — protected Authenticode signing model for stable Windows publication.
+- [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) — artifact, metadata, SHA-256, signing-state and package verification.
+- [`SIGNING.md`](SIGNING.md) — optional protected Authenticode signing model and truthful unsigned-release policy.
 - [`VERSIONING.md`](VERSIONING.md) — semantic versioning and stable/prerelease policy.
 
 The stable workflow publishes **9 platform artifacts** and **12 public files** on each canonical GitHub Release. The same verified release directory is also mirrored to GitHub Packages as a non-runtime OCI distribution bundle.
@@ -50,7 +50,7 @@ Historical sections intentionally preserve older version numbers and Beta termin
 
 ## Stable 1.0 release contract
 
-Ghost FTP 1.0.0 is the first stable release. It is published as a normal GitHub Release with `prerelease=false`. Stable Windows publication remains gated on the protected trusted Authenticode identity. Linux packages are generated and metadata-verified for amd64, arm64 and i386.
+Ghost FTP 1.0.0 is the first stable release. It is published as a normal GitHub Release with `prerelease=false`. Windows Authenticode is optional: when a trusted production certificate is configured the workflow signs and verifies the Windows artifacts; otherwise it publishes them explicitly as unsigned and records `WINDOWS_AUTHENTICODE=unsigned` in release metadata. Linux packages are generated and metadata-verified for amd64, arm64 and i386.
 
 The production workflow also publishes:
 

--- a/docs/RELEASE-VERIFICATION.md
+++ b/docs/RELEASE-VERIFICATION.md
@@ -1,6 +1,6 @@
 # Ghost FTP release verification
 
-This document defines how to verify Ghost FTP **1.0.0 Stable** and later stable releases. Verification covers source identity, Windows signing, Linux package metadata, per-file SHA-256 values, GitHub Release state and GitHub Packages registry state.
+This document defines how to verify Ghost FTP **1.0.0 Stable** and later stable releases. Verification covers source identity, Windows signing state, Linux package metadata, per-file SHA-256 values, GitHub Release state and GitHub Packages registry state.
 
 ## Expected release identity
 
@@ -43,7 +43,23 @@ Do not treat a matching filename as proof of authenticity; verify the digest and
 
 ## Windows Authenticode
 
-Stable Windows publication is blocked unless the protected workflow reports a trusted signing identity as configured and every Setup/Portable artifact passes Authenticode verification during the production build.
+Read `WINDOWS_AUTHENTICODE` from `BUILD-METADATA.txt` before interpreting the Windows signature state.
+
+If it is:
+
+```text
+WINDOWS_AUTHENTICODE=signed
+```
+
+then the protected workflow used a configured production certificate and every Setup/Portable artifact was required to pass Authenticode verification during the production build.
+
+If it is:
+
+```text
+WINDOWS_AUTHENTICODE=unsigned
+```
+
+then the release intentionally contains unsigned Windows artifacts. This is a truthful supported publication state, not a failed or partially signed release.
 
 On Windows, inspect the signature with PowerShell:
 
@@ -51,7 +67,9 @@ On Windows, inspect the signature with PowerShell:
 Get-AuthenticodeSignature .\Ghost-FTP-1.0.0-Setup-x64.exe | Format-List
 ```
 
-A stable file should have a valid signature and the expected publisher identity. If signature validation fails, do not bypass it by disabling operating-system security checks.
+For a signed release, verify that the signature is valid and that the publisher identity is the expected trusted identity. For an unsigned release, Windows may show SmartScreen/publisher warnings. Do not bypass enterprise or operating-system security policy solely to suppress such warnings.
+
+The release workflow does not create a self-signed production identity. Short-lived self-signed certificates are allowed only in CI signing smoke tests and are not public publisher credentials.
 
 ## x86/x32 alias verification
 
@@ -87,7 +105,8 @@ Confirm that:
 - `prerelease` is false;
 - tag resolves to the documented source commit;
 - remote asset names exactly match the 12-file allow-list;
-- `SHA256.txt` verifies the downloaded content.
+- `SHA256.txt` verifies the downloaded content;
+- `BUILD-METADATA.txt` truthfully reports `WINDOWS_AUTHENTICODE=signed` or `unsigned`.
 
 The production workflow performs immediate and delayed Release read-back; manual verification is still useful before broad deployment.
 
@@ -130,12 +149,13 @@ Before trusting a new stable version, inspect that the exact revision passed:
 - Python regression suite;
 - Windows production package build;
 - Linux production package build;
-- Authenticode stable gate;
+- Authenticode verification when a production certificate is configured;
+- explicit unsigned metadata when no production certificate is configured;
 - GitHub Package push/read-back;
 - GitHub Release asset/read-back verification.
 
 ## Failure interpretation
 
-A failed gate is meaningful. Do not manually relabel a failed candidate as stable or bypass integrity checks to make a release appear complete. Fix the source, documentation, packaging or protected release configuration and rerun the exact workflow.
+A failed gate is meaningful. Do not manually relabel a failed candidate as stable or bypass integrity checks to make a release appear complete. Fix the source, documentation, packaging, configured signing identity or publication infrastructure and rerun the exact workflow.
 
 See [GitHub Releases](GITHUB-RELEASES.md), [Packages](PACKAGES.md), [Signing](SIGNING.md), [Security](SECURITY.md) and [Privacy](PRIVACY.md).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -82,16 +82,19 @@ The production release workflow:
 - disables Go telemetry and external Go module resolution;
 - runs race tests, vet and security/privacy/dependency audits;
 - builds Windows/Linux artifacts from exact source;
-- requires protected trusted Authenticode for stable Windows publication;
-- removes temporary signing material from the runner;
+- optionally signs Windows artifacts with a protected trusted Authenticode identity when configured;
+- verifies every configured production signature and never labels unsigned artifacts as signed;
+- never generates a self-signed production publisher identity;
+- removes temporary signing material from the runner when signing is used;
 - assembles only an explicit release file set;
+- records the Windows signing state in `BUILD-METADATA.txt`;
 - generates SHA-256 checksums;
 - prevents an existing version tag from being rewritten to another commit;
 - verifies the published GitHub Release asset set and stable `prerelease=false` state;
 - publishes the stable GHCR release bundle only from the verified `release/` directory;
 - verifies the registry artifact can be read back.
 
-Private signing material must never be committed to source.
+Private signing material must never be committed to source. Absence of a production code-signing certificate is represented truthfully as an unsigned Windows release rather than “fixed” with an untrusted generated key.
 
 ## GitHub Packages boundary
 

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,22 +1,37 @@
 # Ghost FTP signing
 
-Ghost FTP **1.0.0 Stable** treats Windows code signing as a release security boundary, not a cosmetic badge.
+Ghost FTP **1.0.0 Stable** supports Windows Authenticode signing as an optional production hardening layer. Signing improves publisher identity and Windows trust UX, but Ghost FTP does not fabricate a trusted identity when no real code-signing certificate is configured.
 
-## Stable requirement
+## Production policy
 
-A stable Windows release is blocked unless the protected GitHub Actions environment provides a trusted Authenticode identity and the resulting Setup/Portable binaries verify successfully.
+A stable Windows release may be published either:
 
-The release workflow reports the signing state through `WINDOWS_SIGNING_STATE`. For `MAJOR >= 1`, the publish job requires:
+- **signed** — when the protected GitHub Actions environment provides a real trusted Authenticode certificate and the produced Setup/Portable binaries verify successfully; or
+- **unsigned** — when no production signing certificate is configured.
+
+The release workflow reports the exact state through `WINDOWS_SIGNING_STATE`, and `BUILD-METADATA.txt` records it as:
 
 ```text
-WINDOWS_SIGNING_STATE=signed
+WINDOWS_AUTHENTICODE=signed
 ```
 
-before the stable GitHub Release and GitHub Package publication can complete.
+or:
 
-## Protected secrets
+```text
+WINDOWS_AUTHENTICODE=unsigned
+```
 
-Production signing uses protected GitHub Actions secrets:
+Unsigned publication is never relabeled as signed.
+
+## Why Ghost FTP does not generate a production key automatically
+
+A locally generated/self-signed certificate can prove that the signing code path works, but it does **not** create a publicly trusted Windows publisher identity. Automatically generating such a key and presenting it as production Authenticode would be misleading and would not provide the normal trust benefit expected from a CA-issued code-signing certificate.
+
+Therefore the production workflow never creates its own long-lived publisher key. The separate CI smoke test may create a short-lived development certificate only to test signing mechanics.
+
+## Optional protected secrets
+
+If a real production certificate is available, signing uses protected GitHub Actions secrets:
 
 ```text
 GHOSTFTP_SIGNING_PFX_BASE64
@@ -24,11 +39,13 @@ GHOSTFTP_SIGNING_PASSWORD
 GHOSTFTP_SIGNING_TIMESTAMP_URL
 ```
 
+If the PFX and password are absent, Windows artifacts remain unsigned and publication continues with explicit unsigned metadata. If one secret is supplied without its required counterpart, the workflow fails rather than silently guessing a signing state.
+
 Private key material must never be committed to the repository, written into release metadata or copied into GitHub Packages.
 
 ## Runner lifetime
 
-The Windows release job decodes the protected PFX only into the runner temporary directory, exposes the path through the job environment for the build/signing step and removes the temporary file in an `always()` cleanup step.
+When signing is configured, the Windows release job decodes the protected PFX only into the runner temporary directory, exposes the path through the job environment for the build/signing step and removes the temporary file in an `always()` cleanup step.
 
 The repository stores only the signing integration code, not the production private key.
 
@@ -36,9 +53,11 @@ The repository stores only the signing integration code, not the production priv
 
 `BUILD-WINDOWS.ps1` signs the Portable executable before it is embedded into Setup, then signs Setup after its payload/resources are finalized. Checksums are generated after artifact mutation/signing so the published hashes represent final bytes.
 
+When no signing identity is configured, the same deterministic build/package path is used without the signing mutation.
+
 ## Verification
 
-During production build, each Windows Setup/Portable artifact is checked with the operating-system Authenticode verification API. A configured signing state whose produced file does not report a valid signature fails the job.
+For a release whose metadata says `WINDOWS_AUTHENTICODE=signed`, each Windows Setup/Portable artifact is checked with the operating-system Authenticode verification API during the production build. A configured signing state whose produced file does not report a valid signature fails the job.
 
 End users can inspect a downloaded artifact with:
 
@@ -46,28 +65,32 @@ End users can inspect a downloaded artifact with:
 Get-AuthenticodeSignature .\Ghost-FTP-1.0.0-Setup-x64.exe | Format-List
 ```
 
-Also verify the file against `SHA256.txt` from the same official release.
+If `BUILD-METADATA.txt` says `WINDOWS_AUTHENTICODE=unsigned`, an absent trusted signature is expected. In both cases, verify the file against `SHA256.txt` from the same official GitHub Release.
+
+## Windows warnings for unsigned builds
+
+Unsigned Windows executables may produce SmartScreen or publisher warnings depending on Windows reputation and local policy. Ghost FTP does not recommend bypassing enterprise or operating-system security policy. A future CA-issued certificate can be added through protected secrets without changing the artifact naming/versioning contract.
 
 ## Development signing smoke test
 
 CI can create a short-lived development code-signing certificate to validate the signing pipeline mechanically. That certificate is a test fixture and must never be represented as the trusted production publisher identity.
 
-The development smoke test exists to catch broken signing scripts and PE-signature plumbing before the protected production job.
+The development smoke test exists to catch broken signing scripts and PE-signature plumbing independently from production certificate availability.
 
 ## Timestamping
 
-When the production timestamp URL is configured, signing uses it according to the build script policy. A timestamp service is not an application telemetry endpoint; it is used only during release signing by the CI runner.
+When a production timestamp URL is configured, signing uses it according to the build script policy. A timestamp service is not an application telemetry endpoint; it is used only during release signing by the CI runner.
 
 ## Linux integrity
 
-Linux DEB packages do not inherit Windows Authenticode. Their direct GitHub Release integrity is established through exact source/release provenance, DEB metadata checks and `SHA256.txt`. A future repository-signing model would require its own protected key, rotation and revocation policy.
+Linux DEB packages do not use Windows Authenticode. Their direct GitHub Release integrity is established through exact source/release provenance, DEB metadata checks and `SHA256.txt`. A future repository-signing model would require its own protected key, rotation and revocation policy.
 
 ## Failure policy
 
-Do not weaken the stable gate because signing secrets are unavailable. Fix the protected release configuration and rerun the exact release candidate. A stable release must not be made “green” by relabeling an unsigned binary as signed.
+Do not create or commit a self-signed production identity just to make a release appear signed. If a real Authenticode certificate is configured, verification is fail-closed. If it is not configured, publication remains truthfully unsigned and all release metadata/checksums continue to identify that state.
 
 ## Packages
 
-The GHCR distribution bundle contains already-built verified release files. The PFX/password are not part of the bundle context. Package metadata may state whether Windows artifacts were signed, but it never carries the signing key.
+The GHCR distribution bundle contains already-built verified release files. PFX/password material is never part of the bundle context. Package metadata records whether Windows artifacts were signed, but it never carries the signing key.
 
 See [Release verification](RELEASE-VERIFICATION.md), [Security](SECURITY.md) and [Packages](PACKAGES.md).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Ghost FTP testing and quality gates
 
-Ghost FTP **1.0.0 Stable** is release-ready only when source tests, audits, native production builds, signing checks and distribution read-back all pass for the exact release revision.
+Ghost FTP **1.0.0 Stable** is release-ready only when source tests, audits, native production builds, signing-state checks and distribution read-back all pass for the exact release revision.
 
 ## Continuous integration
 
@@ -78,7 +78,7 @@ Portable x86
 
 The release assembly also creates the byte-identical x32 Setup compatibility alias from x86.
 
-CI validates executable/package metadata and runs the development Authenticode pipeline smoke test. Stable publication then requires the protected trusted Authenticode identity in the release workflow.
+CI validates executable/package metadata and runs the development Authenticode pipeline smoke test with a short-lived development certificate. Production publication does not convert that test identity into a trusted publisher. When real protected Authenticode secrets are configured, the release workflow signs and verifies each Windows artifact; when they are absent, the release is explicitly marked unsigned.
 
 ## Linux production gate
 
@@ -116,6 +116,8 @@ The assembled GitHub Release contains **9 platform artifacts** and **12 public f
 
 Before and after publication, the workflow verifies that `main` is still the exact release commit and that an existing version tag is not being rewritten.
 
+The release gate also validates that `WINDOWS_SIGNING_STATE` is either `signed` or `unsigned`. A configured signing identity that does not produce valid signatures fails. Absence of a production certificate does not fail the release; it is carried through as `WINDOWS_AUTHENTICODE=unsigned` in release metadata.
+
 ## GitHub Packages gate
 
 Stable releases publish:
@@ -128,6 +130,6 @@ The OCI distribution bundle is built from `FROM scratch`, copies only `release/`
 
 ## Release-readiness rule
 
-A source branch that merely compiles is not a release. Stable readiness requires all automated gates plus exact artifact/signing/package/release verification on the final source revision.
+A source branch that merely compiles is not a release. Stable readiness requires all automated gates plus exact artifact/signing-state/package/release verification on the final source revision.
 
 See [Release verification](RELEASE-VERIFICATION.md), [Security](SECURITY.md), [Privacy](PRIVACY.md) and [Packages](PACKAGES.md).

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -64,8 +64,10 @@ def main() -> int:
         "GHOSTFTP_SIGNING_PFX_BASE64",
         "GHOSTFTP_SIGNING_PASSWORD",
         "GHOSTFTP_SIGNING_TIMESTAMP_URL",
+        "state=unsigned",
+        "state=signed",
+        "Publishing Stable with explicitly unsigned Windows artifacts",
         "WINDOWS_AUTHENTICODE=${WINDOWS_SIGNING_STATE}",
-        "Stable Windows releases require a configured trusted Authenticode identity.",
         "python scripts/audit_platform_contract.py",
         "python scripts/audit_desktop_surface.py",
         "Ghost-FTP-${VERSION}-Portable-x64.exe",
@@ -96,6 +98,11 @@ def main() -> int:
     ):
         if forbidden in lowered:
             fail(f"release workflow contains retired publication/platform marker: {forbidden}")
+
+    if "Stable Windows releases require a configured trusted Authenticode identity." in workflow:
+        fail("stable release workflow still blocks publication solely because Authenticode secrets are absent")
+    if "New-DevCodeSigningCertificate.ps1" in workflow:
+        fail("production release workflow must not create a self-signed publisher identity")
 
     # Stable package aliases must never be emitted by the pre-1.0 branch of the channel switch.
     stable_package_pos = workflow.find("Publish stable bundle to GitHub Packages")
@@ -173,7 +180,9 @@ def main() -> int:
     print("PRE_1_0_CHANNEL=BETA")
     print("FIRST_STABLE_VERSION=1.0.0")
     print("AUTHENTICODE_PRIVATE_KEY_IN_REPOSITORY=BLOCKED")
-    print("STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES")
+    print("STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
+    print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
+    print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("PUBLIC_PLATFORM_ARTIFACTS=9")
     print("PUBLIC_RELEASE_FILES=12")
     print("WINDOWS_PORTABLE=x64,x86")

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -80,7 +80,7 @@ Release contract
 
 Signing and trust
 -----------------
-The workflow never fabricates publisher identities. Stable Windows publication requires the configured trusted Authenticode identity. Release signing secrets are supplied only through protected GitHub Actions secrets and are removed from the runner after use. Always verify SHA256.txt before installation or deployment.
+The workflow never fabricates publisher identities. Production Authenticode signing is optional: when a protected trusted certificate is configured, Windows artifacts are signed and verified; when it is not configured, the release remains explicitly unsigned and BUILD-METADATA.txt records WINDOWS_AUTHENTICODE=unsigned. Never treat a locally generated or self-signed certificate as a trusted public publisher identity. Always verify SHA256.txt and the official GitHub release location before installation or deployment.
 
 Privacy
 -------

--- a/scripts/test_maintenance.py
+++ b/scripts/test_maintenance.py
@@ -68,6 +68,18 @@ class MaintenanceRegressionTests(unittest.TestCase):
         self.assertIn("gh release create", workflow)
         self.assertLess(workflow.index("main moved from release commit"), workflow.index("gh release create"))
 
+    def test_stable_release_allows_truthfully_unsigned_windows(self) -> None:
+        workflow = read(".github/workflows/release.yml")
+        signing = read("docs/SIGNING.md")
+        self.assertIn("state=unsigned", workflow)
+        self.assertIn("state=signed", workflow)
+        self.assertIn("Publishing Stable with explicitly unsigned Windows artifacts", workflow)
+        self.assertIn("WINDOWS_AUTHENTICODE=${WINDOWS_SIGNING_STATE}", workflow)
+        self.assertNotIn("Stable Windows releases require a configured trusted Authenticode identity.", workflow)
+        self.assertNotIn("New-DevCodeSigningCertificate.ps1", workflow)
+        self.assertIn("WINDOWS_AUTHENTICODE=unsigned", signing)
+        self.assertIn("does **not** create a publicly trusted Windows publisher identity", signing)
+
     def test_version_history_and_current_desktop_contract(self) -> None:
         version = read("VERSION").strip()
         self.assertRegex(version, r"^\d+\.\d+\.\d+$")

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -41,7 +41,9 @@ class ReleaseNotesTests(unittest.TestCase):
             "12 public release files",
             "SHA256.txt",
             "BUILD-METADATA.txt",
-            "Stable Windows publication requires the configured trusted Authenticode identity",
+            "Production Authenticode signing is optional",
+            "WINDOWS_AUTHENTICODE=unsigned",
+            "Never treat a locally generated or self-signed certificate as a trusted public publisher identity",
             "Application telemetry: disabled",
         ):
             self.assertIn(marker, notes)


### PR DESCRIPTION
## Summary

This change removes the artificial requirement to configure a production Authenticode certificate before Ghost FTP 1.0.0 Stable can be published.

Windows code signing remains supported and fail-closed **when a real protected certificate is configured**, but certificate absence now produces a truthful unsigned release instead of blocking publication.

## Security model

- No production private key is generated or committed.
- The release workflow explicitly supports `WINDOWS_SIGNING_STATE=signed|unsigned`.
- A configured production PFX must still produce valid Authenticode signatures or the Windows job fails.
- Without signing secrets, `BUILD-METADATA.txt` records `WINDOWS_AUTHENTICODE=unsigned`.
- The production workflow is audited to reject a self-signed development publisher identity.
- The existing CI development certificate remains only a signing-pipeline smoke test.
- SHA-256, exact-head, immutable tag, Release read-back and GHCR read-back gates remain intact.

## Documentation and regression coverage

Updated README, architecture, installation, security, testing, signing, GitHub Releases, release verification, CHANGELOG and generated release notes. Regression tests now require truthful signed/unsigned behavior and explicitly reject the old mandatory-certificate blocker.

## Release intent

After this PR passes exact-head Windows/Linux/Core CI and is merged, the existing release workflow can publish `ghostftp-v1.0.0` as a normal Stable release (`prerelease=false`) without requiring the user to create GitHub signing secrets. If a real trusted code-signing certificate is added later, the same pipeline will automatically sign and verify Windows artifacts.