### PR TITLE
Document 1.1.6 as the published stable release

### DIFF
--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -1,10 +1,10 @@
 # Ghost FTP GitHub Releases
 
-Ghost FTP **1.1.6 Stable** is the current maintained stable release candidate. Ghost FTP **1.1.5 Stable** is the previously published maintenance release; earlier published Stable tags/releases remain immutable historical identities. Official releases are created only by the canonical release workflow from the exact verified `main` commit.
+Ghost FTP **1.1.6 Stable** is the current published stable release. Ghost FTP **1.1.5 Stable** is the previous maintenance release; all published Stable tags/releases through 1.1.6 remain immutable historical identities. Official releases are created only by the canonical release workflow from the exact verified `main` commit.
 
 ## Release identity
 
-For version `1.1.6`:
+The published 1.1.6 identity is:
 
 ```text
 Tag: ghostftp-v1.1.6
@@ -18,19 +18,19 @@ The release workflow reads `VERSION` directly and rejects a manual workflow vers
 
 A version with major number `1` or greater is treated as Stable. The release workflow does not pass GitHub's prerelease flag for stable versions.
 
-Historical 0.x releases were Beta/prerelease builds and remain part of release history; they are not rewritten or relabeled as stable. Existing published Stable tags through `ghostftp-v1.1.5` remain bound to their original release commits.
+Historical 0.x releases were Beta/prerelease builds and remain part of release history; they are not rewritten or relabeled as stable. Existing published Stable tags through `ghostftp-v1.1.6` remain bound to their original release commits.
 
 ## Canonical release trigger
 
 `release.yml` is intentionally `workflow_dispatch`-only. A push to `main`, including a commit that changes `VERSION`, must not publish a release directly.
 
-The generic canonical release-branch namespace is `release/ghostftp-vX.Y.Z`. For version 1.1.6, the release-prep PR first passes exact-head CI and authentic Windows UI evidence. After merge, the exact current `main` SHA must pass post-merge Core, Windows and Linux CI. Only then is `release/ghostftp-v1.1.6` created at that exact `main` SHA. `.github/workflows/release-branch-trigger.yml` verifies both branch-to-main SHA equality and branch-version-to-`VERSION` equality before dispatching `release.yml` on `main` with the expected version guard.
+The generic canonical release-branch namespace is `release/ghostftp-vX.Y.Z`. For 1.1.6, the release-prep PR passed exact-head CI and authentic Windows UI evidence. After merge, the exact `main` SHA passed post-merge Core, Windows and Linux CI. Only then was `release/ghostftp-v1.1.6` created at that exact `main` SHA. `.github/workflows/release-branch-trigger.yml` verified both branch-to-main SHA equality and branch-version-to-`VERSION` equality before dispatching `release.yml` on `main` with the expected version guard.
 
-This keeps publication behind one canonical branch trigger and prevents duplicate or premature releases caused by a `VERSION` push.
+Future releases must follow the same canonical branch-dispatch model. This keeps publication behind one controlled trigger and prevents duplicate or premature releases caused by a `VERSION` push.
 
-## Required public files
+## Published 1.1.6 public files
 
-The stable Release exposes **9 platform artifacts**.
+The immutable 1.1.6 Release exposes **9 platform artifacts**.
 
 Windows:
 
@@ -59,19 +59,19 @@ RELEASE-NOTES.txt
 SHA256.txt
 ```
 
-That is **12 public files** in total.
+That is **12 public files** in total. Post-1.1.6 source/CI builds also create verified Linux `.tar.gz` portable archives, but those are not retroactive 1.1.6 assets. A future release may publish them only after its own release allow-list change passes review and CI.
 
 ## Exact-head rule
 
 Before publication, the workflow queries current `main` and requires it to equal the release source SHA. It verifies the condition again after release publication. If `main` moves during the transaction, publication fails instead of silently attaching files to stale source.
 
-The canonical `release/ghostftp-v1.1.6` trigger branch must therefore be created from the exact `main` commit that passed the complete post-merge quality gate. The release-branch trigger independently verifies that equality before it dispatches publication.
+For 1.1.6, the canonical `release/ghostftp-v1.1.6` trigger branch was created from the exact `main` commit that passed the complete post-merge quality gate. Future release branches must satisfy the same equality check before publication dispatch.
 
