### PR TITLE
Ghost FTP 1.0.0 — post-release documentation and policy consistency

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -85,7 +85,8 @@ All local links must pass `scripts/audit_docs.py`.
 
 Changes to `.github/workflows/release.yml`, packaging or signing must preserve fail-closed behavior:
 
-- stable Windows Authenticode gate;
+- truthful Windows signing state: verify a configured trusted Authenticode identity fail-closed, otherwise preserve explicit `WINDOWS_AUTHENTICODE=unsigned` metadata;
+- never generate or present a self-signed development certificate as the trusted production publisher identity;
 - exact `main` commit binding;
 - immutable version tags;
 - explicit 9-platform-artifact / 12-public-file allow-list;
@@ -93,6 +94,8 @@ Changes to `.github/workflows/release.yml`, packaging or signing must preserve f
 - GitHub Release read-back;
 - stable GitHub Package/GHCR distribution-bundle read-back;
 - no release secret material inside artifacts.
+
+A missing production code-signing certificate alone is not a release failure. A partially configured certificate or an invalid signature when signing is configured **is** a release failure.
 
 ## Pull request expectations
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -42,7 +42,10 @@ Every stable package is produced only after the same release quality gates used 
 - Linux amd64/arm64/i386 DEB builds;
 - release asset allow-list verification;
 - SHA-256 manifest generation;
-- trusted Authenticode requirement for stable Windows publication.
+- Authenticode verification **when a trusted production certificate is configured**;
+- explicit `WINDOWS_AUTHENTICODE=unsigned` metadata when no production certificate is configured.
+
+Production signing is optional, but its state is never ambiguous. A configured trusted signing identity is verified fail-closed; absence of a production certificate does not cause Ghost FTP to fabricate a self-signed publisher identity or label unsigned files as signed.
 
 The OCI package carries repository source, version and commit labels. The release workflow performs a registry read-back with `docker buildx imagetools inspect` after push.
 
@@ -62,6 +65,7 @@ For high-assurance automation:
 2. pin the digest in downstream automation;
 3. extract `/ghostftp-release/SHA256.txt`;
 4. verify every release file before use;
-5. compare the expected source commit with `BUILD-METADATA.txt` and the OCI revision label.
+5. compare the expected source commit with `BUILD-METADATA.txt` and the OCI revision label;
+6. inspect `WINDOWS_AUTHENTICODE` before interpreting Windows publisher-signature state.
 
-This provides two independent integrity references: the OCI manifest digest and the per-file SHA-256 manifest.
+This provides two independent integrity references: the OCI manifest digest and the per-file SHA-256 manifest, plus an explicit signing-state declaration for Windows artifacts.

--- a/docs/PLATFORM-PARITY.md
+++ b/docs/PLATFORM-PARITY.md
@@ -57,7 +57,7 @@ Windows provides richer native keyboard/sorting behavior; Linux maintains equiva
 
 Windows uses native Win32 UI, per-monitor layout handling, native dialogs and the current-user Windows saved-secret protection boundary. Production packages include x64/x86 Setup and Portable binaries.
 
-Stable Windows publication requires the trusted protected Authenticode release identity.
+Production Authenticode is optional. When a trusted protected signing identity is configured, every generated Windows artifact must verify successfully; when it is absent, official Stable publication remains explicitly unsigned and records `WINDOWS_AUTHENTICODE=unsigned`. A generated/self-signed development certificate is never substituted for the trusted production publisher identity.
 
 ## Linux-specific implementation
 
@@ -75,6 +75,8 @@ The production workflow independently builds/verifies both platform families bef
 
 The GitHub Release contains **9 platform artifacts** across Windows/Linux and **12 public files** total. The stable GHCR package mirrors the verified assembled release directory and does not introduce a third application implementation.
 
+Signing parity is represented truthfully rather than forced: a configured Windows production signature is verified fail-closed, while an unsigned Windows release is allowed only when release metadata states that unsigned status explicitly. Linux integrity continues to use exact build provenance, package metadata and SHA-256 verification rather than Windows Authenticode.
+
 ## Definition of parity complete
 
 A cross-platform feature is complete when:
@@ -86,4 +88,4 @@ A cross-platform feature is complete when:
 5. platform tests and production builds pass;
 6. documentation describes only capabilities actually maintained on both platforms or clearly labels a platform-specific difference.
 
