### PR TITLE
Add distro-neutral Linux portable archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,22 +193,41 @@ jobs:
           test "$(go telemetry)" = 'off'
       - name: Linux tests and package build
         shell: bash
+        env:
+          GHOSTFTP_REQUIRE_DEB: '1'
         run: |
           set -euo pipefail
           go test ./...
           go vet ./...
           bash linux/BUILD.sh
-      - name: Verify DEB packages
+      - name: Verify DEB and portable packages
         shell: bash
         run: |
           set -euo pipefail
           version="$(tr -d '\r\n' < VERSION)"
           for arch in amd64 arm64 i386; do
             pkg="dist/Ghost-FTP-${version}-Linux-${arch}.deb"
+            portable="dist/Ghost-FTP-${version}-Linux-${arch}.tar.gz"
             test -s "$pkg"
+            test -s "$portable"
             test "$(dpkg-deb -f "$pkg" Package)" = 'ghost-ftp'
             test "$(dpkg-deb -f "$pkg" Version)" = "$version"
             test "$(dpkg-deb -f "$pkg" Architecture)" = "$arch"
+
+            work="$(mktemp -d)"
+            trap 'rm -rf "$work"' EXIT
+            mkdir -p "$work/deb" "$work/portable"
+            dpkg-deb -x "$pkg" "$work/deb"
+            tar -xzf "$portable" -C "$work/portable"
+            root="$work/portable/Ghost-FTP-${version}-Linux-${arch}"
+            test -x "$root/ghostftp"
+            test -f "$root/ghost-ftp.desktop"
+            test -f "$root/ghost-ftp.png"
+            test -f "$root/LICENSE"
+            test -f "$root/README.md"
+            cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"
+            rm -rf "$work"
+            trap - EXIT
           done
       - name: Store Linux packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -216,4 +235,6 @@ jobs:
           name: ghostftp-linux-stage
           if-no-files-found: error
           retention-days: 7
-          path: dist/Ghost-FTP-*-Linux-*.deb
+          path: |
+            dist/Ghost-FTP-*-Linux-*.deb
+            dist/Ghost-FTP-*-Linux-*.tar.gz

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Ghost FTP dependencies
 
-Ghost FTP **1.1.1 Stable** minimizes bundled third-party code, keeps the maintained Go module free of external module requirements and makes operating-system protocol prerequisites explicit.
+Ghost FTP **1.1.6 Stable** minimizes bundled third-party code, keeps the maintained Go module free of external module requirements and makes operating-system protocol prerequisites explicit. The maintained `main` source may contain post-1.1.6 hardening and packaging improvements before the next maintenance release is prepared.
 
 ## Go module contract
 
@@ -47,11 +47,13 @@ The Windows desktop frontend uses native Win32/DWM/common-control facilities. Gh
 
 Windows production packages are native application executables/Setup wrappers generated from the repository build. Classic Light/Dark rendering uses local native drawing state and does not load a remote theme service.
 
-## Linux UI dependency boundary
+## Linux UI and packaging dependency boundary
 
-Linux uses the maintained native X11/XWayland-compatible frontend backed by the same Engine. The Linux package therefore requires the normal display/runtime environment appropriate to that frontend in addition to protocol tools.
+Linux uses the maintained native X11/XWayland-compatible frontend backed by the same Engine. The Linux renderer is not a second protocol implementation.
 
-The Linux renderer is not a second protocol implementation.
+The DEB format declares `ca-certificates`, `curl` and `openssh-client` as package dependencies. Post-1.1.6 source/CI packaging also builds package-manager-neutral `.tar.gz` archives for amd64, arm64 and i386. Those archives intentionally do **not** bundle Debian metadata, `curl`, OpenSSH, CA certificates or a desktop toolkit; users on non-Debian distributions must provide equivalent system protocol prerequisites through their own package manager.
+
+Creating a portable tarball therefore does not change Ghost FTP's runtime dependency model and does not justify claiming a distribution-specific RPM/AppImage/Flatpak/Snap package until that format has its own build and verification contract.
 
 ## Accurate dependency wording
 