-## Immutable tag rule
+## Immutable tag and asset rule
 
-If `ghostftp-v1.1.6` already exists unexpectedly before publication, the release must stop. The tag must not be moved, deleted, reused or force-pushed.
+A release workflow must fail if the requested release tag or GitHub Release already exists. Existing tags are not moved, deleted, reused or force-pushed, and published assets are not overwritten or clobbered.
 
-The already-published Stable tags through `ghostftp-v1.1.5` are immutable release history. After successful 1.1.6 publication, `ghostftp-v1.1.6` becomes immutable under the same rule.
+The already-published Stable tags/releases through `ghostftp-v1.1.6` are immutable release history. Later source hardening, packaging improvements or documentation corrections do not rewrite their tag targets, assets, notes or checksums.
 
 ## Product and publisher identity
 
@@ -97,21 +97,23 @@ The publish job assembles a fresh `release/` directory from only the verified Wi
 
 `Setup-x32.exe` is intentionally a byte-identical compatibility alias of `Setup-x86.exe`; the workflow verifies their SHA-256 values match. It is not a separate architecture build.
 
+Published release immutability is fail-closed: the workflow rejects an existing tag or release rather than using `gh release upload` or `--clobber` to replace historical assets.
+
 ## Read-back verification
 
-After creating the Release, the workflow reads the remote asset set from GitHub and compares it with the expected sorted list. It also reads `prerelease` and requires it to be `false` for the stable channel. A delayed second read-back catches asynchronous publication issues.
+After creating a new Release, the workflow reads the remote asset set from GitHub and compares it with the expected sorted list. It also reads `prerelease` and requires it to be `false` for the stable channel. A delayed second read-back catches asynchronous publication issues.
 
-A release is not considered published merely because a local build succeeded; remote Release/tag state must agree with the verified source revision and file contract.
+A release is not considered published merely because a local build succeeded; remote Release/tag state must agree with the verified source revision and file contract. Ghost FTP 1.1.6 completed those remote read-back gates.
 
 ## GitHub Packages
 
-Stable 1.1.6 publication additionally pushes the verified release directory to:
+Stable 1.1.6 is published at:
 
 ```text
 ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
-Compatible stable aliases are published only after successful registry publication/read-back:
+Compatible stable aliases were published after successful registry publication/read-back:
 
 ```text
 1.1
@@ -127,10 +129,12 @@ See [Packages](PACKAGES.md).
 
 The 1.1.6 release contains four verified hardening changes since 1.1.5: root-handle recursive local delete, root-handle local `Mkdir`, in-memory SFTP fingerprint derivation bound to the exact scanned key, and fail-closed remote cleanup proof that rejects spoofable diagnostic text.
 
-The release-prep version change alters public version presentation. Authentic Main Workspace, Site Manager, Settings and About screenshots must therefore be generated from the real production Windows x64 Portable executable on the exact final release-prep head and visually reviewed before merge. Mockups or generated approximations are not accepted as release evidence.
+The release-prep version change altered public version presentation. Authentic Main Workspace, Site Manager, Settings and About screenshots were generated from the real production Windows x64 Portable executable on the exact final release-prep head and visually reviewed before merge. Mockups or generated approximations were not accepted as release evidence.
+
+Post-1.1.6 `main` additionally includes further hardening and Linux packaging work. Those source changes are not retroactively described as contents of the immutable 1.1.6 release.
 
 ## Failure behavior
 
-A failed quality gate, production build, configured-signing verification, package push, tag validation, Release upload or read-back check causes the workflow to fail. Absence of a production Authenticode certificate alone does not fail publication; that state is preserved as `unsigned` metadata.
+A failed quality gate, production build, configured-signing verification, package push, tag validation, Release creation or read-back check causes the workflow to fail. Absence of a production Authenticode certificate alone does not fail publication; that state is preserved as `unsigned` metadata.
 
 See [Release verification](RELEASE-VERIFICATION.md), [Signing](SIGNING.md) and [Versioning](VERSIONING.md).