-See [Architecture](ARCHITECTURE.md), [Testing](TESTING.md) and [Security](SECURITY.md).
+See [Architecture](ARCHITECTURE.md), [Testing](TESTING.md), [Signing](SIGNING.md) and [Security](SECURITY.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@ The stable gate includes:
 - 24-language local catalog with English default/fallback;
 - production race/vet/security/privacy/dependency/documentation audits;
 - normal stable GitHub Release publication with `prerelease=false`;
+- truthful Windows signing-state metadata with fail-closed verification when trusted production signing is configured;
 - stable GitHub Packages/GHCR distribution-bundle publication and read-back.
 
 ## 1.0.x priorities
@@ -60,7 +61,8 @@ Future work must preserve:
 - local path containment and symlink/reparse safety;
 - fail-closed transfer cleanup/commit behavior;
 - exact source/version binding for public releases;
-- stable Windows signing gate;
+- truthful Windows signing states: configured trusted signatures verify fail-closed, otherwise Stable publication remains explicitly `WINDOWS_AUTHENTICODE=unsigned`;
+- no generated/self-signed production identity represented as a trusted publisher;
 - verified GitHub Release and GitHub Package publication;
 - no unreviewed external Go dependencies.
 
@@ -78,6 +80,8 @@ Optimization work should target measured hotspots:
 ## Security/privacy direction
 
 Security hardening should favor deterministic rejection and actionable errors over permissive fallback. Privacy improvements should reduce secret lifetime and diagnostic exposure rather than adding remote reporting.
+
+Release security should improve publisher trust when a real certificate is available without weakening integrity verification or inventing trust when it is not.
 
 ## Definition of roadmap completion
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -9,9 +9,11 @@ https://github.com/bren-wp/Ghost-FTP/issues
 1. confirm the installed version and architecture;
 2. confirm the file came from the official stable GitHub Release;
 3. verify `SHA256.txt`;
-4. on Windows, verify the Authenticode signature;
+4. on Windows, inspect `WINDOWS_AUTHENTICODE` in `BUILD-METADATA.txt`; verify Authenticode when it says `signed`, or record that the official file is explicitly `unsigned` when it says `unsigned`;
 5. confirm the intended protocol (FTP, FTPS or SFTP), host and port;
 6. reproduce with the smallest safe example possible.
+
+An unsigned Stable artifact is not automatically a corrupted artifact. Its integrity must still match the official tag/release location and SHA-256 manifest. Conversely, if metadata says `signed` and Windows signature verification fails, treat that as a release-integrity problem.
 
 ## Bug report information
 
@@ -20,6 +22,7 @@ Include:
 - Ghost FTP version/tag;
 - Windows or Linux and architecture;
 - Setup/Portable/DEB package used;
+- Windows signing state from `BUILD-METADATA.txt` when relevant;
 - protocol and authentication type;
 - exact reproduction steps;
 - expected vs actual behavior;
@@ -48,7 +51,7 @@ For SFTP host-key problems, provide only the public fingerprint if it is safe to
 
 ## Release/package problems
 
-For GitHub Release issues include the exact filename and SHA-256 value.
+For GitHub Release issues include the exact filename and SHA-256 value. For Windows artifacts also include only the public signing status (`signed`/`unsigned`) and signature-verification result when applicable; never share certificate private material or Actions secrets.
 
 For GitHub Packages issues include the semantic tag/digest for:
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -73,9 +73,11 @@ Source entry points retain `version = "dev"` and receive production versions onl
 
 ## Stable GitHub Release rule
 
-For `MAJOR >= 1`, the publication workflow selects the stable channel and does not apply the GitHub prerelease flag. A stable Windows release is blocked unless the protected trusted Authenticode identity is configured and the produced files verify successfully.
+For `MAJOR >= 1`, the publication workflow selects the stable channel and does not apply the GitHub prerelease flag. The official stable release must point to the exact `main` commit that passed release quality gates.
 
-The official stable release must point to the exact `main` commit that passed release quality gates.
+Windows Authenticode is an **optional production hardening layer**, not a prerequisite for stable version identity. When a trusted production PFX is configured through protected Actions secrets, every produced Windows artifact must verify successfully or publication fails. When no production certificate is configured, stable publication may continue only with an explicit `WINDOWS_AUTHENTICODE=unsigned` declaration in `BUILD-METADATA.txt`.
+
+Ghost FTP never generates a self-signed production certificate and presents it as a trusted publisher identity.
 
 ## GitHub Packages versioning
 
@@ -102,9 +104,13 @@ The release workflow rejects:
 - a malformed semantic version;
 - a manual version different from `VERSION`;
 - an existing release tag that points to a different commit;
-- a stable release whose Windows signing state is not trusted/configured;
+- a partially configured production signing identity;
+- a configured signing identity whose produced Windows signatures do not verify;
+- any attempt to substitute a generated/self-signed production identity for a trusted publisher certificate;
 - release output whose expected asset set is incomplete;
 - release/package read-back failures.
+
+Absence of a production Authenticode certificate by itself is not a versioning failure. The resulting Windows signing state must instead remain truthfully `unsigned` throughout build metadata, documentation and verification.
 
 ## Changelog and release notes
 
@@ -124,7 +130,7 @@ Ghost FTP 1.0.0 is considered release-ready only when the exact candidate passes
 - localization checks;
 - security/privacy/dependency/repository audits;
 - release asset allow-list and SHA-256 verification;
-- stable Authenticode gate;
+- Authenticode verification when a trusted production certificate is configured, or explicit unsigned metadata when it is absent;
 - GitHub Release normal-release verification;
 - stable GitHub Package publication/read-back;
 - current documentation/support/license synchronization.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,7 +39,9 @@ Historical tags are immutable and are not reused for another commit. `1.0.0` and
 
 Production workflows disable Go telemetry, use `GOTOOLCHAIN=local`, `GOPROXY=off` and `GOSUMDB=off`, and build Windows and Linux from the exact source revision. Public artifacts are assembled only after the platform and quality gates pass, then checksummed in `SHA256.txt`.
 
-Stable Windows publication additionally requires the protected trusted Authenticode identity. The repository must never contain the production private key or password.
+Windows production signing is optional. If protected trusted Authenticode credentials are configured, the workflow must sign and verify the Windows artifacts fail-closed. If no production certificate is configured, the release remains explicitly `WINDOWS_AUTHENTICODE=unsigned`. A partially configured signing identity is an error, and a self-signed development certificate must never be substituted for a trusted production publisher identity.
+
+The repository must never contain the production private key or password.
 
 The GitHub Packages distribution bundle is built with network access disabled from only the already verified `release/` directory. Source worktrees, user data and release secrets must not be copied into that package.
 
@@ -53,6 +55,8 @@ Before publication the maintained workflow and audits verify, as applicable:
 - security, privacy, dependency, version, localization and documentation contracts;
 - Windows x64/x86 Setup and Portable production builds;
 - Linux amd64/arm64/i386 package metadata;
+- Authenticode verification when a trusted production identity is configured;
+- explicit unsigned release metadata when no production certificate is configured;
 - the exact 9-platform-artifact / 12-public-file release set;
 - stable `prerelease=false` state;
 - GitHub Release read-back;

--- a/scripts/audit_docs.py
+++ b/scripts/audit_docs.py
@@ -17,10 +17,12 @@ CURRENT_RELEASE_RE = re.compile(r"\*\*Current Ghost FTP release:\s*(\d+\.\d+\.\d
 IGNORED_PREFIXES = ("http://", "https://", "mailto:", "data:", "//", "#")
 RETIRED_ACTIVE_MARKERS = ("android/", "ios/", "macos/", "ghostftp web/", "web companion", "pwa")
 STALE_SIGNING_POLICY_MARKERS = (
-    "trusted Authenticode requirement for stable Windows publication",
-    "A stable Windows release is blocked unless",
-    "stable release whose Windows signing state is not trusted/configured",
-    "stable Authenticode gate",
+    "trusted authenticode requirement for stable windows publication",
+    "a stable windows release is blocked unless",
+    "stable release whose windows signing state is not trusted/configured",
+    "stable windows authenticode gate",
+    "stable windows publication requires",
+    "stable windows publication additionally requires",
 )
 ACTIVE_DOCS = (
     "README.md",
@@ -130,7 +132,7 @@ def main() -> int:
             if marker in lowered:
                 fail(f"retired application surface appears in active guidance: {rel} -> {marker}")
         for marker in STALE_SIGNING_POLICY_MARKERS:
-            if marker in text:
+            if marker in lowered:
                 fail(f"stale mandatory-signing policy appears in active guidance: {rel} -> {marker}")
 
     for marker in ("Windows", "Linux", "24", "FTP", "FTPS", "SFTP"):
@@ -148,6 +150,8 @@ def main() -> int:
         "SFTP key passphrase",
         "24-language",
         "same typed `internal/api.Engine`",
+        "Production Authenticode is optional.",
+        "WINDOWS_AUTHENTICODE=unsigned",
     ):
         if marker not in parity:
             fail(f"platform parity documentation missing marker: {marker}")
@@ -180,6 +184,24 @@ def main() -> int:
     ):
         if marker not in packages:
             fail(f"packages documentation missing marker: {marker}")
+
+    contributing = (DOCS / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    for marker in (
+        "truthful Windows signing state",
+        "WINDOWS_AUTHENTICODE=unsigned",
+        "A missing production code-signing certificate alone is not a release failure.",
+    ):
+        if marker not in contributing:
+            fail(f"contributing documentation missing signing marker: {marker}")
+
+    scripts_readme = (ROOT / "scripts/README.md").read_text(encoding="utf-8")
+    for marker in (
+        "Windows production signing is optional.",
+        "WINDOWS_AUTHENTICODE=unsigned",
+        "self-signed development certificate must never be substituted",
+    ):
+        if marker not in scripts_readme:
+            fail(f"scripts README missing signing marker: {marker}")
 
     signing = (DOCS / "SIGNING.md").read_text(encoding="utf-8")
     for marker in (

--- a/scripts/audit_docs.py
+++ b/scripts/audit_docs.py
@@ -16,6 +16,12 @@ HTML_LINK_RE = re.compile(r"\b(?:href|src)\s*=\s*[\"']([^\"']+)[\"']", re.IGNORE
 CURRENT_RELEASE_RE = re.compile(r"\*\*Current Ghost FTP release:\s*(\d+\.\d+\.\d+)\*\*")
 IGNORED_PREFIXES = ("http://", "https://", "mailto:", "data:", "//", "#")
 RETIRED_ACTIVE_MARKERS = ("android/", "ios/", "macos/", "ghostftp web/", "web companion", "pwa")
+STALE_SIGNING_POLICY_MARKERS = (
+    "trusted Authenticode requirement for stable Windows publication",
+    "A stable Windows release is blocked unless",
+    "stable release whose Windows signing state is not trusted/configured",
+    "stable Authenticode gate",
+)
 ACTIVE_DOCS = (
     "README.md",
     "docs/README.md",
@@ -118,10 +124,14 @@ def main() -> int:
         path = ROOT / rel
         if not path.is_file():
             fail(f"missing active document: {rel}")
-        lowered = path.read_text(encoding="utf-8").lower()
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
         for marker in RETIRED_ACTIVE_MARKERS:
             if marker in lowered:
                 fail(f"retired application surface appears in active guidance: {rel} -> {marker}")
+        for marker in STALE_SIGNING_POLICY_MARKERS:
+            if marker in text:
+                fail(f"stale mandatory-signing policy appears in active guidance: {rel} -> {marker}")
 
     for marker in ("Windows", "Linux", "24", "FTP", "FTPS", "SFTP"):
         if marker not in readme:
@@ -143,7 +153,18 @@ def main() -> int:
             fail(f"platform parity documentation missing marker: {marker}")
 
     versioning = (DOCS / "VERSIONING.md").read_text(encoding="utf-8")
-    for marker in ("0.1.0", "0.x.y", "Beta", "Stable", "1.0.0", "Setup", "Portable"):
+    for marker in (
+        "0.1.0",
+        "0.x.y",
+        "Beta",
+        "Stable",
+        "1.0.0",
+        "Setup",
+        "Portable",
+        "optional production hardening layer",
+        "WINDOWS_AUTHENTICODE=unsigned",
+        "Absence of a production Authenticode certificate by itself is not a versioning failure.",
+    ):
         if marker not in versioning:
             fail(f"versioning documentation missing marker: {marker}")
 
@@ -154,9 +175,30 @@ def main() -> int:
         "not a runtime container",
         "/ghostftp-release/",
         "SHA256.txt",
+        "Authenticode verification **when a trusted production certificate is configured**",
+        "WINDOWS_AUTHENTICODE=unsigned",
     ):
         if marker not in packages:
             fail(f"packages documentation missing marker: {marker}")
+
+    signing = (DOCS / "SIGNING.md").read_text(encoding="utf-8")
+    for marker in (
+        "supports Windows Authenticode signing as an optional production hardening layer",
+        "WINDOWS_AUTHENTICODE=signed",
+        "WINDOWS_AUTHENTICODE=unsigned",
+        "production workflow never creates its own long-lived publisher key",
+    ):
+        if marker not in signing:
+            fail(f"signing documentation missing marker: {marker}")
+
+    release_verification = (DOCS / "RELEASE-VERIFICATION.md").read_text(encoding="utf-8")
+    for marker in (
+        "truthful supported publication state",
+        "does not create a self-signed production identity",
+        "explicit unsigned metadata when no production certificate is configured",
+    ):
+        if marker not in release_verification:
+            fail(f"release verification documentation missing signing marker: {marker}")
 
     print(f"DOCS_AUDIT=PASS ({version}; {len(files)} Markdown files)")
     print("PUBLIC_BRAND=Ghost FTP")
@@ -164,6 +206,9 @@ def main() -> int:
     print("PRE_1_0_CHANNEL=BETA")
     print("FIRST_STABLE_VERSION=1.0.0")
     print("STABLE_GITHUB_RELEASE_PRERELEASE=FALSE")
+    print("STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
+    print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
+    print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("PUBLIC_PLATFORM_ARTIFACTS=9")
     print("PUBLIC_RELEASE_FILES=12")
     print("STABLE_GITHUB_PACKAGE=ghcr.io/bren-wp/ghost-ftp")

--- a/scripts/audit_docs.py
+++ b/scripts/audit_docs.py
@@ -21,6 +21,7 @@ STALE_SIGNING_POLICY_MARKERS = (
     "a stable windows release is blocked unless",
     "stable release whose windows signing state is not trusted/configured",
     "stable windows authenticode gate",
+    "stable windows signing gate",
     "stable windows publication requires",
     "stable windows publication additionally requires",
 )
@@ -193,6 +194,24 @@ def main() -> int:
     ):
         if marker not in contributing:
             fail(f"contributing documentation missing signing marker: {marker}")
+
+    roadmap = (DOCS / "ROADMAP.md").read_text(encoding="utf-8")
+    for marker in (
+        "truthful Windows signing-state metadata",
+        "WINDOWS_AUTHENTICODE=unsigned",
+        "no generated/self-signed production identity represented as a trusted publisher",
+    ):
+        if marker not in roadmap:
+            fail(f"roadmap documentation missing signing marker: {marker}")
+
+    support = (DOCS / "SUPPORT.md").read_text(encoding="utf-8")
+    for marker in (
+        "inspect `WINDOWS_AUTHENTICODE` in `BUILD-METADATA.txt`",
+        "official file is explicitly `unsigned`",
+        "if metadata says `signed` and Windows signature verification fails",
+    ):
+        if marker not in support:
+            fail(f"support documentation missing signing-state guidance: {marker}")
 
     scripts_readme = (ROOT / "scripts/README.md").read_text(encoding="utf-8")
     for marker in (

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -66,7 +66,29 @@ def main() -> int:
             fail("1.0.0 README must explicitly identify the first stable release")
 
     versioning = read("docs/VERSIONING.md")
-    require(versioning, ("0.1.0", "0.x.y", "1.0.0", "Beta", "Stable", "Portable", "Setup"), "docs/VERSIONING.md")
+    require(
+        versioning,
+        (
+            "0.1.0",
+            "0.x.y",
+            "1.0.0",
+            "Beta",
+            "Stable",
+            "Portable",
+            "Setup",
+            "optional production hardening layer",
+            "WINDOWS_AUTHENTICODE=unsigned",
+            "Absence of a production Authenticode certificate by itself is not a versioning failure.",
+        ),
+        "docs/VERSIONING.md",
+    )
+    for stale in (
+        "A stable Windows release is blocked unless",
+        "stable release whose Windows signing state is not trusted/configured",
+        "stable Authenticode gate",
+    ):
+        if stale in versioning:
+            fail(f"docs/VERSIONING.md contains stale mandatory-signing policy: {stale}")
 
     windows_build = read("BUILD-WINDOWS.ps1")
     require(windows_build, ("Get-Content -LiteralPath $versionFile", "-X main.version=$version"), "BUILD-WINDOWS.ps1")
@@ -105,12 +127,25 @@ def main() -> int:
         "packages: write",
         "ghcr.io/${owner}/ghost-ftp",
         "if: env.RELEASE_CHANNEL == 'stable'",
+        "state=unsigned",
+        "state=signed",
+        "Publishing Stable with explicitly unsigned Windows artifacts",
         "PUBLIC_PLATFORM_ARTIFACTS=9",
         "PUBLIC_RELEASE_FILES=12",
     ), ".github/workflows/release.yml")
+    if "Stable Windows releases require a configured trusted Authenticode identity." in release_workflow:
+        fail("release workflow contradicts the supported explicit-unsigned stable state")
+    if "New-DevCodeSigningCertificate.ps1" in release_workflow:
+        fail("production release workflow must not generate a self-signed publisher identity")
 
     require(read("scripts/audit_platform_contract.py"), ("ACTIVE_APPLICATION_PLATFORMS=WINDOWS,LINUX", "RETIRED_APPLICATION_SURFACES=WEB,PWA"), "scripts/audit_platform_contract.py")
-    require(read("scripts/audit_release.py"), ("PUBLIC_PLATFORM_ARTIFACTS=9", "PUBLIC_RELEASE_FILES=12", "STABLE_GHCR_BUNDLE=REQUIRED"), "scripts/audit_release.py")
+    require(read("scripts/audit_release.py"), (
+        "PUBLIC_PLATFORM_ARTIFACTS=9",
+        "PUBLIC_RELEASE_FILES=12",
+        "STABLE_GHCR_BUNDLE=REQUIRED",
+        "STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO",
+        "TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED",
+    ), "scripts/audit_release.py")
 
     bug_template = read(".github/ISSUE_TEMPLATE/bug_report.yml")
     if re.search(r"(?m)^\s*placeholder:\s*['\"]\d+\.\d+\.\d+['\"]", bug_template):
@@ -130,6 +165,9 @@ def main() -> int:
     print("PRE_1_0_CHANNEL=BETA")
     print("FIRST_STABLE_VERSION=1.0.0")
     print("STABLE_RELEASE_PRERELEASE_FLAG=FALSE")
+    print("STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
+    print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
+    print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("STABLE_GITHUB_PACKAGE=GHCR_RELEASE_BUNDLE")
     return 0
 


### PR DESCRIPTION
## Authorization

- [x] This maintenance change was explicitly requested/authorized for Ghost FTP.
- [x] Existing proprietary/source-available license and product identity are preserved.

## Summary

Post-release consistency pass for the already-published **Ghost FTP 1.0.0 Stable** baseline. This PR does not change application binaries or the published release identity.

### Fixed

- aligns `docs/PACKAGES.md` with the actual Authenticode policy: trusted production signing is verified when configured; otherwise Stable publication remains explicitly `WINDOWS_AUTHENTICODE=unsigned`;
- corrects `docs/VERSIONING.md`, which still contained obsolete wording that Stable publication was blocked without a trusted PFX;
- strengthens `scripts/audit_docs.py` to reject obsolete mandatory-signing language across active documentation and require the truthful signed/unsigned contract;
- strengthens `scripts/audit_version.py` so version policy cannot drift back to a fake certificate requirement;
- preserves the rule that production never generates a self-signed certificate and presents it as a trusted publisher identity.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or hidden network destination added.
- [x] No credentials, private signing keys or customer data added.
- [x] SFTP/FTPS/FTP runtime behavior is unchanged.
- [x] No external Go module added.
- [x] Windows/Linux-only shipping scope is unchanged.

## Release behavior

`VERSION` remains `1.0.0` and `.github/workflows/release.yml` is unchanged. The Release workflow is path-filtered to `VERSION` and `.github/workflows/release.yml`, so this documentation/audit maintenance merge cannot rewrite or republish the existing `ghostftp-v1.0.0` Stable release.

## Validation

Normal PR CI must pass the Core quality/security/docs gate plus Windows x64/x86 and Linux amd64/arm64/i386 production builds before merge. The strengthened audits are themselves part of that gate.