--- a/docs/PLATFORM-PARITY.md
+++ b/docs/PLATFORM-PARITY.md
@@ -1,6 +1,6 @@
 # Windows and Linux platform parity
 
-Ghost FTP **1.1.1 Stable** is one desktop product with native Windows and Linux frontends. Both platforms use the **same typed `internal/api.Engine`** and the same protocol, transfer, profile, settings, localization and security layers.
+Ghost FTP **1.1.6 Stable** is one desktop product with native Windows and Linux frontends. Both platforms use the **same typed `internal/api.Engine`** and the same protocol, transfer, profile, settings, localization and security layers.
 
 Parity means equivalent protocol/security semantics and honest native-platform UX, not pixel-identical widgets or a requirement to expose a control before its backend lifecycle is complete.
 
@@ -28,7 +28,7 @@ Windows and Linux use the same typed configuration/profile model. Platform-speci
 
 Settings normalization, conflict policy, retry behavior, parallelism, timeout, language and appearance defaults remain shared contracts. Compatibility JSON fields are migration state, not justification for duplicate UI controls.
 
-## Appearance in 1.1.1
+## Appearance in 1.1.6
 
 **Classic Light is the primary fresh/fallback appearance.**
 
@@ -47,7 +47,7 @@ Security/privacy-sensitive credential-persistence prompts are catalog-backed rat
 
 Both platforms route transfers through the same transfer manager and remote abstraction. Shared behavior includes queued/running/terminal states, pause/resume/cancel/retry/clear lifecycle, connection-generation binding, truthful progress/speed/ETA snapshots, retry classification, local containment, upload-source snapshot validation, staged/rollback-oriented remote operations, cleanup and terminal-state correctness.
 
-Renderer timing must not alter transfer semantics.
+Tree-download directory preparation is anchored to opened filesystem roots so boundary or ancestor pathname replacement cannot redirect local directory creation. Renderer timing must not alter transfer semantics.
 
 ## Connection-manager parity
 
@@ -87,7 +87,9 @@ A generated/self-signed development certificate is never substituted for trusted
 
 ## Linux-specific implementation
 
-Linux uses the maintained native X11/XWayland-compatible frontend and platform-local saved-secret/storage protections. Production packages include amd64, arm64 and i386 DEB builds.
+Linux uses the maintained native X11/XWayland-compatible frontend and platform-local saved-secret/storage protections. The published 1.1.6 release contains amd64, arm64 and i386 DEB builds.
+
+Post-1.1.6 source/CI packaging additionally builds package-manager-neutral `.tar.gz` archives for the same three architectures. CI proves that each DEB and portable archive contains the same compiled `ghostftp` executable byte-for-byte. This expands practical distribution compatibility without pretending that an unverified RPM/AppImage/Flatpak/Snap lifecycle already exists.
 
 Idle rendering is state/event driven so the complete workspace is not continuously repainted while nothing relevant changes.
 
@@ -95,7 +97,9 @@ Idle rendering is state/event driven so the complete workspace is not continuous
 
 The production workflow independently builds and verifies both platform families before publication. A successful Windows build cannot substitute for a failed Linux build, and vice versa.
 
-The GitHub Release contract remains **9 platform artifacts / 12 public files**. GHCR mirrors the verified assembled release directory and is a distribution bundle, not a third application implementation.
+The already published Ghost FTP 1.1.6 GitHub Release remains immutable with its original **9 platform artifacts / 12 public files**. The new Linux portable archives are source/CI outputs only until a separate release-contract change is reviewed and gated; documentation must not retroactively list them as 1.1.6 assets.
+
+GHCR mirrors the verified assembled release directory and is a distribution bundle, not a third application implementation.
 
 ## Definition of parity complete
 

