### PR TITLE
Verify Linux distro package installation lifecycle

### DIFF
--- a/.github/workflows/linux-distro-install.yml
+++ b/.github/workflows/linux-distro-install.yml
@@ -1,0 +1,127 @@
+name: Ghost FTP Linux Distro Install Matrix
+
+on:
+  pull_request:
+    paths:
+      - 'VERSION'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'linux/**'
+      - 'build/icon.png'
+      - 'LICENSE'
+      - '.github/workflows/linux-distro-install.yml'
+      - 'scripts/verify_linux_distro_install.sh'
+      - 'scripts/test_linux_distro_install_contract.py'
+  push:
+    branches:
+      - main
+      - 'packaging/**'
+    paths:
+      - 'VERSION'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'linux/**'
+      - 'build/icon.png'
+      - 'LICENSE'
+      - '.github/workflows/linux-distro-install.yml'
+      - 'scripts/verify_linux_distro_install.sh'
+      - 'scripts/test_linux_distro_install_contract.py'
+
+permissions:
+  contents: read
+
+env:
+  GOTOOLCHAIN: local
+  GOPROXY: off
+  GOSUMDB: off
+
+jobs:
+  native-amd64-install:
+    name: Install remove and GUI smoke on Debian Ubuntu Fedora
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+
+      - name: Install package build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends rpm cpio
+          command -v dpkg-deb
+          command -v rpmbuild
+          command -v rpm
+          command -v docker
+
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+
+      - name: Verify install-gate source contract
+        shell: bash
+        run: python scripts/test_linux_distro_install_contract.py
+
+      - name: Build exact-head distro packages
+        shell: bash
+        env:
+          GHOSTFTP_REQUIRE_DEB: '1'
+          GHOSTFTP_REQUIRE_RPM: '1'
+        run: |
+          set -euo pipefail
+          bash linux/BUILD-DISTROS.sh
+
+      - name: Verify Debian 13 native amd64 install lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          docker run --rm --pull=always \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -w /workspace \
+            debian:13-slim \
+            bash scripts/verify_linux_distro_install.sh debian "$version" 13 \
+              "/workspace/dist/Ghost-FTP-${version}-Linux-Debian-amd64.deb"
+
+      - name: Verify Ubuntu 26.04 LTS native amd64 install lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          docker run --rm --pull=always \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -w /workspace \
+            ubuntu:26.04 \
+            bash scripts/verify_linux_distro_install.sh ubuntu "$version" 26.04 \
+              "/workspace/dist/Ghost-FTP-${version}-Linux-Ubuntu-amd64.deb"
+
+      - name: Verify Fedora 44 native x86_64 install lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          docker run --rm --pull=always \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -w /workspace \
+            fedora:44 \
+            bash scripts/verify_linux_distro_install.sh fedora "$version" 44 \
+              "/workspace/dist/Ghost-FTP-${version}-Linux-Fedora-x86_64.rpm"
+
+      - name: Record install matrix scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'LINUX_DISTRO_INSTALL_MATRIX=PASS'
+          echo 'Native install runtime coverage: Debian 13 amd64; Ubuntu 26.04 amd64; Fedora 44 x86_64.'
+          echo 'arm64 and 32-bit artifacts remain covered by exact-head build, metadata and byte-parity gates; this native runner does not emulate those kernels.'

--- a/.github/workflows/linux-distro-install.yml
+++ b/.github/workflows/linux-distro-install.yml
@@ -71,7 +71,11 @@ jobs:
 
       - name: Verify install-gate source contract
         shell: bash
