### PR TITLE
Publish verified Linux portable archives in future releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,19 +188,38 @@ jobs:
           set -euo pipefail
           go telemetry off
           test "$(go telemetry)" = 'off'
-      - name: Build DEB packages
+      - name: Build Linux packages
+        env:
+          GHOSTFTP_REQUIRE_DEB: '1'
         run: bash linux/BUILD.sh
-      - name: Verify DEB metadata
+      - name: Verify DEB and portable packages
         shell: bash
         run: |
           set -euo pipefail
           version="$(tr -d '\r\n' < VERSION)"
           for arch in amd64 arm64 i386; do
             pkg="dist/Ghost-FTP-${version}-Linux-${arch}.deb"
+            portable="dist/Ghost-FTP-${version}-Linux-${arch}.tar.gz"
             test -s "$pkg"
+            test -s "$portable"
             test "$(dpkg-deb -f "$pkg" Package)" = 'ghost-ftp'
             test "$(dpkg-deb -f "$pkg" Version)" = "$version"
             test "$(dpkg-deb -f "$pkg" Architecture)" = "$arch"
+
+            work="$(mktemp -d)"
+            trap 'rm -rf "$work"' EXIT
+            mkdir -p "$work/deb" "$work/portable"
+            dpkg-deb -x "$pkg" "$work/deb"
+            tar -xzf "$portable" -C "$work/portable"
+            root="$work/portable/Ghost-FTP-${version}-Linux-${arch}"
+            test -x "$root/ghostftp"
+            test -f "$root/ghost-ftp.desktop"
+            test -f "$root/ghost-ftp.png"
+            test -f "$root/LICENSE"
+            test -f "$root/README.md"
+            cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"
+            rm -rf "$work"
+            trap - EXIT
           done
       - name: Store Linux packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -208,7 +227,9 @@ jobs:
           name: ghostftp-linux-stage
           if-no-files-found: error
           retention-days: 7
-          path: dist/Ghost-FTP-*-Linux-*.deb
+          path: |
+            dist/Ghost-FTP-*-Linux-*.deb
+            dist/Ghost-FTP-*-Linux-*.tar.gz
 
   publish:
     name: Assemble and publish Windows and Linux release
@@ -279,6 +300,7 @@ jobs:
           cp "staging/windows/Ghost-FTP-${VERSION}-Portable-x86.exe" "release/Ghost-FTP-${VERSION}-Portable-x86.exe"
           for arch in amd64 arm64 i386; do
             cp "staging/linux/Ghost-FTP-${VERSION}-Linux-${arch}.deb" "release/Ghost-FTP-${VERSION}-Linux-${arch}.deb"
+            cp "staging/linux/Ghost-FTP-${VERSION}-Linux-${arch}.tar.gz" "release/Ghost-FTP-${VERSION}-Linux-${arch}.tar.gz"
           done
           (
             cd staging/linux
@@ -300,12 +322,13 @@ jobs:
           WINDOWS_PORTABLE=x64,x86
           WINDOWS_AUTHENTICODE=${WINDOWS_SIGNING_STATE}
           LINUX_DEB=amd64,arm64,i386
+          LINUX_PORTABLE=amd64,arm64,i386
           LINUX_BUNDLE=multiarch-amd64-arm64-i386
           LANGUAGES=24
           DEFAULT_LANGUAGE=en
           TELEMETRY=disabled
-          PUBLIC_PLATFORM_ARTIFACTS=9
-          PUBLIC_RELEASE_FILES=12
+          PUBLIC_PLATFORM_ARTIFACTS=12
+          PUBLIC_RELEASE_FILES=15
           GITHUB_PACKAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/ghost-ftp:${VERSION}
           EOF
           sed -i 's/^          //' release/BUILD-METADATA.txt
@@ -314,7 +337,7 @@ jobs:
             find . -maxdepth 1 -type f ! -name SHA256.txt -printf '%f\n' | LC_ALL=C sort | xargs sha256sum > SHA256.txt
           )
           count="$(find release -maxdepth 1 -type f | wc -l | tr -d ' ')"
-          test "$count" = '12'
+          test "$count" = '15'
           test "$(sha256sum "release/Ghost-FTP-${VERSION}-Setup-x86.exe" | awk '{print $1}')" = "$(sha256sum "release/Ghost-FTP-${VERSION}-Setup-x32.exe" | awk '{print $1}')"
       - name: Publish stable bundle to GitHub Packages
         if: env.RELEASE_CHANNEL == 'stable'
