### PR TITLE
Track SFTP protected-secret ownership

### DIFF
--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -23,13 +23,13 @@ import (
 const maxPrivateKeySize = 1 << 20
 
 type SFTP struct {
-	host                               string
-	port                               int
-	passwordBlob, passphraseBlob       string
+	host                                 string
+	port                                 int
+	passwordBlob, passphraseBlob         string
 	ownsPasswordBlob, ownsPassphraseBlob bool
-	knownHosts, sshConfig, sessionHost string
-	privateKeyCopy                     string
-	exePath, sftp                      string
+	knownHosts, sshConfig, sessionHost   string
+	privateKeyCopy                       string
+	exePath, sftp                        string
 }
 
 func windowsOpenSSHCandidates(systemDir, arch, name string) []string {

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -26,6 +26,7 @@ type SFTP struct {
 	host                               string
 	port                               int
 	passwordBlob, passphraseBlob       string
+	ownsPasswordBlob, ownsPassphraseBlob bool
 	knownHosts, sshConfig, sessionHost string
 	privateKeyCopy                     string
 	exePath, sftp                      string
@@ -412,21 +413,35 @@ func newSFTPWithProtectedSecrets(host string, port int, username, password, pass
 	if err != nil {
 		return nil, err
 	}
+	ownsPasswordBlob := false
+	ownsPassphraseBlob := false
+	forgetOwnedSecrets := func() {
+		if ownsPasswordBlob {
+			security.ForgetProtectedSecret(passwordBlob)
+		}
+		if ownsPassphraseBlob {
+			security.ForgetProtectedSecret(passphraseBlob)
+		}
+	}
 	if password != "" {
 		passwordBlob, err = security.ProtectString(password)
 		if err != nil {
 			return nil, err
 		}
+		ownsPasswordBlob = true
 	}
 	if passphrase != "" {
 		passphraseBlob, err = security.ProtectString(passphrase)
 		if err != nil {
+			forgetOwnedSecrets()
 			return nil, err
 		}
+		ownsPassphraseBlob = true
 	}
 	sessionDir := filepath.Dir(knownHosts)
 	privateKeyCopy, err := snapshotPrivateKey(sessionDir, keyPath)
 	if err != nil {
+		forgetOwnedSecrets()
 		return nil, err
 	}
 	configKeyPath := keyPath
@@ -436,10 +451,12 @@ func newSFTPWithProtectedSecrets(host string, port int, username, password, pass
 	sshConfig, sessionHost, err := createSSHSessionConfig(sessionDir, host, port, username, configKeyPath, knownHosts, hostKeyAlgorithm, connectTimeout)
 	if err != nil {
 		_ = os.Remove(privateKeyCopy)
+		forgetOwnedSecrets()
 		return nil, err
 	}
 	return &SFTP{
 		host: host, port: port, passwordBlob: passwordBlob, passphraseBlob: passphraseBlob,
+		ownsPasswordBlob: ownsPasswordBlob, ownsPassphraseBlob: ownsPassphraseBlob,
 		knownHosts: knownHosts, sshConfig: sshConfig, sessionHost: sessionHost, privateKeyCopy: privateKeyCopy,
 		exePath: exePath, sftp: sftp,
 	}, nil
@@ -458,10 +475,16 @@ func (s *SFTP) Close() error {
 			errs = append(errs, err)
 		}
 	}
-	security.ForgetProtectedSecret(s.passwordBlob)
-	security.ForgetProtectedSecret(s.passphraseBlob)
+	if s.ownsPasswordBlob {
+		security.ForgetProtectedSecret(s.passwordBlob)
+	}
+	if s.ownsPassphraseBlob {
+		security.ForgetProtectedSecret(s.passphraseBlob)
+	}
 	s.passwordBlob = ""
 	s.passphraseBlob = ""
+	s.ownsPasswordBlob = false
+	s.ownsPassphraseBlob = false
 	s.host = ""
 	s.knownHosts = ""
 	s.sshConfig = ""

--- a/internal/remote/sftp_secret_lifetime_linux_test.go
+++ b/internal/remote/sftp_secret_lifetime_linux_test.go
@@ -12,7 +12,7 @@ func requireProtectedSecretAvailable(t *testing.T, blob string) {
 	t.Helper()
 	plain, err := security.UnprotectBytes(blob)
 	if err != nil {
-		t.Fatalf("protected secret should be available before SFTP close: %v", err)
+		t.Fatalf("protected secret should be available: %v", err)
 	}
 	security.WipeBytes(plain)
 }
@@ -22,11 +22,11 @@ func requireProtectedSecretForgotten(t *testing.T, blob string) {
 	plain, err := security.UnprotectBytes(blob)
 	if err == nil {
 		security.WipeBytes(plain)
-		t.Fatal("protected secret remained available after SFTP close")
+		t.Fatal("protected secret remained available after owner cleanup")
 	}
 }
 
-func TestSFTPCloseForgetsLinuxProtectedSecrets(t *testing.T) {
+func TestSFTPCloseForgetsOwnedLinuxProtectedSecrets(t *testing.T) {
 	passwordBlob, err := security.ProtectString("sftp-password-secret")
 	if err != nil {
 		t.Fatal(err)
@@ -42,12 +42,17 @@ func TestSFTPCloseForgetsLinuxProtectedSecrets(t *testing.T) {
 	requireProtectedSecretAvailable(t, passwordBlob)
 	requireProtectedSecretAvailable(t, passphraseBlob)
 
-	s := &SFTP{passwordBlob: passwordBlob, passphraseBlob: passphraseBlob}
+	s := &SFTP{
+		passwordBlob:       passwordBlob,
+		passphraseBlob:     passphraseBlob,
+		ownsPasswordBlob:   true,
+		ownsPassphraseBlob: true,
+	}
 	if err := s.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if s.passwordBlob != "" || s.passphraseBlob != "" {
-		t.Fatal("SFTP close did not clear protected secret handles")
+	if s.passwordBlob != "" || s.passphraseBlob != "" || s.ownsPasswordBlob || s.ownsPassphraseBlob {
+		t.Fatal("SFTP close did not clear protected secret state")
 	}
 
 	requireProtectedSecretForgotten(t, passwordBlob)
@@ -56,4 +61,26 @@ func TestSFTPCloseForgetsLinuxProtectedSecrets(t *testing.T) {
 	if err := s.Close(); err != nil {
 		t.Fatalf("SFTP close should remain idempotent: %v", err)
 	}
+}
+
+func TestSFTPClosePreservesBorrowedLinuxProtectedSecrets(t *testing.T) {
+	passwordBlob, err := security.ProtectString("profile-password-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passwordBlob)
+
+	passphraseBlob, err := security.ProtectString("profile-passphrase-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passphraseBlob)
+
+	s := &SFTP{passwordBlob: passwordBlob, passphraseBlob: passphraseBlob}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	requireProtectedSecretAvailable(t, passwordBlob)
+	requireProtectedSecretAvailable(t, passphraseBlob)
 }


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized as Ghost FTP 1.0.x hardening.
- [x] The change follows the repository license and contribution requirements.

## Summary

- make SFTP session secret ownership explicit instead of assuming every protected blob belongs to the session
- preserve borrowed protected blobs, such as credentials resolved from a saved profile, when a session closes
- still forget session-owned password/passphrase blobs immediately on close
- clean up session-owned protected blobs if SFTP construction fails after a plaintext credential has already been protected
- extend Linux regression coverage for owned vs borrowed secret lifetime and idempotent close

## Why

The previous close hardening shortened Linux SFTP secret lifetime, but `SFTP.Close()` could not distinguish a session-owned blob from a blob borrowed from a saved profile. On Linux, forgetting a borrowed broker blob on disconnect can invalidate the profile credential for a later reconnect in the same process. This PR makes ownership explicit and fail-safe.

## Security / privacy

- [x] no telemetry, analytics, advertising, tracking or hidden network destination added
- [x] no external Go dependency added
- [x] SFTP host-key verification/pinning remains unchanged
- [x] no credential is added to command-line arguments or logs

## Regression coverage

Linux tests verify that session-owned protected secrets are forgotten on close, borrowed/profile-owned secrets remain available after close, protected-secret state is cleared from the session object, and repeated close remains safe.

## Required CI

This PR must not merge unless exact-head CI passes Core quality/security/docs, Windows x64/x86 production build, and Linux amd64/arm64/i386 production build.

## Release integrity

- no `VERSION` change
- no release workflow change
- no release/tag/package publication
- `ghostftp-v1.0.0` remains untouched
- no platform expansion
