### PR TITLE
Harden local download root against path-swap races

### DIFF
--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -460,37 +460,25 @@ func (c *CurlFTP) Download(ctx context.Context, remotePath, local string, option
 	if err := security.ValidateRemoteFilePath(remotePath); err != nil {
 		return err
 	}
-	if options.SkipExisting {
-		if st, err := os.Lstat(local); err == nil {
-			if st.IsDir() || st.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(local) {
-				return errors.New("target path is not a regular file")
-			}
-			return ErrSkipped
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-	}
-	total := bestEffortRemoteFileSize(ctx, remotePath, c.List)
-	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
-		return err
-	}
-	part, err := localTransferSibling(local, "part", false)
+	target, err := prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)
 	if err != nil {
 		return err
 	}
-	stopProgress := startLocalFileProgressMonitor(ctx, part, total, options.Progress)
-	lines := []string{"url = " + cfgQuote(c.baseURL(remotePath)), "output = " + cfgQuote(part), "speed-time = 30", "speed-limit = 1"}
+	defer target.Close()
+	total := bestEffortRemoteFileSize(ctx, remotePath, c.List)
+	stopProgress := startLocalFileProgressMonitor(ctx, target.partPath, total, options.Progress)
+	lines := []string{"url = " + cfgQuote(c.baseURL(remotePath)), "output = " + cfgQuote(target.partPath), "speed-time = 30", "speed-limit = 1"}
 	_, runErr := c.run(ctx, lines)
 	stopProgress()
 	if runErr != nil {
-		_ = os.Remove(part)
+		target.cleanupPart()
 		return runErr
 	}
