### PR TITLE
Harden remote tree directory verification

### DIFF
--- a/internal/api/tree_transfer.go
+++ b/internal/api/tree_transfer.go
@@ -268,6 +268,35 @@ func ensureRemoteDirectory(ctx context.Context, sess remote.Session, target stri
 	return ensureRemoteDirectoryCached(ctx, sess, target, make(map[string]struct{}))
 }
 
+func remoteDirectoryEntry(ctx context.Context, sess remote.Session, target string) (bool, error) {
+	target = path.Clean(strings.ReplaceAll(strings.TrimSpace(target), "\\", "/"))
+	if target == "/" || target == "." {
+		return true, nil
+	}
+	parent := path.Dir(target)
+	if parent == "" {
+		parent = "."
+	}
+	name := path.Base(target)
+	items, err := sess.List(ctx, parent)
+	if err != nil {
+		return false, err
+	}
+	for _, item := range items {
+		if item.Name != name {
+			continue
+		}
+		if item.IsSymlink {
+			return false, errors.New("udaljena putanja sadrži simboličku poveznicu")
+		}
+		if !item.IsDirectory {
+			return false, errors.New("udaljena putanja nije mapa")
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 func ensureRemoteDirectoryCached(ctx context.Context, sess remote.Session, target string, known map[string]struct{}) error {
 	target = path.Clean(strings.ReplaceAll(strings.TrimSpace(target), "\\", "/"))
 	if target == "/" || target == "." {
@@ -277,10 +306,7 @@ func ensureRemoteDirectoryCached(ctx context.Context, sess remote.Session, targe
 	if _, ok := known[target]; ok {
 		return nil
 	}
-	if _, err := sess.List(ctx, target); err == nil {
-		known[target] = struct{}{}
-		return nil
-	}
+
 	parent := path.Dir(target)
 	name := path.Base(target)
 	if parent == "" {
@@ -289,17 +315,37 @@ func ensureRemoteDirectoryCached(ctx context.Context, sess remote.Session, targe
 	if err := ensureRemoteDirectoryCached(ctx, sess, parent, known); err != nil {
 		return err
 	}
+
+	exists, err := remoteDirectoryEntry(ctx, sess, target)
+	if err != nil {
+		return err
+	}
+	if exists {
+		known[target] = struct{}{}
+		return nil
+	}
+
 	if err := sess.Mkdir(ctx, parent, name); err != nil {
 		// A race or server-specific "already exists" response is acceptable only
-		// when a fresh listing proves the directory now exists.
-		if _, listErr := sess.List(ctx, target); listErr == nil {
+		// when a fresh parent listing proves that the exact entry is now a real
+		// directory and not a file or symlink.
+		exists, verifyErr := remoteDirectoryEntry(ctx, sess, target)
+		if verifyErr == nil && exists {
 			known[target] = struct{}{}
 			return nil
 		}
+		if verifyErr != nil {
+			return errors.Join(err, verifyErr)
+		}
 		return err
 	}
-	if _, err := sess.List(ctx, target); err != nil {
+
+	exists, err = remoteDirectoryEntry(ctx, sess, target)
+	if err != nil {
 		return err
+	}
+	if !exists {
+		return errors.New("udaljena mapa nije potvrđena nakon izrade")
 	}
 	known[target] = struct{}{}
 	return nil

--- a/internal/api/tree_transfer_test.go
+++ b/internal/api/tree_transfer_test.go
@@ -15,9 +15,12 @@ import (
 )
 
 type fakeTreeSession struct {
-	mu        sync.Mutex
-	dirs      map[string]bool
-	listCalls map[string]int
+	mu               sync.Mutex
+	dirs             map[string]bool
+	items            map[string]model.Item
+	listCalls        map[string]int
+	mkdirRaceDirs    map[string]bool
+	mkdirRaceEntries map[string]model.Item
 }
 
 func newFakeTreeSession(dirs ...string) *fakeTreeSession {
@@ -25,7 +28,13 @@ func newFakeTreeSession(dirs ...string) *fakeTreeSession {
 	for _, d := range dirs {
 		m[path.Clean(d)] = true
 	}
-	return &fakeTreeSession{dirs: m, listCalls: make(map[string]int)}
+	return &fakeTreeSession{
+		dirs:             m,
+		items:            make(map[string]model.Item),
+		listCalls:        make(map[string]int),
+		mkdirRaceDirs:    make(map[string]bool),
+		mkdirRaceEntries: make(map[string]model.Item),
+	}
 }
 
 func (f *fakeTreeSession) Protocol() string { return "sftp" }
@@ -39,7 +48,23 @@ func (f *fakeTreeSession) List(_ context.Context, p string) ([]model.Item, error
 	if !f.dirs[p] {
 		return nil, errors.New("not found")
 	}
-	return nil, nil
+	items := make([]model.Item, 0)
+	for full := range f.dirs {
+		if full == p || path.Dir(full) != p {
+			continue
+		}
+		items = append(items, model.Item{Name: path.Base(full), IsDirectory: true})
+	}
+	for full, item := range f.items {
+		if path.Dir(full) != p {
+			continue
+		}
+		if item.Name == "" {
+			item.Name = path.Base(full)
+		}
+		items = append(items, item)
+	}
+	return items, nil
 }
 func (f *fakeTreeSession) Mkdir(_ context.Context, base, name string) error {
 	f.mu.Lock()
@@ -48,7 +73,19 @@ func (f *fakeTreeSession) Mkdir(_ context.Context, base, name string) error {
 	if !f.dirs[base] {
 		return errors.New("parent missing")
 	}
-	f.dirs[path.Join(base, name)] = true
+	target := path.Join(base, name)
+	if f.mkdirRaceDirs[target] {
+		f.dirs[target] = true
+		return errors.New("already exists")
+	}
+	if item, ok := f.mkdirRaceEntries[target]; ok {
+		if item.Name == "" {
+			item.Name = path.Base(target)
+		}
+		f.items[target] = item
+		return errors.New("already exists")
+	}
+	f.dirs[target] = true
 	return nil
 }
 func (f *fakeTreeSession) Rename(context.Context, string, string, string) error { return nil }
@@ -99,6 +136,46 @@ func TestEnsureRemoteDirectoryRelativeFromHome(t *testing.T) {
 		if !f.dirs[path.Clean(want)] {
 			t.Fatalf("missing relative created directory %q; got %#v", want, f.dirs)
 		}
+	}
+}
+
+func TestEnsureRemoteDirectoryRejectsExistingFile(t *testing.T) {
+	f := newFakeTreeSession()
+	f.items["/blocked"] = model.Item{Name: "blocked"}
+	if err := ensureRemoteDirectory(context.Background(), f, "/blocked/child"); err == nil {
+		t.Fatal("existing remote file was accepted as a directory component")
+	}
+}
+
+func TestEnsureRemoteDirectoryRejectsExistingSymlink(t *testing.T) {
+	f := newFakeTreeSession()
+	f.items["/linked"] = model.Item{Name: "linked", IsDirectory: true, IsSymlink: true}
+	if err := ensureRemoteDirectory(context.Background(), f, "/linked/child"); err == nil {
+		t.Fatal("existing remote symlink was accepted as a directory component")
+	}
+}
+
+func TestEnsureRemoteDirectoryAcceptsMkdirRaceOnlyWhenDirectoryIsVerified(t *testing.T) {
+	f := newFakeTreeSession()
+	f.mkdirRaceDirs["/race"] = true
+	if err := ensureRemoteDirectory(context.Background(), f, "/race"); err != nil {
+		t.Fatalf("verified concurrent directory creation should succeed: %v", err)
+	}
+}
+
+func TestEnsureRemoteDirectoryRejectsMkdirRaceToFile(t *testing.T) {
+	f := newFakeTreeSession()
+	f.mkdirRaceEntries["/race"] = model.Item{Name: "race"}
+	if err := ensureRemoteDirectory(context.Background(), f, "/race"); err == nil {
+		t.Fatal("mkdir race that produced a file was accepted")
+	}
+}
+
+func TestEnsureRemoteDirectoryRejectsMkdirRaceToSymlink(t *testing.T) {
+	f := newFakeTreeSession()
+	f.mkdirRaceEntries["/race"] = model.Item{Name: "race", IsDirectory: true, IsSymlink: true}
+	if err := ensureRemoteDirectory(context.Background(), f, "/race"); err == nil {
+		t.Fatal("mkdir race that produced a symlink was accepted")
 	}
 }
 
@@ -153,11 +230,11 @@ func TestEnsureRemoteDirectoryCacheAvoidsRelistingKnownParents(t *testing.T) {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	// Each missing directory needs one failing existence probe and one successful
-	// verification after creation. Its already-known parent must not be probed again.
-	for _, target := range []string{"/one", "/one/two", "/one/two/three"} {
-		if got := f.listCalls[target]; got != 2 {
-			t.Fatalf("List(%s) calls=%d want 2", target, got)
+	// Each missing directory requires one parent listing before creation and one
+	// read-back after creation. Known ancestors are not recursively revalidated.
+	for _, parent := range []string{"/", "/one", "/one/two"} {
+		if got := f.listCalls[parent]; got != 2 {
+			t.Fatalf("List(%s) calls=%d want 2", parent, got)
 		}
 	}
 }


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] Repository license and contribution requirements remain unchanged.

## Summary

- verify every existing remote upload-tree component from its parent listing
- reject remote files and symlinks where a directory is required
- accept concurrent `Mkdir` races only after a fresh parent listing proves the resulting entry is a real directory
- update the test session to model real parent-directory listing semantics
- add regression coverage for existing file/symlink components and `Mkdir` races to a directory, file, or symlink

## Security and privacy

- [x] No telemetry, analytics, external API, dependency, logging, or credential handling changes
- [x] SFTP host-key verification/pinning remains unchanged
- [x] Local path protections remain unchanged
- [x] No UI or release/version changes

## Validation gates

- [x] exact-head `go test ./...`, race/vet and repository/security/privacy audits
- [x] exact-head Windows x64/x86 production build and artifact/signing smoke checks
- [x] exact-head Linux amd64/arm64/i386 production build
- [x] diff-level review complete
- [x] post-merge CI green on exact new `main` SHA

## Regression coverage

The tests explicitly prove that a remote ordinary file or symlink cannot satisfy a required upload-tree directory component, and that an `Mkdir` race is accepted only when a fresh read-back proves another actor created a real directory.

Verified PR head: `eb7fa2597198d0bf37a6807794c0e231b7e5384b` (CI #2518).

Merged as `e3f328b6c42622b714b33fd5f8d3fdd8bf5cacc3`; exact-main post-merge CI #2519 completed successfully.