### PR TITLE
Harden SFTP pending trust credential ownership

### DIFF
--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -60,13 +60,29 @@ type Manager struct {
 }
 
 type pendingTrustState struct {
-	endpointKey    string
-	username       string
-	keyPath        string
-	fingerprint    string
-	passwordBlob   string
-	passphraseBlob string
-	expires        time.Time
+	endpointKey                            string
+	username                               string
+	keyPath                                string
+	fingerprint                            string
+	passwordBlob, passphraseBlob           string
+	ownsPasswordBlob, ownsPassphraseBlob   bool
+	expires                                time.Time
+}
+
+func (p *pendingTrustState) forgetOwnedSecrets() {
+	if p == nil {
+		return
+	}
+	if p.ownsPasswordBlob {
+		security.ForgetProtectedSecret(p.passwordBlob)
+	}
+	if p.ownsPassphraseBlob {
+		security.ForgetProtectedSecret(p.passphraseBlob)
+	}
+	p.passwordBlob = ""
+	p.passphraseBlob = ""
+	p.ownsPasswordBlob = false
+	p.ownsPassphraseBlob = false
 }
 
 func NewManager(p *config.Profiles, settings *config.SettingsStore, dataDir, exePath string) *Manager {
@@ -74,9 +90,42 @@ func NewManager(p *config.Profiles, settings *config.SettingsStore, dataDir, exe
 }
 
 type resolvedConnection struct {
-	Config         model.ConnectionConfig
-	PasswordBlob   string
-	PassphraseBlob string
+	Config                               model.ConnectionConfig
+	PasswordBlob, PassphraseBlob         string
+	ownsPasswordBlob, ownsPassphraseBlob bool
+}
+
+func (r *resolvedConnection) forgetOwnedSecrets() {
+	if r == nil {
+		return
+	}
+	if r.ownsPasswordBlob {
+		security.ForgetProtectedSecret(r.PasswordBlob)
+		r.PasswordBlob = ""
+	}
+	if r.ownsPassphraseBlob {
+		security.ForgetProtectedSecret(r.PassphraseBlob)
+		r.PassphraseBlob = ""
+	}
+	r.ownsPasswordBlob = false
+	r.ownsPassphraseBlob = false
+}
+
+// transferResolvedSecretOwnershipToSFTP moves only process-owned protected
+// secret handles whose exact blob was accepted by the constructed SFTP session.
+// Borrowed profile blobs deliberately remain profile-owned.
+func transferResolvedSecretOwnershipToSFTP(resolved *resolvedConnection, s *SFTP) {
+	if resolved == nil || s == nil {
+		return
+	}
+	if resolved.ownsPasswordBlob && resolved.PasswordBlob != "" && s.passwordBlob == resolved.PasswordBlob {
+		s.ownsPasswordBlob = true
+		resolved.ownsPasswordBlob = false
+	}
+	if resolved.ownsPassphraseBlob && resolved.PassphraseBlob != "" && s.passphraseBlob == resolved.PassphraseBlob {
+		s.ownsPassphraseBlob = true
+		resolved.ownsPassphraseBlob = false
+	}
 }
 
 // sanitizeProtocolState removes fields that have no meaning outside SFTP.
@@ -187,8 +236,15 @@ type ConnectResult struct {
 	Diagnostics   ConnectionDiagnostics `json:"diagnostics"`
 }
 
-func (m *Manager) clearPendingTrustLocked() {
+func (m *Manager) takePendingTrustLocked() pendingTrustState {
+	p := m.pendingTrust
 	m.pendingTrust = pendingTrustState{}
+	return p
+}
+
+func (m *Manager) clearPendingTrustLocked() {
+	p := m.takePendingTrustLocked()
+	p.forgetOwnedSecrets()
 }
 
 func (m *Manager) CancelPendingTrust() {
@@ -198,48 +254,72 @@ func (m *Manager) CancelPendingTrust() {
 }
 
 func (m *Manager) stashPendingTrust(cfg model.ConnectionConfig, resolved resolvedConnection, fingerprint string) error {
+	m.clearPendingTrustLocked()
 	passwordBlob := resolved.PasswordBlob
 	passphraseBlob := resolved.PassphraseBlob
+	ownsPasswordBlob := false
+	ownsPassphraseBlob := false
 	var err error
 	if cfg.Password != "" {
 		passwordBlob, err = security.ProtectString(cfg.Password)
 		if err != nil {
 			return err
 		}
+		ownsPasswordBlob = true
 	}
 	if cfg.Passphrase != "" {
 		passphraseBlob, err = security.ProtectString(cfg.Passphrase)
 		if err != nil {
+			if ownsPasswordBlob {
+				security.ForgetProtectedSecret(passwordBlob)
+			}
 			return err
 		}
+		ownsPassphraseBlob = true
 	}
 	m.pendingTrust = pendingTrustState{
-		endpointKey:    profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port),
-		username:       cfg.Username,
-		keyPath:        cfg.PrivateKeyPath,
-		fingerprint:    fingerprint,
-		passwordBlob:   passwordBlob,
-		passphraseBlob: passphraseBlob,
-		expires:        time.Now().Add(2 * time.Minute),
+		endpointKey:          profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port),
+		username:             cfg.Username,
+		keyPath:              cfg.PrivateKeyPath,
+		fingerprint:          fingerprint,
+		passwordBlob:         passwordBlob,
+		passphraseBlob:       passphraseBlob,
+		ownsPasswordBlob:     ownsPasswordBlob,
+		ownsPassphraseBlob:   ownsPassphraseBlob,
+		expires:              time.Now().Add(2 * time.Minute),
 	}
 	return nil
 }
 
 func (m *Manager) applyPendingTrust(cfg model.ConnectionConfig, resolved *resolvedConnection, fingerprint string) {
-	p := m.pendingTrust
-	m.clearPendingTrustLocked()
-	if time.Now().After(p.expires) ||
+	p := m.takePendingTrustLocked()
+	defer p.forgetOwnedSecrets()
+	if resolved == nil || time.Now().After(p.expires) ||
 		p.endpointKey != profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port) ||
 		p.username != cfg.Username ||
 		!profilebinding.PrivateKeyPathMatches(p.keyPath, cfg.PrivateKeyPath) ||
 		p.fingerprint != fingerprint {
 		return
 	}
-	if cfg.Password == "" && resolved.PasswordBlob == "" {
+	// A credential captured for the exact trust prompt belongs to that connection
+	// attempt and takes precedence over a profile blob re-resolved on confirmation.
+	// An explicitly re-entered plaintext credential on the confirmation request
+	// still wins and causes the pending owned blob to be discarded below.
+	if cfg.Password == "" && p.passwordBlob != "" {
+		if resolved.ownsPasswordBlob {
+			security.ForgetProtectedSecret(resolved.PasswordBlob)
+		}
 		resolved.PasswordBlob = p.passwordBlob
+		resolved.ownsPasswordBlob = p.ownsPasswordBlob
+		p.ownsPasswordBlob = false
 	}
-	if cfg.Passphrase == "" && resolved.PassphraseBlob == "" {
+	if cfg.Passphrase == "" && p.passphraseBlob != "" {
+		if resolved.ownsPassphraseBlob {
+			security.ForgetProtectedSecret(resolved.PassphraseBlob)
+		}
 		resolved.PassphraseBlob = p.passphraseBlob
+		resolved.ownsPassphraseBlob = p.ownsPassphraseBlob
+		p.ownsPassphraseBlob = false
 	}
 }
 
@@ -271,6 +351,9 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 		m.clearPendingTrustLocked()
 		return ConnectResult{}, err
 	}
+	defer func() {
+		resolved.forgetOwnedSecrets()
+	}()
 	cfg := resolved.Config
 	profileEndpoint := profileEndpointMatches(profile, cfg)
 	connectTimeout := m.settings.Effective().ConnectionTimeoutSeconds
@@ -328,11 +411,13 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 			}
 		}
 		hostKeyConstraint := hostKeyConstraintForScannedKey(keyAlgorithm)