@@ -398,8 +421,11 @@ jobs:
           expected_assets="$(cat <<EOF
           BUILD-METADATA.txt
           Ghost-FTP-${VERSION}-Linux-amd64.deb
+          Ghost-FTP-${VERSION}-Linux-amd64.tar.gz
           Ghost-FTP-${VERSION}-Linux-arm64.deb
+          Ghost-FTP-${VERSION}-Linux-arm64.tar.gz
           Ghost-FTP-${VERSION}-Linux-i386.deb
+          Ghost-FTP-${VERSION}-Linux-i386.tar.gz
           Ghost-FTP-${VERSION}-Linux-multiarch.zip
           Ghost-FTP-${VERSION}-Portable-x64.exe
           Ghost-FTP-${VERSION}-Portable-x86.exe

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ See [Installation](docs/INSTALLATION.md) and [Signing](docs/SIGNING.md).
 
 ## Linux installation
 
+Published 1.1.6 Linux files are:
+
 ```text
 Ghost-FTP-1.1.6-Linux-amd64.deb
 Ghost-FTP-1.1.6-Linux-arm64.deb
@@ -127,21 +129,23 @@ Ghost-FTP-1.1.6-Linux-i386.deb
 Ghost-FTP-1.1.6-Linux-multiarch.zip
 ```
 
-The DEB metadata is generated from root `VERSION`, uses the product homepage `https://ghostftp.com`, identifies BRENDIGO LTD as publisher/maintainer and is verified before publication.
+The DEB metadata is generated from root `VERSION`, uses the product homepage `https://ghostftp.com`, identifies BRENDIGO LTD as publisher/maintainer and is verified before publication. The maintained source also builds package-manager-neutral `.tar.gz` archives for amd64, arm64 and i386; those are post-1.1.6 outputs and are not retroactive 1.1.6 assets.
 
 See [Linux documentation](linux/README.md).
 
 ## Releases and Packages
 
-The canonical user-installable files are attached to the official GitHub Release. The stable workflow publishes **9 platform artifacts** plus release metadata, notes and `SHA256.txt`, for **12 public files** in total.
+The canonical user-installable files are attached to the official GitHub Release. The **published Ghost FTP 1.1.6** release contains **9 platform artifacts** plus release metadata, notes and `SHA256.txt`, for **12 public files** in total.
 
-Stable releases also publish an OCI **distribution bundle** to GitHub Packages:
+The maintained source release workflow for the next version is stricter and broader: it requires **12 platform artifacts / 15 public files**, adding verified Linux `.tar.gz` archives for amd64, arm64 and i386. Each portable executable must be byte-identical to the executable in its matching DEB before publication. This future-source contract does not modify the immutable 1.1.6 release.
+
+Stable releases also publish an OCI **distribution bundle** to GitHub Packages. The current published package is:
 
 ```text
 ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
-The package mirrors `/ghostftp-release/` from the verified release assembly and is **not a runtime container**. Successful stable publication updates `1.1`, `1` and `latest` only after registry publication and read-back succeed.
+The package mirrors `/ghostftp-release/` from the verified release assembly and is **not a runtime container**. Successful stable publication updates compatible aliases only after registry publication and read-back succeed.
 
 See [GitHub Packages](docs/PACKAGES.md), [GitHub Releases](docs/GITHUB-RELEASES.md) and [Release verification](docs/RELEASE-VERIFICATION.md).
 

--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -59,7 +59,21 @@ RELEASE-NOTES.txt
 SHA256.txt
 ```
 
-That is **12 public files** in total. Post-1.1.6 source/CI builds also create verified Linux `.tar.gz` portable archives, but those are not retroactive 1.1.6 assets. A future release may publish them only after its own release allow-list change passes review and CI.
+That is **12 public files** in total. Post-1.1.6 source/CI builds also create verified Linux `.tar.gz` portable archives, but those are not retroactive 1.1.6 assets.
+
+## Maintained next-release allow-list
+
+The current source release workflow is prepared for a later version with **12 platform artifacts** and **15 public files** total. It retains the five Windows artifacts, three Linux DEBs and Linux multiarch DEB bundle, and adds three separately downloadable portable archives:
+
+```text
+Ghost-FTP-X.Y.Z-Linux-amd64.tar.gz
+Ghost-FTP-X.Y.Z-Linux-arm64.tar.gz
+Ghost-FTP-X.Y.Z-Linux-i386.tar.gz
+```
+
+Before those archives can be published for a future version, the production Linux job requires `GHOSTFTP_REQUIRE_DEB=1`, builds both formats, extracts them and compares the DEB-installed `ghostftp` executable with the portable archive executable byte-for-byte. The publish job then stages the exact 15-file set, includes every file in `SHA256.txt`, and requires both immediate and delayed remote asset read-back to match the allow-list exactly.
+
+This source contract is not publication evidence for any unreleased version and does not alter the 1.1.6 tag, release assets, notes, checksums or GHCR bundle.
 
 ## Exact-head rule
 
