### PR TITLE
Stabilize process-tree cancellation regression

### DIFF
--- a/internal/remote/process_lifecycle_test.go
+++ b/internal/remote/process_lifecycle_test.go
@@ -76,8 +76,8 @@ func TestProcessLifecycleHelper(t *testing.T) {
 			processHelperEnv:          "child",
 			"GhostFTP_PROCESS_MARKER": marker,
 			"GhostFTP_PROCESS_READY":  "",
-			processChildReadyEnv:       childReady,
-			processSurvivalTriggerEnv:  survivalTrigger,
+			processChildReadyEnv:      childReady,
+			processSurvivalTriggerEnv: survivalTrigger,
 		})
 		if err := child.Start(); err != nil {
 			os.Exit(11)
@@ -132,8 +132,8 @@ func TestConfigureToolCommandCancelsDescendantProcess(t *testing.T) {
 		processHelperEnv:          "parent",
 		"GhostFTP_PROCESS_MARKER": marker,
 		"GhostFTP_PROCESS_READY":  ready,
-		processChildReadyEnv:       childReady,
-		processSurvivalTriggerEnv:  survivalTrigger,
+		processChildReadyEnv:      childReady,
+		processSurvivalTriggerEnv: survivalTrigger,
 	})
 	configureToolCommand(cmd)
 	done := make(chan error, 1)

--- a/internal/remote/process_lifecycle_test.go
+++ b/internal/remote/process_lifecycle_test.go
@@ -11,7 +11,11 @@ import (
 	"time"
 )
 
