### PR TITLE
Keep terminal language help in sync with the 24-language registry

### DIFF
--- a/internal/i18n/terminal_usage.go
+++ b/internal/i18n/terminal_usage.go
@@ -1,0 +1,31 @@
+package i18n
+
+import "strings"
+
+func supportedLanguageCodeList() string {
+	codes := make([]string, 0, len(supportedLanguages))
+	for _, language := range supportedLanguages {
+		codes = append(codes, language.Code)
+	}
+	return strings.Join(codes, "|")
+}
+
+func expandTerminalLanguageUsage(raw string) string {
+	codes := supportedLanguageCodeList()
+	open := strings.IndexByte(raw, '<')
+	close := strings.LastIndexByte(raw, '>')
+	if open < 0 || close <= open {
+		return "Usage: language <" + codes + ">"
+	}
+	return raw[:open+1] + codes + raw[close:]
+}
+
+func init() {
+	// The language command accepts every language in the canonical registry.
+	// Expand the localized usage template from that registry at startup so a
+	// newly added locale cannot be accepted by the engine while being omitted
+	// from terminal help. The surrounding translated text remains untouched.
+	for _, catalog := range catalogs {
+		catalog["terminal.language_usage"] = expandTerminalLanguageUsage(catalog["terminal.language_usage"])
+	}
+}

--- a/internal/i18n/terminal_usage_test.go
+++ b/internal/i18n/terminal_usage_test.go
@@ -1,0 +1,44 @@
+package i18n
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTerminalLanguageUsageTracksSupportedRegistry(t *testing.T) {
+	codes := make([]string, 0, len(Languages()))
+	for _, language := range Languages() {
+		codes = append(codes, language.Code)
+	}
+	want := "<" + strings.Join(codes, "|") + ">"
+	if len(codes) != 24 {
+		t.Fatalf("supported language registry contains %d languages, want 24", len(codes))
+	}
+
+	for _, language := range Languages() {
+		usage := T(language.Code, "terminal.language_usage")
+		if !strings.Contains(usage, want) {
+			t.Fatalf("terminal language usage for %s = %q, want registry %q", language.Code, usage, want)
+		}
+	}
+}
+
+func TestExpandTerminalLanguageUsagePreservesLocalizedText(t *testing.T) {
+	got := expandTerminalLanguageUsage("Upotreba: language <en|hr>")
+	if !strings.HasPrefix(got, "Upotreba: language <") {
+		t.Fatalf("localized prefix was not preserved: %q", got)
+	}
+	if !strings.Contains(got, "|ko>") {
+		t.Fatalf("expanded usage does not include the last supported language: %q", got)
+	}
+}
+
+func TestExpandTerminalLanguageUsageFailsSafeOnMalformedTemplate(t *testing.T) {
+	got := expandTerminalLanguageUsage("broken template")
+	if !strings.HasPrefix(got, "Usage: language <en|hr|") {
+		t.Fatalf("malformed template fallback = %q", got)
+	}
+	if !strings.HasSuffix(got, "|ko>") {
+		t.Fatalf("malformed template fallback is incomplete: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fix a real Linux terminal localization drift without changing the published Ghost FTP 1.1.1 release.

The `language` command already accepts every language from the canonical 24-language registry, but `terminal.language_usage` still advertised only the original 12 language codes. Valid choices such as `it`, `pl`, `nl`, `cs`, `uk`, `sv`, `ro`, `hu`, `da`, `fi`, `no` and `ko` therefore looked unsupported.

## Changes

- derive the terminal language-code list from the canonical `supportedLanguages` registry;
- expand each locale's existing `terminal.language_usage` template from that registry while preserving the translated surrounding text;
- fail safely to an English usage sentence if a malformed usage template is encountered;
- add regression tests that require all 24 registered codes to be advertised for every locale.

## Scope / safety

- no VERSION change;
- no release/tag/package change;
- no network or credential-handling change;
- no telemetry, analytics, advertising or external dependency added;
- active platforms remain Windows and Linux only.

## Validation

Merge only after the exact PR head passes the normal Ghost FTP CI contract: `gofmt`, `go test -race ./...`, `go vet ./...`, repository/platform/security/privacy/docs/release audits, Python regressions, and Windows/Linux production builds.