@@ -95,6 +109,8 @@ The workflow never generates a self-signed production publisher identity and nev
 
 The publish job assembles a fresh `release/` directory from only the verified Windows and Linux staging artifacts plus generated notes/metadata/checksums. The final file count and expected filenames are checked before upload.
 
+For the maintained next-release source contract, metadata records `LINUX_PORTABLE=amd64,arm64,i386`, `PUBLIC_PLATFORM_ARTIFACTS=12` and `PUBLIC_RELEASE_FILES=15`. The historical 1.1.6 metadata remains unchanged at its originally published values.
+
 `Setup-x32.exe` is intentionally a byte-identical compatibility alias of `Setup-x86.exe`; the workflow verifies their SHA-256 values match. It is not a separate architecture build.
 
 Published release immutability is fail-closed: the workflow rejects an existing tag or release rather than using `gh release upload` or `--clobber` to replace historical assets.
@@ -121,7 +137,7 @@ Compatible stable aliases were published after successful registry publication/r
 latest
 ```
 
-The registry package is an OCI distribution bundle, not a runtime container. The package build copies only the verified `release/` assembly, disables build networking, adds source/version/revision labels and verifies registry read-back.
+The registry package is an OCI distribution bundle, not a runtime container. The package build copies only the verified `release/` assembly, disables build networking, adds source/version/revision labels and verifies registry read-back. For a future release, the verified Linux portable archives will be mirrored only if that version's 15-file release assembly passes publication and read-back.
 
 See [Packages](PACKAGES.md).
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -30,7 +30,20 @@ For 1.1.6, that directory contains the same Windows Setup/Portable packages, Lin
 
 This is a **distribution bundle**, not a runtime container. Ghost FTP is a native desktop application for Windows and Linux; GHCR exists so CI systems, mirrors and administrators can retrieve a versioned, repository-linked release bundle.
 
-Post-1.1.6 source/CI builds additionally produce package-manager-neutral Linux `.tar.gz` archives. They are not retroactive contents of the immutable 1.1.6 GHCR bundle; a later release may include them only after its own release-contract gates pass.
+Post-1.1.6 source builds additionally produce package-manager-neutral Linux `.tar.gz` archives. They are not retroactive contents of the immutable 1.1.6 GHCR bundle.
+
+## Maintained next-release bundle contract
+
+The source release workflow for a later version now stages the three verified Linux portable archives alongside the matching DEBs. Its final assembly contract is **12 platform artifacts / 15 public files**. Because the GHCR image copies only the already verified `release/` directory, those tarballs are mirrored into a future GHCR version only after the production job has:
+
+- built the DEB and `.tar.gz` for amd64, arm64 and i386;
+- validated DEB metadata and portable archive structure;
+- proved DEB/portable `ghostftp` executable byte parity;
+- matched the exact 15-file release allow-list;
+- generated `SHA256.txt` over the assembly;
+- passed GitHub Release publication and remote read-back for that future version.
+
+This contract does not create a new package version by itself and does not alter `ghcr.io/bren-wp/ghost-ftp:1.1.6` or its aliases/digest history.
 
 ## Canonical installation source
 
@@ -52,7 +65,7 @@ Every stable package is produced only after the same quality gates used for GitH
 - explicit `WINDOWS_AUTHENTICODE=unsigned` metadata when no production certificate is configured;
 - exact source/release version binding and post-publication read-back.
 
-For the historical 1.1.6 release, the Linux public artifacts remain three DEBs plus the Linux multiarch ZIP. Current source/CI additionally validates distro-neutral Linux tarballs, but that does not mutate the already published bundle.
+For the historical 1.1.6 release, the Linux public artifacts remain three DEBs plus the Linux multiarch ZIP. The maintained next-release workflow additionally validates and stages distro-neutral Linux tarballs, but that does not mutate the already published bundle.
 
 Production signing is optional, but its state is never ambiguous. A configured trusted signing identity is verified fail-closed; absence of a production certificate does not cause Ghost FTP to fabricate a self-signed publisher identity or label unsigned files as signed.
 
@@ -72,6 +85,8 @@ For the published 1.1.6 package:
 4. verify every release file before use;
 5. compare the expected source commit with `BUILD-METADATA.txt` and the OCI revision label;
 6. inspect `WINDOWS_AUTHENTICODE` before interpreting Windows publisher-signature state.
+
+For later versions, perform the same checks against that exact version and verify the asset contract recorded by its `BUILD-METADATA.txt`; do not assume the historical 1.1.6 file count applies to future bundles.
 
 This provides two integrity references: the OCI manifest digest and the per-file SHA-256 manifest, plus an explicit Windows signing-state declaration.
 

--- a/docs/PLATFORM-PARITY.md
+++ b/docs/PLATFORM-PARITY.md
@@ -91,15 +91,17 @@ Linux uses the maintained native X11/XWayland-compatible frontend and platform-l
 
 Post-1.1.6 source/CI packaging additionally builds package-manager-neutral `.tar.gz` archives for the same three architectures. CI proves that each DEB and portable archive contains the same compiled `ghostftp` executable byte-for-byte. This expands practical distribution compatibility without pretending that an unverified RPM/AppImage/Flatpak/Snap lifecycle already exists.
 
+The maintained production release workflow now applies the same parity proof before publication and stages both DEB and `.tar.gz` formats. A future release can therefore expose the portable archives as first-class Linux release assets only after the complete exact-head and post-merge release gates succeed.
+
 Idle rendering is state/event driven so the complete workspace is not continuously repainted while nothing relevant changes.
 
 ## Release parity
 
 The production workflow independently builds and verifies both platform families before publication. A successful Windows build cannot substitute for a failed Linux build, and vice versa.
 
-The already published Ghost FTP 1.1.6 GitHub Release remains immutable with its original **9 platform artifacts / 12 public files**. The new Linux portable archives are source/CI outputs only until a separate release-contract change is reviewed and gated; documentation must not retroactively list them as 1.1.6 assets.
+The already published Ghost FTP 1.1.6 GitHub Release remains immutable with its original **9 platform artifacts / 12 public files**. The maintained next-release source contract now requires **12 platform artifacts / 15 public files**: the historical Windows/DEB/multiarch set plus verified Linux `.tar.gz` archives for amd64, arm64 and i386. This does not retroactively list those archives as 1.1.6 assets.
 
-GHCR mirrors the verified assembled release directory and is a distribution bundle, not a third application implementation.
+GHCR mirrors the verified assembled release directory and is a distribution bundle, not a third application implementation. For a later version, that mirrored directory will include the tarballs only if that version independently passes the release allow-list, SHA-256 and remote read-back gates.
 
 ## Definition of parity complete
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,14 +21,14 @@ The root [`VERSION`](../VERSION) file is the authoritative production version so
 
 ## Installation and distribution
 
-- [`INSTALLATION.md`](INSTALLATION.md) — Windows Setup/Portable and Linux DEB installation/upgrade guidance.
+- [`INSTALLATION.md`](INSTALLATION.md) — Windows Setup/Portable and Linux installation/upgrade guidance.
 - [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) — canonical GitHub Release structure and release-channel rules.
 - [`PACKAGES.md`](PACKAGES.md) — stable GHCR distribution bundle.
 - [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) — artifact, metadata, SHA-256 and signing-state verification.
 - [`SIGNING.md`](SIGNING.md) — optional protected Authenticode signing and truthful unsigned-release policy.
 - [`VERSIONING.md`](VERSIONING.md) — semantic versioning and stable/prerelease rules.
 
-The stable workflow publishes **9 platform artifacts** and **12 public files** for each canonical release. The same verified release directory is mirrored to GitHub Packages as a non-runtime OCI distribution bundle.
+The **published 1.1.6** release contains **9 platform artifacts** and **12 public files**. The maintained source release workflow for the next version expects **12 platform artifacts / 15 public files**, adding verified Linux `.tar.gz` archives for amd64, arm64 and i386 while preserving the historical 1.1.6 asset set. The same verified release directory is mirrored to GitHub Packages as a non-runtime OCI distribution bundle.
 
 ## Security and privacy
 
@@ -64,7 +64,7 @@ The release preserves existing FTPS certificate/hostname validation, SFTP host-k
 
 ## Stable publication
 
-A stable 1.1.6 publication is a normal GitHub Release with `prerelease=false` and immutable tag:
+The published 1.1.6 release is a normal GitHub Release with `prerelease=false` and immutable tag:
 
 ```text
 ghostftp-v1.1.6