--- a/linux/BUILD.sh
+++ b/linux/BUILD.sh
@@ -8,7 +8,7 @@ MIN_GO_MAJOR=1
 MIN_GO_MINOR=26
 MIN_GO_PATCH=5
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'Invalid VERSION.' >&2; exit 1; }
-for tool in go dpkg-deb sed; do command -v "$tool" >/dev/null || { echo "Missing required tool: $tool" >&2; exit 1; }; done
+for tool in go tar gzip sed; do command -v "$tool" >/dev/null || { echo "Missing required tool: $tool" >&2; exit 1; }; done
 
 raw_go="$(go env GOVERSION)"
 if [[ ! "$raw_go" =~ ^go([0-9]+)\.([0-9]+)(\.([0-9]+))?$ ]]; then
@@ -34,28 +34,64 @@ telemetry="$(go telemetry)"
 export GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off CGO_ENABLED=0 GOOS=linux
 mkdir -p dist
 
+have_dpkg=0
+if command -v dpkg-deb >/dev/null; then
+  have_dpkg=1
+elif [[ "${GHOSTFTP_REQUIRE_DEB:-0}" == "1" ]]; then
+  echo 'Missing required tool for DEB production build: dpkg-deb' >&2
+  exit 1
+fi
+
 build_arch() {
   local goarch="$1" debarch="$2"
-  local root="dist/linux-${debarch}-root"
-  local out="dist/Ghost-FTP-${VERSION}-Linux-${debarch}.deb"
-  rm -rf "$root" "$out"
-  mkdir -p "$root/DEBIAN" "$root/usr/bin" "$root/usr/share/applications" "$root/usr/share/icons/hicolor/512x512/apps"
+  local binary="dist/.ghostftp-linux-${debarch}"
+  local deb_root="dist/linux-${debarch}-root"
+  local deb_out="dist/Ghost-FTP-${VERSION}-Linux-${debarch}.deb"
+  local portable_name="Ghost-FTP-${VERSION}-Linux-${debarch}"
+  local portable_root="dist/${portable_name}"
+  local portable_out="dist/${portable_name}.tar.gz"
+
+  rm -rf "$binary" "$deb_root" "$deb_out" "$portable_root" "$portable_out"
 
   echo "[Linux ${debarch}] Building Ghost FTP"
-  GOARCH="$goarch" go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=${VERSION}" -o "$root/usr/bin/ghostftp" ./cmd/ghostftp
-  chmod 0755 "$root/usr/bin/ghostftp"
-  cp build/icon.png "$root/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png"
-  cp linux/ghost-ftp.desktop "$root/usr/share/applications/ghost-ftp.desktop"
-  sed -e "s/@VERSION@/${VERSION}/g" -e "s/@ARCH@/${debarch}/g" linux/debian/control.in > "$root/DEBIAN/control"
+  GOARCH="$goarch" go build -trimpath -buildvcs=false -ldflags "-s -w -X main.version=${VERSION}" -o "$binary" ./cmd/ghostftp
+  chmod 0755 "$binary"
 
-  dpkg-deb --root-owner-group --build "$root" "$out" >/dev/null
-  rm -rf "$root"
-  test -s "$out"
-  echo "LINUX_PACKAGE_OK=${debarch}:$out"
+  mkdir -p "$portable_root"
+  cp "$binary" "$portable_root/ghostftp"
+  cp linux/ghost-ftp.desktop "$portable_root/ghost-ftp.desktop"
+  cp build/icon.png "$portable_root/ghost-ftp.png"
+  cp LICENSE "$portable_root/LICENSE"
+  cp linux/README.md "$portable_root/README.md"
+  chmod 0755 "$portable_root/ghostftp"
+  chmod 0644 "$portable_root/ghost-ftp.desktop" "$portable_root/ghost-ftp.png" "$portable_root/LICENSE" "$portable_root/README.md"
+
+  tar --sort=name --owner=0 --group=0 --numeric-owner --mtime='UTC 2020-01-01' -C dist -cf - "$portable_name" | gzip -n -9 > "$portable_out"
+  test -s "$portable_out"
+  echo "LINUX_PORTABLE_OK=${debarch}:$portable_out"
+
+  if (( have_dpkg )); then
+    mkdir -p "$deb_root/DEBIAN" "$deb_root/usr/bin" "$deb_root/usr/share/applications" "$deb_root/usr/share/icons/hicolor/512x512/apps"
+    cp "$binary" "$deb_root/usr/bin/ghostftp"
+    chmod 0755 "$deb_root/usr/bin/ghostftp"
+    cp build/icon.png "$deb_root/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png"
+    cp linux/ghost-ftp.desktop "$deb_root/usr/share/applications/ghost-ftp.desktop"
+    sed -e "s/@VERSION@/${VERSION}/g" -e "s/@ARCH@/${debarch}/g" linux/debian/control.in > "$deb_root/DEBIAN/control"
+
+    dpkg-deb --root-owner-group --build "$deb_root" "$deb_out" >/dev/null
+    test -s "$deb_out"
+    echo "LINUX_DEB_OK=${debarch}:$deb_out"
+  fi
+
+  rm -rf "$binary" "$deb_root" "$portable_root"
 }
 
 build_arch amd64 amd64
 build_arch arm64 arm64
 build_arch 386 i386
 
