### PR TITLE
Anchor tree-download directory preparation to opened filesystem roots

### DIFF
--- a/internal/api/tree_transfer.go
+++ b/internal/api/tree_transfer.go
@@ -214,14 +214,17 @@ func (s *Engine) addDownloadTree(ctx context.Context, sess remote.Session, local
 		}
 		defer reservation.Cancel()
 	}
-	prepared, err := prepareLocalDirectories(localBoundary, plan.localDirs)
+	releasePrepared, err := prepareLocalDirectories(localBoundary, plan.localDirs)
 	if err != nil {
 		return TreeTransferResult{Directories: len(plan.localDirs), SkippedSymlinks: plan.skippedSymlinks}, err
 	}
-	defer prepared.Close()
+	defer releasePrepared()
 	if reservation != nil {
 		if _, err := reservation.Commit(); err != nil {
-			prepared.Cleanup()
+			// Deliberately leave prepared empty directories in place. A pathname may
+			// have been replaced after preparation; deleting by terminal name could
+			// remove an unrelated replacement object. Residual empty directories are
+			// safer than risking user-data loss.
 			return TreeTransferResult{Directories: len(plan.localDirs), SkippedSymlinks: plan.skippedSymlinks}, err
 		}
 	}
@@ -230,20 +233,6 @@ func (s *Engine) addDownloadTree(ctx context.Context, sess remote.Session, local
 
 type localDirectoryPreparationHooks struct {
 	beforeMkdir func(relative string)
-}
-
-type preparedLocalDirectory struct {
-	rel     string
-	name    string
-	parent  *os.Root
-	root    *os.Root
-	created bool
-}
-
-type localDirectoryPreparation struct {
-	boundary *os.Root
-	nodes    []preparedLocalDirectory
-	closed   bool
 }
 
 func relativePreparedDirectory(localBoundary, dir string) (string, error) {
@@ -279,62 +268,30 @@ func openStablePreparedDirectory(parent *os.Root, name string, before os.FileInf
 	return child, nil
 }
 
-func (p *localDirectoryPreparation) Close() error {
-	if p == nil || p.closed {
-		return nil
-	}
-	var closeErr error
-	for i := len(p.nodes) - 1; i >= 0; i-- {
-		if p.nodes[i].root != nil {
-			closeErr = errors.Join(closeErr, p.nodes[i].root.Close())
-			p.nodes[i].root = nil
-		}
-	}
-	if p.boundary != nil {
-		closeErr = errors.Join(closeErr, p.boundary.Close())
-		p.boundary = nil
-	}
-	p.closed = true
-	return closeErr
-}
-
-func (p *localDirectoryPreparation) Cleanup() {
-	if p == nil || p.closed {
-		return
-	}
-	for i := len(p.nodes) - 1; i >= 0; i-- {
-		node := &p.nodes[i]
-		if node.root != nil {
-			_ = node.root.Close()
-			node.root = nil
-		}
-		if node.created && node.parent != nil {
-			// Empty-only removal is deliberate: if another local action created
-			// content after preparation, rollback must never delete that content.
-			_ = node.parent.Remove(node.name)
-		}
-	}
-	if p.boundary != nil {
-		_ = p.boundary.Close()
-		p.boundary = nil
-	}
-	p.closed = true
-}
-
-func prepareLocalDirectories(localBoundary string, dirs []string) (*localDirectoryPreparation, error) {
+func prepareLocalDirectories(localBoundary string, dirs []string) (func(), error) {
 	return prepareLocalDirectoriesWithHooks(localBoundary, dirs, nil)
 }
 
-func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks *localDirectoryPreparationHooks) (*localDirectoryPreparation, error) {
+func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks *localDirectoryPreparationHooks) (func(), error) {
 	boundary, err := os.OpenRoot(localBoundary)
 	if err != nil {
 		return nil, err
 	}
-	prepared := &localDirectoryPreparation{boundary: boundary, nodes: make([]preparedLocalDirectory, 0, len(dirs))}
 	opened := map[string]*os.Root{".": boundary}
-
-	fail := func(err error) (*localDirectoryPreparation, error) {
-		prepared.Cleanup()
+	openedOrder := make([]*os.Root, 0, len(dirs))
+	closed := false
+	closePrepared := func() {
+		if closed {
+			return
+		}
+		for i := len(openedOrder) - 1; i >= 0; i-- {
+			_ = openedOrder[i].Close()
+		}
+		_ = boundary.Close()
+		closed = true
+	}
+	fail := func(err error) (func(), error) {
+		closePrepared()
 		return nil, err
 	}
 
@@ -356,7 +313,6 @@ func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks
 		}
 		name := filepath.Base(rel)
 		st, statErr := parent.Lstat(name)
-		created := false
 		if errors.Is(statErr, os.ErrNotExist) {
 			if hooks != nil && hooks.beforeMkdir != nil {
 				hooks.beforeMkdir(rel)
@@ -364,8 +320,6 @@ func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks
 			if err := parent.Mkdir(name, 0755); err != nil {
 				return fail(err)
 			}
-			created = true
-			prepared.nodes = append(prepared.nodes, preparedLocalDirectory{rel: rel, name: name, parent: parent, created: true})
 			st, statErr = parent.Lstat(name)
 		}
 		if statErr != nil {
@@ -378,14 +332,10 @@ func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks
 		if err != nil {
 			return fail(err)
 		}
-		if created {
-			prepared.nodes[len(prepared.nodes)-1].root = child
-		} else {
-			prepared.nodes = append(prepared.nodes, preparedLocalDirectory{rel: rel, name: name, parent: parent, root: child})
-		}
 		opened[rel] = child
+		openedOrder = append(openedOrder, child)
 	}
-	return prepared, nil
+	return closePrepared, nil
 }
 
 func ensureRemoteDirectory(ctx context.Context, sess remote.Session, target string) error {

--- a/internal/api/tree_transfer.go
+++ b/internal/api/tree_transfer.go
@@ -214,54 +214,178 @@ func (s *Engine) addDownloadTree(ctx context.Context, sess remote.Session, local
 		}
 		defer reservation.Cancel()
 	}
-	cleanupCreated, err := prepareLocalDirectories(localBoundary, plan.localDirs)
+	prepared, err := prepareLocalDirectories(localBoundary, plan.localDirs)
 	if err != nil {
 		return TreeTransferResult{Directories: len(plan.localDirs), SkippedSymlinks: plan.skippedSymlinks}, err
 	}
+	defer prepared.Close()
 	if reservation != nil {
 		if _, err := reservation.Commit(); err != nil {
-			cleanupCreated()
+			prepared.Cleanup()
 			return TreeTransferResult{Directories: len(plan.localDirs), SkippedSymlinks: plan.skippedSymlinks}, err
 		}
 	}
 	return TreeTransferResult{Queued: len(plan.requests), Directories: len(plan.localDirs), SkippedSymlinks: plan.skippedSymlinks}, nil
 }
 
-func prepareLocalDirectories(localBoundary string, dirs []string) (func(), error) {
-	created := make([]string, 0, len(dirs))
-	cleanup := func() {
-		for i := len(created) - 1; i >= 0; i-- {
+type localDirectoryPreparationHooks struct {
+	beforeMkdir func(relative string)
+}
+
+type preparedLocalDirectory struct {
+	rel     string
+	name    string
+	parent  *os.Root
+	root    *os.Root
+	created bool
+}
+
+type localDirectoryPreparation struct {
+	boundary *os.Root
+	nodes    []preparedLocalDirectory
+	closed   bool
+}
+
+func relativePreparedDirectory(localBoundary, dir string) (string, error) {
+	boundary := filepath.Clean(localBoundary)
+	target := filepath.Clean(dir)
+	rel, err := filepath.Rel(boundary, target)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("lokalna putanja izlazi iz odabrane mape")
+	}
+	if strings.ContainsAny(rel, "\x00\r\n") {
+		return "", errors.New("neispravna lokalna putanja")
+	}
+	return filepath.Clean(rel), nil
+}
+
+func openStablePreparedDirectory(parent *os.Root, name string, before os.FileInfo) (*os.Root, error) {
+	if before == nil || before.Mode().Type() != os.ModeDir {
+		return nil, errors.New("lokalna putanja nije obična mapa")
+	}
+	child, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := child.Stat(".")
+	if err != nil {
+		child.Close()
+		return nil, err
+	}
+	if opened.Mode().Type() != os.ModeDir || !os.SameFile(before, opened) {
+		child.Close()
+		return nil, errors.New("lokalna mapa se promijenila tijekom sigurnog otvaranja")
+	}
+	return child, nil
+}
+
+func (p *localDirectoryPreparation) Close() error {
+	if p == nil || p.closed {
+		return nil
+	}
+	var closeErr error
+	for i := len(p.nodes) - 1; i >= 0; i-- {
+		if p.nodes[i].root != nil {
+			closeErr = errors.Join(closeErr, p.nodes[i].root.Close())
+			p.nodes[i].root = nil
+		}
+	}
+	if p.boundary != nil {
+		closeErr = errors.Join(closeErr, p.boundary.Close())
+		p.boundary = nil
+	}
+	p.closed = true
+	return closeErr
+}
+
+func (p *localDirectoryPreparation) Cleanup() {
+	if p == nil || p.closed {
+		return
+	}
+	for i := len(p.nodes) - 1; i >= 0; i-- {
+		node := &p.nodes[i]
+		if node.root != nil {
+			_ = node.root.Close()
+			node.root = nil
+		}
+		if node.created && node.parent != nil {
 			// Empty-only removal is deliberate: if another local action created
 			// content after preparation, rollback must never delete that content.
-			_ = os.Remove(created[i])
+			_ = node.parent.Remove(node.name)
 		}
 	}
+	if p.boundary != nil {
+		_ = p.boundary.Close()
+		p.boundary = nil
+	}
+	p.closed = true
+}
+
+func prepareLocalDirectories(localBoundary string, dirs []string) (*localDirectoryPreparation, error) {
+	return prepareLocalDirectoriesWithHooks(localBoundary, dirs, nil)
+}
+
+func prepareLocalDirectoriesWithHooks(localBoundary string, dirs []string, hooks *localDirectoryPreparationHooks) (*localDirectoryPreparation, error) {
+	boundary, err := os.OpenRoot(localBoundary)
+	if err != nil {
+		return nil, err
+	}
+	prepared := &localDirectoryPreparation{boundary: boundary, nodes: make([]preparedLocalDirectory, 0, len(dirs))}
+	opened := map[string]*os.Root{".": boundary}
+
+	fail := func(err error) (*localDirectoryPreparation, error) {
+		prepared.Cleanup()
+		return nil, err
+	}
+
 	for _, dir := range dirs {
-		if err := security.EnsureLocalWithinRoot(localBoundary, dir); err != nil {
-			cleanup()
-			return cleanup, err
+		rel, err := relativePreparedDirectory(localBoundary, dir)
+		if err != nil {
+			return fail(err)
 		}
-		st, err := os.Lstat(dir)
-		if err == nil {
-			if !st.IsDir() {
-				cleanup()
-				return cleanup, errors.New("lokalna putanja nije mapa")
-			}
+		if rel == "." {
 			continue
 		}
-		if !errors.Is(err, os.ErrNotExist) {
-			cleanup()
-			return cleanup, err
+		if _, exists := opened[rel]; exists {
+			continue
 		}
-		// Plans are parent-first, so Mkdir is intentionally used instead of
-		// MkdirAll. This prevents creation outside the validated plan.
-		if err := os.Mkdir(dir, 0755); err != nil {
-			cleanup()
-			return cleanup, err
+		parentRel := filepath.Dir(rel)
+		parent := opened[parentRel]
+		if parent == nil {
+			return fail(errors.New("lokalni plan mapa nije poredan od roditelja prema djeci"))
 		}
-		created = append(created, dir)
+		name := filepath.Base(rel)
+		st, statErr := parent.Lstat(name)
+		created := false
+		if errors.Is(statErr, os.ErrNotExist) {
+			if hooks != nil && hooks.beforeMkdir != nil {
+				hooks.beforeMkdir(rel)
+			}
+			if err := parent.Mkdir(name, 0755); err != nil {
+				return fail(err)
+			}
+			created = true
+			prepared.nodes = append(prepared.nodes, preparedLocalDirectory{rel: rel, name: name, parent: parent, created: true})
+			st, statErr = parent.Lstat(name)
+		}
+		if statErr != nil {
+			return fail(statErr)
+		}
+		if st.Mode().Type() != os.ModeDir {
+			return fail(errors.New("lokalna putanja nije obična mapa"))
+		}
+		child, err := openStablePreparedDirectory(parent, name, st)
+		if err != nil {
+			return fail(err)
+		}
+		if created {
+			prepared.nodes[len(prepared.nodes)-1].root = child
+		} else {
+			prepared.nodes = append(prepared.nodes, preparedLocalDirectory{rel: rel, name: name, parent: parent, root: child})
+		}
+		opened[rel] = child
 	}
-	return cleanup, nil
+	return prepared, nil
 }
 
 func ensureRemoteDirectory(ctx context.Context, sess remote.Session, target string) error {

--- a/internal/api/tree_transfer_security_test.go
+++ b/internal/api/tree_transfer_security_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,5 +47,107 @@ func TestUploadTreeBoundaryRejectsLateRootRedirect(t *testing.T) {
 	}
 	if err := security.EnsureLocalWithinRoot(job.LocalRoot, job.LocalPath); err == nil {
 		t.Fatal("late upload-root symlink redirect unexpectedly accepted")
+	}
+}
+
+func TestPrepareLocalDirectoriesAnchorsOpenedBoundaryAcrossPathSwap(t *testing.T) {
+	parent := t.TempDir()
+	boundary := filepath.Join(parent, "boundary")
+	movedBoundary := filepath.Join(parent, "boundary-opened")
+	if err := os.Mkdir(boundary, 0700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(boundary, "download")
+
+	var swapErr error
+	releasePrepared, err := prepareLocalDirectoriesWithHooks(boundary, []string{target}, &localDirectoryPreparationHooks{
+		beforeMkdir: func(relative string) {
+			if relative != "download" || swapErr != nil {
+				return
+			}
+			if err := os.Rename(boundary, movedBoundary); err != nil {
+				swapErr = err
+				return
+			}
+			if err := os.Mkdir(boundary, 0700); err != nil {
+				swapErr = err
+			}
+		},
+	})
+	if releasePrepared != nil {
+		defer releasePrepared()
+	}
+	if swapErr != nil {
+		t.Skipf("platform does not allow deterministic rename of opened boundary: %v", swapErr)
+	}
+	if err != nil {
+		t.Fatalf("prepareLocalDirectoriesWithHooks: %v", err)
+	}
+	if st, err := os.Stat(filepath.Join(movedBoundary, "download")); err != nil || !st.IsDir() {
+		t.Fatalf("directory was not created below opened boundary object, stat=%v err=%v", st, err)
+	}
+	if _, err := os.Stat(filepath.Join(boundary, "download")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("replacement boundary unexpectedly received prepared directory, err=%v", err)
+	}
+}
+
+func TestPrepareLocalDirectoriesAnchorsOpenedParentAndNeverDeletesReplacement(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "download")
+	nested := filepath.Join(root, "nested")
+	movedRoot := filepath.Join(base, "download-opened")
+	marker := filepath.Join(root, "replacement.txt")
+
+	var swapErr error
+	releasePrepared, err := prepareLocalDirectoriesWithHooks(base, []string{root, nested}, &localDirectoryPreparationHooks{
+		beforeMkdir: func(relative string) {
+			if relative != filepath.Join("download", "nested") || swapErr != nil {
+				return
+			}
+			if err := os.Rename(root, movedRoot); err != nil {
+				swapErr = err
+				return
+			}
+			if err := os.Mkdir(root, 0700); err != nil {
+				swapErr = err
+				return
+			}
+			if err := os.WriteFile(marker, []byte("replacement"), 0600); err != nil {
+				swapErr = err
+			}
+		},
+	})
+	if swapErr != nil {
+		if releasePrepared != nil {
+			releasePrepared()
+		}
+		t.Skipf("platform does not allow deterministic rename of opened parent: %v", swapErr)
+	}
+	if err != nil {
+		if releasePrepared != nil {
+			releasePrepared()
+		}
+		t.Fatalf("prepareLocalDirectoriesWithHooks: %v", err)
+	}
+
+	if st, err := os.Stat(filepath.Join(movedRoot, "nested")); err != nil || !st.IsDir() {
+		releasePrepared()
+		t.Fatalf("nested directory was not created below held parent object, stat=%v err=%v", st, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "nested")); !errors.Is(err, os.ErrNotExist) {
+		releasePrepared()
+		t.Fatalf("replacement parent unexpectedly received nested directory, err=%v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		releasePrepared()
+		t.Fatalf("replacement marker missing before rooted handles are released: %v", err)
+	}
+
+	releasePrepared()
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("releasing preparation deleted replacement user content: %v", err)
+	}
+	if st, err := os.Stat(root); err != nil || !st.IsDir() {
+		t.Fatalf("replacement directory must survive release, stat=%v err=%v", st, err)
 	}
 }

--- a/internal/api/tree_transfer_test.go
+++ b/internal/api/tree_transfer_test.go
@@ -179,7 +179,7 @@ func TestEnsureRemoteDirectoryRejectsMkdirRaceToSymlink(t *testing.T) {
 	}
 }
 
-func TestPrepareLocalDirectoriesRollbackRemovesOnlyCreatedEmptyDirs(t *testing.T) {
+func TestPrepareLocalDirectoriesReleaseLeavesPreparedDirs(t *testing.T) {
 	base := t.TempDir()
 	preexisting := filepath.Join(base, "existing")
 	if err := os.Mkdir(preexisting, 0755); err != nil {
@@ -187,26 +187,26 @@ func TestPrepareLocalDirectoriesRollbackRemovesOnlyCreatedEmptyDirs(t *testing.T
 	}
 	root := filepath.Join(base, "download")
 	nested := filepath.Join(root, "nested")
-	cleanup, err := prepareLocalDirectories(base, []string{root, nested, preexisting})
+	releasePrepared, err := prepareLocalDirectories(base, []string{root, nested, preexisting})
 	if err != nil {
 		t.Fatalf("prepareLocalDirectories: %v", err)
 	}
 	if _, err := os.Stat(nested); err != nil {
 		t.Fatalf("nested directory was not prepared: %v", err)
 	}
-	cleanup()
-	if _, err := os.Stat(root); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("created directory should be removed on rollback, err=%v", err)
+	releasePrepared()
+	if st, err := os.Stat(root); err != nil || !st.IsDir() {
+		t.Fatalf("prepared directory must remain after releasing rooted handles, stat=%v err=%v", st, err)
 	}
 	if st, err := os.Stat(preexisting); err != nil || !st.IsDir() {
-		t.Fatalf("pre-existing directory must survive rollback, stat=%v err=%v", st, err)
+		t.Fatalf("pre-existing directory must survive release, stat=%v err=%v", st, err)
 	}
 }
 
-func TestPrepareLocalDirectoriesRollbackNeverDeletesNewContent(t *testing.T) {
+func TestPrepareLocalDirectoriesReleaseNeverDeletesNewContent(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "download")
-	cleanup, err := prepareLocalDirectories(base, []string{root})
+	releasePrepared, err := prepareLocalDirectories(base, []string{root})
 	if err != nil {
 		t.Fatalf("prepareLocalDirectories: %v", err)
 	}
@@ -214,9 +214,9 @@ func TestPrepareLocalDirectoriesRollbackNeverDeletesNewContent(t *testing.T) {
 	if err := os.WriteFile(marker, []byte("keep"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	cleanup()
+	releasePrepared()
 	if _, err := os.Stat(marker); err != nil {
-		t.Fatalf("rollback must not recursively delete content created later: %v", err)
+		t.Fatalf("releasing rooted preparation must not delete later content: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Tree-download directory preparation validated paths and then used pathname-based `Lstat` / `Mkdir` / rollback removal. A local boundary or ancestor pathname could be swapped between validation and creation, redirecting directory preparation to a different filesystem object. Pathname-based rollback also risked deleting an unrelated replacement object after a terminal-name swap.

## Fix

- Open the local download boundary once with `os.OpenRoot`.
- Create each planned directory relative to a held parent `os.Root`.
- Open and retain each created/existing child root for nested preparation.
- Verify the directory identity with `os.SameFile` after opening.
- Keep the whole parent chain rooted through queue finalization.
- On finalization failure, close rooted handles but deliberately leave prepared empty directories rather than delete by a potentially replaced terminal pathname.

## Regression coverage

- deterministic boundary-path swap test verifies creation remains under the originally opened boundary object;
- deterministic nested-parent swap test verifies child creation remains under the held parent object;
- replacement user content is verified to survive rooted-handle release;
- existing preparation tests now encode fail-safe residual-directory behavior.

## Scope

- no VERSION change;
- no UI change;
- no dependency/telemetry change;
- no release/tag/assets touched.

Merge only after exact-head Core, Linux and Windows CI are green, then verify post-merge exact-main CI.