@@ -95,9 +95,13 @@ GitHub Package:
 ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
-Stable aliases `1.1`, `1` and `latest` are updated only after successful publication and registry read-back. The package contains `/ghostftp-release/` and is a distribution bundle, not a runtime container.
+Stable aliases `1.1`, `1` and `latest` were updated only after successful publication and registry read-back. The package contains `/ghostftp-release/` and is a distribution bundle, not a runtime container.
 
 Production Authenticode remains optional. If a trusted certificate is configured, Windows signatures are verified fail-closed. Otherwise the release is explicitly unsigned and `BUILD-METADATA.txt` records `WINDOWS_AUTHENTICODE=unsigned`; a generated/self-signed identity is never represented as a trusted production publisher.
+
+## Next-release Linux portable contract
+
+The maintained release workflow now stages package-manager-neutral Linux tarballs for `amd64`, `arm64` and `i386` alongside the matching DEBs. Before a future version can publish, production release CI verifies archive structure and byte-for-byte parity between each portable `ghostftp` executable and `/usr/bin/ghostftp` from its DEB. The final future-version contract is 12 platform artifacts / 15 public files with exact remote asset read-back. These files are not retroactively added to 1.1.6.
 
 ## Release history
 
@@ -110,11 +114,13 @@ Historical version references describe their original release state and are not 
 
 A release is complete only after the exact source revision passes Core, Windows and Linux gates and the immutable tag, GitHub Release asset set, `SHA256.txt`, metadata and stable GitHub Package have all been read back successfully.
 