-		s, err = newSFTPWithProtectedSecrets(cfg.Host, cfg.Port, cfg.Username, cfg.Password, resolved.PasswordBlob, cfg.PrivateKeyPath, cfg.Passphrase, resolved.PassphraseBlob, kh, hostKeyConstraint, m.exePath, connectTimeout)
+		sftpSession, err := newSFTPWithProtectedSecrets(cfg.Host, cfg.Port, cfg.Username, cfg.Password, resolved.PasswordBlob, cfg.PrivateKeyPath, cfg.Passphrase, resolved.PassphraseBlob, kh, hostKeyConstraint, m.exePath, connectTimeout)
 		if err != nil {
 			_ = os.Remove(kh)
 			return ConnectResult{}, err
 		}
+		transferResolvedSecretOwnershipToSFTP(&resolved, sftpSession)
+		s = sftpSession
 		cfg.Fingerprint = fp
 	} else {
 		s, err = newCurlFTPWithProtectedSecret(cfg.Protocol, cfg.Host, cfg.Port, cfg.Username, cfg.Password, resolved.PasswordBlob, connectTimeout)

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -60,13 +60,13 @@ type Manager struct {
 }
 
 type pendingTrustState struct {
-	endpointKey                            string
-	username                               string
-	keyPath                                string
-	fingerprint                            string
-	passwordBlob, passphraseBlob           string
-	ownsPasswordBlob, ownsPassphraseBlob   bool
-	expires                                time.Time
+	endpointKey                          string
+	username                             string
+	keyPath                              string
+	fingerprint                          string
+	passwordBlob, passphraseBlob         string
+	ownsPasswordBlob, ownsPassphraseBlob bool
+	expires                              time.Time
 }
 
 func (p *pendingTrustState) forgetOwnedSecrets() {
@@ -278,15 +278,15 @@ func (m *Manager) stashPendingTrust(cfg model.ConnectionConfig, resolved resolve
 		ownsPassphraseBlob = true
 	}
 	m.pendingTrust = pendingTrustState{
-		endpointKey:          profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port),
-		username:             cfg.Username,
-		keyPath:              cfg.PrivateKeyPath,
-		fingerprint:          fingerprint,
-		passwordBlob:         passwordBlob,
-		passphraseBlob:       passphraseBlob,
-		ownsPasswordBlob:     ownsPasswordBlob,
-		ownsPassphraseBlob:   ownsPassphraseBlob,
-		expires:              time.Now().Add(2 * time.Minute),
+		endpointKey:        profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port),
+		username:           cfg.Username,
+		keyPath:            cfg.PrivateKeyPath,
+		fingerprint:        fingerprint,
+		passwordBlob:       passwordBlob,
+		passphraseBlob:     passphraseBlob,
+		ownsPasswordBlob:   ownsPasswordBlob,
+		ownsPassphraseBlob: ownsPassphraseBlob,
+		expires:            time.Now().Add(2 * time.Minute),
 	}
 	return nil
 }