-const processHelperEnv = "GhostFTP_PROCESS_HELPER"
+const (
+	processHelperEnv          = "GhostFTP_PROCESS_HELPER"
+	processChildReadyEnv      = "GhostFTP_PROCESS_CHILD_READY"
+	processSurvivalTriggerEnv = "GhostFTP_PROCESS_SURVIVAL_TRIGGER"
+)
 
 func helperEnv(base []string, values map[string]string) []string {
 	out := make([]string, 0, len(base)+len(values))
@@ -41,11 +45,29 @@ func TestProcessLifecycleHelper(t *testing.T) {
 	}
 	marker := os.Getenv("GhostFTP_PROCESS_MARKER")
 	ready := os.Getenv("GhostFTP_PROCESS_READY")
+	childReady := os.Getenv(processChildReadyEnv)
+	survivalTrigger := os.Getenv(processSurvivalTriggerEnv)
 	switch mode {
 	case "child":
-		time.Sleep(700 * time.Millisecond)
-		if marker != "" {
-			_ = os.WriteFile(marker, []byte("orphan"), 0600)
+		if childReady != "" {
+			if err := os.WriteFile(childReady, []byte("ready"), 0600); err != nil {
+				os.Exit(14)
+			}
+		}
+		if survivalTrigger == "" {
+			os.Exit(0)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(survivalTrigger); err == nil {
+				if marker != "" {
+					_ = os.WriteFile(marker, []byte("orphan"), 0600)
+				}
+				os.Exit(0)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				os.Exit(15)
+			}
+			time.Sleep(10 * time.Millisecond)
 		}
 		os.Exit(0)
 	case "parent":
@@ -54,13 +76,23 @@ func TestProcessLifecycleHelper(t *testing.T) {
 			processHelperEnv:          "child",
 			"GhostFTP_PROCESS_MARKER": marker,
 			"GhostFTP_PROCESS_READY":  "",
+			processChildReadyEnv:       childReady,
+			processSurvivalTriggerEnv:  survivalTrigger,
 		})
 		if err := child.Start(); err != nil {
 			os.Exit(11)
 		}
+		if childReady != "" {
+			if err := waitForProcessMarker(childReady, 3*time.Second); err != nil {
+				_ = child.Process.Kill()
+				_ = child.Wait()
+				os.Exit(16)
+			}
+		}
 		if ready != "" {
 			if err := os.WriteFile(ready, []byte("ready"), 0600); err != nil {
 				_ = child.Process.Kill()
+				_ = child.Wait()
 				os.Exit(12)
 			}
 		}
@@ -91,6 +123,8 @@ func TestConfigureToolCommandCancelsDescendantProcess(t *testing.T) {
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "orphan.txt")
 	ready := filepath.Join(dir, "ready.txt")
+	childReady := filepath.Join(dir, "child-ready.txt")
+	survivalTrigger := filepath.Join(dir, "survival-trigger.txt")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestProcessLifecycleHelper")
@@ -98,10 +132,15 @@ func TestConfigureToolCommandCancelsDescendantProcess(t *testing.T) {
 		processHelperEnv:          "parent",
 		"GhostFTP_PROCESS_MARKER": marker,
 		"GhostFTP_PROCESS_READY":  ready,
+		processChildReadyEnv:       childReady,
+		processSurvivalTriggerEnv:  survivalTrigger,
 	})
 	configureToolCommand(cmd)
 	done := make(chan error, 1)
 	go func() { done <- cmd.Run() }()
+	// The parent publishes ready only after the descendant itself has initialized
+	// and entered its survival-trigger wait. Cancellation therefore always tests
+	// a real descendant process instead of racing a fixed child-side sleep.
 	if err := waitForProcessMarker(ready, 3*time.Second); err != nil {
 		cancel()
 		<-done
@@ -116,9 +155,15 @@ func TestConfigureToolCommandCancelsDescendantProcess(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("canceled helper process did not terminate")
 	}
-	// The descendant writes only if it survives cancellation long enough. Give
-	// it more time than its own delay and prove that no orphan remained alive.
-	time.Sleep(950 * time.Millisecond)
+
+	// Arm the descendant only after cancellation has completed. A child that was
+	// correctly terminated cannot observe this trigger; any surviving orphan will
+	// observe it and write the marker. This avoids depending on scheduler timing
+	// between process launch and context cancellation under the race detector.
+	if err := os.WriteFile(survivalTrigger, []byte("probe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
 	if data, err := os.ReadFile(marker); err == nil {
 		t.Fatalf("descendant survived cancellation and wrote %q", data)
 	} else if !errors.Is(err, os.ErrNotExist) {

--- a/scripts/test_process_lifecycle_hardening.py
+++ b/scripts/test_process_lifecycle_hardening.py
@@ -49,13 +49,22 @@ class ProcessLifecycleHardeningTests(unittest.TestCase):
     def test_functional_regression_uses_real_descendant(self) -> None:
         text = self.read("internal/remote/process_lifecycle_test.go")
         for marker in (
-            'processHelperEnv = "GhostFTP_PROCESS_HELPER"',
+            '"GhostFTP_PROCESS_HELPER"',
+            'processChildReadyEnv      = "GhostFTP_PROCESS_CHILD_READY"',
+            'processSurvivalTriggerEnv = "GhostFTP_PROCESS_SURVIVAL_TRIGGER"',
             'child := exec.Command(os.Args[0], "-test.run=TestProcessLifecycleHelper")',
+            "waitForProcessMarker(childReady, 3*time.Second)",
             "configureToolCommand(cmd)",
             "cancel()",
+            'os.WriteFile(survivalTrigger, []byte("probe"), 0600)',
             "descendant survived cancellation",
         ):
             self.assertIn(marker, text)
+
+        # The descendant must not use a fixed pre-cancel sleep as its survival
+        # signal. It is armed only after cancellation through a test-controlled
+        # file trigger, avoiding scheduler-dependent false failures under -race.
+        self.assertNotIn("time.Sleep(700 * time.Millisecond)", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up stability hardening after the Ghost FTP 1.1.3 release.

The production process-tree cancellation implementations are unchanged. This PR removes a timing-sensitive false-negative window from `TestConfigureToolCommandCancelsDescendantProcess` that surfaced once during the 1.1.3 post-merge `-race` gate and passed on an exact-SHA rerun.

## Change

- descendant explicitly signals that it has initialized
- parent publishes readiness only after that descendant handshake
- descendant waits for a test-controlled survival trigger instead of a fixed 700 ms sleep
- the trigger is created only after context cancellation and direct command termination have completed
- any descendant that survives cancellation still writes the orphan marker and fails the regression

This makes the assertion stronger and more deterministic under heavily loaded/race-instrumented CI without weakening production process cleanup behavior.

## Scope

- [x] Test-only change
- [x] No runtime/process cancellation code change
- [x] No UI change
- [x] No version/release change
- [x] No dependency, telemetry, network or credential change

## Gates

- [ ] exact-head `go test -race ./...` / `go vet ./...`
- [ ] repository/security/privacy/docs/release audits
- [ ] Windows x64/x86 production build
- [ ] Linux amd64/arm64/i386 production build
- [ ] post-merge CI green on exact `main` SHA