### PR TITLE
Harden local recursive delete against path-swap traversal

### DIFF
--- a/internal/security/remove_tree.go
+++ b/internal/security/remove_tree.go
@@ -13,6 +13,10 @@ const (
 
 type removeTreeGuard struct{ items int }
 
+type removeTreeHooks struct {
+	beforeDescend func(parent string, entry os.DirEntry)
+}
+
 // IsReparsePoint reports whether path is a Windows reparse/junction-like entry.
 // On non-Windows builds it always returns false.
 func IsReparsePoint(path string) bool { return isReparsePoint(path) }
@@ -84,14 +88,18 @@ func readStableDirectory(target string, before os.FileInfo) ([]os.DirEntry, erro
 }
 
 func RemoveTreeNoFollow(root string) error {
+	return removeTreeNoFollowWithHooks(root, nil)
+}
+
+func removeTreeNoFollowWithHooks(root string, hooks *removeTreeHooks) error {
 	root = filepath.Clean(root)
 	if root == "." || root == "" || isFilesystemRoot(root) {
 		return errors.New("nije dopušteno brisanje korijenske lokalne mape")
 	}
-	return removeTreeNoFollow(root, 0, &removeTreeGuard{})
+	return removeTreeNoFollow(root, 0, &removeTreeGuard{}, hooks)
 }
 
-func removeTreeNoFollow(target string, depth int, guard *removeTreeGuard) error {
+func removeTreeNoFollow(target string, depth int, guard *removeTreeGuard, hooks *removeTreeHooks) error {
 	if err := guard.step(depth); err != nil {
 		return err
 	}
@@ -117,7 +125,10 @@ func removeTreeNoFollow(target string, depth int, guard *removeTreeGuard) error 
 		if parentNow.Mode()&os.ModeSymlink != 0 || isReparsePoint(target) || !sameRegularObject(st, parentNow) {
 			return errors.New("lokalna mapa je zamijenjena tijekom rekurzivnog brisanja")
 		}
-		if err := removeTreeNoFollow(filepath.Join(target, entry.Name()), depth+1, guard); err != nil {
+		if hooks != nil && hooks.beforeDescend != nil {
+			hooks.beforeDescend(target, entry)
+		}
+		if err := removeTreeNoFollow(filepath.Join(target, entry.Name()), depth+1, guard, hooks); err != nil {
 			return err
 		}
 	}

--- a/internal/security/remove_tree.go
+++ b/internal/security/remove_tree.go
@@ -14,7 +14,7 @@ const (
 type removeTreeGuard struct{ items int }
 
 type removeTreeHooks struct {
-	beforeDescend func(parent string, entry os.DirEntry)
+	beforeDescend func()
 }
 
 // IsReparsePoint reports whether path is a Windows reparse/junction-like entry.
@@ -49,42 +49,41 @@ func sameRegularObject(before, after os.FileInfo) bool {
 	return before.Mode().Type() == after.Mode().Type() && os.SameFile(before, after)
 }
 
-// readStableDirectory opens the already inspected directory and verifies that
-// the handle still refers to the same filesystem object before reading entries.
-// This prevents a path swap to a symlink/junction from turning ReadDir into an
-// unintended traversal of the replacement target.
-func readStableDirectory(target string, before os.FileInfo) ([]os.DirEntry, error) {
-	f, err := os.Open(target)
+// openStableRootDirectory opens name relative to an already trusted parent root
+// and proves that the resulting directory handle still refers to the object
+// inspected by Lstat. All recursive mutation then proceeds through this held
+// root instead of rebuilding child pathnames from a mutable directory name.
+func openStableRootDirectory(parent *os.Root, name string, before os.FileInfo) (*os.Root, []os.DirEntry, error) {
+	child, err := parent.OpenRoot(name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	defer f.Close()
-	opened, err := f.Stat()
+	opened, err := child.Stat(".")
 	if err != nil {
-		return nil, err
+		child.Close()
+		return nil, nil, err
 	}
 	if !opened.IsDir() || !sameRegularObject(before, opened) {
-		return nil, errors.New("lokalna mapa se promijenila tijekom sigurnog otvaranja")
+		child.Close()
+		return nil, nil, errors.New("lokalna mapa se promijenila tijekom sigurnog otvaranja")
 	}
-	entries, err := f.ReadDir(-1)
+
+	dir, err := child.Open(".")
 	if err != nil {
-		return nil, err
+		child.Close()
+		return nil, nil, err
 	}
-	afterRead, err := f.Stat()
-	if err != nil {
-		return nil, err
+	entries, readErr := dir.ReadDir(-1)
+	closeErr := dir.Close()
+	if readErr != nil {
+		child.Close()
+		return nil, nil, readErr
 	}
-	if !sameRegularObject(opened, afterRead) {
-		return nil, errors.New("lokalna mapa se promijenila tijekom čitanja")
+	if closeErr != nil {
+		child.Close()
+		return nil, nil, closeErr
 	}
-	pathNow, err := os.Lstat(target)
-	if err != nil {
-		return nil, err
-	}
-	if pathNow.Mode()&os.ModeSymlink != 0 || isReparsePoint(target) || !sameRegularObject(opened, pathNow) {
-		return nil, errors.New("lokalna mapa je zamijenjena tijekom brisanja")
-	}
-	return entries, nil
+	return child, entries, nil
 }
 
 func RemoveTreeNoFollow(root string) error {
@@ -96,48 +95,59 @@ func removeTreeNoFollowWithHooks(root string, hooks *removeTreeHooks) error {
 	if root == "." || root == "" || isFilesystemRoot(root) {
 		return errors.New("nije dopušteno brisanje korijenske lokalne mape")
 	}
-	return removeTreeNoFollow(root, 0, &removeTreeGuard{}, hooks)
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	parentPath := filepath.Dir(abs)
+	name := filepath.Base(abs)
+	parent, err := os.OpenRoot(parentPath)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	return removeRootEntry(parent, name, abs, 0, &removeTreeGuard{}, hooks)
 }
 
-func removeTreeNoFollow(target string, depth int, guard *removeTreeGuard, hooks *removeTreeHooks) error {
+func removeRootEntry(parent *os.Root, name, displayPath string, depth int, guard *removeTreeGuard, hooks *removeTreeHooks) error {
 	if err := guard.step(depth); err != nil {
 		return err
 	}
-	st, err := os.Lstat(target)
+	before, err := parent.Lstat(name)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	if st.Mode()&os.ModeSymlink != 0 || isReparsePoint(target) || !st.IsDir() {
-		return os.Remove(target)
+	if before.Mode()&os.ModeSymlink != 0 || isReparsePoint(displayPath) || !before.IsDir() {
+		return parent.Remove(name)
 	}
-	entries, err := readStableDirectory(target, st)
+
+	child, entries, err := openStableRootDirectory(parent, name, before)
 	if err != nil {
 		return err
 	}
+
 	for _, entry := range entries {
-		parentNow, err := os.Lstat(target)
-		if err != nil {
-			return err
-		}
-		if parentNow.Mode()&os.ModeSymlink != 0 || isReparsePoint(target) || !sameRegularObject(st, parentNow) {
-			return errors.New("lokalna mapa je zamijenjena tijekom rekurzivnog brisanja")
-		}
 		if hooks != nil && hooks.beforeDescend != nil {
-			hooks.beforeDescend(target, entry)
+			hooks.beforeDescend()
 		}
-		if err := removeTreeNoFollow(filepath.Join(target, entry.Name()), depth+1, guard, hooks); err != nil {
+		if err := removeRootEntry(child, entry.Name(), filepath.Join(displayPath, entry.Name()), depth+1, guard, hooks); err != nil {
+			child.Close()
 			return err
 		}
 	}
-	final, err := os.Lstat(target)
+	if err := child.Close(); err != nil {
+		return err
+	}
+
+	current, err := parent.Lstat(name)
 	if err != nil {
 		return err
 	}
-	if final.Mode()&os.ModeSymlink != 0 || isReparsePoint(target) || !sameRegularObject(st, final) {
-		return errors.New("lokalna mapa je zamijenjena prije završnog brisanja")
+	if current.Mode()&os.ModeSymlink != 0 || isReparsePoint(displayPath) || !sameRegularObject(before, current) {
+		return errors.New("lokalna mapa je zamijenjena tijekom rekurzivnog brisanja")
 	}
-	return os.Remove(target)
+	return parent.Remove(name)
 }

--- a/internal/security/remove_tree_stability_other_test.go
+++ b/internal/security/remove_tree_stability_other_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestReadStableDirectoryRejectsPathSwapToSymlink(t *testing.T) {
+func TestOpenStableRootDirectoryRejectsPathSwapToSymlink(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "root")
 	outside := filepath.Join(base, "outside")
@@ -21,10 +21,17 @@ func TestReadStableDirectoryRejectsPathSwapToSymlink(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(outside, "must-survive.txt"), []byte("safe"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	before, err := os.Lstat(root)
+
+	parent, err := os.OpenRoot(base)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer parent.Close()
+	before, err := parent.Lstat("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	original := root + ".original"
 	if err := os.Rename(root, original); err != nil {
 		t.Fatal(err)
@@ -32,7 +39,11 @@ func TestReadStableDirectoryRejectsPathSwapToSymlink(t *testing.T) {
 	if err := os.Symlink(outside, root); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readStableDirectory(root, before); err == nil {
+	opened, _, err := openStableRootDirectory(parent, "root", before)
+	if opened != nil {
+		opened.Close()
+	}
+	if err == nil {
 		t.Fatal("expected path-swap protection to reject symlink replacement")
 	}
 	got, err := os.ReadFile(filepath.Join(outside, "must-survive.txt"))
@@ -62,8 +73,8 @@ func TestRemoveTreeNoFollowDoesNotTraverseSwappedRoot(t *testing.T) {
 	}
 
 	swapped := false
-	hooks := &removeTreeHooks{beforeDescend: func(parent string, _ os.DirEntry) {
-		if swapped || filepath.Clean(parent) != filepath.Clean(root) {
+	hooks := &removeTreeHooks{beforeDescend: func() {
+		if swapped {
 			return
 		}
 		if err := os.Rename(root, original); err != nil {

--- a/internal/security/remove_tree_stability_other_test.go
+++ b/internal/security/remove_tree_stability_other_test.go
@@ -40,3 +40,49 @@ func TestReadStableDirectoryRejectsPathSwapToSymlink(t *testing.T) {
 		t.Fatalf("outside file changed: %q err=%v", got, err)
 	}
 }
+
+func TestRemoveTreeNoFollowDoesNotTraverseSwappedRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	original := root + ".original"
+	outside := filepath.Join(base, "outside")
+
+	if err := os.MkdirAll(filepath.Join(root, "child"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "child", "delete-me.txt"), []byte("delete"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, "child"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	outsideFile := filepath.Join(outside, "child", "must-survive.txt")
+	if err := os.WriteFile(outsideFile, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	swapped := false
+	hooks := &removeTreeHooks{beforeDescend: func(parent string, _ os.DirEntry) {
+		if swapped || filepath.Clean(parent) != filepath.Clean(root) {
+			return
+		}
+		if err := os.Rename(root, original); err != nil {
+			t.Fatalf("rename root: %v", err)
+		}
+		if err := os.Symlink(outside, root); err != nil {
+			t.Fatalf("replace root with symlink: %v", err)
+		}
+		swapped = true
+	}}
+
+	if err := removeTreeNoFollowWithHooks(root, hooks); err == nil {
+		t.Fatal("expected root identity change to abort deletion")
+	}
+	if !swapped {
+		t.Fatal("test did not perform the deterministic root swap")
+	}
+	got, err := os.ReadFile(outsideFile)
+	if err != nil || string(got) != "safe" {
+		t.Fatalf("outside file changed through swapped root: %q err=%v", got, err)
+	}
+}

--- a/scripts/audit_security.py
+++ b/scripts/audit_security.py
@@ -51,14 +51,30 @@ def main() -> int:
             "target.activate(options.KeepBackup, options.SkipExisting)",
         ))
 
+    # Recursive local deletion must remain rooted in already-open directory
+    # capabilities. Rebuilding child pathnames from a mutable parent would
+    # reintroduce the rename+symlink/junction traversal race covered below.
     require("internal/security/remove_tree.go", (
         "func RemoveTreeNoFollow(",
         "func isFilesystemRoot(target string) bool",
         "isFilesystemRoot(root)",
         "maxRemoveTreeDepth",
         "maxRemoveTreeItems",
-        "isReparsePoint(target)",
+        "os.OpenRoot(parentPath)",
+        "parent.OpenRoot(name)",
+        "parent.Lstat(name)",
+        "child.Open(\".\")",
+        "sameRegularObject(before, opened)",
+        "isReparsePoint(displayPath)",
         "os.ModeSymlink",
+        "parent.Remove(name)",
+    ))
+    require("internal/security/remove_tree_stability_other_test.go", (
+        "TestOpenStableRootDirectoryRejectsPathSwapToSymlink",
+        "TestRemoveTreeNoFollowDoesNotTraverseSwappedRoot",
+        "os.Rename(root, original)",
+        "os.Symlink(outside, root)",
+        "must-survive.txt",
     ))
     require("internal/localfs/service.go", ("security.IsReparsePoint", "platform.RenameNoReplace"))
     require("internal/platform/filemove_windows.go", ("MoveFileExW", "moveFileWriteThrough", "RenameNoReplace"))
@@ -211,6 +227,8 @@ def main() -> int:
     print("DOWNLOAD_ROOT_CAPABILITY=ENABLED")
     print("DOWNLOAD_STAGING_IDENTITY_VALIDATION=ENABLED")
     print("DOWNLOAD_COMMIT_ROOT_RELATIVE=ENABLED")
+    print("LOCAL_RECURSIVE_DELETE_ROOT_RELATIVE=ENABLED")
+    print("LOCAL_RECURSIVE_DELETE_PATH_SWAP_REGRESSION=ENFORCED")
     print("SFTP_PRIVATE_KEY_REPARSE=BLOCKED")
     print("REMOTE_SESSION_CLOSE_RACE=BLOCKED")
     print("FILESYSTEM_ROOT_DELETE=BLOCKED")

--- a/scripts/test_filesystem_hardening.py
+++ b/scripts/test_filesystem_hardening.py
@@ -75,13 +75,32 @@ def run_checks() -> None:
     for retired in ("android", "ios", "macos", "internal/platform/filemove_darwin.go"):
         require_absent(retired)
 
+    # Recursive delete must keep traversal anchored to held os.Root
+    # capabilities. Path-based ReadDir/recursive descent would reopen the
+    # rename+symlink/junction escape window.
     require("internal/security/remove_tree.go", (
-        "readStableDirectory",
-        "f.ReadDir(-1)",
+        "os.OpenRoot(parentPath)",
+        "parent.OpenRoot(name)",
+        "parent.Lstat(name)",
+        "child.Open(\".\")",
+        "dir.ReadDir(-1)",
         "os.SameFile",
+        "isReparsePoint(displayPath)",
+        "parent.Remove(name)",
         "lokalna mapa je zamijenjena",
     ))
-    forbid("internal/security/remove_tree.go", ("os.ReadDir(target)",))
+    forbid("internal/security/remove_tree.go", (
+        "os.ReadDir(target)",
+        "removeTreeNoFollow(filepath.Join(target",
+    ))
+    require("internal/security/remove_tree_stability_other_test.go", (
+        "TestOpenStableRootDirectoryRejectsPathSwapToSymlink",
+        "TestRemoveTreeNoFollowDoesNotTraverseSwappedRoot",
+        "os.Rename(root, original)",
+        "os.Symlink(outside, root)",
+        "must-survive.txt",
+    ))
+
     require("internal/remote/sftp.go", (
         "maxPrivateKeySize",
         "snapshotPrivateKey",


### PR DESCRIPTION
## Problem

`RemoveTreeNoFollow` je provjeravao identitet parent direktorija, a zatim ponovno ulazio u child preko pathnamea. Između te provjere i rekurzije parent se mogao preimenovati i zamijeniti symlinkom/junctionom, pa bi brisanje moglo nastaviti kroz zamijenjenu putanju izvan odabranog stabla.

## Reprodukcija prije fixa

Deterministički regression test `TestRemoveTreeNoFollowDoesNotTraverseSwappedRoot` radi rename + symlink swap točno nakon postojeće parent-identity provjere. Na pre-fix headu `22bcf4f2ad23dd0445be3fdb9f74e4a0fc002256` CI #2599 je pao jer je `outside/child/must-survive.txt` stvarno obrisan kroz zamijenjeni root.

## Fix

- Otvara parent selected treea kroz `os.OpenRoot`.
- Svaki verificirani child direktorij otvara kroz `parent.OpenRoot(name)` i drži njegov root handle tijekom rekurzije.
- `Lstat`, child traversal i `Remove` ostaju root-relative umjesto ponovnog građenja mutable pathnamea.
- Zadržani su depth/item limiti, symlink/reparse fail-closed ponašanje i object-identity provjere.
- Security audit sada zahtijeva rooted delete primitive i deterministički path-swap regression anchor, umjesto zastarjelog literalnog pathname markera.

## Scope / gates

- No VERSION change.
- No UI source/output change; Windows screenshot evidence is not required for this PR.
- No new dependency.
- Published Ghost FTP 1.1.5 release/tag/assets remain untouched.
- `go test -race ./...`, gofmt and `go vet ./...` already passed on intermediate rooted implementation head `9712f4c3eaf7d47197295d90d54d21190d26bcf4`; final exact-head CI must still pass after the security-contract update.
- Merge only after all final-head jobs are green.