--- a/internal/remote/pending_trust_secret_lifetime_linux_test.go
+++ b/internal/remote/pending_trust_secret_lifetime_linux_test.go
@@ -1,0 +1,174 @@
+//go:build linux
+
+package remote
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+func pendingTrustLinuxTestConfig() model.ConnectionConfig {
+	return model.ConnectionConfig{
+		Protocol:       "sftp",
+		Host:           "example.test",
+		Port:           22,
+		Username:       "user",
+		PrivateKeyPath: "key",
+	}
+}
+
+func TestCancelPendingTrustForgetsOwnedLinuxSecrets(t *testing.T) {
+	cfg := pendingTrustLinuxTestConfig()
+	cfg.Password = "pending-password"
+	cfg.Passphrase = "pending-passphrase"
+	m := &Manager{}
+	if err := m.stashPendingTrust(cfg, resolvedConnection{Config: cfg}, managerTestFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	passwordBlob := m.pendingTrust.passwordBlob
+	passphraseBlob := m.pendingTrust.passphraseBlob
+	defer security.ForgetProtectedSecret(passwordBlob)
+	defer security.ForgetProtectedSecret(passphraseBlob)
+	if !m.pendingTrust.ownsPasswordBlob || !m.pendingTrust.ownsPassphraseBlob {
+		t.Fatal("plaintext trust credentials were not marked as pending-owned")
+	}
+	requireProtectedSecretAvailable(t, passwordBlob)
+	requireProtectedSecretAvailable(t, passphraseBlob)
+
+	m.CancelPendingTrust()
+
+	requireProtectedSecretForgotten(t, passwordBlob)
+	requireProtectedSecretForgotten(t, passphraseBlob)
+}
+
+func TestCancelPendingTrustPreservesBorrowedLinuxSecrets(t *testing.T) {
+	passwordBlob, err := security.ProtectString("borrowed-profile-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passwordBlob)
+	passphraseBlob, err := security.ProtectString("borrowed-profile-passphrase")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer security.ForgetProtectedSecret(passphraseBlob)
+
+	cfg := pendingTrustLinuxTestConfig()
+	m := &Manager{}
+	if err := m.stashPendingTrust(cfg, resolvedConnection{
+		Config:         cfg,
+		PasswordBlob:   passwordBlob,
+		PassphraseBlob: passphraseBlob,
+	}, managerTestFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	if m.pendingTrust.ownsPasswordBlob || m.pendingTrust.ownsPassphraseBlob {
+		t.Fatal("borrowed profile secrets became pending-owned")
+	}
+
+	m.CancelPendingTrust()
+
+	requireProtectedSecretAvailable(t, passwordBlob)
+	requireProtectedSecretAvailable(t, passphraseBlob)
+}
+
+func TestPendingTrustMismatchForgetsOwnedLinuxSecrets(t *testing.T) {
+	cfg := pendingTrustLinuxTestConfig()
+	cfg.Password = "pending-password"
+	cfg.Passphrase = "pending-passphrase"
+	m := &Manager{}
+	if err := m.stashPendingTrust(cfg, resolvedConnection{Config: cfg}, managerTestFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	passwordBlob := m.pendingTrust.passwordBlob
+	passphraseBlob := m.pendingTrust.passphraseBlob
+	defer security.ForgetProtectedSecret(passwordBlob)
+	defer security.ForgetProtectedSecret(passphraseBlob)
+
+	confirmCfg := cfg
+	confirmCfg.Password = ""
+	confirmCfg.Passphrase = ""
+	resolved := resolvedConnection{Config: confirmCfg}
+	m.applyPendingTrust(confirmCfg, &resolved, "SHA256:mismatched")
+
+	if resolved.PasswordBlob != "" || resolved.PassphraseBlob != "" {
+		t.Fatal("mismatched pending trust credentials were transferred")
+	}
+	requireProtectedSecretForgotten(t, passwordBlob)
+	requireProtectedSecretForgotten(t, passphraseBlob)
+}
+
+func TestExpiredPendingTrustForgetsOwnedLinuxSecrets(t *testing.T) {
+	cfg := pendingTrustLinuxTestConfig()
+	cfg.Password = "pending-password"
+	cfg.Passphrase = "pending-passphrase"
+	m := &Manager{}
+	if err := m.stashPendingTrust(cfg, resolvedConnection{Config: cfg}, managerTestFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	passwordBlob := m.pendingTrust.passwordBlob
+	passphraseBlob := m.pendingTrust.passphraseBlob
+	defer security.ForgetProtectedSecret(passwordBlob)
+	defer security.ForgetProtectedSecret(passphraseBlob)
+	m.pendingTrust.expires = time.Now().Add(-time.Second)
+
+	confirmCfg := cfg
+	confirmCfg.Password = ""
+	confirmCfg.Passphrase = ""
+	resolved := resolvedConnection{Config: confirmCfg}
+	m.applyPendingTrust(confirmCfg, &resolved, managerTestFingerprint)
+
+	if resolved.PasswordBlob != "" || resolved.PassphraseBlob != "" {
+		t.Fatal("expired pending trust credentials were transferred")
+	}
+	requireProtectedSecretForgotten(t, passwordBlob)
+	requireProtectedSecretForgotten(t, passphraseBlob)
+}
+
+func TestPendingTrustOwnedSecretsTransferToSFTPSession(t *testing.T) {
+	cfg := pendingTrustLinuxTestConfig()
+	cfg.Password = "pending-password"
+	cfg.Passphrase = "pending-passphrase"
+	m := &Manager{}
+	if err := m.stashPendingTrust(cfg, resolvedConnection{Config: cfg}, managerTestFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	passwordBlob := m.pendingTrust.passwordBlob
+	passphraseBlob := m.pendingTrust.passphraseBlob
+	defer security.ForgetProtectedSecret(passwordBlob)
+	defer security.ForgetProtectedSecret(passphraseBlob)
+
+	confirmCfg := cfg
+	confirmCfg.Password = ""
+	confirmCfg.Passphrase = ""
+	resolved := resolvedConnection{
+		Config:         confirmCfg,
+		PasswordBlob:   "stale-profile-password",
+		PassphraseBlob: "stale-profile-passphrase",
+	}
+	m.applyPendingTrust(confirmCfg, &resolved, managerTestFingerprint)
+	if resolved.PasswordBlob != passwordBlob || resolved.PassphraseBlob != passphraseBlob {
+		t.Fatal("captured pending trust credentials did not replace stale profile blobs")
+	}
+	if !resolved.ownsPasswordBlob || !resolved.ownsPassphraseBlob {
+		t.Fatal("pending secret ownership was not transferred to resolved connection")
+	}
+
+	s := &SFTP{passwordBlob: resolved.PasswordBlob, passphraseBlob: resolved.PassphraseBlob}
+	transferResolvedSecretOwnershipToSFTP(&resolved, s)
+	if resolved.ownsPasswordBlob || resolved.ownsPassphraseBlob {
+		t.Fatal("resolved connection retained ownership after SFTP transfer")
+	}
+	if !s.ownsPasswordBlob || !s.ownsPassphraseBlob {
+		t.Fatal("SFTP session did not receive pending secret ownership")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	requireProtectedSecretForgotten(t, passwordBlob)
+	requireProtectedSecretForgotten(t, passphraseBlob)
+}

--- a/internal/remote/pending_trust_test.go
+++ b/internal/remote/pending_trust_test.go
@@ -1,0 +1,45 @@
+package remote
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/profilebinding"
+)
+
+func TestApplyPendingTrustPrefersCapturedCredentialOverReresolvedProfile(t *testing.T) {
+	cfg := model.ConnectionConfig{
+		Protocol:       "sftp",
+		Host:           "example.test",
+		Port:           22,
+		Username:       "user",
+		PrivateKeyPath: "key",
+	}
+	m := &Manager{pendingTrust: pendingTrustState{
+		endpointKey:    profilebinding.EndpointKey(cfg.Protocol, cfg.Host, cfg.Port),
+		username:       cfg.Username,
+		keyPath:        cfg.PrivateKeyPath,
+		fingerprint:    managerTestFingerprint,
+		passwordBlob:   "captured-password",
+		passphraseBlob: "captured-passphrase",
+		expires:        time.Now().Add(time.Minute),
+	}}
+	resolved := resolvedConnection{
+		Config:         cfg,
+		PasswordBlob:   "reresolved-profile-password",
+		PassphraseBlob: "reresolved-profile-passphrase",
+	}
+
+	m.applyPendingTrust(cfg, &resolved, managerTestFingerprint)
+
+	if resolved.PasswordBlob != "captured-password" {
+		t.Fatalf("password blob=%q, want captured trust-attempt credential", resolved.PasswordBlob)
+	}
+	if resolved.PassphraseBlob != "captured-passphrase" {
+		t.Fatalf("passphrase blob=%q, want captured trust-attempt credential", resolved.PassphraseBlob)
+	}
+	if m.pendingTrust.passwordBlob != "" || m.pendingTrust.passphraseBlob != "" {
+		t.Fatal("pending trust state was not consumed")
+	}
+}


### PR DESCRIPTION
## Authorization

- [x] This source-code change is explicitly authorized as Ghost FTP 1.0.x hardening.
- [x] The change follows the repository license and contribution requirements.

## Summary

- track ownership of protected credentials temporarily captured for an SFTP host-key trust prompt
- immediately forget pending-owned Linux broker secrets on cancel, expiry, mismatch, replacement, disconnect, or other abandoned trust paths
- preserve borrowed profile-owned blobs instead of deleting them
- transfer pending-owned blob ownership to the SFTP session only when the exact protected blob is accepted by the constructed session
- ensure cleanup remains fail-closed if connection setup fails before ownership reaches the session
- preserve the credential captured for the confirmed trust attempt over a stale profile blob re-resolved during confirmation
- allow an explicitly re-entered plaintext credential on confirmation to override and discard the pending credential

## Regression coverage

- Cancel forgets pending-owned password/passphrase blobs
- Cancel preserves borrowed profile blobs
- fingerprint mismatch forgets pending-owned blobs
- expiry forgets pending-owned blobs
- ownership transfers from pending state -> resolved connection -> SFTP session -> session Close cleanup
- trust-confirmation credential takes precedence over a stale re-resolved profile credential

## Security / privacy

- [x] no telemetry, analytics, ads, tracking or hidden network destination
- [x] no external Go dependency
- [x] no change to SFTP host-key verification/pinning
- [x] no secret added to command-line arguments or persistent logs

## Required CI

Do not merge unless exact-head CI passes:
- Core quality/security/docs, including gofmt, `go test -race ./...`, `go vet ./...`, all audits and Python regressions
- Windows x64/x86 production build
- Linux amd64/arm64/i386 production build and DEB verification

## Release integrity

- no `VERSION` change
- no release workflow change
- no Release/Package publication
- `ghostftp-v1.0.0` remains untouched
- Windows and Linux remain the only active application platforms