-        run: python scripts/test_linux_distro_install_contract.py
+        run: |
+          set -euo pipefail
+          bash -n scripts/verify_linux_distro_install.sh
+          python -m py_compile scripts/test_linux_distro_install_contract.py
+          python scripts/test_linux_distro_install_contract.py
 
       - name: Build exact-head distro packages
         shell: bash

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -25,17 +25,30 @@ for token in (
     require(token in VERIFY, f"missing distro identity guard: {token}")
 
 # Real install/remove state is mandatory; file-existence-only checks are not.
+# Fedora's minimal image may globally set tsflags=nodocs, so its Ghost FTP
+# transaction must explicitly clear that optimization and verify the full RPM.
 for token in (
     'apt-get install -y --no-install-recommends "$package_path"',
     "dpkg-query -W -f='${Status}' ghost-ftp",
     "dpkg-query -L ghost-ftp",
     "apt-get remove -y ghost-ftp",
-    'dnf install -y "$package_path"',
+    'dnf --setopt=tsflags= install -y "$package_path"',
     "rpm -q --qf '%{VERSION}' ghost-ftp",
     "rpm -ql ghost-ftp",
     "dnf remove -y ghost-ftp",
 ):
     require(token in VERIFY, f"missing package lifecycle verification: {token}")
+require(
+    'dnf install -y "$package_path"' not in VERIFY,
+    "Fedora Ghost FTP install must clear minimal-image tsflags=nodocs",
+)
+for token in (
+    "/usr/share/doc/ghost-ftp/LICENSE",
+    "/usr/share/doc/ghost-ftp/README.md",
+    "fedora_fail license-file",
+    "fedora_fail readme-file",
+):
+    require(token in VERIFY, f"missing full Fedora documentation payload verification: {token}")
 
 # Dependency contracts and installed runtime tools must be proved inside the
 # clean target distribution after package installation. Fedora may satisfy the

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Static regression contract for Linux package installation verification."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY = (ROOT / "scripts" / "verify_linux_distro_install.sh").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github" / "workflows" / "linux-distro-install.yml").read_text(encoding="utf-8") if (ROOT / ".github" / "workflows" / "linux-distro-install.yml").exists() else ""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+# The verifier must fail closed when the actual container OS/version differs
+# from the public distro target that the package claims to support.
+for token in (
+    "source /etc/os-release",
+    '[[ "${ID:-}" == "debian" ]]',
+    '[[ "${ID:-}" == "ubuntu" ]]',
+    '[[ "${ID:-}" == "fedora" ]]',
+    '[[ "${VERSION_ID:-}" == "$expected_os_version" ]]',
+):
+    require(token in VERIFY, f"missing distro identity guard: {token}")
+
+# Real install/remove state is mandatory; file-existence-only checks are not.
+for token in (
+    'apt-get install -y --no-install-recommends "$package_path"',
+    "dpkg-query -W -f='${Status}' ghost-ftp",
+    "dpkg-query -L ghost-ftp",
+    "apt-get remove -y ghost-ftp",
+    'dnf install -y "$package_path"',
+    "rpm -q --qf '%{VERSION}' ghost-ftp",
+    "rpm -ql ghost-ftp",
+    "dnf remove -y ghost-ftp",
+):
+    require(token in VERIFY, f"missing package lifecycle verification: {token}")
+
+# Dependency contracts and installed runtime tools must be proved inside the
+# clean target distribution after package installation.
+for token in (
+    "ca-certificates, curl, openssh-client",
+    "openssh-clients",
+    "command -v curl",
+    "command -v ssh",
+    "command -v sftp",
+):
+    require(token in VERIFY, f"missing dependency/runtime verification: {token}")
+
+# The installed GUI must actually start under an isolated local X server.
+for token in (
+    "Xvfb :99",
+    "-nolisten tcp",
+    "HOME=\"$smoke_home\" DISPLAY=:99",
+    "/usr/bin/ghostftp",
+    'kill -0 "$app_pid"',
+    "GHOSTFTP_INSTALLED_GUI_SMOKE=PASS",
+):
+    require(token in VERIFY, f"missing installed GUI smoke contract: {token}")
+
+# Uninstall verification is scoped to package-owned system locations; user data
+# must never be deleted merely to make an uninstall test pass.
+for path in (
+    "/usr/bin/ghostftp",
+    "/usr/share/applications/ghost-ftp.desktop",
+    "/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png",
+):
+    require(f"test ! -e {path}" in VERIFY, f"missing uninstall residue assertion: {path}")
+require("rm -rf /root" not in VERIFY, "verifier must not delete user home data")
+
+# The workflow pins concrete supported distro generations and rebuilds package
+# artifacts from the exact checked-out commit before entering clean containers.
+for image in ("debian:13-slim", "ubuntu:26.04", "fedora:44"):
+    require(image in WORKFLOW, f"missing pinned install-test image: {image}")
+for token in (
+    "GHOSTFTP_REQUIRE_DEB: '1'",
+    "GHOSTFTP_REQUIRE_RPM: '1'",
+    "bash linux/BUILD-DISTROS.sh",
+    ":/workspace:ro",
+    "scripts/verify_linux_distro_install.sh debian",
+    "scripts/verify_linux_distro_install.sh ubuntu",
+    "scripts/verify_linux_distro_install.sh fedora",
+):
+    require(token in WORKFLOW, f"missing workflow install contract: {token}")
+require("--privileged" not in WORKFLOW, "install verification containers must not be privileged")
+
+print("LINUX_DISTRO_INSTALL_CONTRACT=PASS")

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -48,16 +48,21 @@ for token in (
 ):
     require(token in VERIFY, f"missing dependency/runtime verification: {token}")
 
-# The installed GUI must actually start under an isolated local X server.
+# The installed GUI must actually start under an isolated local X server. Its
+# HOME must stay under a root-owned system path so the production safe-path
+# checks are exercised rather than bypassed by a world-writable /tmp ancestor.
 for token in (
     "Xvfb :99",
     "-nolisten tcp",
+    "mktemp -d /var/lib/ghostftp-ci-home.XXXXXX",
+    'chmod 0700 "$smoke_home"',
     "HOME=\"$smoke_home\" DISPLAY=:99",
     "/usr/bin/ghostftp",
     'kill -0 "$app_pid"',
     "GHOSTFTP_INSTALLED_GUI_SMOKE=PASS",
 ):
     require(token in VERIFY, f"missing installed GUI smoke contract: {token}")
