### PR TITLE
Fix Windows integrated uninstall registry contract

### DIFF
--- a/cmd/installer/uninstall_registration_windows.go
+++ b/cmd/installer/uninstall_registration_windows.go
@@ -22,13 +22,21 @@ func registerIntegratedUninstall(appPath, currentVersion string) error {
 		{"InstallLocation", filepath.Dir(appPath)},
 		{"DisplayIcon", appPath + ",0"},
 		{"UninstallString", quoted},
-		{"QuietUninstallString", quoted},
 		{"URLInfoAbout", brand.Website},
 	}
 	for _, item := range values {
 		if err := platform.SetRegistryString(uninstallKey, item.name, item.value); err != nil {
 			return err
 		}
+	}
+
+	// The integrated uninstaller is intentionally interactive: it requires
+	// confirmation and reports completion to the user. Do not advertise that
+	// same command as QuietUninstallString. Remove the stale value left by
+	// earlier installers; the surrounding registry snapshot restores it if the
+	// installation transaction later rolls back.
+	if err := platform.DeleteRegistryValue(uninstallKey, "QuietUninstallString"); err != nil {
+		return err
 	}
 	if err := platform.SetRegistryDWORD(uninstallKey, "NoModify", 1); err != nil {
 		return err

--- a/scripts/test_windows_uninstall_contract.py
+++ b/scripts/test_windows_uninstall_contract.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsUninstallContractTests(unittest.TestCase):
+    def test_interactive_uninstaller_is_not_advertised_as_quiet(self):
+        registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
+        runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
+
+        self.assertIn('fmt.Sprintf("\\\"%s\\\" --uninstall", appPath)', registration)
+        self.assertNotIn('{"QuietUninstallString", quoted}', registration)
+        self.assertIn('DeleteRegistryValue(uninstallKey, "QuietUninstallString")', registration)
+
+        # The current integrated uninstall command is deliberately interactive,
+        # so a Windows QuietUninstallString would be a false OS integration contract.
+        self.assertIn('strings.TrimSpace(args[1]), "--uninstall"', runtime)
+        self.assertIn("ConfirmDialog(", runtime)
+        self.assertIn("InfoDialog(", runtime)
+
+    def test_stale_quiet_value_remains_inside_registry_rollback_snapshot(self):
+        snapshot = (ROOT / "cmd/installer/registry_snapshot.go").read_text(encoding="utf-8")
+        self.assertIn('{uninstallKey, "QuietUninstallString"}', snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested for `bren-wp/Ghost-FTP`.
- [x] Scope is limited to Ghost FTP; `bren-wp/Ghost` is not touched.

## Summary

Post-1.1.2 Windows installer hardening without a version bump.

- stop registering the interactive `--uninstall` command as `QuietUninstallString`
- remove the stale `QuietUninstallString` value during upgrades
- keep that value in the installer registry snapshot so a later transaction rollback restores the pre-install state exactly
- add regression coverage binding the registry entry to the real interactive uninstall runtime

## Scope and invariants

- `VERSION` remains `1.1.2`
- no release/tag changes
- no UI layout or dialog changes
- no telemetry, analytics, advertising or dependencies added
- installed-executable ownership validation remains unchanged
- saved profiles/settings remain preserved by uninstall

## Validation before merge

Exact audited PR head: `91633a12d3f20e4b27e7d07aa2c2815fb9123ed2`.

- [x] exact-head Ghost FTP CI green — run #2515
- [x] Go tests/vet and Python regression suite green
- [x] repository/security/privacy/release audits green
- [x] Windows x64/x86 production build and artifact verification green
- [x] Authenticode private-key pipeline smoke test green
- [x] Linux amd64/arm64/i386 build green

No screenshot gate is required because this change does not modify graphical UI source or uninstall dialogs.