### PR TITLE
Fail closed on spoofable remote cleanup diagnostics

### DIFF
--- a/internal/remote/remote_cleanup_hardening.go
+++ b/internal/remote/remote_cleanup_hardening.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // remoteResidualArtifactError marks a remote operation whose cleanup could not
@@ -52,20 +51,19 @@ func HasUncertainRemoteState(err error) bool {
 	return isRemoteResidualArtifactError(err)
 }
 
-// A failed upload can legitimately fail before the remote staging object is
-// created. In that case a cleanup delete returning a precise not-found result
-// confirms there is no residual object and must not hide the original error.
+// remoteCleanupConfirmsMissing accepts only a machine-readable tool result as
+// proof that a failed cleanup target did not exist. Server-controlled stderr or
+// command output such as "not found" is diagnostic text, not a security signal:
+// a hostile or unusual server can emit that text for an operation whose remote
+// state is still unknown. Curl exit 78 is curl's structured REMOTE_FILE_NOT_FOUND
+// result. OpenSSH sftp exposes no equivalent machine-readable delete status to
+// this process, so every non-zero SFTP cleanup remains fail-closed.
 func remoteCleanupConfirmsMissing(err error) bool {
 	if err == nil {
 		return true
 	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{"no such file", "does not exist", "not found"} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+	var te *toolError
+	return errors.As(err, &te) && te.tool == "curl" && te.code == 78
 }
 
 func cleanupRemoteArtifact(dir, name string, delete remoteDeleteFunc) error {

--- a/internal/remote/remote_cleanup_hardening_test.go
+++ b/internal/remote/remote_cleanup_hardening_test.go
@@ -25,13 +25,39 @@ func TestCleanupFailureReturnsOriginalWhenCleanupSucceeds(t *testing.T) {
 	}
 }
 
-func TestCleanupFailureAcceptsConfirmedMissingArtifact(t *testing.T) {
+func TestCleanupFailureRejectsSpoofedMissingText(t *testing.T) {
 	original := errors.New("upload failed")
+	cleanup := errors.New("550 No such file; operation not found")
 	err := cleanupFailure(original, "/www", ".GhostFTP-part-test", func(context.Context, string, string, bool) error {
-		return errors.New("No such file")
+		return cleanup
+	})
+	if !isRemoteResidualArtifactError(err) {
+		t.Fatalf("server-controlled missing text must not prove cleanup: %v", err)
+	}
+	if !errors.Is(err, original) || !errors.Is(err, cleanup) {
+		t.Fatalf("fail-closed cleanup must preserve both causes: %v", err)
+	}
+}
+
+func TestCleanupFailureAcceptsStructuredCurlMissingResult(t *testing.T) {
+	original := errors.New("upload failed")
+	missing := &toolError{tool: "curl", code: 78, message: "server text is irrelevant"}
+	err := cleanupFailure(original, "/www", ".GhostFTP-part-test", func(context.Context, string, string, bool) error {
+		return missing
 	})
 	if !errors.Is(err, original) || isRemoteResidualArtifactError(err) {
-		t.Fatalf("confirmed missing artifact should preserve original error: %v", err)
+		t.Fatalf("curl REMOTE_FILE_NOT_FOUND should confirm absence: %v", err)
+	}
+}
+
+func TestCleanupFailureRejectsSFTPMissingText(t *testing.T) {
+	original := errors.New("upload failed")
+	missingText := &toolError{tool: "sftp", code: 1, message: "No such file"}
+	err := cleanupFailure(original, "/www", ".GhostFTP-part-test", func(context.Context, string, string, bool) error {
+		return missingText
+	})
+	if !isRemoteResidualArtifactError(err) {
+		t.Fatalf("SFTP diagnostic text is not structured proof of absence: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Summary

Remote staging cleanup treated text such as `No such file`, `does not exist`, or `not found` from a failed delete as proof that the staging object was absent. That text is server/tool diagnostic output and is not a safe security signal; a hostile or unusual server can emit it while remote state remains uncertain.

The fix removes text matching from cleanup proof. Only a successful delete or curl's structured exit code 78 (`REMOTE_FILE_NOT_FOUND`) confirms absence. OpenSSH SFTP exposes no equivalent machine-readable delete result through the current subprocess interface, so every non-zero SFTP cleanup remains fail-closed and blocks automatic retry.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] SFTP host-key verification and pinning remain active.
- [x] No external Go module was added.
- [x] Existing remote residual-state errors remain non-retryable.

## Regression coverage

- spoofed plain `No such file` text produces uncertain remote state
- structured curl exit 78 confirms absence
- SFTP exit 1 with `No such file` text remains uncertain
- existing cleanup/retry/commit regression coverage retained

## Validation gates

- exact-head Ghost FTP CI required before merge
- `go test`, race tests, vet, security/privacy audits and production builds are covered by CI
- no VERSION change
- no Windows UI source change; authentic screenshot gate is not required for this PR