+require('smoke_home="$(mktemp -d)"' not in VERIFY, "GUI smoke HOME must not be created under default /tmp")
 
 # Uninstall verification is scoped to package-owned system locations; user data
 # must never be deleted merely to make an uninstall test pass.

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -39,17 +39,31 @@ for token in (
 
 # Dependency contracts and installed runtime tools must be proved inside the
 # clean target distribution after package installation. Fedora may satisfy the
-# `curl` capability with curl-minimal, so verify the provider rather than an
-# implementation-specific RPM package name.
+# `curl` dependency with an implementation-specific provider such as
+# curl-minimal, so bind the proof to the actual executable and its RPM owner.
 for token in (
     "ca-certificates, curl, openssh-client",
     "openssh-clients",
-    "rpm -q --whatprovides curl",
-    "command -v curl",
+    'curl_path="$(command -v curl)"',
+    'rpm -qf "$curl_path"',
     "command -v ssh",
     "command -v sftp",
 ):
     require(token in VERIFY, f"missing dependency/runtime verification: {token}")
+require("rpm -q --whatprovides curl" not in VERIFY, "Fedora verifier must not assume a literal curl capability provider name")
+
+# Fedora assertions should identify the exact failing contract instead of being
+# silent under set -e. This keeps future packaging regressions deterministic.
+for token in (
+    "GHOSTFTP_FEDORA_VERIFY_FAIL=",
+    "fedora_fail installed-version",
+    "fedora_fail curl-rpm-owner",
+    "fedora_fail ca-bundle",
+    "fedora_fail ghostftp-executable",
+    "fedora_fail owns-executable",
+    "fedora_fail package-still-installed",
+):
+    require(token in VERIFY, f"missing Fedora diagnostic contract: {token}")
 
 # The installed GUI must actually start under an isolated local X server. The
 # test reproduces a normal Linux data-root precondition instead of weakening the

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -48,21 +48,27 @@ for token in (
 ):
     require(token in VERIFY, f"missing dependency/runtime verification: {token}")
 
-# The installed GUI must actually start under an isolated local X server. Its
-# HOME must stay under a root-owned system path so the production safe-path
-# checks are exercised rather than bypassed by a world-writable /tmp ancestor.
+# The installed GUI must actually start under an isolated local X server. The
+# test reproduces a normal Linux data-root precondition instead of weakening the
+# production safe-path validator, and it provides a private runtime directory.
 for token in (
     "Xvfb :99",
     "-nolisten tcp",
     "mktemp -d /var/lib/ghostftp-ci-home.XXXXXX",
     'chmod 0700 "$smoke_home"',
-    "HOME=\"$smoke_home\" DISPLAY=:99",
+    'mkdir -p "$smoke_home/.local/share"',
+    'chmod 0700 "$smoke_home/.local" "$smoke_home/.local/share"',
+    'data_root="$smoke_home/.local/share"',
+    'runtime_dir="$smoke_home/runtime"',
+    'chmod 0700 "$runtime_dir"',
+    "HOME=\"$smoke_home\" XDG_RUNTIME_DIR=\"$runtime_dir\" DISPLAY=:99",
     "/usr/bin/ghostftp",
     'kill -0 "$app_pid"',
     "GHOSTFTP_INSTALLED_GUI_SMOKE=PASS",
 ):
     require(token in VERIFY, f"missing installed GUI smoke contract: {token}")
 require('smoke_home="$(mktemp -d)"' not in VERIFY, "GUI smoke HOME must not be created under default /tmp")
+require("XDG_DATA_HOME=" not in VERIFY, "smoke should exercise the default $HOME/.local/share LocalAppData path")
 
 # Uninstall verification is scoped to package-owned system locations; user data
 # must never be deleted merely to make an uninstall test pass.

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -52,6 +52,18 @@ for token in (
     require(token in VERIFY, f"missing dependency/runtime verification: {token}")
 require("rpm -q --whatprovides curl" not in VERIFY, "Fedora verifier must not assume a literal curl capability provider name")
 
+# Fedora CA trust layout must be derived from the installed ca-certificates RPM,
+# not from one historical /etc/pki path that may change between Fedora releases.
+for token in (
+    "verify_fedora_ca_bundle()",
+    "rpm -ql ca-certificates",
+    "*/tls-ca-bundle.pem|*/ca-bundle.crt|*/ca-certificates.crt",
+    'rpm -qf "$ca_bundle"',
+    "GHOSTFTP_FEDORA_CA_BUNDLE=",
+):
+    require(token in VERIFY, f"missing Fedora CA-bundle contract: {token}")
+require("/etc/pki/tls/certs/ca-bundle.crt" not in VERIFY, "Fedora verifier must not hardcode one CA bundle path")
+
 # Fedora assertions should identify the exact failing contract instead of being
 # silent under set -e. This keeps future packaging regressions deterministic.
 for token in (

--- a/scripts/test_linux_distro_install_contract.py
+++ b/scripts/test_linux_distro_install_contract.py
@@ -38,10 +38,13 @@ for token in (
     require(token in VERIFY, f"missing package lifecycle verification: {token}")
 
 # Dependency contracts and installed runtime tools must be proved inside the
-# clean target distribution after package installation.
+# clean target distribution after package installation. Fedora may satisfy the
+# `curl` capability with curl-minimal, so verify the provider rather than an
+# implementation-specific RPM package name.
 for token in (
     "ca-certificates, curl, openssh-client",
     "openssh-clients",
+    "rpm -q --whatprovides curl",
     "command -v curl",
     "command -v ssh",
     "command -v sftp",

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -89,7 +89,11 @@ verify_common_runtime_tools() {
   command -v curl >/dev/null
   command -v ssh >/dev/null
   command -v sftp >/dev/null
-  test -s /etc/ssl/certs/ca-certificates.crt
+  if [[ "$target" == "fedora" ]]; then
+    test -s /etc/pki/tls/certs/ca-bundle.crt
+  else
+    test -s /etc/ssl/certs/ca-certificates.crt
+  fi
 }
 
 if [[ "$target" == "debian" || "$target" == "ubuntu" ]]; then

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -183,7 +183,10 @@ else
   rpm -qp --requires "$package_path" | grep -Fx 'curl' >/dev/null || fedora_fail requires-curl
   rpm -qp --requires "$package_path" | grep -Fx 'openssh-clients' >/dev/null || fedora_fail requires-openssh-clients
 
-  dnf install -y "$package_path" >/dev/null
+  # Fedora's minimal container image may globally enable tsflags=nodocs. Clear
+  # that container-only optimization for the Ghost FTP transaction so the gate
+  # verifies the complete package payload a normal workstation install receives.
+  dnf --setopt=tsflags= install -y "$package_path" >/dev/null
   [[ "$(rpm -q --qf '%{VERSION}' ghost-ftp)" == "$expected_version" ]] || fedora_fail installed-version
   [[ "$(rpm -q --qf '%{ARCH}' ghost-ftp)" == "x86_64" ]] || fedora_fail installed-arch
   rpm -q ca-certificates >/dev/null || fedora_fail ca-certificates-package

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -106,16 +106,33 @@ verify_common_runtime_tools() {
   command -v curl >/dev/null
   command -v ssh >/dev/null
   command -v sftp >/dev/null
-  if [[ "$target" == "fedora" ]]; then
-    test -s /etc/pki/tls/certs/ca-bundle.crt
-  else
-    test -s /etc/ssl/certs/ca-certificates.crt
-  fi
+  test -s /etc/ssl/certs/ca-certificates.crt
 }
 
 fedora_fail() {
   echo "GHOSTFTP_FEDORA_VERIFY_FAIL=$1" >&2
   exit 1
+}
+
+verify_fedora_ca_bundle() {
+  local candidate ca_bundle=""
+  # Fedora's ca-certificates layout is an implementation detail that may move
+  # between releases. Derive the runtime trust bundle from the installed RPM
+  # instead of hardcoding one historical /etc/pki path.
+  while IFS= read -r candidate; do
+    case "$candidate" in
+      */tls-ca-bundle.pem|*/ca-bundle.crt|*/ca-certificates.crt)
+        if [[ -s "$candidate" ]]; then
+          ca_bundle="$candidate"
+          break
+        fi
+        ;;
+    esac
+  done < <(rpm -ql ca-certificates)
+
+  [[ -n "$ca_bundle" ]] || fedora_fail ca-bundle
+  rpm -qf "$ca_bundle" >/dev/null || fedora_fail ca-bundle-rpm-owner
+  echo "GHOSTFTP_FEDORA_CA_BUNDLE=$ca_bundle"
 }
 
 if [[ "$target" == "debian" || "$target" == "ubuntu" ]]; then
@@ -177,7 +194,7 @@ else
   rpm -qf "$curl_path" >/dev/null || fedora_fail curl-rpm-owner
   command -v ssh >/dev/null || fedora_fail ssh-command
   command -v sftp >/dev/null || fedora_fail sftp-command
-  test -s /etc/pki/tls/certs/ca-bundle.crt || fedora_fail ca-bundle
+  verify_fedora_ca_bundle
 
   test -x /usr/bin/ghostftp || fedora_fail ghostftp-executable
   test -f /usr/share/applications/ghost-ftp.desktop || fedora_fail desktop-file

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -164,7 +164,8 @@ else
   dnf install -y "$package_path" >/dev/null
   [[ "$(rpm -q --qf '%{VERSION}' ghost-ftp)" == "$expected_version" ]]
   [[ "$(rpm -q --qf '%{ARCH}' ghost-ftp)" == "x86_64" ]]
-  rpm -q ca-certificates curl openssh-clients >/dev/null
+  rpm -q ca-certificates openssh-clients >/dev/null
+  rpm -q --whatprovides curl >/dev/null
   verify_common_runtime_tools
 
   test -x /usr/bin/ghostftp

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <debian|ubuntu|fedora> <expected-version> <expected-os-version> <package-path>" >&2
+  exit 2
+fi
+
+target="$1"
+expected_version="$2"
+expected_os_version="$3"
+package_path="$4"
+
+[[ -s "$package_path" ]] || { echo "package not found: $package_path" >&2; exit 1; }
+
+# The install gate must prove the package in the distro it claims to target.
+# Fail closed if a workflow/container change silently substitutes another OS.
+# shellcheck disable=SC1091
+source /etc/os-release
+case "$target" in
+  debian)
+    [[ "${ID:-}" == "debian" ]] || { echo "expected Debian, got ${ID:-unknown}" >&2; exit 1; }
+    [[ "${VERSION_ID:-}" == "$expected_os_version" ]] || { echo "expected Debian $expected_os_version, got ${VERSION_ID:-unknown}" >&2; exit 1; }
+    ;;
+  ubuntu)
+    [[ "${ID:-}" == "ubuntu" ]] || { echo "expected Ubuntu, got ${ID:-unknown}" >&2; exit 1; }
+    [[ "${VERSION_ID:-}" == "$expected_os_version" ]] || { echo "expected Ubuntu $expected_os_version, got ${VERSION_ID:-unknown}" >&2; exit 1; }
+    ;;
+  fedora)
+    [[ "${ID:-}" == "fedora" ]] || { echo "expected Fedora, got ${ID:-unknown}" >&2; exit 1; }
+    [[ "${VERSION_ID:-}" == "$expected_os_version" ]] || { echo "expected Fedora $expected_os_version, got ${VERSION_ID:-unknown}" >&2; exit 1; }
+    ;;
+  *)
+    echo "unsupported target: $target" >&2
+    exit 2
+    ;;
+esac
+
+verify_gui_smoke() {
+  local smoke_home xvfb_pid app_pid app_status=0
+  smoke_home="$(mktemp -d)"
+  chmod 0700 "$smoke_home"
+
+  Xvfb :99 -screen 0 1280x800x24 -nolisten tcp -ac >"$smoke_home/xvfb.log" 2>&1 &
+  xvfb_pid=$!
+  trap 'kill "$xvfb_pid" 2>/dev/null || true; rm -rf "$smoke_home"' RETURN
+
+  for _ in $(seq 1 50); do
+    [[ -S /tmp/.X11-unix/X99 ]] && break
+    kill -0 "$xvfb_pid" 2>/dev/null || {
+      cat "$smoke_home/xvfb.log" >&2 || true
+      echo "Xvfb exited before becoming ready" >&2
+      return 1
+    }
+    sleep 0.1
+  done
+  [[ -S /tmp/.X11-unix/X99 ]] || { echo "Xvfb socket did not become ready" >&2; return 1; }
+
+  HOME="$smoke_home" DISPLAY=:99 XAUTHORITY= /usr/bin/ghostftp >"$smoke_home/ghostftp.log" 2>&1 &
+  app_pid=$!
+  sleep 2
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    wait "$app_pid" || app_status=$?
+    cat "$smoke_home/ghostftp.log" >&2 || true
+    echo "installed Ghost FTP exited during GUI startup smoke (status=$app_status)" >&2
+    return 1
+  fi
+
+  kill -TERM "$app_pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$app_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  if kill -0 "$app_pid" 2>/dev/null; then
+    kill -KILL "$app_pid" 2>/dev/null || true
+  fi
+  wait "$app_pid" 2>/dev/null || true
+
+  kill "$xvfb_pid" 2>/dev/null || true
+  wait "$xvfb_pid" 2>/dev/null || true
+  rm -rf "$smoke_home"
+  trap - RETURN
+  echo "GHOSTFTP_INSTALLED_GUI_SMOKE=PASS target=$target"
+}
+
+verify_common_runtime_tools() {
+  command -v curl >/dev/null
+  command -v ssh >/dev/null
+  command -v sftp >/dev/null
+  test -s /etc/ssl/certs/ca-certificates.crt
+}
+
+if [[ "$target" == "debian" || "$target" == "ubuntu" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y --no-install-recommends xvfb >/dev/null
+
+  expected_distro="Debian"
+  [[ "$target" == "ubuntu" ]] && expected_distro="Ubuntu"
+  [[ "$(dpkg-deb -f "$package_path" Package)" == "ghost-ftp" ]]
+  [[ "$(dpkg-deb -f "$package_path" Version)" == "$expected_version" ]]
+  [[ "$(dpkg-deb -f "$package_path" Architecture)" == "amd64" ]]
+  [[ "$(dpkg-deb -f "$package_path" X-GhostFTP-Distribution)" == "$expected_distro" ]]
+  [[ "$(dpkg-deb -f "$package_path" Depends)" == "ca-certificates, curl, openssh-client" ]]
+
+  apt-get install -y --no-install-recommends "$package_path" >/dev/null
+  [[ "$(dpkg-query -W -f='${Status}' ghost-ftp)" == "install ok installed" ]]
+  [[ "$(dpkg-query -W -f='${Version}' ghost-ftp)" == "$expected_version" ]]
+  [[ "$(dpkg-query -W -f='${Architecture}' ghost-ftp)" == "amd64" ]]
+  dpkg-query -W ca-certificates curl openssh-client >/dev/null
+  verify_common_runtime_tools
+
+  test -x /usr/bin/ghostftp
+  test -f /usr/share/applications/ghost-ftp.desktop
+  test -f /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
+  dpkg-query -L ghost-ftp | grep -Fx '/usr/bin/ghostftp' >/dev/null
+  dpkg-query -L ghost-ftp | grep -Fx '/usr/share/applications/ghost-ftp.desktop' >/dev/null
+  dpkg-query -L ghost-ftp | grep -Fx '/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png' >/dev/null
+
+  verify_gui_smoke
+
+  apt-get remove -y ghost-ftp >/dev/null
+  if dpkg-query -W ghost-ftp >/dev/null 2>&1; then
+    state="$(dpkg-query -W -f='${db:Status-Abbrev}' ghost-ftp 2>/dev/null || true)"
+    [[ "$state" != ii* ]] || { echo "ghost-ftp remains installed after removal" >&2; exit 1; }
+  fi
+  test ! -e /usr/bin/ghostftp
+  test ! -e /usr/share/applications/ghost-ftp.desktop
+  test ! -e /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
+else
+  dnf install -y xorg-x11-server-Xvfb >/dev/null
+
+  [[ "$(rpm -qp --qf '%{NAME}' "$package_path")" == "ghost-ftp" ]]
+  [[ "$(rpm -qp --qf '%{VERSION}' "$package_path")" == "$expected_version" ]]
+  [[ "$(rpm -qp --qf '%{ARCH}' "$package_path")" == "x86_64" ]]
+  [[ "$(rpm -qp --qf '%{DISTRIBUTION}' "$package_path")" == "Fedora" ]]
+  rpm -qp --requires "$package_path" | grep -Fx 'ca-certificates' >/dev/null
+  rpm -qp --requires "$package_path" | grep -Fx 'curl' >/dev/null
+  rpm -qp --requires "$package_path" | grep -Fx 'openssh-clients' >/dev/null
+
+  dnf install -y "$package_path" >/dev/null
+  [[ "$(rpm -q --qf '%{VERSION}' ghost-ftp)" == "$expected_version" ]]
+  [[ "$(rpm -q --qf '%{ARCH}' ghost-ftp)" == "x86_64" ]]
+  rpm -q ca-certificates curl openssh-clients >/dev/null
+  verify_common_runtime_tools
+
+  test -x /usr/bin/ghostftp
+  test -f /usr/share/applications/ghost-ftp.desktop
+  test -f /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
+  test -f /usr/share/doc/ghost-ftp/LICENSE
+  test -f /usr/share/doc/ghost-ftp/README.md
+  rpm -ql ghost-ftp | grep -Fx '/usr/bin/ghostftp' >/dev/null
+  rpm -ql ghost-ftp | grep -Fx '/usr/share/applications/ghost-ftp.desktop' >/dev/null
+  rpm -ql ghost-ftp | grep -Fx '/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png' >/dev/null
+
+  verify_gui_smoke
+
+  dnf remove -y ghost-ftp >/dev/null
+  ! rpm -q ghost-ftp >/dev/null 2>&1
+  test ! -e /usr/bin/ghostftp
+  test ! -e /usr/share/applications/ghost-ftp.desktop
+  test ! -e /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
+  test ! -e /usr/share/doc/ghost-ftp/LICENSE
+  test ! -e /usr/share/doc/ghost-ftp/README.md
+fi
+
+echo "GHOSTFTP_DISTRO_INSTALL=PASS target=$target os=${ID}-${VERSION_ID} package_version=$expected_version"

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -37,12 +37,22 @@ case "$target" in
 esac
 
 verify_gui_smoke() {
-  local smoke_home xvfb_pid app_pid app_status=0
-  # Ghost FTP intentionally rejects data roots reached through unsafe/writable
-  # ancestor directories. Keep the test HOME under root-owned /var/lib so the
-  # production filesystem hardening remains enabled during the smoke test.
+  local smoke_home data_root runtime_dir xvfb_pid app_pid app_status=0
+  # Keep the test HOME under a non-world-writable system path, then create the
+  # standard Linux user-data root that normally already exists in a desktop
+  # session. Ghost FTP deliberately treats LocalAppData as a trusted root and
+  # only creates/verifies Ghost FTP-owned descendants beneath it.
   smoke_home="$(mktemp -d /var/lib/ghostftp-ci-home.XXXXXX)"
   chmod 0700 "$smoke_home"
+  mkdir -p "$smoke_home/.local/share"
+  chmod 0700 "$smoke_home/.local" "$smoke_home/.local/share"
+  data_root="$smoke_home/.local/share"
+
+  # Use a private runtime directory so the single-instance lock and any future
+  # per-user runtime state do not share the container's global /tmp namespace.
+  runtime_dir="$smoke_home/runtime"
+  mkdir "$runtime_dir"
+  chmod 0700 "$runtime_dir"
 
   Xvfb :99 -screen 0 1280x800x24 -nolisten tcp -ac >"$smoke_home/xvfb.log" 2>&1 &
   xvfb_pid=$!
@@ -59,7 +69,11 @@ verify_gui_smoke() {
   done
   [[ -S /tmp/.X11-unix/X99 ]] || { echo "Xvfb socket did not become ready" >&2; return 1; }
 
-  HOME="$smoke_home" DISPLAY=:99 XAUTHORITY= /usr/bin/ghostftp >"$smoke_home/ghostftp.log" 2>&1 &
+  test -d "$data_root"
+  test "$(stat -c '%a' "$data_root")" = "700"
+  test "$(stat -c '%a' "$runtime_dir")" = "700"
+
+  HOME="$smoke_home" XDG_RUNTIME_DIR="$runtime_dir" DISPLAY=:99 XAUTHORITY= /usr/bin/ghostftp >"$smoke_home/ghostftp.log" 2>&1 &
   app_pid=$!
   sleep 2
   if ! kill -0 "$app_pid" 2>/dev/null; then

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -38,7 +38,10 @@ esac
 
 verify_gui_smoke() {
   local smoke_home xvfb_pid app_pid app_status=0
-  smoke_home="$(mktemp -d)"
+  # Ghost FTP intentionally rejects data roots reached through unsafe/writable
+  # ancestor directories. Keep the test HOME under root-owned /var/lib so the
+  # production filesystem hardening remains enabled during the smoke test.
+  smoke_home="$(mktemp -d /var/lib/ghostftp-ci-home.XXXXXX)"
   chmod 0700 "$smoke_home"
 
   Xvfb :99 -screen 0 1280x800x24 -nolisten tcp -ac >"$smoke_home/xvfb.log" 2>&1 &

--- a/scripts/verify_linux_distro_install.sh
+++ b/scripts/verify_linux_distro_install.sh
@@ -113,6 +113,11 @@ verify_common_runtime_tools() {
   fi
 }
 
+fedora_fail() {
+  echo "GHOSTFTP_FEDORA_VERIFY_FAIL=$1" >&2
+  exit 1
+}
+
 if [[ "$target" == "debian" || "$target" == "ubuntu" ]]; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get update -qq
@@ -153,39 +158,45 @@ if [[ "$target" == "debian" || "$target" == "ubuntu" ]]; then
 else
   dnf install -y xorg-x11-server-Xvfb >/dev/null
 
-  [[ "$(rpm -qp --qf '%{NAME}' "$package_path")" == "ghost-ftp" ]]
-  [[ "$(rpm -qp --qf '%{VERSION}' "$package_path")" == "$expected_version" ]]
-  [[ "$(rpm -qp --qf '%{ARCH}' "$package_path")" == "x86_64" ]]
-  [[ "$(rpm -qp --qf '%{DISTRIBUTION}' "$package_path")" == "Fedora" ]]
-  rpm -qp --requires "$package_path" | grep -Fx 'ca-certificates' >/dev/null
-  rpm -qp --requires "$package_path" | grep -Fx 'curl' >/dev/null
-  rpm -qp --requires "$package_path" | grep -Fx 'openssh-clients' >/dev/null
+  [[ "$(rpm -qp --qf '%{NAME}' "$package_path")" == "ghost-ftp" ]] || fedora_fail package-name
+  [[ "$(rpm -qp --qf '%{VERSION}' "$package_path")" == "$expected_version" ]] || fedora_fail package-version
+  [[ "$(rpm -qp --qf '%{ARCH}' "$package_path")" == "x86_64" ]] || fedora_fail package-arch
+  [[ "$(rpm -qp --qf '%{DISTRIBUTION}' "$package_path")" == "Fedora" ]] || fedora_fail package-distribution
+  rpm -qp --requires "$package_path" | grep -Fx 'ca-certificates' >/dev/null || fedora_fail requires-ca-certificates
+  rpm -qp --requires "$package_path" | grep -Fx 'curl' >/dev/null || fedora_fail requires-curl
+  rpm -qp --requires "$package_path" | grep -Fx 'openssh-clients' >/dev/null || fedora_fail requires-openssh-clients
 
   dnf install -y "$package_path" >/dev/null
-  [[ "$(rpm -q --qf '%{VERSION}' ghost-ftp)" == "$expected_version" ]]
-  [[ "$(rpm -q --qf '%{ARCH}' ghost-ftp)" == "x86_64" ]]
-  rpm -q ca-certificates openssh-clients >/dev/null
-  rpm -q --whatprovides curl >/dev/null
-  verify_common_runtime_tools
+  [[ "$(rpm -q --qf '%{VERSION}' ghost-ftp)" == "$expected_version" ]] || fedora_fail installed-version
+  [[ "$(rpm -q --qf '%{ARCH}' ghost-ftp)" == "x86_64" ]] || fedora_fail installed-arch
+  rpm -q ca-certificates >/dev/null || fedora_fail ca-certificates-package
+  rpm -q openssh-clients >/dev/null || fedora_fail openssh-clients-package
 
-  test -x /usr/bin/ghostftp
-  test -f /usr/share/applications/ghost-ftp.desktop
-  test -f /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
-  test -f /usr/share/doc/ghost-ftp/LICENSE
-  test -f /usr/share/doc/ghost-ftp/README.md
-  rpm -ql ghost-ftp | grep -Fx '/usr/bin/ghostftp' >/dev/null
-  rpm -ql ghost-ftp | grep -Fx '/usr/share/applications/ghost-ftp.desktop' >/dev/null
-  rpm -ql ghost-ftp | grep -Fx '/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png' >/dev/null
+  curl_path="$(command -v curl)" || fedora_fail curl-command
+  [[ -x "$curl_path" ]] || fedora_fail curl-executable
+  rpm -qf "$curl_path" >/dev/null || fedora_fail curl-rpm-owner
+  command -v ssh >/dev/null || fedora_fail ssh-command
+  command -v sftp >/dev/null || fedora_fail sftp-command
+  test -s /etc/pki/tls/certs/ca-bundle.crt || fedora_fail ca-bundle
+
+  test -x /usr/bin/ghostftp || fedora_fail ghostftp-executable
+  test -f /usr/share/applications/ghost-ftp.desktop || fedora_fail desktop-file
+  test -f /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png || fedora_fail icon-file
+  test -f /usr/share/doc/ghost-ftp/LICENSE || fedora_fail license-file
+  test -f /usr/share/doc/ghost-ftp/README.md || fedora_fail readme-file
+  rpm -ql ghost-ftp | grep -Fx '/usr/bin/ghostftp' >/dev/null || fedora_fail owns-executable
+  rpm -ql ghost-ftp | grep -Fx '/usr/share/applications/ghost-ftp.desktop' >/dev/null || fedora_fail owns-desktop-file
+  rpm -ql ghost-ftp | grep -Fx '/usr/share/icons/hicolor/512x512/apps/ghost-ftp.png' >/dev/null || fedora_fail owns-icon-file
 
   verify_gui_smoke
 
   dnf remove -y ghost-ftp >/dev/null
-  ! rpm -q ghost-ftp >/dev/null 2>&1
-  test ! -e /usr/bin/ghostftp
-  test ! -e /usr/share/applications/ghost-ftp.desktop
-  test ! -e /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png
-  test ! -e /usr/share/doc/ghost-ftp/LICENSE
-  test ! -e /usr/share/doc/ghost-ftp/README.md
+  ! rpm -q ghost-ftp >/dev/null 2>&1 || fedora_fail package-still-installed
+  test ! -e /usr/bin/ghostftp || fedora_fail executable-residue
+  test ! -e /usr/share/applications/ghost-ftp.desktop || fedora_fail desktop-residue
+  test ! -e /usr/share/icons/hicolor/512x512/apps/ghost-ftp.png || fedora_fail icon-residue
+  test ! -e /usr/share/doc/ghost-ftp/LICENSE || fedora_fail license-residue
+  test ! -e /usr/share/doc/ghost-ftp/README.md || fedora_fail readme-residue
 fi
 
 echo "GHOSTFTP_DISTRO_INSTALL=PASS target=$target os=${ID}-${VERSION_ID} package_version=$expected_version"


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] This change is limited to the connected `bren-wp/Ghost-FTP` repository and its documented maintenance/release scope.

## Scope

Adds a dedicated Phase 2 installation gate for the Linux distro packages merged in PR #178.

The gate rebuilds packages from the exact checked-out commit, then verifies real native x86-64 package installation inside clean target-distribution containers:

- Debian 13 amd64
- Ubuntu 26.04 LTS amd64
- Fedora 44 x86_64

For each target it verifies package metadata, dependency resolution, installed runtime tools, package-owned system file locations, startup of the installed `/usr/bin/ghostftp` under an isolated local Xvfb server, package removal, and absence of package-owned system residue.

The verifier fails closed if `/etc/os-release` does not match the expected distro generation. Containers mount the repository read-only and are not privileged.

## Fedora-specific verification

- Fedora may satisfy the RPM `curl` requirement through an implementation-specific provider such as `curl-minimal`; the gate therefore verifies the installed `curl` executable and its RPM owner instead of assuming a concrete provider package name.
- Fedora CA trust is derived from the installed `ca-certificates` RPM instead of hardcoding one historical CA-bundle path.
- Minimal Fedora container images may enable `tsflags=nodocs`; the Ghost FTP install transaction explicitly clears that container optimization so the gate verifies the full RPM payload, including packaged LICENSE and README documentation.
- Fedora assertions emit deterministic `GHOSTFTP_FEDORA_VERIFY_FAIL=<contract>` markers for actionable failures.

## Architecture scope

This PR intentionally does not claim emulated runtime installation coverage for arm64 or 32-bit packages. Those artifacts remain covered by the existing exact-head build, metadata, extraction and byte-parity gates. Native package-manager/runtime installation coverage in this PR is x86-64 only.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No Web/PWA runtime or hidden backend was added.
- [x] No credentials, customer data or external FTP/SFTP test-server secrets are used.
- [x] No external Go module was added.
- [x] Xvfb listens only locally (`-nolisten tcp`).
- [x] GUI smoke uses a private test HOME under `/var/lib`, pre-creates the standard `$HOME/.local/share` data root, and uses a private `XDG_RUNTIME_DIR`.
- [x] The production filesystem safety validator is not weakened or bypassed.
- [x] Uninstall assertions are restricted to package-owned system paths; no user-data deletion is added.

## Regression coverage

- `scripts/test_linux_distro_install_contract.py` locks the install/remove, dependency, distro identity, Fedora full-payload, safe GUI smoke and non-privileged container contracts.
- `scripts/verify_linux_distro_install.sh` performs the real package lifecycle assertions inside each target container.
- `.github/workflows/linux-distro-install.yml` rebuilds packages from the exact source head and runs the clean-container matrix.

`VERSION` remains `1.1.6`; no tag, release, signing identity or published 1.1.6 asset is changed.

This PR must not merge until the new install matrix and all existing required Ghost FTP CI gates are green on the same final head. Any code-head change invalidates previous gate results.