-echo "Ghost FTP ${VERSION} Linux packages built with ${raw_go} and telemetry=${telemetry}."
+if (( have_dpkg )); then
+  echo "Ghost FTP ${VERSION} Linux DEB and portable packages built with ${raw_go} and telemetry=${telemetry}."
+else
+  echo "Ghost FTP ${VERSION} distro-neutral Linux portable packages built with ${raw_go} and telemetry=${telemetry}; dpkg-deb was not available, so DEB packaging was skipped."
+fi

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,6 +1,6 @@
 # Ghost FTP for Linux
 
-Ghost FTP **1.1.1 Stable** is the current source candidate. Linux packages are built by `linux/BUILD.sh` for `amd64`, `arm64` and `i386`. Linux uses the same connection, profile, local-filesystem, remote-operation, transfer, settings and localization engine as the Windows application.
+Ghost FTP **1.1.6 Stable** is the current published release. The maintained `main` source may contain post-1.1.6 hardening and packaging improvements before a later maintenance release is prepared. Linux uses the same connection, profile, local-filesystem, remote-operation, transfer, settings and localization engine as the Windows application.
 
 ## Build
 
@@ -9,7 +9,15 @@ go telemetry off
 bash linux/BUILD.sh
 ```
 
-The script creates:
+The build always creates package-manager-neutral portable archives for `amd64`, `arm64` and `i386`:
+
+```text
+dist/Ghost-FTP-X.Y.Z-Linux-amd64.tar.gz
+dist/Ghost-FTP-X.Y.Z-Linux-arm64.tar.gz
+dist/Ghost-FTP-X.Y.Z-Linux-i386.tar.gz
+```
+
+When `dpkg-deb` is available, the same build also creates:
 
 ```text
 dist/Ghost-FTP-X.Y.Z-Linux-amd64.deb