-For 1.1.6 the canonical publication branch is `release/ghostftp-v1.1.6`, created only from the exact post-merge `main` SHA that passed the complete quality gate.
+For 1.1.6 the canonical publication branch was `release/ghostftp-v1.1.6`, created only from the exact post-merge `main` SHA that passed the complete quality gate. A later release must repeat this process independently; current source workflow readiness is not publication evidence.
 
 ## UI evidence rule
 
-The 1.1.6 release-prep changes the public version displayed by the built application. Authentic screenshots must therefore come from the real production Windows x64 Portable executable for Main Workspace, Site Manager, Settings and About and must be visually reviewed on the exact final release-prep source revision.
+The 1.1.6 release-prep changed the public version displayed by the built application. Authentic screenshots therefore came from the real production Windows x64 Portable executable for Main Workspace, Site Manager, Settings and About and were visually reviewed on the exact final release-prep source revision.
+
+Future public Windows UI/version changes remain subject to the maintained authentic exact-head evidence rule.
 
 ## Privacy-safe documentation rule
 

--- a/docs/RELEASE-VERIFICATION.md
+++ b/docs/RELEASE-VERIFICATION.md
@@ -62,7 +62,30 @@ RELEASE-NOTES.txt
 SHA256.txt
 ```
 
-Post-1.1.6 source/CI builds also create package-manager-neutral Linux `.tar.gz` archives for amd64, arm64 and i386. Those source outputs are not part of the immutable 1.1.6 asset set unless a future version is published with a separately reviewed release contract.
+Post-1.1.6 source/CI builds also create package-manager-neutral Linux `.tar.gz` archives for amd64, arm64 and i386. Those source outputs are not part of the immutable 1.1.6 asset set.
+
+## Maintained next-release public file contract
+
+The current source release workflow is prepared for a later version with **12 platform artifacts** and **15 public files** total. The additional Linux assets are:
+
+```text
+Ghost-FTP-X.Y.Z-Linux-amd64.tar.gz
+Ghost-FTP-X.Y.Z-Linux-arm64.tar.gz
+Ghost-FTP-X.Y.Z-Linux-i386.tar.gz
+```
+
+The future-version release job must fail closed unless, for every Linux architecture:
+
+- both the `.deb` and `.tar.gz` exist and are non-empty;
+- DEB package/version/architecture metadata is valid;
+- the portable archive contains `ghostftp`, `ghost-ftp.desktop`, `ghost-ftp.png`, `LICENSE` and `README.md`;
+- the DEB-installed `/usr/bin/ghostftp` and portable `ghostftp` are byte-identical;
+- all three tarballs are staged into the final `release/` directory;
+- `BUILD-METADATA.txt` records `LINUX_PORTABLE=amd64,arm64,i386`, `PUBLIC_PLATFORM_ARTIFACTS=12` and `PUBLIC_RELEASE_FILES=15`;
+- `SHA256.txt` covers every public file except itself;
+- the immediate and delayed GitHub Release read-back asset sets exactly match the 15-file allow-list.
+
+These are source workflow requirements for the next release version, not evidence that another version is already published. They do not modify 1.1.6.
 
 ## SHA-256 verification
 
@@ -80,7 +103,7 @@ The production workflow **does not create a self-signed production identity**. S
 
 ## x86/x32 alias verification
 
-`Ghost-FTP-1.1.6-Setup-x86.exe` and `Ghost-FTP-1.1.6-Setup-x32.exe` must be byte-identical. The release workflow compares their SHA-256 values before publication.
+`Ghost-FTP-1.1.6-Setup-x86.exe` and `Ghost-FTP-1.1.6-Setup-x32.exe` must be byte-identical. The release workflow compares their SHA-256 values before publication. Future releases preserve the same alias rule.
 
 ## Linux DEB verification
 
@@ -96,9 +119,11 @@ dpkg-deb -f Ghost-FTP-1.1.6-Linux-amd64.deb Homepage
 dpkg-deb -f Ghost-FTP-1.1.6-Linux-amd64.deb Maintainer
 ```
 