--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -67,7 +67,7 @@ Before publication, the workflow queries current `main` and requires it to equal
 
 For 1.1.6, the canonical `release/ghostftp-v1.1.6` trigger branch was created from the exact `main` commit that passed the complete post-merge quality gate. Future release branches must satisfy the same equality check before publication dispatch.
 
-## Immutable tag and asset rule
+## Immutable tag rule
 
 A release workflow must fail if the requested release tag or GitHub Release already exists. Existing tags are not moved, deleted, reused or force-pushed, and published assets are not overwritten or clobbered.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,12 +1,14 @@
 # Ghost FTP installation
 
-Ghost FTP **1.1.6 Stable** is the current source candidate and ships as native Windows and Linux packages after the complete release gate succeeds. Use only official artifacts whose version and SHA-256 values match the corresponding published GitHub Release. Published 1.1.5 and earlier releases remain immutable historical releases and are not rewritten.
+Ghost FTP **1.1.6 Stable** is the current published stable release. Use only official artifacts whose version and SHA-256 values match the corresponding published GitHub Release. Published Stable releases through 1.1.6 are immutable historical release identities and are not rewritten by later source or packaging work.
 
 The official Ghost FTP product website is **https://ghostftp.com**. Ghost FTP is developed and published by **BRENDIGO LTD**; the author's official website is **https://brendigo.com**.
 
 ## Windows
 
 ### Setup packages
+
+The published 1.1.6 Windows files are:
 
 ```text
 Ghost-FTP-1.1.6-Setup-x64.exe
@@ -37,7 +39,7 @@ In both cases verify `SHA256.txt`. For a signed release, also verify the Authent
 
 ## Linux
 
-Official Debian packages for 1.1.6 are:
+The published Linux files for 1.1.6 are:
 
 ```text
 Ghost-FTP-1.1.6-Linux-amd64.deb
@@ -46,7 +48,9 @@ Ghost-FTP-1.1.6-Linux-i386.deb
 Ghost-FTP-1.1.6-Linux-multiarch.zip
 ```
 
-Install the package matching the machine architecture with the system package manager. The package installs `ghostftp` and the maintained Linux desktop integration. DEB metadata uses `Homepage: https://ghostftp.com` and the BRENDIGO LTD publisher identity.
+Install the DEB matching the machine architecture with the system package manager. The package installs `ghostftp` and the maintained Linux desktop integration. DEB metadata uses `Homepage: https://ghostftp.com` and the BRENDIGO LTD publisher identity.
+
+Post-1.1.6 source/CI builds additionally create verified package-manager-neutral `.tar.gz` archives for amd64, arm64 and i386. Those archives are not retroactive 1.1.6 release assets; see the Linux documentation for source-build and portable-installation instructions.
 
 ## Upgrade to 1.1.6
 
@@ -54,7 +58,7 @@ Ghost FTP 1.1.6 is a backward-compatible 1.x maintenance release. Existing 1.x l
 
 Before upgrading critical systems, keep an appropriate backup of local configuration and verify the stable package checksum and, when present, its signing state.
 
-Windows Setup performs a staged replacement with rollback-oriented transaction behavior. Linux upgrades use standard DEB package-manager semantics.
+Windows Setup performs a staged replacement with rollback-oriented transaction behavior. Linux upgrades using the published 1.1.6 DEBs use standard DEB package-manager semantics.
 
 ## First connection defaults
 
@@ -70,7 +74,7 @@ If a protected secret cannot be decrypted under the current user/device context,
 
 ## GitHub Packages
 