@@ -17,20 +25,58 @@ dist/Ghost-FTP-X.Y.Z-Linux-arm64.deb
 dist/Ghost-FTP-X.Y.Z-Linux-i386.deb
 ```
 
-The GitHub Release combines these verified packages into one additional public download:
+Production CI sets `GHOSTFTP_REQUIRE_DEB=1`, so an official Linux production build fails closed if the DEB tooling is unavailable. On distributions that do not ship `dpkg-deb`, a local source build can still produce the portable tarballs without installing a Debian packaging tool solely for that purpose.
+
+The portable archive and DEB for each architecture are built from the same compiled `ghostftp` binary. CI extracts both formats and compares those executables byte-for-byte before accepting the Linux job.
+
+### Published 1.1.6 note
+
+The already published Ghost FTP 1.1.6 release is immutable and keeps its original Linux asset set: three DEB files plus `Ghost-FTP-1.1.6-Linux-multiarch.zip`. The portable `.tar.gz` output is a post-1.1.6 source/CI packaging improvement and is **not** retroactively claimed as a 1.1.6 release asset.
+
+## Distro-neutral portable use
+
+The `.tar.gz` package is intended for Linux distributions where a Debian package is not the native installation format, including RPM-based and rolling-release environments. It does not pretend to be an RPM, Flatpak, AppImage, Snap or distribution repository package; those formats require their own verified packaging lifecycle before they can be called officially supported artifacts.
+
+Extract the archive matching the machine architecture:
+
+```bash
+tar -xzf Ghost-FTP-X.Y.Z-Linux-amd64.tar.gz
+cd Ghost-FTP-X.Y.Z-Linux-amd64
+./ghostftp
+```
+
+Each archive contains:
 
 ```text
-Ghost-FTP-X.Y.Z-Linux-multiarch.zip
+ghostftp
+ghost-ftp.desktop
+ghost-ftp.png
+LICENSE
+README.md
 ```
+
+For optional per-user desktop integration without root privileges:
+
+```bash
+mkdir -p "$HOME/.local/bin" \
+  "$HOME/.local/share/applications" \
+  "$HOME/.local/share/icons/hicolor/512x512/apps"
+install -m 0755 ghostftp "$HOME/.local/bin/ghostftp"
+install -m 0644 ghost-ftp.desktop "$HOME/.local/share/applications/ghost-ftp.desktop"
+install -m 0644 ghost-ftp.png "$HOME/.local/share/icons/hicolor/512x512/apps/ghost-ftp.png"
+```
+
+Ensure `$HOME/.local/bin` is on `PATH` before launching from the desktop entry. System protocol prerequisites still apply: a usable CA certificate store, `curl` for FTP/FTPS and OpenSSH client tools for SFTP.
 
 ## Installed identity
 
 - Debian package: `ghost-ftp`
-- executable: `/usr/bin/ghostftp`
+- executable installed by DEB: `/usr/bin/ghostftp`
+- user-local portable executable: `$HOME/.local/bin/ghostftp` when installed as shown above
 - desktop name: **Ghost FTP**
 - desktop entry: `ghost-ftp.desktop`
 
-Runtime dependencies declared by the package are `ca-certificates`, `curl` and `openssh-client`. Ghost FTP does not bundle those projects or add external Go modules to the desktop/core module.
+The DEB declares runtime dependencies on `ca-certificates`, `curl` and `openssh-client`. The portable archive intentionally does not bundle distribution package-manager metadata or copies of those system tools.
 
 ## Graphical desktop
 
@@ -48,7 +94,7 @@ For a headless session, or to explicitly use the hardened command interface, set
 GHOSTFTP_UI=terminal ghostftp
 ```
 
-A graphical session requires a local X11-compatible display (native X11 or XWayland). The file-transfer protocols continue to use the system transport prerequisites documented below.
+A graphical session requires a local X11-compatible display (native X11 or XWayland). The file-transfer protocols continue to use the system transport prerequisites documented above.
 
 ## Authentication
 
