### PR TITLE
Bind SFTP trust fingerprint directly to scanned key

### DIFF
--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -3,6 +3,9 @@ package remote
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -145,7 +148,28 @@ func scanKeyAlgorithm(line string) string {
 	}
 }
 
-func ScanFingerprint(ctx context.Context, host string, port int, tempDir string) (string, string, string, error) {
+func fingerprintScannedKey(line string) (string, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return "", errors.New("neispravan SSH host ključ")
+	}
+	algorithm := scanKeyAlgorithm(line)
+	if algorithm == "" {
+		return "", errors.New("nepodržan algoritam SSH host ključa")
+	}
+	blob, err := base64.StdEncoding.DecodeString(fields[2])
+	if err != nil || len(blob) < 4 {
+		return "", errors.New("neispravan SSH host ključ")
+	}
+	algorithmLength := int(binary.BigEndian.Uint32(blob[:4]))
+	if algorithmLength <= 0 || algorithmLength > len(blob)-4 || string(blob[4:4+algorithmLength]) != algorithm {
+		return "", errors.New("SSH host ključ ne odgovara deklariranom algoritmu")
+	}
+	sum := sha256.Sum256(blob)
+	return "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:]), nil
+}
+
+func ScanFingerprint(ctx context.Context, host string, port int, _ string) (string, string, string, error) {
 	if err := security.ValidateHost(host); err != nil {
 		return "", "", "", err
 	}
@@ -153,14 +177,7 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if port < 1 || port > 65535 {
 		return "", "", "", errors.New("invalid SFTP port")
 	}
-	if err := os.MkdirAll(tempDir, 0700); err != nil {
-		return "", "", "", err
-	}
 	scan, err := findOpenSSH("ssh-keyscan.exe")
-	if err != nil {
-		return "", "", "", err
-	}
-	keygen, err := findOpenSSH("ssh-keygen.exe")
 	if err != nil {
 		return "", "", "", err
 	}
@@ -223,40 +240,11 @@ func ScanFingerprint(ctx context.Context, host string, port int, tempDir string)
 	if algorithm == "" {
 		return "", "", "", errors.New("poslužitelj je vratio nepodržan SSH host ključ")
 	}
-
-	name, err := writePrivateTempFile(tempDir, "GhostFTP-key-*.known_hosts", []byte(selected+"\n"))
+	fingerprint, err := fingerprintScannedKey(selected)
 	if err != nil {
 		return "", "", "", err
 	}
-	defer os.Remove(name)
-	keygenCtx, keygenCancel := context.WithTimeout(ctx, 8*time.Second)
-	defer keygenCancel()
-	cmd = exec.CommandContext(keygenCtx, keygen, "-lf", name, "-E", "sha256")
-	configureToolCommand(cmd)
-	cmd.WaitDelay = 5 * time.Second
-	cmd.Dir = filepath.Dir(keygen)
-	cmd.Env = sanitizedToolEnv(os.Environ())
-	out.Reset()
-	er.Reset()
-	cmd.Stdout = out
-	cmd.Stderr = er
-	if err := cmd.Run(); err != nil {
-		if ctxErr := keygenCtx.Err(); ctxErr != nil {
-			return "", "", "", ctxErr
-		}
-		if overflowErr := er.Err("odgovor"); overflowErr != nil {
-			return "", "", "", overflowErr
-		}
-		return "", "", "", fmt.Errorf("nije moguće izračunati fingerprint: %s", strings.TrimSpace(er.String()))
-	}
-	if err := out.Err("odgovor"); err != nil {
-		return "", "", "", err
-	}
-	fields := strings.Fields(out.String())
-	if len(fields) < 2 || !strings.HasPrefix(fields[1], "SHA256:") {
-		return "", "", "", errors.New("nepoznat format SHA-256 fingerprinta")
-	}
-	return fields[1], selected + "\n", algorithm, nil
+	return fingerprint, selected + "\n", algorithm, nil
 }
 
 func randomSFTPAlias() (string, error) {

--- a/internal/remote/sftp_fingerprint_test.go
+++ b/internal/remote/sftp_fingerprint_test.go
@@ -1,0 +1,28 @@
+package remote
+
+import "testing"
+
+func TestFingerprintScannedKeyMatchesOpenSSHFormat(t *testing.T) {
+	line := "example.test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"
+	got, err := fingerprintScannedKey(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "SHA256:ZkAslGjFiUHdGf/WUL8rQvkib4PTvQatUV0OUQSncCA"
+	if got != want {
+		t.Fatalf("fingerprint=%q want %q", got, want)
+	}
+}
+
+func TestFingerprintScannedKeyRejectsAlgorithmMismatch(t *testing.T) {
+	line := "example.test ssh-rsa AAAAC3NzaC1lZDI1NTE5AAAAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"
+	if _, err := fingerprintScannedKey(line); err == nil {
+		t.Fatal("expected declared algorithm mismatch to fail")
+	}
+}
+
+func TestFingerprintScannedKeyRejectsMalformedBlob(t *testing.T) {
+	if _, err := fingerprintScannedKey("example.test ssh-ed25519 not-base64"); err == nil {
+		t.Fatal("expected malformed key blob to fail")
+	}
+}


### PR DESCRIPTION
## Problem
`ScanFingerprint` wrote the selected `ssh-keyscan` host key to a temporary pathname, closed it, and then invoked `ssh-keygen -lf` on that pathname. A local pathname substitution between those steps could make the fingerprint shown for trust differ from the exact `keyLine` later written to the pinned known-hosts file.

## Fix
- compute the OpenSSH SHA-256 fingerprint directly from the selected base64 public-key blob in memory
- verify the key blob's embedded algorithm matches the algorithm declared by `ssh-keyscan`
- remove the fingerprint-only temp file and `ssh-keygen` subprocess from `ScanFingerprint`
- retain `ssh-keyscan` as the network host-key acquisition mechanism

## Regression coverage
- known ed25519 fixture must match a fixed OpenSSH `SHA256:` fingerprint
- declared/blob algorithm mismatch is rejected
- malformed base64 key blob is rejected

## Gate expectations
- no VERSION change
- no Windows UI source change; screenshot gate not required
- exact-head CI required before merge