### PR TITLE
Fail closed when a Ghost FTP release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,19 +379,21 @@ jobs:
           git fetch --tags --force
           if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
             tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
-            test "$tag_sha" = "$GITHUB_SHA" || { echo "Existing $RELEASE_TAG points to $tag_sha, not $GITHUB_SHA; refusing to rewrite it." >&2; exit 1; }
+            echo "$RELEASE_TAG already exists at $tag_sha; refusing to rewrite an existing release tag." >&2
+            exit 1
           fi
 
           if gh release view "$RELEASE_TAG" --repo "$repo" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" release/* --repo "$repo" --clobber
-          else
-            gh release create "$RELEASE_TAG" release/* \
-              --repo "$repo" \
-              --target "$GITHUB_SHA" \
-              --title "$RELEASE_TITLE" \
-              --notes-file release/RELEASE-NOTES.txt \
-              "${prerelease_args[@]}"
+            echo "$RELEASE_TAG release already exists; refusing to rewrite published assets." >&2
+            exit 1
           fi
+
+          gh release create "$RELEASE_TAG" release/* \
+            --repo "$repo" \
+            --target "$GITHUB_SHA" \
+            --title "$RELEASE_TITLE" \
+            --notes-file release/RELEASE-NOTES.txt \
+            "${prerelease_args[@]}"
 
           expected_assets="$(cat <<EOF
           BUILD-METADATA.txt

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -88,7 +88,7 @@ def main() -> int:
         "docker buildx imagetools inspect",
         "if: env.RELEASE_CHANNEL == 'stable'",
         "main moved from release commit",
-        "refusing to rewrite it",
+        "release already exists; refusing to rewrite published assets",
         "RELEASE_ASSET_READBACK=PASS",
     )
     lowered = workflow.lower()
@@ -98,6 +98,10 @@ def main() -> int:
     ):
         if forbidden in lowered:
             fail(f"release workflow contains retired publication/platform marker: {forbidden}")
+
+    for forbidden in ("gh release upload", "--clobber"):
+        if forbidden in workflow:
+            fail(f"release workflow may rewrite historical release assets: {forbidden}")
 
     if "Stable Windows releases require a configured trusted Authenticode identity." in workflow:
         fail("stable release workflow still blocks publication solely because Authenticode secrets are absent")

--- a/scripts/test_maintenance.py
+++ b/scripts/test_maintenance.py
@@ -64,7 +64,10 @@ class MaintenanceRegressionTests(unittest.TestCase):
         workflow = read(".github/workflows/release.yml")
         self.assertIn("RELEASE_TAG=ghostftp-v$version", workflow)
         self.assertIn("main moved from release commit", workflow)
-        self.assertIn("refusing to rewrite it", workflow)
+        self.assertIn("refusing to rewrite an existing release tag", workflow)
+        self.assertIn("release already exists; refusing to rewrite published assets", workflow)
+        self.assertNotIn("gh release upload", workflow)
+        self.assertNotIn("--clobber", workflow)
         self.assertIn("gh release create", workflow)
         self.assertLess(workflow.index("main moved from release commit"), workflow.index("gh release create"))
 

--- a/scripts/test_release_trigger_contract.py
+++ b/scripts/test_release_trigger_contract.py
@@ -14,6 +14,12 @@ class ReleaseTriggerContractTests(unittest.TestCase):
         self.assertNotIn("\n  create:\n", header)
         self.assertNotIn("\n  pull_request:\n", header)
 
+    def test_existing_release_is_never_clobbered(self):
+        release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        self.assertNotIn("gh release upload", release)
+        self.assertNotIn("--clobber", release)
+        self.assertIn("release already exists; refusing to rewrite published assets", release)
+
     def test_release_branch_trigger_verifies_exact_main_before_dispatch(self):
         trigger = (ROOT / ".github/workflows/release-branch-trigger.yml").read_text(encoding="utf-8")
         required = [


### PR DESCRIPTION
## Problem

The canonical release workflow could enter an existing-release branch and run `gh release upload ... --clobber`, allowing a rerun to replace already published release assets. That conflicts with the repository's historical-release immutability contract.

## Fix

- Existing release tags now fail closed instead of being reused.
- Existing GitHub Releases now fail closed instead of uploading/clobbering assets.
- New releases still use the same verified create/read-back path.
- Added regression coverage that rejects `gh release upload` and `--clobber` from the publish workflow.

## Safety

- Does not modify the published 1.1.6 release, tag or assets.
- Does not change VERSION.
- No UI/product runtime change.
- No dependency or telemetry change.

## Gates

Merge only after exact-head Ghost FTP CI is green, then verify post-merge exact-main CI before continuing the next audit item.