### PR TITLE
Harden local mkdir against base path swaps

### DIFF
--- a/internal/localfs/service.go
+++ b/internal/localfs/service.go
@@ -79,16 +79,28 @@ func (s *Service) ListContext(ctx context.Context, p string) (string, []model.It
 	itemlist.Sort(items)
 	return p, items, nil
 }
+
+func mkdirRelativeToOpenedRoot(base, name string, beforeMkdir func()) error {
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	if beforeMkdir != nil {
+		beforeMkdir()
+	}
+	return root.Mkdir(name, 0755)
+}
+
 func (s *Service) Mkdir(base, name string) error {
 	base, err := cleanPath(base)
 	if err != nil {
 		return err
 	}
-	p, err := security.SafeLocalChild(base, name)
-	if err != nil {
+	if _, err := security.SafeLocalChild(base, name); err != nil {
 		return err
 	}
-	return os.Mkdir(p, 0755)
+	return mkdirRelativeToOpenedRoot(base, name, nil)
 }
 func (s *Service) Rename(base, oldName, newName string) error {
 	base, err := cleanPath(base)

--- a/internal/localfs/service_test.go
+++ b/internal/localfs/service_test.go
@@ -13,6 +13,37 @@ func TestDeleteMissingItemReturnsError(t *testing.T) {
 	}
 }
 
+func TestMkdirAnchorsOpenedBaseAcrossPathSwap(t *testing.T) {
+	parent := t.TempDir()
+	base := filepath.Join(parent, "base")
+	moved := filepath.Join(parent, "moved")
+	replacement := filepath.Join(parent, "replacement")
+	if err := os.Mkdir(base, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(replacement, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := mkdirRelativeToOpenedRoot(base, "child", func() {
+		if err := os.Rename(base, moved); err != nil {
+			t.Skipf("platform does not allow swapping an opened directory: %v", err)
+		}
+		if err := os.Rename(replacement, base); err != nil {
+			t.Fatalf("install replacement base: %v", err)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st, err := os.Stat(filepath.Join(moved, "child")); err != nil || !st.IsDir() {
+		t.Fatalf("child was not created under the opened directory: stat=%v err=%v", st, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "child")); !os.IsNotExist(err) {
+		t.Fatalf("child followed the swapped base pathname: %v", err)
+	}
+}
+
 func TestRenameDoesNotOverwriteExistingItem(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0600); err != nil {


### PR DESCRIPTION
## Problem
`internal/localfs.Service.Mkdir` validated a child path lexically and then called `os.Mkdir` on a full pathname. If the selected base directory pathname was swapped after validation but before creation, the new directory could be created in a different filesystem object.

## Fix
- open the selected base directory with `os.OpenRoot`
- perform `Mkdir` relative to the held root handle
- preserve existing name validation

## Regression coverage
`TestMkdirAnchorsOpenedBaseAcrossPathSwap` deterministically renames the opened base and installs a replacement pathname before creation. The test verifies the child is created under the originally opened directory and not under the replacement path.

## Gate expectations
- no VERSION change
- no Windows UI source change; screenshot gate not required
- exact-head CI required before merge