### PR TITLE
Harden Ghost FTP 1.1.4 quality and desktop performance

### DIFF
--- a/internal/desktop/icons_windows.go
+++ b/internal/desktop/icons_windows.go
@@ -6,7 +6,8 @@ import "unsafe"
 
 // Windows system icon glyphs. The core code points are shared by Segoe Fluent
 // Icons and Segoe MDL2 Assets, which lets Ghost FTP use the modern Windows 11
-// font while retaining a Windows 10 fallback without shipping font files.
+// font while retaining a Windows 10 fallback without shipping fonts, icon packs
+// or other network-fetched UI assets.
 const (
 	iconConnect     = "\uE703"
 	iconCancel      = "\uE711"
@@ -48,24 +49,23 @@ type buttonVisual struct {
 	Vertical bool
 }
 
-func (a *app) registerButton(hwnd uintptr, icon, label string, variant buttonVariant) uintptr {
-	if hwnd != 0 {
-		if a.buttons == nil {
-			a.buttons = make(map[uintptr]buttonVisual)
-		}
-		a.buttons[hwnd] = buttonVisual{Icon: icon, Label: label, Variant: variant}
+func (a *app) registerButtonVisual(hwnd uintptr, icon, label string, variant buttonVariant, vertical bool) uintptr {
+	if hwnd == 0 {
+		return hwnd
 	}
+	if a.buttons == nil {
+		a.buttons = make(map[uintptr]buttonVisual)
+	}
+	a.buttons[hwnd] = buttonVisual{Icon: icon, Label: label, Variant: variant, Vertical: vertical}
 	return hwnd
 }
 
+func (a *app) registerButton(hwnd uintptr, icon, label string, variant buttonVariant) uintptr {
+	return a.registerButtonVisual(hwnd, icon, label, variant, false)
+}
+
 func (a *app) registerToolbarButton(hwnd uintptr, icon, label string, variant buttonVariant) uintptr {
-	if hwnd != 0 {
-		if a.buttons == nil {
-			a.buttons = make(map[uintptr]buttonVisual)
-		}
-		a.buttons[hwnd] = buttonVisual{Icon: icon, Label: label, Variant: variant, Vertical: true}
-	}
-	return hwnd
+	return a.registerButtonVisual(hwnd, icon, label, variant, true)
 }
 
 func createIconFont(height int32) uintptr {

--- a/internal/desktop/localization_windows.go
+++ b/internal/desktop/localization_windows.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	idLanguage     = 96
-	cbResetContent = 0x014B
-	lvmSetColumnW  = lvmFirst + 96
+	idLanguage      = 96
+	cbResetContent  = 0x014B
+	cbShowDropDown  = 0x014F
+	lvmSetColumnW   = lvmFirst + 96
 )
 
 func (a *app) languageCode() string {
@@ -227,23 +228,41 @@ func (a *app) changeLanguageFromUI() {
 	if index < 0 || index >= len(languages) {
 		return
 	}
+	// CBN_SELCHANGE can arrive while the native list is still visible. Close it
+	// explicitly so changing language has an immediate, predictable interaction
+	// on every supported Windows version.
+	sendMessageW.Call(a.languageCombo, cbShowDropDown, 0, 0)
+
 	old := a.settings
 	next := old
 	next.Language = languages[index].Code
-	if next.Language == a.languageCode() {
+	if i18n.Normalize(next.Language) == a.languageCode() {
 		return
 	}
+
+	// Apply the selected locale once, immediately, while persistence happens off
+	// the UI thread. Disable the combo until the write completes so a slower disk
+	// cannot let two language saves race and restore stale state out of order.
+	enableWindow.Call(a.languageCombo, 0)
 	a.applyLanguage(next.Language)
-	saved, err := a.engine.SetSettings(next)
-	if err != nil {
-		a.settings = old
-		a.applyLanguage(old.Language)
-		platform.ErrorDialog(a.tr("settings.title"), a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
-		return
-	}
-	a.settings = saved
-	a.applyLanguage(saved.Language)
-	a.setStatus(a.tr("settings.saved", saved.Parallelism, saved.ConnectionTimeoutSeconds, retrySummary(a, saved), overwriteSummary(a, saved)))
+	a.goSafe(func() {
+		saved, err := a.engine.SetSettings(next)
+		a.dispatch(func() {
+			enableWindow.Call(a.languageCombo, 1)
+			if err != nil {
+				a.settings = old
+				a.applyLanguage(old.Language)
+				platform.ErrorDialog(a.tr("settings.title"), a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
+				return
+			}
+			displayedLanguage := a.languageCode()
+			a.settings = saved
+			if i18n.Normalize(saved.Language) != displayedLanguage {
+				a.applyLanguage(saved.Language)
+			}
+			a.setStatus(a.tr("settings.saved", saved.Parallelism, saved.ConnectionTimeoutSeconds, retrySummary(a, saved), overwriteSummary(a, saved)))
+		})
+	})
 }
 
 func retrySummary(a *app, settings model.Settings) string {

--- a/internal/desktop/localization_windows.go
+++ b/internal/desktop/localization_windows.go
@@ -241,14 +241,14 @@ func (a *app) changeLanguageFromUI() {
 	}
 
 	// Apply the selected locale once, immediately, while persistence happens off
-	// the UI thread. Disable the combo until the write completes so a slower disk
-	// cannot let two language saves race and restore stale state out of order.
-	enableWindow.Call(a.languageCombo, 0)
+	// the UI thread. Lock both settings entry points until the write completes so
+	// full-settings writes cannot race and restore stale state out of order.
+	a.setSettingsControlsEnabled(false)
 	a.applyLanguage(next.Language)
 	a.goSafe(func() {
 		saved, err := a.engine.SetSettings(next)
 		a.dispatch(func() {
-			enableWindow.Call(a.languageCombo, 1)
+			a.setSettingsControlsEnabled(true)
 			if err != nil {
 				a.settings = old
 				a.applyLanguage(old.Language)

--- a/internal/desktop/localization_windows.go
+++ b/internal/desktop/localization_windows.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	idLanguage      = 96
-	cbResetContent  = 0x014B
-	cbShowDropDown  = 0x014F
-	lvmSetColumnW   = lvmFirst + 96
+	idLanguage     = 96
+	cbResetContent = 0x014B
+	cbShowDropDown = 0x014F
+	lvmSetColumnW  = lvmFirst + 96
 )
 
 func (a *app) languageCode() string {

--- a/internal/desktop/settings_windows.go
+++ b/internal/desktop/settings_windows.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
+	"github.com/bren-wp/Ghost-FTP/internal/config"
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 )
@@ -136,23 +137,31 @@ func (a *app) promptConflictPolicy(settings model.Settings) (model.Settings, boo
 	return settings, true
 }
 
+func normalizeSettingsForPrompt(settings model.Settings) model.Settings {
+	defaults := config.DefaultSettings()
+	if settings.Appearance == "" {
+		settings.Appearance = defaults.Appearance
+	}
+	if settings.Parallelism < config.MinParallelism || settings.Parallelism > config.MaxParallelism {
+		settings.Parallelism = defaults.Parallelism
+	}
+	if settings.AutoRetryCount < config.MinAutoRetryCount || settings.AutoRetryCount > config.MaxAutoRetryCount {
+		settings.AutoRetryCount = defaults.AutoRetryCount
+	}
+	if settings.RetryDelaySeconds < config.MinRetryDelaySeconds || settings.RetryDelaySeconds > config.MaxRetryDelaySeconds {
+		settings.RetryDelaySeconds = defaults.RetryDelaySeconds
+	}
+	if settings.ConnectionTimeoutSeconds < config.MinConnectionTimeoutSeconds || settings.ConnectionTimeoutSeconds > config.MaxConnectionTimeoutSeconds {
+		settings.ConnectionTimeoutSeconds = defaults.ConnectionTimeoutSeconds
+	}
+	return settings
+}
+
 func (a *app) openSettings() {
 	if a.connectionBusy {
 		return
 	}
-	settings := a.settings
-	if settings.Appearance == "" {
-		settings.Appearance = model.AppearanceLight
-	}
-	if settings.Parallelism < 1 {
-		settings.Parallelism = 2
-	}
-	if settings.RetryDelaySeconds < 1 {
-		settings.RetryDelaySeconds = 3
-	}
-	if settings.ConnectionTimeoutSeconds < 5 {
-		settings.ConnectionTimeoutSeconds = 15
-	}
+	settings := normalizeSettingsForPrompt(a.settings)
 
 	var ok bool
 	settings, ok = a.promptAppearance(settings)
@@ -160,25 +169,45 @@ func (a *app) openSettings() {
 		return
 	}
 
-	parallel, ok := a.promptNumber("settings.parallel", settings.Parallelism, 1, 8)
+	parallel, ok := a.promptNumber(
+		"settings.parallel",
+		settings.Parallelism,
+		config.MinParallelism,
+		config.MaxParallelism,
+	)
 	if !ok {
 		return
 	}
 	settings.Parallelism = parallel
 
-	connectTimeout, ok := a.promptNumber("settings.timeout", settings.ConnectionTimeoutSeconds, 5, 60)
+	connectTimeout, ok := a.promptNumber(
+		"settings.timeout",
+		settings.ConnectionTimeoutSeconds,
+		config.MinConnectionTimeoutSeconds,
+		config.MaxConnectionTimeoutSeconds,
+	)
 	if !ok {
 		return
 	}
 	settings.ConnectionTimeoutSeconds = connectTimeout
 
-	retries, ok := a.promptNumber("settings.retries", settings.AutoRetryCount, 0, 3)
+	retries, ok := a.promptNumber(
+		"settings.retries",
+		settings.AutoRetryCount,
+		config.MinAutoRetryCount,
+		config.MaxAutoRetryCount,
+	)
 	if !ok {
 		return
 	}
 	settings.AutoRetryCount = retries
 	if retries > 0 {
-		delay, ok := a.promptNumber("settings.retry_delay", settings.RetryDelaySeconds, 1, 30)
+		delay, ok := a.promptNumber(
+			"settings.retry_delay",
+			settings.RetryDelaySeconds,
+			config.MinRetryDelaySeconds,
+			config.MaxRetryDelaySeconds,
+		)
 		if !ok {
 			return
 		}

--- a/internal/desktop/settings_windows.go
+++ b/internal/desktop/settings_windows.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
 	"github.com/bren-wp/Ghost-FTP/internal/config"
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 )
@@ -33,6 +34,18 @@ func (a *app) loadSettings() {
 			a.updateActionControls()
 		})
 	})
+}
+
+func (a *app) setSettingsControlsEnabled(enabled bool) {
+	value := uintptr(0)
+	if enabled {
+		value = 1
+	}
+	for _, hwnd := range []uintptr{a.languageCombo, a.settingsBtn} {
+		if hwnd != 0 {
+			enableWindow.Call(hwnd, value)
+		}
+	}
 }
 
 func (a *app) promptNumber(instructionKey string, current, min, max int) (int, bool) {
@@ -222,15 +235,20 @@ func (a *app) openSettings() {
 	title := a.tr("settings.title")
 	settings.ConfirmDelete = platform.ConfirmDialog(title, a.tr("settings.confirm_delete_title"), a.tr("settings.confirm_delete_body"))
 
+	a.setSettingsControlsEnabled(false)
 	a.goSafe(func() {
 		saved, err := a.engine.SetSettings(settings)
 		a.dispatch(func() {
+			a.setSettingsControlsEnabled(true)
 			if err != nil {
 				platform.ErrorDialog(title, a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
 				return
 			}
+			displayedLanguage := a.languageCode()
 			a.settings = saved
-			a.applyLanguage(saved.Language)
+			if i18n.Normalize(saved.Language) != displayedLanguage {
+				a.applyLanguage(saved.Language)
+			}
 			status := a.tr("settings.saved", saved.Parallelism, saved.ConnectionTimeoutSeconds, retrySummary(a, saved), overwriteSummary(a, saved))
 			if isDarkAppearance(saved.Appearance) != activeThemeIsDark() {
 				status += " · " + appearanceText(saved.Language).Hint

--- a/internal/desktop/transfers_windows.go
+++ b/internal/desktop/transfers_windows.go
@@ -88,9 +88,16 @@ func (a *app) restoreTransferSelection(selected map[string]struct{}) {
 }
 
 func (a *app) refreshTransfers() {
-	selected := a.selectedTransferIDSet()
 	events, seq := a.engine.TransferEvents(a.transferSeq)
 	a.transferSeq = seq
+	// The timer polls once per second. When the engine has no new events there is
+	// nothing to redraw or recompute, so keep the idle path allocation-free and
+	// avoid touching selection/action state on every tick.
+	if len(events) == 0 {
+		return
+	}
+
+	selected := a.selectedTransferIDSet()
 	if !a.applyTransferEvents(events) {
 		a.updateTransferSummary()
 		a.updateActionControls()

--- a/internal/desktop/windows.go
+++ b/internal/desktop/windows.go
@@ -269,7 +269,6 @@ func wndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
 		}
 		if id == idLanguage && notify == cbnSelChange {
 			a.changeLanguageFromUI()
-			a.refineWorkspaceLayout()
 			return 0
 		}
 		if notify == bnClicked || notify == acceleratorCommandNotification {

--- a/scripts/test_release_1_1_4_desktop_quality.py
+++ b/scripts/test_release_1_1_4_desktop_quality.py
@@ -21,14 +21,32 @@ class Release114DesktopQualityTests(unittest.TestCase):
         self.assertIn(
             "sendMessageW.Call(a.languageCombo, cbShowDropDown, 0, 0)", change
         )
-        self.assertIn("enableWindow.Call(a.languageCombo, 0)", change)
-        self.assertIn("enableWindow.Call(a.languageCombo, 1)", change)
+        self.assertIn("a.setSettingsControlsEnabled(false)", change)
+        self.assertIn("a.setSettingsControlsEnabled(true)", change)
         self.assertIn("a.goSafe(func() {", change)
         self.assertIn("a.dispatch(func() {", change)
         self.assertLess(change.index("a.goSafe(func() {"), change.index("a.engine.SetSettings(next)"))
         self.assertEqual(change.count("a.engine.SetSettings(next)"), 1)
         self.assertIn("displayedLanguage := a.languageCode()", change)
         self.assertIn("if i18n.Normalize(saved.Language) != displayedLanguage", change)
+
+    def test_settings_writes_share_one_ui_lock_and_avoid_redundant_locale_refresh(self) -> None:
+        text = self.read("internal/desktop/settings_windows.go")
+        helper = text.split("func (a *app) setSettingsControlsEnabled", 1)[1].split(
+            "func (a *app) promptNumber", 1
+        )[0]
+        save = text.split("func (a *app) openSettings()", 1)[1].split(
+            "func (a *app) openAbout()", 1
+        )[0]
+
+        self.assertIn("a.languageCombo", helper)
+        self.assertIn("a.settingsBtn", helper)
+        self.assertIn("enableWindow.Call(hwnd, value)", helper)
+        self.assertIn("a.setSettingsControlsEnabled(false)", save)
+        self.assertIn("a.setSettingsControlsEnabled(true)", save)
+        self.assertIn("displayedLanguage := a.languageCode()", save)
+        self.assertIn("if i18n.Normalize(saved.Language) != displayedLanguage", save)
+        self.assertNotIn("\n\t\t\ta.applyLanguage(saved.Language)\n", save)
 
     def test_idle_transfer_poll_has_no_redraw_work(self) -> None:
         text = self.read("internal/desktop/transfers_windows.go")

--- a/scripts/test_release_1_1_4_desktop_quality.py
+++ b/scripts/test_release_1_1_4_desktop_quality.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class Release114DesktopQualityTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_language_combo_closes_and_persists_off_ui_thread(self) -> None:
+        text = self.read("internal/desktop/localization_windows.go")
+        change = text.split("func (a *app) changeLanguageFromUI()", 1)[1].split(
+            "func retrySummary", 1
+        )[0]
+
+        self.assertIn("cbShowDropDown  = 0x014F", text)
+        self.assertIn(
+            "sendMessageW.Call(a.languageCombo, cbShowDropDown, 0, 0)", change
+        )
+        self.assertIn("enableWindow.Call(a.languageCombo, 0)", change)
+        self.assertIn("enableWindow.Call(a.languageCombo, 1)", change)
+        self.assertIn("a.goSafe(func() {", change)
+        self.assertIn("a.dispatch(func() {", change)
+        self.assertLess(change.index("a.goSafe(func() {"), change.index("a.engine.SetSettings(next)"))
+        self.assertEqual(change.count("a.engine.SetSettings(next)"), 1)
+        self.assertIn("displayedLanguage := a.languageCode()", change)
+        self.assertIn("if i18n.Normalize(saved.Language) != displayedLanguage", change)
+
+    def test_idle_transfer_poll_has_no_redraw_work(self) -> None:
+        text = self.read("internal/desktop/transfers_windows.go")
+        refresh = text.split("func (a *app) refreshTransfers()", 1)[1].split(
+            "func (a *app) pauseTransfers()", 1
+        )[0]
+
+        self.assertIn("events, seq := a.engine.TransferEvents(a.transferSeq)", refresh)
+        self.assertIn("if len(events) == 0 {\n\t\treturn\n\t}", refresh)
+        self.assertLess(refresh.index("if len(events) == 0"), refresh.index("selected := a.selectedTransferIDSet()"))
+        self.assertLess(refresh.index("if len(events) == 0"), refresh.index("a.updateTransferSummary()"))
+
+    def test_windows_settings_share_backend_limits_and_defaults(self) -> None:
+        text = self.read("internal/desktop/settings_windows.go")
+        self.assertIn('"github.com/bren-wp/Ghost-FTP/internal/config"', text)
+        self.assertIn("func normalizeSettingsForPrompt", text)
+        for marker in (
+            "config.DefaultSettings()",
+            "config.MinParallelism",
+            "config.MaxParallelism",
+            "config.MinAutoRetryCount",
+            "config.MaxAutoRetryCount",
+            "config.MinRetryDelaySeconds",
+            "config.MaxRetryDelaySeconds",
+            "config.MinConnectionTimeoutSeconds",
+            "config.MaxConnectionTimeoutSeconds",
+        ):
+            self.assertIn(marker, text)
+
+        for stale in (
+            'a.promptNumber("settings.parallel", settings.Parallelism, 1, 8)',
+            'a.promptNumber("settings.timeout", settings.ConnectionTimeoutSeconds, 5, 60)',
+            'a.promptNumber("settings.retries", settings.AutoRetryCount, 0, 3)',
+            'a.promptNumber("settings.retry_delay", settings.RetryDelaySeconds, 1, 30)',
+        ):
+            self.assertNotIn(stale, text)
+
+    def test_windows_icons_remain_local_and_registration_is_deduplicated(self) -> None:
+        text = self.read("internal/desktop/icons_windows.go")
+        self.assertIn('name = "Segoe Fluent Icons"', text)
+        self.assertIn('name := "Segoe MDL2 Assets"', text)
+        self.assertIn("func (a *app) registerButtonVisual", text)
+        self.assertIn("return a.registerButtonVisual(hwnd, icon, label, variant, false)", text)
+        self.assertIn("return a.registerButtonVisual(hwnd, icon, label, variant, true)", text)
+        self.assertEqual(text.count("make(map[uintptr]buttonVisual)"), 1)
+        self.assertNotIn("http://", text)
+        self.assertNotIn("https://", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_1_1_4_desktop_quality.py
+++ b/scripts/test_release_1_1_4_desktop_quality.py
@@ -17,7 +17,7 @@ class Release114DesktopQualityTests(unittest.TestCase):
             "func retrySummary", 1
         )[0]
 
-        self.assertIn("cbShowDropDown  = 0x014F", text)
+        self.assertIn("cbShowDropDown = 0x014F", text)
         self.assertIn(
             "sendMessageW.Call(a.languageCombo, cbShowDropDown, 0, 0)", change
         )

--- a/scripts/test_release_1_1_4_desktop_quality.py
+++ b/scripts/test_release_1_1_4_desktop_quality.py
@@ -30,6 +30,14 @@ class Release114DesktopQualityTests(unittest.TestCase):
         self.assertIn("displayedLanguage := a.languageCode()", change)
         self.assertIn("if i18n.Normalize(saved.Language) != displayedLanguage", change)
 
+    def test_language_command_does_not_repeat_layout_refinement(self) -> None:
+        text = self.read("internal/desktop/windows.go")
+        handler = text.split("if id == idLanguage && notify == cbnSelChange {", 1)[1].split(
+            "return 0", 1
+        )[0]
+        self.assertIn("a.changeLanguageFromUI()", handler)
+        self.assertNotIn("a.refineWorkspaceLayout()", handler)
+
     def test_settings_writes_share_one_ui_lock_and_avoid_redundant_locale_refresh(self) -> None:
         text = self.read("internal/desktop/settings_windows.go")
         helper = text.split("func (a *app) setSettingsControlsEnabled", 1)[1].split(


### PR DESCRIPTION
## Summary

Ghost FTP 1.1.4 hardening from the fully verified post-1.1.3 `main` line.

### Correctness and options

- Windows language dropdown closes immediately after a language is selected.
- Language persistence runs off the UI thread instead of blocking the native message loop.
- Language and Settings writes share one UI-side serialization lock so two whole-settings snapshots cannot race and let an older save overwrite newer options.
- Windows Settings now uses canonical backend min/max/default constants instead of duplicated numeric ranges.
- Invalid/out-of-range prompt state is normalized to safe canonical defaults before it is displayed.
- Ordinary Settings saves no longer rebuild localization, local/remote lists and layout unless the persisted language actually changed.
- Removed the second redundant `refineWorkspaceLayout()` call from the Windows language-selection command handler.

### Performance and cleanup

- Windows transfer polling exits immediately when `TransferEvents` returns no new events, avoiding idle selection-map allocation, summary recomputation, action-state work and list redraw.
- Deduplicated Windows button/icon registration through one canonical helper.
- Retained modern OS-local **Segoe Fluent Icons** on Windows 11 with **Segoe MDL2 Assets** fallback on Windows 10; no web font or third-party icon runtime was introduced.
- Repository/dead-code audit found no tracked file that could be safely removed without deleting an active build, platform fallback, security regression, release contract or package asset. Generated artifacts, retired application surfaces and one-shot workflows are already blocked by repository/platform audits, so no cosmetic file deletion was performed.

### Stability follow-up included in the 1.1.4 line

- The already merged post-1.1.3 process-tree regression stabilization now uses a deterministic descendant-ready / post-cancel survival handshake instead of a fixed child-side delay, without changing production cancellation behavior.

## Local-only / privacy / security

- [x] no telemetry, analytics, advertising or tracking added
- [x] no external icon/font library
- [x] no new fixed runtime HTTP destination
- [x] no external Go module dependency
- [x] settings/profile state remains local
- [x] existing FTP/FTPS/SFTP security boundaries remain unchanged or stronger

## Verified final head

- exact PR head: `3c69931569543bd3d764600945e2fab9b076c7a7`
- CI #2545
- [x] `gofmt`, `go test -race ./...`, `go vet ./...`
- [x] repository/platform/security/privacy/localization/documentation/release audits
- [x] full Python regression suite including 1.1.4 desktop quality contracts
- [x] Windows x64/x86 production build + release artifact verification + Authenticode private-key pipeline smoke
- [x] Linux amd64/arm64/i386 production build + DEB verification

## Release discipline

This hardening PR intentionally does not change `VERSION` or mutate the published 1.1.3 release. Ghost FTP 1.1.4 will be prepared in a dedicated release-prep PR only after this exact head is merged and the resulting exact `main` SHA passes post-merge Core/Windows/Linux CI.