-	if err := validateDownloadedPart(part); err != nil {
-		_ = os.Remove(part)
+	if err := target.validatePart(); err != nil {
+		target.cleanupPart()
 		return err
 	}
-	return replaceLocalFileAtomic(local, part, options.KeepBackup)
+	return target.activate(options.KeepBackup, options.SkipExisting)
 }
 
 func removeCommittedLocalRollback(path string, remove func(string) error) error {

--- a/internal/remote/local_download_root.go
+++ b/internal/remote/local_download_root.go
@@ -1,0 +1,340 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+const localDownloadSentinelSize = 32
+
+type localDownloadTarget struct {
+	root       *os.Root
+	rootPath   string
+	targetPath string
+	targetRel  string
+	partName   string
+	partPath   string
+	partInfo   os.FileInfo
+	sentinel   []byte
+}
+
+func localPathRelativeToRoot(rootPath, targetPath string) (string, error) {
+	rootAbs, err := filepath.Abs(filepath.Clean(rootPath))
+	if err != nil {
+		return "", err
+	}
+	targetAbs, err := filepath.Abs(filepath.Clean(targetPath))
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", errors.New("lokalna datoteka nije unutar dopuštenog korijena preuzimanja")
+	}
+	return filepath.Clean(rel), nil
+}
+
+func prepareLocalDownloadTarget(local, requestedRoot string, skipExisting bool) (*localDownloadTarget, error) {
+	local = filepath.Clean(local)
+	if requestedRoot == "" {
+		requestedRoot = filepath.Dir(local)
+	}
+	rootPath, err := filepath.Abs(filepath.Clean(requestedRoot))
+	if err != nil {
+		return nil, err
+	}
+	targetPath, err := filepath.Abs(local)
+	if err != nil {
+		return nil, err
+	}
+	if err := security.EnsureLocalWithinRoot(rootPath, targetPath); err != nil {
+		return nil, err
+	}
+	targetRel, err := localPathRelativeToRoot(rootPath, targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	cleanupRoot := true
+	defer func() {
+		if cleanupRoot {
+			_ = root.Close()
+		}
+	}()
+
+	parentRel := filepath.Dir(targetRel)
+	if parentRel != "." {
+		if err := root.MkdirAll(parentRel, 0755); err != nil {
+			return nil, err
+		}
+	}
+	// Preserve Ghost FTP's stricter policy of rejecting links/junctions below the
+	// user-selected root. The Root handle remains the containment boundary even if
+	// the filesystem changes again immediately after this policy check.
+	if err := security.EnsureLocalWithinRoot(rootPath, targetPath); err != nil {
+		return nil, err
+	}
+
+	if st, err := root.Lstat(targetRel); err == nil {
+		if !st.Mode().IsRegular() || st.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(targetPath) {
+			return nil, errors.New("ciljna putanja nije obična datoteka")
+		}
+		if skipExisting {
+			return nil, ErrSkipped
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	rootReal := rootPath
+	if resolved, err := filepath.EvalSymlinks(rootPath); err == nil {
+		if abs, absErr := filepath.Abs(resolved); absErr == nil {
+			rootReal = abs
+		}
+	}
+
+	token, err := randomTransferToken()
+	if err != nil {
+		return nil, err
+	}
+	partName := ".GhostFTP-part-" + token
+	part, err := root.OpenFile(partName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return nil, err
+	}
+	sentinel := make([]byte, localDownloadSentinelSize)
+	if _, err = rand.Read(sentinel); err != nil {
+		_ = part.Close()
+		_ = root.Remove(partName)
+		return nil, err
+	}
+	if _, err = part.Write(sentinel); err != nil {
+		_ = part.Close()
+		_ = root.Remove(partName)
+		return nil, err
+	}
+	if err = part.Sync(); err != nil {
+		_ = part.Close()
+		_ = root.Remove(partName)
+		return nil, err
+	}
+	partInfo, err := part.Stat()
+	if closeErr := part.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = root.Remove(partName)
+		return nil, err
+	}
+
+	cleanupRoot = false
+	return &localDownloadTarget{
+		root: root, rootPath: rootPath, targetPath: targetPath, targetRel: targetRel,
+		partName: partName, partPath: filepath.Join(rootReal, partName), partInfo: partInfo, sentinel: sentinel,
+	}, nil
+}
+
+func (d *localDownloadTarget) Close() error {
+	if d == nil || d.root == nil {
+		return nil
+	}
+	err := d.root.Close()
+	d.root = nil
+	return err
+}
+
+func (d *localDownloadTarget) cleanupPart() {
+	if d == nil || d.root == nil || d.partName == "" {
+		return
+	}
+	_ = d.root.Remove(d.partName)
+}
+
+func (d *localDownloadTarget) validatePart() error {
+	if d == nil || d.root == nil {
+		return errors.New("lokalni korijen preuzimanja nije dostupan")
+	}
+	st, err := d.root.Lstat(d.partName)
+	if err != nil {
+		return err
+	}
+	if !st.Mode().IsRegular() || st.Mode()&os.ModeSymlink != 0 || !os.SameFile(d.partInfo, st) || security.IsReparsePoint(d.partPath) {
+		return errors.New("preuzeta privremena datoteka nije ista obična lokalna datoteka koja je sigurno pripremljena")
+	}
+	f, err := d.root.Open(d.partName)
+	if err != nil {
+		return err
+	}
+	prefix := make([]byte, len(d.sentinel))
+	n, readErr := io.ReadFull(f, prefix)
+	closeErr := f.Close()
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		return readErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if n == len(d.sentinel) && bytes.Equal(prefix, d.sentinel) {
+		return errors.New("alat za prijenos nije zamijenio sigurno pripremljenu privremenu datoteku")
+	}
+	return nil
+}
+
+func rootSiblingRelative(targetPath, rootPath, kind string, preserveBase bool) (string, error) {
+	candidate, err := localTransferSibling(targetPath, kind, preserveBase)
+	if err != nil {
+		return "", err
+	}
+	return localPathRelativeToRoot(rootPath, candidate)
+}
+
+func rootEntryIsSame(root *os.Root, name string, expected os.FileInfo) bool {
+	if root == nil || expected == nil {
+		return false
+	}
+	st, err := root.Lstat(name)
+	return err == nil && os.SameFile(expected, st)
+}
+
+func restoreRootBackup(root *os.Root, backupRel, targetRel string) error {
+	if root == nil || backupRel == "" {
+		return nil
+	}
+	if _, err := root.Lstat(targetRel); err == nil {
+		return errors.New("ciljna datoteka se ponovno pojavila; sigurnosna kopija nije prepisana")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Prefer a hard-link restore because creation of targetRel is no-replace.
+	// If the filesystem does not support links, fall back to root-relative Rename;
+	// the preceding absence check is advisory, while os.Root still guarantees the
+	// operation cannot escape the selected root.
+	if err := root.Link(backupRel, targetRel); err == nil {
+		if removeErr := root.Remove(backupRel); removeErr != nil {
+			return fmt.Errorf("izvorna datoteka je vraćena, ali rollback kopija nije uklonjena: %w", removeErr)
+		}
+		return nil
+	}
+	return root.Rename(backupRel, targetRel)
+}
+
+func (d *localDownloadTarget) activate(keepBackup, skipExisting bool) error {
+	if err := d.validatePart(); err != nil {
+		d.cleanupPart()
+		return err
+	}
+	if err := security.EnsureLocalWithinRoot(d.rootPath, d.targetPath); err != nil {
+		d.cleanupPart()
+		return err
+	}
+
+	var (
+		existed    bool
+		backupRel  string
+		backupInfo os.FileInfo
+	)
+	if st, err := d.root.Lstat(d.targetRel); err == nil {
+		if !st.Mode().IsRegular() || st.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(d.targetPath) {
+			d.cleanupPart()
+			return errors.New("ciljna putanja nije obična datoteka")
+		}
+		if skipExisting {
+			d.cleanupPart()
+			return ErrSkipped
+		}
+		existed = true
+		kind := "rollback"
+		preserveBase := false
+		if keepBackup {
+			kind = "backup"
+			preserveBase = true
+		}
+		backupRel, err = rootSiblingRelative(d.targetPath, d.rootPath, kind, preserveBase)
+		if err != nil {
+			d.cleanupPart()
+			return err
+		}
+		if _, err := d.root.Lstat(backupRel); err == nil {
+			d.cleanupPart()
+			return errors.New("nasumična lokalna sigurnosna kopija već postoji")
+		} else if !errors.Is(err, os.ErrNotExist) {
+			d.cleanupPart()
+			return err
+		}
+		if err := d.root.Rename(d.targetRel, backupRel); err != nil {
+			d.cleanupPart()
+			return err
+		}
+		backupInfo, err = d.root.Lstat(backupRel)
+		if err != nil || !backupInfo.Mode().IsRegular() {
+			d.cleanupPart()
+			return errors.New("nije moguće potvrditi lokalnu sigurnosnu kopiju prije aktivacije")
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		d.cleanupPart()
+		return err
+	}
+
+	placeholder, err := d.root.OpenFile(d.targetRel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		d.cleanupPart()
+		if existed {
+			return fmt.Errorf("ciljna datoteka se promijenila prije aktivacije; izvorna datoteka ostaje u sigurnosnoj kopiji %s: %w", backupRel, err)
+		}
+		return err
+	}
+	placeholderInfo, statErr := placeholder.Stat()
+	closeErr := placeholder.Close()
+	if statErr != nil || closeErr != nil {
+		if rootEntryIsSame(d.root, d.targetRel, placeholderInfo) {
+			_ = d.root.Remove(d.targetRel)
+		}
+		d.cleanupPart()
+		if existed {
+			_ = restoreRootBackup(d.root, backupRel, d.targetRel)
+		}
+		return errors.Join(statErr, closeErr)
+	}
+	if !rootEntryIsSame(d.root, d.targetRel, placeholderInfo) {
+		d.cleanupPart()
+		if existed {
+			_ = restoreRootBackup(d.root, backupRel, d.targetRel)
+		}
+		return errors.New("ciljna datoteka se promijenila neposredno prije aktivacije")
+	}
+
+	if err := d.root.Rename(d.partName, d.targetRel); err != nil {
+		if rootEntryIsSame(d.root, d.targetRel, placeholderInfo) {
+			_ = d.root.Remove(d.targetRel)
+		}
+		d.cleanupPart()
+		if existed {
+			if restoreErr := restoreRootBackup(d.root, backupRel, d.targetRel); restoreErr != nil {
+				return fmt.Errorf("aktivacija nove datoteke nije uspjela, a izvorna datoteka ostaje u sigurnosnoj kopiji %s: %w", backupRel, restoreErr)
+			}
+		}
+		return err
+	}
+
+	if existed && !keepBackup {
+		if !rootEntryIsSame(d.root, backupRel, backupInfo) {
+			return fmt.Errorf("nova datoteka je aktivna, ali rollback kopija %s promijenila se prije čišćenja", backupRel)
+		}
+		if err := d.root.Remove(backupRel); err != nil {
+			return fmt.Errorf("nova datoteka je aktivna, ali lokalni rollback nije moguće ukloniti na %s: %w", backupRel, err)
+		}
+	}
+	return nil
+}

--- a/internal/remote/local_download_root_test.go
+++ b/internal/remote/local_download_root_test.go
@@ -1,0 +1,143 @@
+package remote
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalDownloadTargetActivatesInsideRoot(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "nested", "file.txt")
+	target, err := prepareLocalDownloadTarget(local, root, false)
+	if err != nil {
+		t.Fatalf("prepareLocalDownloadTarget: %v", err)
+	}
+	defer target.Close()
+	if err := os.WriteFile(target.partPath, []byte("downloaded"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := target.activate(false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	got, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "downloaded" {
+		t.Fatalf("downloaded content=%q", got)
+	}
+}
+
+func TestLocalDownloadTargetRejectsUnchangedSentinel(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "file.txt")
+	target, err := prepareLocalDownloadTarget(local, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	if err := target.validatePart(); err == nil {
+		t.Fatal("unchanged prepared staging file was accepted as transferred data")
+	}
+	target.cleanupPart()
+}
+
+func TestLocalDownloadTargetRejectsLateNestedRedirect(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	localDir := filepath.Join(root, "nested")
+	local := filepath.Join(localDir, "file.txt")
+	target, err := prepareLocalDownloadTarget(local, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	if err := os.WriteFile(target.partPath, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(localDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, localDir); err != nil {
+		t.Skipf("symlink nije dostupan: %v", err)
+	}
+	if err := target.activate(false, false); err == nil {
+		t.Fatal("late nested symlink redirect was accepted")
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "file.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("download escaped root through late redirect: %v", err)
+	}
+}
+
+func TestLocalDownloadTargetRechecksSkipExistingAtCommit(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "file.txt")
+	target, err := prepareLocalDownloadTarget(local, root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	if err := os.WriteFile(target.partPath, []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(local, []byte("raced"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := target.activate(false, true); !errors.Is(err, ErrSkipped) {
+		t.Fatalf("late existing target error=%v want ErrSkipped", err)
+	}
+	got, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "raced" {
+		t.Fatalf("late existing target was overwritten: %q", got)
+	}
+}
+
+func TestLocalDownloadTargetKeepsVerifiedBackup(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "nested", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(local, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	target, err := prepareLocalDownloadTarget(local, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	if err := os.WriteFile(target.partPath, []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := target.activate(true, false); err != nil {
+		t.Fatalf("activate with backup: %v", err)
+	}
+	got, err := os.ReadFile(local)
+	if err != nil || string(got) != "new" {
+		t.Fatalf("active file=%q err=%v", got, err)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(local), "file.txt.GhostFTP-backup-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("backup matches=%v want one", matches)
+	}
+	backup, err := os.ReadFile(matches[0])
+	if err != nil || string(backup) != "old" {
+		t.Fatalf("backup=%q err=%v", backup, err)
+	}
+}
+
+func TestLocalPathRelativeToRootRejectsEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if _, err := localPathRelativeToRoot(root, outside); err == nil {
+		t.Fatal("path outside root was accepted")
+	}
+}

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -726,34 +726,22 @@ func (s *SFTP) Download(ctx context.Context, remotePath, local string, options T
 	if err := security.ValidateRemoteFilePath(remotePath); err != nil {
 		return err
 	}
-	if options.SkipExisting {
-		if st, err := os.Lstat(local); err == nil {
-			if st.IsDir() || st.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(local) {
-				return errors.New("ciljna putanja nije obična datoteka")
-			}
-			return ErrSkipped
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-	}
-	total := bestEffortRemoteFileSize(ctx, remotePath, s.List)
-	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
-		return err
-	}
-	part, err := localTransferSibling(local, "part", false)
+	target, err := prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)
 	if err != nil {
 		return err
 	}
-	stopProgress := startLocalFileProgressMonitor(ctx, part, total, options.Progress)
-	_, runErr := s.run(ctx, "get "+sftpQuote(remotePath)+" "+sftpQuote(part))
+	defer target.Close()
+	total := bestEffortRemoteFileSize(ctx, remotePath, s.List)
+	stopProgress := startLocalFileProgressMonitor(ctx, target.partPath, total, options.Progress)
+	_, runErr := s.run(ctx, "get "+sftpQuote(remotePath)+" "+sftpQuote(target.partPath))
 	stopProgress()
 	if runErr != nil {
-		_ = os.Remove(part)
+		target.cleanupPart()
 		return runErr
 	}
-	if err := validateDownloadedPart(part); err != nil {
-		_ = os.Remove(part)
+	if err := target.validatePart(); err != nil {
+		target.cleanupPart()
 		return err
 	}
-	return replaceLocalFileAtomic(local, part, options.KeepBackup)
+	return target.activate(options.KeepBackup, options.SkipExisting)
 }

--- a/internal/remote/types.go
+++ b/internal/remote/types.go
@@ -11,6 +11,7 @@ var ErrSkipped = errors.New("prijenos je preskočen jer odredišna datoteka već
 type TransferOptions struct {
 	KeepBackup   bool
 	SkipExisting bool
+	LocalRoot    string
 	Progress     TransferProgressFunc
 }
 

--- a/internal/transfer/local_root_propagation_test.go
+++ b/internal/transfer/local_root_propagation_test.go
@@ -1,0 +1,79 @@
+package transfer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/config"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/remote"
+)
+
+type rootCaptureSession struct {
+	root string
+}
+
+func (s *rootCaptureSession) Protocol() string { return "sftp" }
+func (s *rootCaptureSession) Host() string     { return "example.test" }
+func (s *rootCaptureSession) Port() int        { return 22 }
+func (s *rootCaptureSession) List(context.Context, string) ([]model.Item, error) {
+	return nil, nil
+}
+func (s *rootCaptureSession) Mkdir(context.Context, string, string) error { return nil }
+func (s *rootCaptureSession) Rename(context.Context, string, string, string) error {
+	return nil
+}
+func (s *rootCaptureSession) Delete(context.Context, string, string, bool) error { return nil }
+func (s *rootCaptureSession) Chmod(context.Context, string, string, string) error {
+	return nil
+}
+func (s *rootCaptureSession) Upload(context.Context, string, string, remote.TransferOptions) error {
+	return nil
+}
+func (s *rootCaptureSession) Download(_ context.Context, _, _ string, options remote.TransferOptions) error {
+	s.root = options.LocalRoot
+	return nil
+}
+func (s *rootCaptureSession) Close() error { return nil }
+
+type rootCaptureProvider struct {
+	session *rootCaptureSession
+}
+
+func (p rootCaptureProvider) Operation(ctx context.Context) (remote.Session, context.Context, func(), error) {
+	return p.session, ctx, func() {}, nil
+}
+func (rootCaptureProvider) ConnectionIdentity() (string, error) { return "root-test", nil }
+
+func TestRunAttemptPreservesExplicitDownloadRoot(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "tree", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(local), 0755); err != nil {
+		t.Fatal(err)
+	}
+	session := &rootCaptureSession{}
+	m := New(rootCaptureProvider{session: session}, config.NewSettings(config.New(t.TempDir())))
+	job := model.TransferJob{ID: "test", Direction: "download", LocalPath: local, LocalRoot: root, RemotePath: "/file.txt"}
+	if err := m.runAttempt(context.Background(), job, config.DefaultSettings()); err != nil {
+		t.Fatalf("runAttempt: %v", err)
+	}
+	if session.root != root {
+		t.Fatalf("download LocalRoot=%q want %q", session.root, root)
+	}
+}
+
+func TestRunAttemptDerivesSingleFileDownloadRoot(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "file.txt")
+	session := &rootCaptureSession{}
+	m := New(rootCaptureProvider{session: session}, config.NewSettings(config.New(t.TempDir())))
+	job := model.TransferJob{ID: "test", Direction: "download", LocalPath: local, RemotePath: "/file.txt"}
+	if err := m.runAttempt(context.Background(), job, config.DefaultSettings()); err != nil {
+		t.Fatalf("runAttempt: %v", err)
+	}
+	if session.root != filepath.Dir(local) {
+		t.Fatalf("derived LocalRoot=%q want %q", session.root, filepath.Dir(local))
+	}
+}

--- a/internal/transfer/manager.go
+++ b/internal/transfer/manager.go
@@ -631,8 +631,12 @@ func waitRetryDelay(ctx context.Context, delay time.Duration) error {
 }
 
 func (m *Manager) runAttempt(ctx context.Context, job model.TransferJob, settings model.Settings) error {
-	if job.LocalRoot != "" {
-		if err := security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath); err != nil {
+	localRoot := job.LocalRoot
+	if job.Direction == "download" && localRoot == "" {
+		localRoot = filepath.Dir(job.LocalPath)
+	}
+	if localRoot != "" {
+		if err := security.EnsureLocalWithinRoot(localRoot, job.LocalPath); err != nil {
 			return err
 		}
 	}
@@ -644,6 +648,7 @@ func (m *Manager) runAttempt(ctx context.Context, job model.TransferJob, setting
 	options := remote.TransferOptions{
 		KeepBackup:   settings.BackupBeforeOverwrite,
 		SkipExisting: settings.SkipExisting,
+		LocalRoot:    localRoot,
 		Progress: func(transferred, total int64) {
 			m.updateProgress(job.ID, transferred, total)
 		},

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -93,6 +93,7 @@ def audit_credentials_and_network_tools() -> None:
         '"-q", "--config", "-"', '"proxy = \\\"\\\""', '"noproxy = \\\"*\\\""',
         "sanitizedToolEnv(os.Environ())", "security.ProtectRuntimeString(password)",
         "security.UnprotectRuntimeBytes(c.passwordBlob)", "security.ForgetRuntimeSecret(c.passwordBlob)",
+        "prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)",
     ))
     if "HTTP_PROXY" in curl or "HTTPS_PROXY" in curl:
         fail("CurlFTP must not directly inherit proxy variables")
@@ -105,6 +106,7 @@ def audit_credentials_and_network_tools() -> None:
         '"  IdentityAgent none"', '"  ClearAllForwardings yes"', '"  ForwardAgent no"',
         "GhostFTP_ASKPASS_TOKEN=", "GhostFTP_PASSWORD_BLOB=", "GhostFTP_PASSPHRASE_BLOB=",
         "sanitizedToolEnv(os.Environ())",
+        "prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)",
     ))
     for forbidden in ("GhostFTP_ASKPASS_FILE", "askpassFile", "os.WriteFile(askpass"):
         if forbidden in sftp:
@@ -112,7 +114,20 @@ def audit_credentials_and_network_tools() -> None:
 
     require("cmd/ghostftp/main.go", ("GhostFTP_ASKPASS_TOKEN", "GhostFTP_PASSWORD_BLOB", "GhostFTP_PASSPHRASE_BLOB", "TrustedAskPassParent", "selectAskpassSecret"))
     require("internal/remote/util.go", ('"http_proxy"', '"https_proxy"', '"ftp_proxy"', '"all_proxy"', '"no_proxy"', '"sslkeylogfile"', '"ssh_askpass"', '"ssh_auth_sock"', "crypto/rand", "func randomTransferToken()"))
-    require("internal/transfer/manager.go", ("recover() != nil", "ConnectionIdentity() (string, error)", "security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath)", "remote.IsRetryable(err)"))
+    require("internal/transfer/manager.go", (
+        "recover() != nil",
+        "ConnectionIdentity() (string, error)",
+        "localRoot := job.LocalRoot",
+        'job.Direction == "download" && localRoot == ""',
+        "security.EnsureLocalWithinRoot(localRoot, job.LocalPath)",
+        "LocalRoot:    localRoot",
+        "remote.IsRetryable(err)",
+    ))
+    require("internal/remote/local_download_root.go", (
+        "os.OpenRoot(rootPath)",
+        "security.EnsureLocalWithinRoot(d.rootPath, d.targetPath)",
+        "d.root.Rename(d.partName, d.targetRel)",
+    ))
     require("internal/localfs/service.go", ("security.IsReparsePoint", "platform.RenameNoReplace"))
     require("internal/security/remove_tree.go", ("func RemoveTreeNoFollow(", "isReparsePoint", "os.ModeSymlink"))
 
@@ -153,6 +168,8 @@ def main() -> None:
     print("FIXED_RUNTIME_HTTP_URLS=BLOCKED")
     print("TELEMETRY_VENDOR_MARKERS=BLOCKED")
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
+    print("DOWNLOAD_LOCAL_ROOT_PROPAGATION=ENFORCED")
+    print("DOWNLOAD_ROOT_RELATIVE_COMMIT=ENFORCED")
 
 
 if __name__ == "__main__":

--- a/scripts/audit_security.py
+++ b/scripts/audit_security.py
@@ -28,16 +28,28 @@ def require(path: str, markers: tuple[str, ...]) -> str:
 
 
 def main() -> int:
-    # Download staging and filesystem traversal protection.
-    require("internal/remote/util.go", (
-        "func validateDownloadedPart(part string) error",
-        "os.Lstat(part)",
-        "security.IsReparsePoint(part)",
-        "func randomTransferToken()",
-        "crypto/rand",
+    # Download staging and filesystem traversal protection. Downloads are
+    # prepared and committed through one open os.Root capability so later
+    # path swaps cannot redirect activation outside the selected local root.
+    require("internal/remote/local_download_root.go", (
+        "func prepareLocalDownloadTarget(",
+        "os.OpenRoot(rootPath)",
+        "root.MkdirAll(parentRel, 0755)",
+        "root.OpenFile(partName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)",
+        "rand.Read(sentinel)",
+        "os.SameFile(d.partInfo, st)",
+        "bytes.Equal(prefix, d.sentinel)",
+        "security.EnsureLocalWithinRoot(d.rootPath, d.targetPath)",
+        "placeholder, err := d.root.OpenFile(d.targetRel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)",
+        "d.root.Rename(d.partName, d.targetRel)",
     ))
     for path in ("internal/remote/curl_ftp.go", "internal/remote/sftp.go"):
-        require(path, ("validateDownloadedPart(part)",))
+        require(path, (
+            "prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)",
+            "target.validatePart()",
+            "target.cleanupPart()",
+            "target.activate(options.KeepBackup, options.SkipExisting)",
+        ))
 
     require("internal/security/remove_tree.go", (
         "func RemoveTreeNoFollow(",
@@ -133,7 +145,10 @@ def main() -> int:
         "security.ValidateConnection(protocol, host, username, port)",
     ))
     require("internal/transfer/manager.go", (
-        "security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath)",
+        "localRoot := job.LocalRoot",
+        'job.Direction == "download" && localRoot == ""',
+        "security.EnsureLocalWithinRoot(localRoot, job.LocalPath)",
+        "LocalRoot:    localRoot",
         "remote.IsRetryable(err)",
         "errors.Is(err, remote.ErrSkipped)",
         "ConnectionIdentity() (string, error)",
@@ -172,6 +187,16 @@ def main() -> int:
     require("internal/remote/sftp_stream_test.go", ("TestSFTPCommandArgsKeepAskPassEnabled", "sftp -b"))
     require("internal/remote/private_key_validation_test.go", ("TestValidatePrivateKeyPathAcceptsRegularFile", "TestValidatePrivateKeyPathRejectsSymlink"))
     require("internal/remote/manager_test.go", ("TestDisconnectWaitsForActiveOperationRelease", "TestDisconnectTimeoutDefersCloseAndBlocksReconnect"))
+    require("internal/remote/local_download_root_test.go", (
+        "TestLocalDownloadTargetRejectsUnchangedSentinel",
+        "TestLocalDownloadTargetRejectsLateNestedRedirect",
+        "TestLocalDownloadTargetRechecksSkipExistingAtCommit",
+        "TestLocalPathRelativeToRootRejectsEscape",
+    ))
+    require("internal/transfer/local_root_propagation_test.go", (
+        "TestRunAttemptPreservesExplicitDownloadRoot",
+        "TestRunAttemptDerivesSingleFileDownloadRoot",
+    ))
     require("internal/transfer/finish_status_test.go", ("TestFinishJobKeepsSuccessfulResultWhenCancelArrivesAfterSuccess", "TestFinishJobMarksActualCancellation"))
     require("internal/security/remove_tree_root_test.go", ("RemoveTreeNoFollow",))
     require("internal/security/remove_tree_root_windows_test.go", ("TestIsFilesystemRootRejectsWindowsVolumeRoots",))
@@ -183,7 +208,9 @@ def main() -> int:
     print("SFTP_ASKPASS_BATCHMODE_CONFLICT=BLOCKED")
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
     print("PROFILE_CREDENTIAL_CROSS_ENDPOINT=BLOCKED")
-    print("DOWNLOAD_STAGING_REPARSE_VALIDATION=ENABLED")
+    print("DOWNLOAD_ROOT_CAPABILITY=ENABLED")
+    print("DOWNLOAD_STAGING_IDENTITY_VALIDATION=ENABLED")
+    print("DOWNLOAD_COMMIT_ROOT_RELATIVE=ENABLED")
     print("SFTP_PRIVATE_KEY_REPARSE=BLOCKED")
     print("REMOTE_SESSION_CLOSE_RACE=BLOCKED")
     print("FILESYSTEM_ROOT_DELETE=BLOCKED")


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] Repository license and contribution requirements remain unchanged.

## Summary

- preserve the original transfer `LocalRoot` through queue execution into FTP/FTPS/SFTP downloads
- use Go `os.Root` as the traversal-resistant capability for final local download operations
- stage external-tool downloads at a random root-level file rather than beneath potentially mutable nested path components
- pre-create staging with an unpredictable sentinel and verify file identity after curl/OpenSSH finishes
- re-check skip-existing policy at commit time
- activate and roll back files using root-relative operations only
- retain the existing stricter policy that symlinks/junctions below the selected root are rejected
- update security/privacy audits to enforce the new root-capability invariants instead of stale literal checks

## Security and privacy

- [x] No telemetry, analytics, logging, external API or dependency added
- [x] No credential/private-key handling change
- [x] No SFTP host-key policy change
- [x] No UI or release/version change
- [x] Download staging remains inside the user-selected root

## Validation gates

- [x] exact-head Go format/test/vet/race and security/privacy/repository audits
- [x] exact-head Windows x64/x86 production build + artifact/signing smoke
- [x] exact-head Linux amd64/arm64/i386 build
- [x] FTP integration regression tests
- [x] local root/path-swap regression tests
- [x] diff review complete
- [x] post-merge CI green on exact new `main` SHA

## Regression coverage

Tests cover explicit tree root propagation, single-file root fallback, staging identity/sentinel verification, late nested symlink redirect rejection, late skip-existing conflicts, backup preservation and lexical root escape rejection.

Verified PR head: `83475a90ecaf3455e5606a2c7795501c064047f0` (CI #2528).

Merged as `e2078483769a593017f85556abe5ac2bd1120012`; exact-main post-merge CI #2529 completed successfully.