-After successful stable publication, the 1.1.6 release is mirrored as:
+The published 1.1.6 release is mirrored as:
 
 ```text
 ghcr.io/bren-wp/ghost-ftp:1.1.6
@@ -92,6 +96,8 @@ Use the registered Ghost FTP uninstall entry. The integrated maintenance/uninsta
 
 Remove the `ghost-ftp` package with the distribution package manager. User-local profiles/settings are separate data; removing application binaries does not imply deletion of all user data unless the product explicitly offers that operation.
 
+For a manually installed package-manager-neutral source/CI tarball, remove only the files that were installed from that archive; do not treat this as a package-manager transaction.
+
 ## Troubleshooting
 
 If Windows shows an unknown-publisher or SmartScreen warning, first inspect `BUILD-METADATA.txt`. If it says `WINDOWS_AUTHENTICODE=unsigned`, verify the official release location and `SHA256.txt`. If metadata says `signed` but signature validation fails, treat that as a release-integrity failure.
@@ -111,6 +117,6 @@ For connection failures, verify protocol, host, port, server policy and system t
 7. test the target server using its intended FTP/FTPS/SFTP mode and do not bypass failed TLS by silently switching protocols;
 8. keep private credentials out of logs and support reports.
 
-The 1.1.6 filenames above describe the candidate contract; they are not proof of publication. Treat 1.1.6 as downloadable only after the official tag, GitHub Release asset set and GHCR package read-back have succeeded.
+Ghost FTP 1.1.6 is already published as Stable. Its official tag, Release asset set and GHCR distribution bundle were read back by the canonical production workflow; later source/CI improvements do not rewrite that historical release.
 
 See [Release verification](RELEASE-VERIFICATION.md), [Signing](SIGNING.md), [Security](SECURITY.md) and [Privacy](PRIVACY.md).

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -8,15 +8,15 @@ Ghost FTP publishes a verified **distribution bundle** to GitHub Packages for ea
 ghcr.io/bren-wp/ghost-ftp:<version>
 ```
 
-For the Ghost FTP 1.1.6 Stable candidate, the canonical immutable version tag is:
+Ghost FTP **1.1.6 Stable is published**. Its canonical immutable version tag is:
 
 ```text
 ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
-Stable publication updates compatible aliases `1.1`, `1` and `latest` only after successful registry publication and read-back. Automation that requires reproducibility should use the full semantic version and, when possible, pin the registry digest.
+The 1.1.6 publication also updated compatible aliases `1.1`, `1` and `latest` after successful registry publication and read-back. Automation that requires reproducibility should use the full semantic version and, when possible, pin the registry digest.
 
-Published 1.1.5 and earlier package versions remain immutable historical distribution identities and are not rewritten for 1.1.6.
+Published package versions through 1.1.6 are immutable historical distribution identities and are not rewritten by later source or packaging work.
 
 ## What the package contains
 
@@ -26,13 +26,15 @@ The image contains the verified release directory under:
 /ghostftp-release/
 ```
 
-That directory contains the same Windows Setup/Portable packages, Linux DEB packages, release notes, build metadata and `SHA256.txt` manifest published on the corresponding GitHub Release.
+For 1.1.6, that directory contains the same Windows Setup/Portable packages, Linux DEB packages and Linux multiarch bundle, release notes, build metadata and `SHA256.txt` manifest published on the corresponding GitHub Release.
 
 This is a **distribution bundle**, not a runtime container. Ghost FTP is a native desktop application for Windows and Linux; GHCR exists so CI systems, mirrors and administrators can retrieve a versioned, repository-linked release bundle.
 
+Post-1.1.6 source/CI builds additionally produce package-manager-neutral Linux `.tar.gz` archives. They are not retroactive contents of the immutable 1.1.6 GHCR bundle; a later release may include them only after its own release-contract gates pass.
+
 ## Canonical installation source
 
-For normal installation, use files attached to the official GitHub Release. GitHub Packages is an additional verified distribution surface and does not replace Setup, Portable or DEB packages.
+For normal installation, use files attached to the official GitHub Release. GitHub Packages is an additional verified distribution surface and does not replace Setup, Portable or Linux packages.
 
 The official product website is **https://ghostftp.com**. Ghost FTP is developed and published by **BRENDIGO LTD**, whose official website is **https://brendigo.com**.
 
@@ -43,12 +45,14 @@ Every stable package is produced only after the same quality gates used for GitH
 - Go formatting, race tests and vet;
 - security, privacy, dependency, repository, platform, localization and documentation audits;
 - Windows x64/x86 Setup and Portable production builds;