+For a future release that includes `.tar.gz`, also extract both formats and compare their `ghostftp` executables byte-for-byte. The portable archive is not a substitute for DEB metadata verification; both production formats have separate structural checks and a shared-binary parity check.
+
 ## GitHub Release verification
 
-Confirm that:
+For published 1.1.6 confirm that:
 
 - tag is `ghostftp-v1.1.6`;
 - title is `Ghost FTP 1.1.6`;
@@ -109,7 +134,9 @@ Confirm that:
 - `BUILD-METADATA.txt` truthfully reports `WINDOWS_AUTHENTICODE=signed` or `unsigned`;
 - release notes correspond to the `CHANGELOG.md` 1.1.6 section.
 
-The production workflow performed immediate and delayed Release read-back. Manual verification remains useful before broad deployment.
+For a later version using the maintained source contract, remote assets must instead exactly match that version's 15-file allow-list, including all three Linux `.tar.gz` files. Do not infer a future release's existence from source code alone.
+
+The production workflow performs immediate and delayed Release read-back. Manual verification remains useful before broad deployment.
 
 ## GitHub Packages verification
 
@@ -120,6 +147,8 @@ ghcr.io/bren-wp/ghost-ftp:1.1.6
 ```
 
 The package is a verified distribution bundle, not a runtime container. OCI metadata must identify the Ghost FTP source repository, stable version and release source revision. Stable aliases `1.1`, `1` and `latest` were updated after publication and registry read-back succeeded.
+
+For a future release, GHCR mirrors the exact verified release assembly. Therefore Linux tarballs become part of that future bundle only if they passed the same release allow-list, SHA-256 generation and GitHub Release read-back gates.
 
 ## 1.1.6 runtime and security verification
 
@@ -138,7 +167,7 @@ The published release preserves the maintained runtime contract while applying t
 - cancellation/retry/connection-generation safeguards remain enabled;
 - no telemetry, analytics, advertising/tracking SDK, hidden product network service or new external Go module dependency is introduced.
 
-Post-1.1.6 `main` contains additional hardening such as rooted tree-download directory preparation and additional Linux source/CI packaging. Those later changes are verified separately and are not retroactively attributed to 1.1.6.
+Post-1.1.6 `main` contains additional hardening such as rooted tree-download directory preparation and additional Linux packaging/release-contract work. Those later changes are verified separately and are not retroactively attributed to 1.1.6.
 
 ## Authentic Windows UI evidence
 
@@ -150,6 +179,8 @@ The 1.1.6 release-prep changed the public version presentation. The exact final 
 - About.
 
 The images were visually reviewed for clipping, overlap, stale branding and correct 1.1.6 version presentation. Mockups or generated approximations were not accepted as release evidence.
+
+A later release that changes public Windows UI or version presentation must independently produce authentic exact-head Windows x64 Portable evidence when required by the maintained release policy.
 
 ## CI/release gate verification
 
@@ -173,6 +204,8 @@ The published 1.1.6 revision passed:
 - canonical release branch equality/version checks before publication dispatch;
 - GitHub Package push/read-back;
 - GitHub Release asset/tag/prerelease read-back verification.
+
+The maintained next-release contract additionally requires production Linux `.tar.gz` construction, structure verification and executable parity against each matching DEB before publication.
 
 ## Privacy verification
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -33,6 +33,10 @@ The portable archive and DEB for each architecture are built from the same compi
 
 The already published Ghost FTP 1.1.6 release is immutable and keeps its original Linux asset set: three DEB files plus `Ghost-FTP-1.1.6-Linux-multiarch.zip`. The portable `.tar.gz` output is a post-1.1.6 source/CI packaging improvement and is **not** retroactively claimed as a 1.1.6 release asset.
 
+### Next release contract
+
+The maintained production release workflow now requires the verified `.tar.gz` archives for `amd64`, `arm64` and `i386` in addition to the matching DEBs. Before a later release can publish, production CI must prove each DEB and tarball carries the same `ghostftp` executable byte-for-byte, stage both formats, include all three tarballs in the release allow-list and pass remote asset read-back. This change applies only to a future version; it does not mutate the published 1.1.6 tag, assets, checksums or GHCR bundle.
+
 ## Distro-neutral portable use
 
 The `.tar.gz` package is intended for Linux distributions where a Debian package is not the native installation format, including RPM-based and rolling-release environments. It does not pretend to be an RPM, Flatpak, AppImage, Snap or distribution repository package; those formats require their own verified packaging lifecycle before they can be called officially supported artifacts.

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -76,11 +76,19 @@ def main() -> int:
         "Ghost-FTP-${VERSION}-Setup-x86.exe",
         "Ghost-FTP-${VERSION}-Setup-x32.exe",
         "Ghost-FTP-${VERSION}-Linux-amd64.deb",
+        "Ghost-FTP-${VERSION}-Linux-amd64.tar.gz",
         "Ghost-FTP-${VERSION}-Linux-arm64.deb",
+        "Ghost-FTP-${VERSION}-Linux-arm64.tar.gz",
         "Ghost-FTP-${VERSION}-Linux-i386.deb",
+        "Ghost-FTP-${VERSION}-Linux-i386.tar.gz",
         "Ghost-FTP-${VERSION}-Linux-multiarch.zip",
-        "PUBLIC_PLATFORM_ARTIFACTS=9",
-        "PUBLIC_RELEASE_FILES=12",
+        "Verify DEB and portable packages",
+        "GHOSTFTP_REQUIRE_DEB: '1'",
+        'cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"',
+        "dist/Ghost-FTP-*-Linux-*.tar.gz",
+        "LINUX_PORTABLE=amd64,arm64,i386",
+        "PUBLIC_PLATFORM_ARTIFACTS=12",
+        "PUBLIC_RELEASE_FILES=15",
         "ghcr.io/${owner}/ghost-ftp",
         "org.opencontainers.image.source",
         "Distribution bundle only; not a supported runtime container.",
@@ -202,12 +210,12 @@ def main() -> int:
     print("STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
     print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
-    print("PUBLIC_PLATFORM_ARTIFACTS=9")
-    print("PUBLIC_RELEASE_FILES=12")
+    print("PUBLIC_PLATFORM_ARTIFACTS=12")
+    print("PUBLIC_RELEASE_FILES=15")
     print("WINDOWS_PORTABLE=x64,x86")
     print("WINDOWS_X32_ALIAS_OF_X86=REQUIRED")
     print("LINUX_DEB=amd64,arm64,i386")
-    print("LINUX_PORTABLE_SOURCE=amd64,arm64,i386")
+    print("LINUX_PORTABLE=amd64,arm64,i386")
     print("STABLE_GHCR_BUNDLE=REQUIRED")
     return 0
 

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -130,8 +130,9 @@ def main() -> int:
         "state=unsigned",
         "state=signed",
         "Publishing Stable with explicitly unsigned Windows artifacts",
-        "PUBLIC_PLATFORM_ARTIFACTS=9",
-        "PUBLIC_RELEASE_FILES=12",
+        "LINUX_PORTABLE=amd64,arm64,i386",
+        "PUBLIC_PLATFORM_ARTIFACTS=12",
+        "PUBLIC_RELEASE_FILES=15",
     ), ".github/workflows/release.yml")
     if "Stable Windows releases require a configured trusted Authenticode identity." in release_workflow:
         fail("release workflow contradicts the supported explicit-unsigned stable state")
@@ -140,8 +141,9 @@ def main() -> int:
 
     require(read("scripts/audit_platform_contract.py"), ("ACTIVE_APPLICATION_PLATFORMS=WINDOWS,LINUX", "RETIRED_APPLICATION_SURFACES=WEB,PWA"), "scripts/audit_platform_contract.py")
     require(read("scripts/audit_release.py"), (
-        "PUBLIC_PLATFORM_ARTIFACTS=9",
-        "PUBLIC_RELEASE_FILES=12",
+        "PUBLIC_PLATFORM_ARTIFACTS=12",
+        "PUBLIC_RELEASE_FILES=15",
+        "LINUX_PORTABLE=amd64,arm64,i386",
         "STABLE_GHCR_BUNDLE=REQUIRED",
         "STABLE_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO",
         "TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED",

--- a/scripts/test_linux_packaging_contract.py
+++ b/scripts/test_linux_packaging_contract.py
@@ -29,12 +29,36 @@ class LinuxPackagingContractTests(unittest.TestCase):
         self.assertIn('cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"', workflow)
         self.assertIn("dist/Ghost-FTP-*-Linux-*.tar.gz", workflow)
 
-    def test_docs_do_not_retroactively_claim_tarballs_for_116(self) -> None:
+    def test_release_workflow_publishes_verified_portable_archives(self) -> None:
+        workflow = read(".github/workflows/release.yml")
+        self.assertIn("Verify DEB and portable packages", workflow)
+        self.assertIn("GHOSTFTP_REQUIRE_DEB: '1'", workflow)
+        self.assertIn('cmp "$work/deb/usr/bin/ghostftp" "$root/ghostftp"', workflow)
+        self.assertIn("dist/Ghost-FTP-*-Linux-*.tar.gz", workflow)
+        self.assertIn(
+            'cp "staging/linux/Ghost-FTP-${VERSION}-Linux-${arch}.tar.gz" "release/Ghost-FTP-${VERSION}-Linux-${arch}.tar.gz"',
+            workflow,
+        )
+        self.assertIn("LINUX_PORTABLE=amd64,arm64,i386", workflow)
+        self.assertIn("PUBLIC_PLATFORM_ARTIFACTS=12", workflow)
+        self.assertIn("PUBLIC_RELEASE_FILES=15", workflow)
+        self.assertIn('test "$count" = \'15\'', workflow)
+        for arch in ("amd64", "arm64", "i386"):
+            self.assertIn(f"Ghost-FTP-${{VERSION}}-Linux-{arch}.tar.gz", workflow)
+
+    def test_docs_keep_116_historical_and_describe_next_release_contract(self) -> None:
         linux_readme = read("linux/README.md")
         parity = read("docs/PLATFORM-PARITY.md")
+        releases = read("docs/GITHUB-RELEASES.md")
+        verification = read("docs/RELEASE-VERIFICATION.md")
         self.assertIn("already published Ghost FTP 1.1.6 release is immutable", linux_readme)
         self.assertIn("is **not** retroactively claimed as a 1.1.6 release asset", linux_readme)
-        self.assertIn("source/CI outputs only until a separate release-contract change", parity)
+        self.assertIn("next release", linux_readme.lower())
+        self.assertIn("12 platform artifacts / 15 public files", parity)
+        self.assertIn("12 platform artifacts", releases)
+        self.assertIn("15 public files", releases)
+        self.assertIn("12 platform artifacts", verification)
+        self.assertIn("15 public files", verification)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Post-1.1.6 CI already builds and byte-compares package-manager-neutral Linux `.tar.gz` archives against the matching DEB executable, but the production release workflow still stages/publishes only DEBs and the historical multiarch ZIP.

## Fix

- require DEB tooling in production Linux release builds;
- verify DEB + portable archive structure and byte-for-byte executable parity for amd64/arm64/i386;
- stage and publish all three Linux `.tar.gz` archives for a future version;
- expand the maintained future release contract to 12 platform artifacts / 15 public files;
- include the tarballs in BUILD-METADATA, SHA256 assembly and exact remote Release read-back;
- mirror the same verified assembly into the future GHCR distribution bundle;
- strengthen `audit_release.py` and Linux packaging regressions so the new contract cannot silently regress;
- document the distinction between immutable published 1.1.6 (9/12) and the maintained next-release source contract (12/15).

## Scope and release safety

- no VERSION change;
- no runtime or UI change;
- no automatic publication;
- release workflow remains `workflow_dispatch`-only;
- no 1.1.6 tag, Release, checksums, assets or GHCR mutation;
- published 1.1.6 remains historical 9 platform artifacts / 12 public files.

Merge only after exact-head Core, Linux and Windows CI are green, followed by exact-main post-merge CI.