@@ -95,7 +141,7 @@ lrename <old> <new>
 ldelete <name>
 ```
 
-Local operations use the shared guarded filesystem service, including safe child-name validation, no-replace rename behavior, symlink/reparse protections and root-delete blocking.
+Local operations use the shared guarded filesystem service, including safe child-name validation, no-replace rename behavior, symlink/reparse protections, rooted local creation/deletion and root-delete blocking.
 
 ## File and folder transfers
 
@@ -108,7 +154,7 @@ puttree <local-directory> <remote-directory>
 
 Relative local paths resolve from the active local terminal directory. Relative remote paths resolve from the active remote directory.
 
-Folder operations use the shared bounded tree-transfer planner. They retain the normal Ghost FTP item/depth limits, symlink handling, path validation, conflict policy and transfer queue behavior.
+Folder operations use the shared bounded tree-transfer planner. They retain the normal Ghost FTP item/depth limits, symlink handling, path validation, conflict policy and transfer queue behavior. Tree-download directory preparation remains anchored to opened filesystem roots so a later boundary or parent pathname swap cannot redirect directory creation.
 
 ## Transfer queue
 

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -108,7 +108,6 @@ def main() -> int:
     if "New-DevCodeSigningCertificate.ps1" in workflow:
         fail("production release workflow must not create a self-signed publisher identity")
 
-    # Stable package aliases must never be emitted by the pre-1.0 branch of the channel switch.
     stable_package_pos = workflow.find("Publish stable bundle to GitHub Packages")
     prerelease_pos = workflow.find("prerelease_args+=(--prerelease)")
     if stable_package_pos < 0 or prerelease_pos < 0:
@@ -127,6 +126,11 @@ def main() -> int:
         "Authenticode private-key pipeline smoke test",
         "New-DevCodeSigningCertificate.ps1",
         "Sign-WindowsArtifacts.ps1",
+        "Verify DEB and portable packages",
+        "GHOSTFTP_REQUIRE_DEB: '1'",
+        "Ghost-FTP-${version}-Linux-${arch}.tar.gz",
+        'cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"',
+        "dist/Ghost-FTP-*-Linux-*.tar.gz",
     )
     require(
         "BUILD-WINDOWS.ps1",
@@ -154,7 +158,18 @@ def main() -> int:
         '"UninstallString"', '"QuietUninstallString"', '"DisplayVersion"', '"NoModify"', '"NoRepair"',
     )
     require("scripts/make_payload.py", "PAYLOAD_SCHEMA = 2", 'add(zf, args.app, "GhostFTP.exe")')
-    require("linux/BUILD.sh", '"$root/usr/bin/ghostftp"', "Ghost-FTP-${VERSION}-Linux-${debarch}.deb")
+    require(
+        "linux/BUILD.sh",
+        'binary="dist/.ghostftp-linux-${debarch}"',
+        'portable_name="Ghost-FTP-${VERSION}-Linux-${debarch}"',
+        'portable_out="dist/${portable_name}.tar.gz"',
+        'cp "$binary" "$portable_root/ghostftp"',
+        'cp "$binary" "$deb_root/usr/bin/ghostftp"',
+        "GHOSTFTP_REQUIRE_DEB",
+        "Ghost-FTP-${VERSION}-Linux-${debarch}.deb",
+        "tar --sort=name --owner=0 --group=0 --numeric-owner",
+        "gzip -n -9",
+    )
     require("linux/debian/control.in", "Package: ghost-ftp")
 
     require(
@@ -192,6 +207,7 @@ def main() -> int:
     print("WINDOWS_PORTABLE=x64,x86")
     print("WINDOWS_X32_ALIAS_OF_X86=REQUIRED")
     print("LINUX_DEB=amd64,arm64,i386")
+    print("LINUX_PORTABLE_SOURCE=amd64,arm64,i386")
     print("STABLE_GHCR_BUNDLE=REQUIRED")
     return 0
 

--- a/scripts/test_linux_packaging_contract.py
+++ b/scripts/test_linux_packaging_contract.py
@@ -12,7 +12,8 @@ def read(relative: str) -> str:
 class LinuxPackagingContractTests(unittest.TestCase):
     def test_build_emits_portable_archives_without_forcing_deb_tooling(self) -> None:
         build = read("linux/BUILD.sh")
-        self.assertIn("Ghost-FTP-${VERSION}-Linux-${debarch}.tar.gz", build)
+        self.assertIn('portable_name="Ghost-FTP-${VERSION}-Linux-${debarch}"', build)
+        self.assertIn('portable_out="dist/${portable_name}.tar.gz"', build)
         self.assertIn("command -v dpkg-deb", build)
         self.assertIn("GHOSTFTP_REQUIRE_DEB", build)
         self.assertIn("tar --sort=name --owner=0 --group=0 --numeric-owner", build)
@@ -32,7 +33,7 @@ class LinuxPackagingContractTests(unittest.TestCase):
         linux_readme = read("linux/README.md")
         parity = read("docs/PLATFORM-PARITY.md")
         self.assertIn("already published Ghost FTP 1.1.6 release is immutable", linux_readme)
-        self.assertIn("not** retroactively claimed as a 1.1.6 release asset", linux_readme.replace(" **", "**"))
+        self.assertIn("is **not** retroactively claimed as a 1.1.6 release asset", linux_readme)
         self.assertIn("source/CI outputs only until a separate release-contract change", parity)
 
 

--- a/scripts/test_linux_packaging_contract.py
+++ b/scripts/test_linux_packaging_contract.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class LinuxPackagingContractTests(unittest.TestCase):
+    def test_build_emits_portable_archives_without_forcing_deb_tooling(self) -> None:
+        build = read("linux/BUILD.sh")
+        self.assertIn("Ghost-FTP-${VERSION}-Linux-${debarch}.tar.gz", build)
+        self.assertIn("command -v dpkg-deb", build)
+        self.assertIn("GHOSTFTP_REQUIRE_DEB", build)
+        self.assertIn("tar --sort=name --owner=0 --group=0 --numeric-owner", build)
+        self.assertIn("gzip -n -9", build)
+        self.assertIn('cp "$binary" "$portable_root/ghostftp"', build)
+        self.assertIn('cp "$binary" "$deb_root/usr/bin/ghostftp"', build)
+
+    def test_ci_proves_deb_and_portable_binary_parity(self) -> None:
+        workflow = read(".github/workflows/ci.yml")
+        self.assertIn("Verify DEB and portable packages", workflow)
+        self.assertIn("GHOSTFTP_REQUIRE_DEB: '1'", workflow)
+        self.assertIn("Ghost-FTP-${version}-Linux-${arch}.tar.gz", workflow)
+        self.assertIn('cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"', workflow)
+        self.assertIn("dist/Ghost-FTP-*-Linux-*.tar.gz", workflow)
+
+    def test_docs_do_not_retroactively_claim_tarballs_for_116(self) -> None:
+        linux_readme = read("linux/README.md")
+        parity = read("docs/PLATFORM-PARITY.md")
+        self.assertIn("already published Ghost FTP 1.1.6 release is immutable", linux_readme)
+        self.assertIn("not** retroactively claimed as a 1.1.6 release asset", linux_readme.replace(" **", "**"))
+        self.assertIn("source/CI outputs only until a separate release-contract change", parity)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Linux production/source packaging was tied to `dpkg-deb`, so non-Debian distributions had no verified package-manager-neutral Ghost FTP artifact even though the Linux binary is built with `CGO_ENABLED=0` and the same shared application engine.

## Fix

- build `.tar.gz` portable archives for amd64, arm64 and i386;
- keep DEB builds when `dpkg-deb` is available;
- make production CI fail closed with `GHOSTFTP_REQUIRE_DEB=1` so DEB coverage cannot disappear silently;
- build DEB and portable packages from the same compiled executable;
- extract both formats in CI and compare their `ghostftp` binaries byte-for-byte;
- include desktop entry, icon, license and Linux README in the portable archive;
- refresh active Linux/parity/dependency documentation and explicitly state that the already-published 1.1.6 release remains immutable and does not retroactively contain these tarballs;
- add a Python regression contract for the packaging/CI behavior.

## Scope

- no VERSION change;
- no GitHub Release/tag/assets change;
- no release workflow publication allow-list change yet;
- no Windows runtime/UI change;
- no new Go module/runtime dependency;
- no telemetry or web/PWA surface.

A separate gated PR will wire these verified tarballs into the future release allow-list after this source/CI packaging change merges cleanly.

Merge only after exact-head Core, Linux and Windows CI are green, then verify post-merge exact-main CI.