-- Linux amd64/arm64/i386 DEB production builds;
+- Linux production builds and package verification;
 - release asset allow-list verification;
 - SHA-256 manifest generation;
 - Authenticode verification **when a trusted production certificate is configured**;
 - explicit `WINDOWS_AUTHENTICODE=unsigned` metadata when no production certificate is configured;
 - exact source/release version binding and post-publication read-back.
+
+For the historical 1.1.6 release, the Linux public artifacts remain three DEBs plus the Linux multiarch ZIP. Current source/CI additionally validates distro-neutral Linux tarballs, but that does not mutate the already published bundle.
 
 Production signing is optional, but its state is never ambiguous. A configured trusted signing identity is verified fail-closed; absence of a production certificate does not cause Ghost FTP to fabricate a self-signed publisher identity or label unsigned files as signed.
 
@@ -60,7 +64,7 @@ The package is built only from the already assembled `release/` allow-list. It d
 
 ## Digest-first automation
 
-After 1.1.6 has actually been published:
+For the published 1.1.6 package:
 
 1. resolve `ghcr.io/bren-wp/ghost-ftp:1.1.6` to its OCI digest;
 2. pin that digest in downstream automation where practical;
@@ -71,4 +75,4 @@ After 1.1.6 has actually been published:
 
 This provides two integrity references: the OCI manifest digest and the per-file SHA-256 manifest, plus an explicit Windows signing-state declaration.
 
-Do not treat this documentation as proof that 1.1.6 has already been published. Publication is complete only after the canonical `release/ghostftp-v1.1.6` path succeeds and remote GitHub Release/GHCR read-back confirms the final state.
+Ghost FTP 1.1.6 publication is complete: the canonical release path succeeded and remote GitHub Release/GHCR read-back confirmed the final state. Future releases must independently satisfy the same fail-closed publication contract.

--- a/docs/RELEASE-VERIFICATION.md
+++ b/docs/RELEASE-VERIFICATION.md
@@ -2,7 +2,7 @@
 
 This document defines how to verify Ghost FTP **1.0.0 Stable** and later stable releases. The current maintained release is **1.1.6 Stable**. Verification covers source identity, Windows signing state, Linux package metadata, per-file SHA-256 values, GitHub Release state and GitHub Packages registry state.
 
-## Expected 1.1.6 release identity
+## Published 1.1.6 release identity
 
 ```text
 VERSION=1.1.6
@@ -11,7 +11,7 @@ TITLE=Ghost FTP 1.1.6
 PRERELEASE=false
 ```
 
-A stable release must not be marked as a prerelease. Previously published Stable tags through `ghostftp-v1.1.5` remain historical identities and must not be moved or reused.
+Ghost FTP 1.1.6 is published Stable and must not be marked as a prerelease. Published Stable tags through `ghostftp-v1.1.6` are historical identities and must not be moved, reused or rewritten.
 
 ## Source revision and canonical publication flow
 
@@ -29,9 +29,11 @@ Publication is not triggered merely because `VERSION` changed on `main`. The can
 
 `release.yml` is publication-only and `workflow_dispatch`-only. A push to `main`, including a change to `VERSION`, must never publish a release directly.
 
-## Public file set
+Ghost FTP 1.1.6 completed this canonical flow. Future releases must independently complete the same gates.
 
-The expected contract is **9 platform artifacts** and **12 public files** total. Extra or missing files fail publication read-back.
+## Published 1.1.6 public file set
+
+The immutable 1.1.6 contract is **9 platform artifacts** and **12 public files** total.
 
 Windows:
 
@@ -60,6 +62,8 @@ RELEASE-NOTES.txt
 SHA256.txt
 ```
 
+Post-1.1.6 source/CI builds also create package-manager-neutral Linux `.tar.gz` archives for amd64, arm64 and i386. Those source outputs are not part of the immutable 1.1.6 asset set unless a future version is published with a separately reviewed release contract.
+
 ## SHA-256 verification
 
 `SHA256.txt` contains hashes for every other public release file. On Linux use `sha256sum -c SHA256.txt`. On Windows use `Get-FileHash -Algorithm SHA256` and compare each value with the manifest. A matching filename alone is not proof of authenticity; verify both the digest and official release location.
@@ -80,7 +84,7 @@ The production workflow **does not create a self-signed production identity**. S
 
 ## Linux DEB verification
 
-For each Linux package, verify package name, version, architecture, Homepage and Maintainer. Expected package name is `ghost-ftp`; version must equal `1.1.6`; architecture must match the file suffix; Homepage must be `https://ghostftp.com`; publisher metadata must identify **BRENDIGO LTD**.
+For each published 1.1.6 Linux package, verify package name, version, architecture, Homepage and Maintainer. Expected package name is `ghost-ftp`; version must equal `1.1.6`; architecture must match the file suffix; Homepage must be `https://ghostftp.com`; publisher metadata must identify **BRENDIGO LTD**.
 
 Example:
 
