### PR TITLE
Forget Linux SFTP secrets when sessions close

### DIFF
--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -458,6 +458,8 @@ func (s *SFTP) Close() error {
 			errs = append(errs, err)
 		}
 	}
+	security.ForgetProtectedSecret(s.passwordBlob)
+	security.ForgetProtectedSecret(s.passphraseBlob)
 	s.passwordBlob = ""
 	s.passphraseBlob = ""
 	s.host = ""

--- a/internal/remote/sftp_secret_lifetime_linux_test.go
+++ b/internal/remote/sftp_secret_lifetime_linux_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+func requireProtectedSecretAvailable(t *testing.T, blob string) {
+	t.Helper()
+	plain, err := security.UnprotectBytes(blob)
+	if err != nil {
+		t.Fatalf("protected secret should be available before SFTP close: %v", err)
+	}
+	security.WipeBytes(plain)
+}
+
+func requireProtectedSecretForgotten(t *testing.T, blob string) {
+	t.Helper()
+	plain, err := security.UnprotectBytes(blob)
+	if err == nil {
+		security.WipeBytes(plain)
+		t.Fatal("protected secret remained available after SFTP close")
+	}
+}
+
+func TestSFTPCloseForgetsLinuxProtectedSecrets(t *testing.T) {
+	passwordBlob, err := security.ProtectString("sftp-password-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passwordBlob)
+
+	passphraseBlob, err := security.ProtectString("sftp-passphrase-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passphraseBlob)
+
+	requireProtectedSecretAvailable(t, passwordBlob)
+	requireProtectedSecretAvailable(t, passphraseBlob)
+
+	s := &SFTP{passwordBlob: passwordBlob, passphraseBlob: passphraseBlob}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if s.passwordBlob != "" || s.passphraseBlob != "" {
+		t.Fatal("SFTP close did not clear protected secret handles")
+	}
+
+	requireProtectedSecretForgotten(t, passwordBlob)
+	requireProtectedSecretForgotten(t, passphraseBlob)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("SFTP close should remain idempotent: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- forget process-owned protected SFTP password/passphrase blobs when an SFTP session closes
- keep Windows behavior unchanged because `ForgetProtectedSecret` is intentionally a DPAPI no-op there
- add a Linux regression test proving protected secrets are retrievable before `Close()`, unavailable immediately after `Close()`, handles are cleared, and repeated close remains safe

## Why

On Linux, protected SFTP credentials are held by the process-local secret broker. `SFTP.Close()` previously cleared only the blob/token strings, leaving the corresponding secret bytes in the broker until its TTL expired. This change shortens credential lifetime to the actual SFTP session lifetime.

## Release integrity

- no VERSION change
- no release workflow change
- no dependency change
- no telemetry/network service change
- no platform expansion
- Ghost FTP 1.0.0 release/tag/package remain untouched