@@ -100,26 +104,26 @@ Confirm that:
 - title is `Ghost FTP 1.1.6`;
 - `prerelease` is false;
 - tag resolves to the documented source commit;
-- remote asset names exactly match the 12-file allow-list;
+- remote asset names exactly match the historical 12-file allow-list;
 - `SHA256.txt` verifies downloaded content;
 - `BUILD-METADATA.txt` truthfully reports `WINDOWS_AUTHENTICODE=signed` or `unsigned`;
 - release notes correspond to the `CHANGELOG.md` 1.1.6 section.
 
-The production workflow performs immediate and delayed Release read-back. Manual verification remains useful before broad deployment.
+The production workflow performed immediate and delayed Release read-back. Manual verification remains useful before broad deployment.
 
 ## GitHub Packages verification
 
-Stable 1.1.6 publishes:
+Stable 1.1.6 is published at:
 
 ```text
 ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
-The package is a verified distribution bundle, not a runtime container. OCI metadata must identify the Ghost FTP source repository, stable version and release source revision. Stable aliases `1.1`, `1` and `latest` are updated only after publication and registry read-back succeed.
+The package is a verified distribution bundle, not a runtime container. OCI metadata must identify the Ghost FTP source repository, stable version and release source revision. Stable aliases `1.1`, `1` and `latest` were updated after publication and registry read-back succeeded.
 
 ## 1.1.6 runtime and security verification
 
-The release candidate must preserve the maintained runtime contract while applying the 1.1.6 hardening changes:
+The published release preserves the maintained runtime contract while applying the 1.1.6 hardening changes:
 
 - recursive local delete cannot traverse a swapped pathname because descent is rooted through opened filesystem handles;
 - local directory creation remains anchored to the originally opened base directory across pathname replacement;
@@ -134,20 +138,22 @@ The release candidate must preserve the maintained runtime contract while applyi
 - cancellation/retry/connection-generation safeguards remain enabled;
 - no telemetry, analytics, advertising/tracking SDK, hidden product network service or new external Go module dependency is introduced.
 
+Post-1.1.6 `main` contains additional hardening such as rooted tree-download directory preparation and additional Linux source/CI packaging. Those later changes are verified separately and are not retroactively attributed to 1.1.6.
+
 ## Authentic Windows UI evidence
 
-The 1.1.6 release-prep changes the public version presentation. The exact final release-prep source must produce authentic screenshots from the real Windows x64 Portable executable for:
+The 1.1.6 release-prep changed the public version presentation. The exact final release-prep source produced authentic screenshots from the real Windows x64 Portable executable for:
 
 - Main Workspace;
 - Site Manager;
 - Settings;
 - About.
 
-The images must be visually reviewed for clipping, overlap, stale branding and correct 1.1.6 version presentation. Mockups or generated approximations are not accepted as release evidence.
+The images were visually reviewed for clipping, overlap, stale branding and correct 1.1.6 version presentation. Mockups or generated approximations were not accepted as release evidence.
 
 ## CI/release gate verification
 
-Before trusting 1.1.6, inspect that the exact revision passed:
+The published 1.1.6 revision passed:
 
 - exact PR-head CI before merge;
 - post-merge CI on the exact `main` SHA;
@@ -174,6 +180,6 @@ A release/package must not contain saved profiles, plaintext passwords, private-
 
 ## Failure interpretation
 
-A failed gate is meaningful. Do not manually relabel a failed candidate as stable or bypass integrity checks to make a release appear complete. Fix the source, documentation, packaging, configured signing identity or publication infrastructure and rerun the exact workflow.
+A failed gate is meaningful. Do not manually relabel a failed build as stable or bypass integrity checks to make a release appear complete. Fix the source, documentation, packaging, configured signing identity or publication infrastructure and rerun the exact workflow.
 
 See [GitHub Releases](GITHUB-RELEASES.md), [Packages](PACKAGES.md), [Signing](SIGNING.md), [Security](SECURITY.md) and [Privacy](PRIVACY.md).

--- a/scripts/test_docs_release_version_contract.py
+++ b/scripts/test_docs_release_version_contract.py
@@ -14,7 +14,7 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
         text = self.read("docs/RELEASE-VERIFICATION.md")
         required = [
             f"current maintained release is **{version} Stable**",
-            f"## Expected {version} release identity",
+            f"## Published {version} release identity",
             f"VERSION={version}",
             f"TAG=ghostftp-v{version}",
             f"TITLE=Ghost FTP {version}",
@@ -39,18 +39,18 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
                 f"ghcr.io/bren-wp/ghost-ftp:{version}",
             ],
             "docs/INSTALLATION.md": [
-                f"Ghost FTP **{version} Stable**",
+                f"Ghost FTP **{version} Stable** is the current published stable release",
                 f"Ghost-FTP-{version}-Setup-x64.exe",
                 f"Ghost-FTP-{version}-Linux-amd64.deb",
                 f"ghcr.io/bren-wp/ghost-ftp:{version}",
             ],
             "docs/PACKAGES.md": [
-                f"Ghost FTP {version} Stable candidate",
+                f"Ghost FTP **{version} Stable is published**",
                 f"ghcr.io/bren-wp/ghost-ftp:{version}",
             ],
             "docs/SUPPORT.md": [f"Ghost FTP **{version} Stable**"],
             "docs/GITHUB-RELEASES.md": [
-                f"Ghost FTP **{version} Stable**",
+                f"Ghost FTP **{version} Stable** is the current published stable release",
                 f"ghostftp-v{version}",
                 f"Ghost-FTP-{version}-Setup-x64.exe",
                 f"ghcr.io/bren-wp/ghost-ftp:{version}",
@@ -60,6 +60,25 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
             text = self.read(relative)
             for marker in required:
                 self.assertIn(marker, text, f"{relative} is missing {marker!r}")
+
+    def test_current_stable_docs_do_not_revert_to_candidate_status(self):
+        version = self.read("VERSION").strip()
+        stale = (
+            f"Ghost FTP {version} Stable candidate",
+            "current source candidate",
+            "current maintained stable release candidate",
+            "filenames above describe the candidate contract",
+            "Do not treat this documentation as proof that 1.1.6 has already been published",
+        )
+        for relative in (
+            "docs/INSTALLATION.md",
+            "docs/PACKAGES.md",
+            "docs/GITHUB-RELEASES.md",
+            "docs/RELEASE-VERIFICATION.md",
+        ):
+            text = self.read(relative)
+            for marker in stale:
+                self.assertNotIn(marker, text, f"{relative} still contains stale published-release wording: {marker!r}")
 
     def test_release_docs_describe_canonical_branch_dispatch(self):
         verification = self.read("docs/RELEASE-VERIFICATION.md")


### PR DESCRIPTION
## Problem

Several active documents still described Ghost FTP 1.1.6 as a release/source candidate even though 1.1.6 has already been published and remotely verified as Stable. One regression test explicitly required that stale candidate wording.

## Fix

- document 1.1.6 as the current published Stable release in Installation, Packages, GitHub Releases and Release Verification;
- preserve the historical 1.1.6 asset contract (9 platform artifacts / 12 public files);
- explicitly distinguish post-1.1.6 Linux portable tarballs from immutable 1.1.6 release assets;
- document fail-closed historical tag/asset immutability;
- update the documentation regression contract to require published status and reject stale candidate wording.

## Scope

- documentation + documentation regression only;
- no VERSION change;
- no release workflow change;
- no tag/Release/GHCR/assets change;
- no runtime/UI change.

Merge only after exact-head Core, Linux and Windows CI are green, then verify post-merge exact-main CI.