### PR TITLE
Windows: fix modal close lifecycle and modernize dialog theming

### DIFF
--- a/internal/desktop/commands_windows.go
+++ b/internal/desktop/commands_windows.go
@@ -2,9 +2,19 @@
 
 package desktop
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+)
 
 func (a *app) command(id int) {
+	// Some legacy file-operation call sites intentionally keep the compact
+	// platform.PromptDialog wrapper. Synchronize its action labels at the command
+	// boundary so the modal always follows Ghost FTP's active runtime language
+	// instead of falling back to English (for example Croatian "Otkaži").
+	platform.SetDialogActionLabels(okLabel(a.languageCode()), a.tr("common.cancel"))
+
 	switch id {
 	case idConnect:
 		a.connectNow()

--- a/internal/desktop/diagnostics_windows.go
+++ b/internal/desktop/diagnostics_windows.go
@@ -21,7 +21,7 @@ var diagnosticsWords = map[string]diagnosticsWordsSet{
 	"fr": {"Aucune télémétrie ni suivi. Les profils enregistrés restent sur cet ordinateur.", "Non connecté"},
 	"es": {"Sin telemetría ni seguimiento. Los perfiles guardados permanecen en este equipo.", "Sin conexión"},
 	"tr": {"Telemetri veya izleme yok. Kaydedilen profiller bu bilgisayarda kalır.", "Bağlı değil"},
-	"el": {"Χωρίς τηλεμετρία ή παρακολούθηση. Τα αποθηκευμένα προφίλ μένουν σε αυτόν τον υπολογιστή.", "Δεν υπάρχει σύνδεση"},
+	"el": {"Χωρίς telemetriju ή παρακολούθηση. Τα αποθηκευμένα προφίλ μένουν σε αυτόν τον υπολογιστή.", "Δεν υπάρχει σύνδεση"},
 	"pt": {"Sem telemetria ou rastreio. Os perfis guardados ficam neste computador.", "Não ligado"},
 	"zh": {"无遥测或跟踪。已保存的配置保留在此计算机上。", "未连接"},
 	"ru": {"Без телеметрии и отслеживания. Сохранённые профили остаются на этом компьютере.", "Не подключено"},
@@ -58,5 +58,13 @@ func (a *app) showDiagnostics() {
 		"Ghost FTP %s\n\n%s · %s\n%s\n\n%s",
 		a.version, strings.ToUpper(a.protocolValue()), state, a.remoteCurrent, words.PrivacyBody,
 	)
-	platform.InfoDialog("Ghost FTP — "+title, title, body)
+	// Diagnostics is application-owned UI. Using the stock TaskDialog made a
+	// Dark Ghost FTP session open a bright white system dialog, which visually
+	// looked like a different product. Keep it in the same owned theme shell.
+	platform.CompactInfoDialog(
+		"Ghost FTP — "+title,
+		title,
+		body,
+		okLabel(a.languageCode()),
+	)
 }

--- a/internal/desktop/diagnostics_windows.go
+++ b/internal/desktop/diagnostics_windows.go
@@ -21,7 +21,7 @@ var diagnosticsWords = map[string]diagnosticsWordsSet{
 	"fr": {"Aucune télémétrie ni suivi. Les profils enregistrés restent sur cet ordinateur.", "Non connecté"},
 	"es": {"Sin telemetría ni seguimiento. Los perfiles guardados permanecen en este equipo.", "Sin conexión"},
 	"tr": {"Telemetri veya izleme yok. Kaydedilen profiller bu bilgisayarda kalır.", "Bağlı değil"},
-	"el": {"Χωρίς telemetriju ή παρακολούθηση. Τα αποθηκευμένα προφίλ μένουν σε αυτόν τον υπολογιστή.", "Δεν υπάρχει σύνδεση"},
+	"el": {"Χωρίς τηλεμετρία ή παρακολούθηση. Τα αποθηκευμένα προφίλ μένουν σε αυτόν τον υπολογιστή.", "Δεν υπάρχει σύνδεση"},
 	"pt": {"Sem telemetria ou rastreio. Os perfis guardados ficam neste computador.", "Não ligado"},
 	"zh": {"无遥测或跟踪。已保存的配置保留在此计算机上。", "未连接"},
 	"ru": {"Без телеметрии и отслеживания. Сохранённые профили остаются на этом компьютере.", "Не подключено"},

--- a/internal/desktop/theme.go
+++ b/internal/desktop/theme.go
@@ -40,31 +40,34 @@ type RGB struct {
 	B byte
 }
 
+// Dark uses a restrained navy/charcoal surface rather than near-black blocks.
+// This preserves contrast while reducing eye strain and keeps list/panel layers
+// visually separable without relying on heavy borders.
 var darkTheme = PremiumTheme{
-	Window:       RGB{0x08, 0x0A, 0x0F},
-	Panel:        RGB{0x0F, 0x13, 0x1C},
-	List:         RGB{0x15, 0x1A, 0x25},
-	Border:       RGB{0x25, 0x2D, 0x3C},
-	Text:         RGB{0xF4, 0xF7, 0xFF},
-	Muted:        RGB{0x8E, 0x99, 0xAD},
-	Accent:       RGB{0x52, 0x77, 0xF5},
-	AccentStrong: RGB{0x72, 0x93, 0xFF},
+	Window:       RGB{0x0B, 0x0F, 0x17},
+	Panel:        RGB{0x12, 0x18, 0x24},
+	List:         RGB{0x16, 0x1D, 0x2A},
+	Border:       RGB{0x2C, 0x36, 0x48},
+	Text:         RGB{0xF2, 0xF5, 0xFA},
+	Muted:        RGB{0x97, 0xA3, 0xB8},
+	Accent:       RGB{0x5B, 0x7C, 0xFA},
+	AccentStrong: RGB{0x7A, 0x98, 0xFF},
 	Success:      RGB{0x4A, 0xD7, 0x9B},
 	Warn:         RGB{0xF2, 0xBA, 0x55},
-	Danger:       RGB{0xFF, 0x64, 0x76},
-	Selection:    RGB{0x1D, 0x2A, 0x4A},
+	Danger:       RGB{0xFF, 0x68, 0x78},
+	Selection:    RGB{0x20, 0x2F, 0x50},
 }
 
-// lightTheme intentionally follows the restrained, information-dense visual
-// language of traditional desktop file-transfer clients while retaining Ghost
-// FTP's own identity. It does not copy third-party branding or assets.
+// Light deliberately avoids pure white as the dominant application surface.
+// The slightly cool neutral hierarchy keeps long file-management sessions less
+// glaring while preserving native-control readability and clear selection.
 var lightTheme = PremiumTheme{
-	Window:       RGB{0xF3, 0xF4, 0xF6},
-	Panel:        RGB{0xFF, 0xFF, 0xFF},
-	List:         RGB{0xFF, 0xFF, 0xFF},
-	Border:       RGB{0xC8, 0xCD, 0xD6},
-	Text:         RGB{0x1F, 0x23, 0x28},
-	Muted:        RGB{0x66, 0x70, 0x85},
+	Window:       RGB{0xEE, 0xF1, 0xF5},
+	Panel:        RGB{0xF6, 0xF8, 0xFB},
+	List:         RGB{0xFA, 0xFB, 0xFD},
+	Border:       RGB{0xC7, 0xCE, 0xD8},
+	Text:         RGB{0x20, 0x25, 0x2B},
+	Muted:        RGB{0x65, 0x70, 0x83},
 	Accent:       RGB{0x3F, 0x63, 0xDD},
 	AccentStrong: RGB{0x25, 0x4B, 0xC7},
 	Success:      RGB{0x1B, 0x7F, 0x4B},

--- a/internal/desktop/theme_test.go
+++ b/internal/desktop/theme_test.go
@@ -35,3 +35,25 @@ func TestClassicLightThemeKeepsReadableContrastDirection(t *testing.T) {
 		t.Fatal("light theme selection is indistinguishable from list background")
 	}
 }
+
+func TestClassicLightAvoidsPureWhitePrimarySurfaces(t *testing.T) {
+	pureWhite := RGB{0xFF, 0xFF, 0xFF}
+	for name, surface := range map[string]RGB{
+		"window": lightTheme.Window,
+		"panel":  lightTheme.Panel,
+		"list":   lightTheme.List,
+	} {
+		if surface == pureWhite {
+			t.Fatalf("Classic Light %s surface regressed to pure white", name)
+		}
+	}
+}
+
+func TestDarkThemeKeepsLayerSeparation(t *testing.T) {
+	if darkTheme.Window == darkTheme.Panel || darkTheme.Panel == darkTheme.List {
+		t.Fatal("dark theme window/panel/list layers are not visually separated")
+	}
+	if darkTheme.Text == darkTheme.Muted {
+		t.Fatal("dark theme primary and muted text are indistinguishable")
+	}
+}

--- a/internal/platform/dialog_premium_windows.go
+++ b/internal/platform/dialog_premium_windows.go
@@ -9,26 +9,24 @@ import (
 	"unsafe"
 )
 
-var (
-	premiumGetSystemMetrics          = user32.NewProc("GetSystemMetrics")
-	premiumGetActiveWindow           = user32.NewProc("GetActiveWindow")
-	premiumGetWindowRect             = user32.NewProc("GetWindowRect")
-	premiumGetDpiForWindow           = user32.NewProc("GetDpiForWindow")
-	premiumGetDpiForSystem           = user32.NewProc("GetDpiForSystem")
-	premiumAdjustWindowRectEx        = user32.NewProc("AdjustWindowRectEx")
-	premiumAdjustWindowRectExForDpi  = user32.NewProc("AdjustWindowRectExForDpi")
-	premiumEnableWindow              = user32.NewProc("EnableWindow")
-	premiumSetActiveWindow           = user32.NewProc("SetActiveWindow")
-	premiumIsWindow                  = user32.NewProc("IsWindow")
-	premiumDwmapi                    = syscall.NewLazyDLL("dwmapi.dll")
-	premiumDwmSetAttribute           = premiumDwmapi.NewProc("DwmSetWindowAttribute")
-	premiumGdi32                     = syscall.NewLazyDLL("gdi32.dll")
-	premiumCreateSolidBrush          = premiumGdi32.NewProc("CreateSolidBrush")
-	premiumSetTextColor              = premiumGdi32.NewProc("SetTextColor")
-	premiumSetBkColor                = premiumGdi32.NewProc("SetBkColor")
-	premiumUxTheme                   = syscall.NewLazyDLL("uxtheme.dll")
-	premiumSetWindowTheme            = premiumUxTheme.NewProc("SetWindowTheme")
-)
+var premiumGetSystemMetrics = user32.NewProc("GetSystemMetrics")
+var premiumGetActiveWindow = user32.NewProc("GetActiveWindow")
+var premiumGetWindowRect = user32.NewProc("GetWindowRect")
+var premiumGetDpiForWindow = user32.NewProc("GetDpiForWindow")
+var premiumGetDpiForSystem = user32.NewProc("GetDpiForSystem")
+var premiumAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
+var premiumAdjustWindowRectExForDpi = user32.NewProc("AdjustWindowRectExForDpi")
+var premiumEnableWindow = user32.NewProc("EnableWindow")
+var premiumSetActiveWindow = user32.NewProc("SetActiveWindow")
+var premiumIsWindow = user32.NewProc("IsWindow")
+var premiumDwmapi = syscall.NewLazyDLL("dwmapi.dll")
+var premiumDwmSetAttribute = premiumDwmapi.NewProc("DwmSetWindowAttribute")
+var premiumGdi32 = syscall.NewLazyDLL("gdi32.dll")
+var premiumCreateSolidBrush = premiumGdi32.NewProc("CreateSolidBrush")
+var premiumSetTextColor = premiumGdi32.NewProc("SetTextColor")
+var premiumSetBkColor = premiumGdi32.NewProc("SetBkColor")
+var premiumUxTheme = syscall.NewLazyDLL("uxtheme.dll")
+var premiumSetWindowTheme = premiumUxTheme.NewProc("SetWindowTheme")
 
 const (
 	premiumWMCtlColorEdit    = 0x0133
@@ -44,19 +42,41 @@ type premiumRect struct {
 	Bottom int32
 }
 
-var (
-	premiumDialogDark    atomic.Bool
-	premiumDarkBrushOnce sync.Once
-	premiumDarkBrush     uintptr
-	premiumLightBrushOnce sync.Once
-	premiumLightBrush     uintptr
-)
+var premiumDialogDark atomic.Bool
+var premiumDarkBrushOnce sync.Once
+var premiumDarkBrush uintptr
+var premiumLightBrushOnce sync.Once
+var premiumLightBrush uintptr
+var premiumDialogLabelsMu sync.RWMutex
+var premiumDialogOKLabel = "OK"
+var premiumDialogCancelLabel = "Cancel"
 
 // SetDialogAppearance synchronizes the small native platform dialogs with the
 // appearance selected by the desktop frontend. The installer does not call this
 // function and therefore keeps the normal Windows light presentation.
 func SetDialogAppearance(dark bool) {
 	premiumDialogDark.Store(dark)
+}
+
+// SetDialogActionLabels keeps compatibility PromptDialog call sites localized
+// without teaching the platform package about Ghost FTP's translation catalog.
+func SetDialogActionLabels(okLabel, cancelLabel string) {
+	if okLabel == "" {
+		okLabel = "OK"
+	}
+	if cancelLabel == "" {
+		cancelLabel = "Cancel"
+	}
+	premiumDialogLabelsMu.Lock()
+	premiumDialogOKLabel = okLabel
+	premiumDialogCancelLabel = cancelLabel
+	premiumDialogLabelsMu.Unlock()
+}
+
+func dialogActionLabels() (string, string) {
+	premiumDialogLabelsMu.RLock()
+	defer premiumDialogLabelsMu.RUnlock()
+	return premiumDialogOKLabel, premiumDialogCancelLabel
 }
 
 func premiumColor(r, g, b byte) uintptr {
@@ -161,6 +181,9 @@ func premiumDialogDPI(owner uintptr) uint32 {
 }
 
 func premiumScale(value int, dpi uint32) int {
+	if value < 0 {
+		return -premiumScale(-value, dpi)
+	}
 	if dpi == 0 {
 		dpi = 96
 	}
@@ -190,7 +213,10 @@ func premiumDialogOuterSize(clientWidth, clientHeight int, style uint32, exStyle
 		)
 	}
 	if adjusted == 0 {
-		r = premiumRect{Right: int32(premiumScale(clientWidth, dpi)), Bottom: int32(premiumScale(clientHeight, dpi))}
+		r = premiumRect{
+			Right:  int32(premiumScale(clientWidth, dpi)),
+			Bottom: int32(premiumScale(clientHeight, dpi)),
+		}
 		adjusted, _, _ = premiumAdjustWindowRectEx.Call(
 			uintptr(unsafe.Pointer(&r)),
 			uintptr(style),

--- a/internal/platform/dialog_premium_windows.go
+++ b/internal/platform/dialog_premium_windows.go
@@ -10,15 +10,24 @@ import (
 )
 
 var (
-	premiumGetSystemMetrics = user32.NewProc("GetSystemMetrics")
-	premiumDwmapi           = syscall.NewLazyDLL("dwmapi.dll")
-	premiumDwmSetAttribute  = premiumDwmapi.NewProc("DwmSetWindowAttribute")
-	premiumGdi32            = syscall.NewLazyDLL("gdi32.dll")
-	premiumCreateSolidBrush = premiumGdi32.NewProc("CreateSolidBrush")
-	premiumSetTextColor     = premiumGdi32.NewProc("SetTextColor")
-	premiumSetBkColor       = premiumGdi32.NewProc("SetBkColor")
-	premiumUxTheme          = syscall.NewLazyDLL("uxtheme.dll")
-	premiumSetWindowTheme   = premiumUxTheme.NewProc("SetWindowTheme")
+	premiumGetSystemMetrics          = user32.NewProc("GetSystemMetrics")
+	premiumGetActiveWindow           = user32.NewProc("GetActiveWindow")
+	premiumGetWindowRect             = user32.NewProc("GetWindowRect")
+	premiumGetDpiForWindow           = user32.NewProc("GetDpiForWindow")
+	premiumGetDpiForSystem           = user32.NewProc("GetDpiForSystem")
+	premiumAdjustWindowRectEx        = user32.NewProc("AdjustWindowRectEx")
+	premiumAdjustWindowRectExForDpi  = user32.NewProc("AdjustWindowRectExForDpi")
+	premiumEnableWindow              = user32.NewProc("EnableWindow")
+	premiumSetActiveWindow           = user32.NewProc("SetActiveWindow")
+	premiumIsWindow                  = user32.NewProc("IsWindow")
+	premiumDwmapi                    = syscall.NewLazyDLL("dwmapi.dll")
+	premiumDwmSetAttribute           = premiumDwmapi.NewProc("DwmSetWindowAttribute")
+	premiumGdi32                     = syscall.NewLazyDLL("gdi32.dll")
+	premiumCreateSolidBrush          = premiumGdi32.NewProc("CreateSolidBrush")
+	premiumSetTextColor              = premiumGdi32.NewProc("SetTextColor")
+	premiumSetBkColor                = premiumGdi32.NewProc("SetBkColor")
+	premiumUxTheme                   = syscall.NewLazyDLL("uxtheme.dll")
+	premiumSetWindowTheme            = premiumUxTheme.NewProc("SetWindowTheme")
 )
 
 const (
@@ -28,10 +37,19 @@ const (
 	premiumWMCtlColorStatic  = 0x0138
 )
 
+type premiumRect struct {
+	Left   int32
+	Top    int32
+	Right  int32
+	Bottom int32
+}
+
 var (
 	premiumDialogDark    atomic.Bool
 	premiumDarkBrushOnce sync.Once
 	premiumDarkBrush     uintptr
+	premiumLightBrushOnce sync.Once
+	premiumLightBrush     uintptr
 )
 
 // SetDialogAppearance synchronizes the small native platform dialogs with the
@@ -49,7 +67,9 @@ func premiumDialogSurfaceColor() uintptr {
 	if premiumDialogDark.Load() {
 		return premiumColor(15, 19, 28)
 	}
-	return premiumColor(255, 255, 255)
+	// A restrained neutral surface avoids the glaring pure-white flash that the
+	// previous application-owned Light dialogs produced next to the main window.
+	return premiumColor(246, 248, 251)
 }
 
 func premiumDialogTextColor() uintptr {
@@ -60,23 +80,28 @@ func premiumDialogTextColor() uintptr {
 }
 
 func premiumDialogBackgroundBrush() uintptr {
-	if !premiumDialogDark.Load() {
-		// COLOR_WINDOW + 1 is the documented class-background convention for a
-		// stock Windows white surface and does not allocate a GDI object.
+	if premiumDialogDark.Load() {
+		premiumDarkBrushOnce.Do(func() {
+			premiumDarkBrush, _, _ = premiumCreateSolidBrush.Call(premiumColor(15, 19, 28))
+		})
+		if premiumDarkBrush != 0 {
+			return premiumDarkBrush
+		}
 		return 6
 	}
-	premiumDarkBrushOnce.Do(func() {
-		premiumDarkBrush, _, _ = premiumCreateSolidBrush.Call(premiumDialogSurfaceColor())
+	premiumLightBrushOnce.Do(func() {
+		premiumLightBrush, _, _ = premiumCreateSolidBrush.Call(premiumColor(246, 248, 251))
 	})
-	if premiumDarkBrush == 0 {
-		return 6
+	if premiumLightBrush != 0 {
+		return premiumLightBrush
 	}
-	return premiumDarkBrush
+	return 6
 }
 
 // premiumDialogControlColor is shared by the prompt/option/about card window
 // procedures. It prevents static labels and edit/list backgrounds from falling
-// back to a white stock brush while the active application appearance is Dark.
+// back to an unrelated stock brush while the active application appearance is
+// Dark or the softened application-owned Light palette is active.
 func premiumDialogControlColor(hdc uintptr) uintptr {
 	if hdc != 0 {
 		premiumSetTextColor.Call(hdc, premiumDialogTextColor())
@@ -105,7 +130,95 @@ func applyPremiumDialogControl(hwnd uintptr, class string) {
 	}
 }
 
-func premiumDialogPosition(width, height int) (int, int) {
+func premiumDialogOwner() uintptr {
+	owner, _, _ := premiumGetActiveWindow.Call()
+	if owner == 0 {
+		return 0
+	}
+	valid, _, _ := premiumIsWindow.Call(owner)
+	if valid == 0 {
+		return 0
+	}
+	return owner
+}
+
+func premiumDialogDPI(owner uintptr) uint32 {
+	if owner != 0 {
+		if err := premiumGetDpiForWindow.Find(); err == nil {
+			dpi, _, _ := premiumGetDpiForWindow.Call(owner)
+			if dpi >= 96 && dpi <= 768 {
+				return uint32(dpi)
+			}
+		}
+	}
+	if err := premiumGetDpiForSystem.Find(); err == nil {
+		dpi, _, _ := premiumGetDpiForSystem.Call()
+		if dpi >= 96 && dpi <= 768 {
+			return uint32(dpi)
+		}
+	}
+	return 96
+}
+
+func premiumScale(value int, dpi uint32) int {
+	if dpi == 0 {
+		dpi = 96
+	}
+	if value == 0 {
+		return 0
+	}
+	return (value*int(dpi) + 48) / 96
+}
+
+// premiumDialogOuterSize converts a desired client-area size into the actual
+// top-level window size. The old code treated the requested outer size as if it
+// were the client size, so the Windows title bar and frame consumed the footer
+// and clipped action buttons on current Windows builds and DPI settings.
+func premiumDialogOuterSize(clientWidth, clientHeight int, style uint32, exStyle uint32, dpi uint32) (int, int) {
+	r := premiumRect{
+		Right:  int32(premiumScale(clientWidth, dpi)),
+		Bottom: int32(premiumScale(clientHeight, dpi)),
+	}
+	adjusted := uintptr(0)
+	if err := premiumAdjustWindowRectExForDpi.Find(); err == nil {
+		adjusted, _, _ = premiumAdjustWindowRectExForDpi.Call(
+			uintptr(unsafe.Pointer(&r)),
+			uintptr(style),
+			0,
+			uintptr(exStyle),
+			uintptr(dpi),
+		)
+	}
+	if adjusted == 0 {
+		r = premiumRect{Right: int32(premiumScale(clientWidth, dpi)), Bottom: int32(premiumScale(clientHeight, dpi))}
+		adjusted, _, _ = premiumAdjustWindowRectEx.Call(
+			uintptr(unsafe.Pointer(&r)),
+			uintptr(style),
+			0,
+			uintptr(exStyle),
+		)
+	}
+	if adjusted == 0 {
+		return premiumScale(clientWidth, dpi), premiumScale(clientHeight+48, dpi)
+	}
+	return int(r.Right - r.Left), int(r.Bottom - r.Top)
+}
+
+func premiumDialogPosition(owner uintptr, width, height int) (int, int) {
+	if owner != 0 {
+		var r premiumRect
+		if ok, _, _ := premiumGetWindowRect.Call(owner, uintptr(unsafe.Pointer(&r))); ok != 0 {
+			x := int(r.Left) + (int(r.Right-r.Left)-width)/2
+			y := int(r.Top) + (int(r.Bottom-r.Top)-height)/2
+			if x < 0 {
+				x = 0
+			}
+			if y < 0 {
+				y = 0
+			}
+			return x, y
+		}
+	}
 	const (
 		smCXScreen = 0
 		smCYScreen = 1
@@ -123,9 +236,31 @@ func premiumDialogPosition(width, height int) (int, int) {
 	return x, y
 }
 
-func premiumDialogFont(height int32, weight uintptr) uintptr {
+// premiumModalOwner makes the custom top-level window actually modal. Without
+// this, the nested message loop still dispatched clicks and keyboard commands
+// to the main Ghost FTP window behind the dialog.
+func premiumModalOwner(owner uintptr) func() {
+	if owner == 0 {
+		return func() {}
+	}
+	premiumEnableWindow.Call(owner, 0)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			valid, _, _ := premiumIsWindow.Call(owner)
+			if valid == 0 {
+				return
+			}
+			premiumEnableWindow.Call(owner, 1)
+			premiumSetActiveWindow.Call(owner)
+		})
+	}
+}
+
+func premiumDialogFontForDPI(height int32, dpi uint32, weight uintptr) uintptr {
+	scaledHeight := int32(premiumScale(int(height), dpi))
 	font, _, _ := promptCreateFontW.Call(
-		uintptr(uint32(height)),
+		uintptr(uint32(scaledHeight)),
 		0, 0, 0,
 		weight,
 		0, 0, 0,
@@ -135,11 +270,14 @@ func premiumDialogFont(height int32, weight uintptr) uintptr {
 	return font
 }
 
+func premiumDialogFont(height int32, weight uintptr) uintptr {
+	return premiumDialogFontForDPI(height, premiumDialogDPI(0), weight)
+}
+
 // applyPremiumDialogWindow uses best-effort DWM hints only. Failure is ignored
 // so the same binary remains usable on Windows builds that do not expose a
-// particular modern composition attribute. Unlike the previous implementation,
-// the title bar follows the active appearance instead of being forced dark while
-// the dialog body remained light.
+// particular modern composition attribute. The title bar follows the active
+// appearance instead of being forced dark while the dialog body remains light.
 func applyPremiumDialogWindow(hwnd uintptr) {
 	if hwnd == 0 {
 		return

--- a/internal/platform/info_card_windows.go
+++ b/internal/platform/info_card_windows.go
@@ -85,24 +85,28 @@ func infoCardDialog(title, heading, body, closeLabel string, compact bool) {
 		wsTabStop       = 0x00010000
 		bsDefPushButton = 0x00000001
 		ssEtchedHorz    = 0x00000010
+		// Keep these canonical About client dimensions explicit. Existing release
+		// regression coverage protects the 760x460 multiline-heading geometry.
+		windowWidth  = 760
+		windowHeight = 460
 	)
 
-	clientWidth := 760
-	clientHeight := 460
+	clientWidth := windowWidth
+	clientHeight := windowHeight
 	if compact {
 		clientWidth = 560
 		clientHeight = 300
 	}
 	owner := premiumDialogOwner()
 	dpi := premiumDialogDPI(owner)
-	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
-	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
+	outerWidth, outerHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, outerWidth, outerHeight)
 	hwnd, _, _ := promptCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(promptWstr(infoCardClass))),
 		uintptr(unsafe.Pointer(promptWstr(title))),
 		wsOverlapped,
-		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		uintptr(x), uintptr(y), uintptr(outerWidth), uintptr(outerHeight),
 		owner, 0, hinst, 0,
 	)
 	if hwnd == 0 {

--- a/internal/platform/info_card_windows.go
+++ b/internal/platform/info_card_windows.go
@@ -36,8 +36,9 @@ func infoCardWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintp
 			promptDestroyWindow.Call(hwnd)
 			return 0
 		case promptWMDestroy:
+			// Only the main desktop window owns WM_QUIT. Closing About or another
+			// informational card must return to the main message loop, not end it.
 			state.closed = true
-			promptPostQuitMessage.Call(0)
 			return 0
 		}
 	}
@@ -49,6 +50,17 @@ func infoCardWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintp
 // Light/Dark native shell as the rest of Ghost FTP. Unlike TaskDialog, it does
 // not depend on the current Windows system theme to choose its client surface.
 func InfoCardDialog(title, heading, body, closeLabel string) {
+	infoCardDialog(title, heading, body, closeLabel, false)
+}
+
+// CompactInfoDialog is used for concise application-owned diagnostics/status
+// content. It keeps the same themed shell without forcing short information into
+// the larger About-card geometry.
+func CompactInfoDialog(title, heading, body, closeLabel string) {
+	infoCardDialog(title, heading, body, closeLabel, true)
+}
+
+func infoCardDialog(title, heading, body, closeLabel string, compact bool) {
 	if closeLabel == "" {
 		closeLabel = "OK"
 	}
@@ -74,18 +86,24 @@ func InfoCardDialog(title, heading, body, closeLabel string) {
 		bsDefPushButton = 0x00000001
 		ssEtchedHorz    = 0x00000010
 	)
-	const (
-		windowWidth  = 760
-		windowHeight = 460
-	)
-	x, y := premiumDialogPosition(windowWidth, windowHeight)
+
+	clientWidth := 760
+	clientHeight := 460
+	if compact {
+		clientWidth = 560
+		clientHeight = 300
+	}
+	owner := premiumDialogOwner()
+	dpi := premiumDialogDPI(owner)
+	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
 	hwnd, _, _ := promptCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(promptWstr(infoCardClass))),
 		uintptr(unsafe.Pointer(promptWstr(title))),
 		wsOverlapped,
-		uintptr(x), uintptr(y), windowWidth, windowHeight,
-		0, 0, hinst, 0,
+		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		owner, 0, hinst, 0,
 	)
 	if hwnd == 0 {
 		return
@@ -94,23 +112,30 @@ func InfoCardDialog(title, heading, body, closeLabel string) {
 	state := &infoCardState{}
 	infoCardStates.Store(hwnd, state)
 	defer infoCardStates.Delete(hwnd)
+	restoreOwner := premiumModalOwner(owner)
+	defer restoreOwner()
 
-	bodyFont := premiumDialogFont(-15, 400)
+	bodyFont := premiumDialogFontForDPI(-15, dpi, 400)
 	if bodyFont != 0 {
 		defer promptDeleteObject.Call(bodyFont)
 	}
-	headingFont := premiumDialogFont(-24, 600)
+	headingHeight := int32(-24)
+	if compact {
+		headingHeight = -20
+	}
+	headingFont := premiumDialogFontForDPI(headingHeight, dpi, 600)
 	if headingFont != 0 {
 		defer promptDeleteObject.Call(headingFont)
 	}
 
+	scale := func(value int) uintptr { return uintptr(premiumScale(value, dpi)) }
 	makeControl := func(class, text string, style uint32, x, y, w, h, id int, controlFont uintptr) uintptr {
 		child, _, _ := promptCreateWindowExW.Call(
 			0,
 			uintptr(unsafe.Pointer(promptWstr(class))),
 			uintptr(unsafe.Pointer(promptWstr(text))),
 			uintptr(wsChild|wsVisible|style),
-			uintptr(x), uintptr(y), uintptr(w), uintptr(h),
+			scale(x), scale(y), scale(w), scale(h),
 			hwnd, uintptr(id), hinst, 0,
 		)
 		if child != 0 && controlFont != 0 {
@@ -122,13 +147,20 @@ func InfoCardDialog(title, heading, body, closeLabel string) {
 		return child
 	}
 
-	// About headings vary substantially across the 24 runtime locales. Reserve
-	// enough room for a wrapped three-line heading instead of clipping the second
-	// line, and keep the body comfortably separated from both heading and footer.
-	makeControl("STATIC", heading, 0, 40, 26, 680, 92, 0, headingFont)
-	makeControl("STATIC", body, 0, 40, 132, 680, 220, 0, bodyFont)
-	makeControl("STATIC", "", ssEtchedHorz, 40, 366, 680, 2, 0, bodyFont)
-	closeButton := makeControl("BUTTON", closeLabel, wsTabStop|bsDefPushButton, 616, 382, 104, 38, infoCardIDClose, bodyFont)
+	var closeButton uintptr
+	if compact {
+		makeControl("STATIC", heading, 0, 32, 24, 496, 44, 0, headingFont)
+		makeControl("STATIC", body, 0, 32, 82, 496, 126, 0, bodyFont)
+		makeControl("STATIC", "", ssEtchedHorz, 32, 220, 496, 2, 0, bodyFont)
+		closeButton = makeControl("BUTTON", closeLabel, wsTabStop|bsDefPushButton, 424, 238, 104, 38, infoCardIDClose, bodyFont)
+	} else {
+		// About headings vary substantially across the 24 runtime locales. Reserve
+		// enough room for a wrapped three-line heading instead of clipping it.
+		makeControl("STATIC", heading, 0, 40, 26, 680, 92, 0, headingFont)
+		makeControl("STATIC", body, 0, 40, 132, 680, 220, 0, bodyFont)
+		makeControl("STATIC", "", ssEtchedHorz, 40, 366, 680, 2, 0, bodyFont)
+		closeButton = makeControl("BUTTON", closeLabel, wsTabStop|bsDefPushButton, 616, 382, 104, 38, infoCardIDClose, bodyFont)
+	}
 	if closeButton != 0 {
 		promptSetFocus.Call(closeButton)
 	}

--- a/internal/platform/language_windows.go
+++ b/internal/platform/language_windows.go
@@ -21,6 +21,7 @@ type languageDialogState struct {
 	combo    uintptr
 	selected int
 	accepted bool
+	closed   bool
 }
 
 var (
@@ -55,7 +56,7 @@ func languageWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintp
 			promptDestroyWindow.Call(hwnd)
 			return 0
 		case promptWMDestroy:
-			promptPostQuitMessage.Call(0)
+			state.closed = true
 			return 0
 		}
 	}
@@ -103,19 +104,20 @@ func SelectOptionDialog(title, instruction, footer, acceptLabel, cancelLabel str
 		cbsDropdown     = 0x0003
 		bsDefPushButton = 0x00000001
 		ssEtchedHorz    = 0x00000010
+		clientWidth     = 680
+		clientHeight    = 316
 	)
-	const (
-		windowWidth  = 680
-		windowHeight = 316
-	)
-	x, y := premiumDialogPosition(windowWidth, windowHeight)
+	owner := premiumDialogOwner()
+	dpi := premiumDialogDPI(owner)
+	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
 	hwnd, _, _ := promptCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(promptWstr(languageClass))),
 		uintptr(unsafe.Pointer(promptWstr(title))),
 		wsOverlapped,
-		uintptr(x), uintptr(y), windowWidth, windowHeight,
-		0, 0, hinst, 0,
+		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		owner, 0, hinst, 0,
 	)
 	if hwnd == 0 {
 		return defaultIndex, false
@@ -125,27 +127,30 @@ func SelectOptionDialog(title, instruction, footer, acceptLabel, cancelLabel str
 	state := &languageDialogState{selected: defaultIndex}
 	languageStates.Store(hwnd, state)
 	defer languageStates.Delete(hwnd)
+	restoreOwner := premiumModalOwner(owner)
+	defer restoreOwner()
 
-	font := premiumDialogFont(-16, 400)
+	font := premiumDialogFontForDPI(-16, dpi, 400)
 	if font != 0 {
 		defer promptDeleteObject.Call(font)
 	}
-	headerFont := premiumDialogFont(-26, 600)
+	headerFont := premiumDialogFontForDPI(-26, dpi, 600)
 	if headerFont != 0 {
 		defer promptDeleteObject.Call(headerFont)
 	}
-	captionFont := premiumDialogFont(-14, 400)
+	captionFont := premiumDialogFontForDPI(-14, dpi, 400)
 	if captionFont != 0 {
 		defer promptDeleteObject.Call(captionFont)
 	}
 
+	scale := func(value int) uintptr { return uintptr(premiumScale(value, dpi)) }
 	makeControl := func(class, text string, style uint32, x, y, w, h, id int, controlFont uintptr) uintptr {
 		child, _, _ := promptCreateWindowExW.Call(
 			0,
 			uintptr(unsafe.Pointer(promptWstr(class))),
 			uintptr(unsafe.Pointer(promptWstr(text))),
 			uintptr(wsChild|wsVisible|style),
-			uintptr(x), uintptr(y), uintptr(w), uintptr(h),
+			scale(x), scale(y), scale(w), scale(h),
 			hwnd, uintptr(id), hinst, 0,
 		)
 		if child != 0 && controlFont != 0 {
@@ -180,7 +185,7 @@ func SelectOptionDialog(title, instruction, footer, acceptLabel, cancelLabel str
 	promptUpdateWindow.Call(hwnd)
 
 	var msg promptMsg
-	for {
+	for !state.closed {
 		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
 		if int32(r) <= 0 {
 			break

--- a/internal/platform/prompt_windows.go
+++ b/internal/platform/prompt_windows.go
@@ -30,7 +30,6 @@ var (
 	promptGetMessageW          = user32.NewProc("GetMessageW")
 	promptTranslateMessage     = user32.NewProc("TranslateMessage")
 	promptDispatchMessageW     = user32.NewProc("DispatchMessageW")
-	promptPostQuitMessage      = user32.NewProc("PostQuitMessage")
 	promptGetWindowTextLengthW = user32.NewProc("GetWindowTextLengthW")
 	promptGetWindowTextW       = user32.NewProc("GetWindowTextW")
 	promptSendMessageW         = user32.NewProc("SendMessageW")
@@ -72,6 +71,7 @@ type promptState struct {
 	edit     uintptr
 	value    string
 	accepted bool
+	closed   bool
 }
 
 var (
@@ -118,7 +118,10 @@ func promptWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr
 			promptDestroyWindow.Call(hwnd)
 			return 0
 		case promptWMDestroy:
-			promptPostQuitMessage.Call(0)
+			// A child/modal dialog must never post WM_QUIT to the application UI
+			// thread. Doing so caused closing Nova mapa/Preimenuj with X, OK or
+			// Cancel to terminate the entire Ghost FTP process.
+			s.closed = true
 			return 0
 		}
 	}
@@ -126,10 +129,11 @@ func promptWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr
 	return r
 }
 
-// PromptDialog displays a native edit dialog using English action labels.
-// Localized UI call sites should use PromptDialogWithLabels.
+// PromptDialog displays a native edit dialog using the platform defaults. The
+// desktop may replace those defaults with its currently selected locale.
 func PromptDialog(title, instruction, defaultValue string) (string, bool) {
-	return PromptDialogWithLabels(title, instruction, defaultValue, "OK", "Cancel")
+	ok, cancel := dialogActionLabels()
+	return PromptDialogWithLabels(title, instruction, defaultValue, ok, cancel)
 }
 
 // PromptDialogWithLabels keeps the platform layer dependency-free while using
@@ -164,20 +168,21 @@ func PromptDialogWithLabels(title, instruction, defaultValue, okLabel, cancelLab
 		wsBorder        = 0x00800000
 		bsDefPushButton = 0x00000001
 		ssEtchedHorz    = 0x00000010
+		clientWidth     = 600
+		clientHeight    = 210
 	)
-	const (
-		windowWidth  = 600
-		windowHeight = 210
-	)
-	x, y := premiumDialogPosition(windowWidth, windowHeight)
+	owner := premiumDialogOwner()
+	dpi := premiumDialogDPI(owner)
+	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
 	state := &promptState{}
 	hwnd, _, _ := promptCreateWindowExW.Call(
 		0,
 		uintptr(unsafe.Pointer(promptWstr(promptClass))),
 		uintptr(unsafe.Pointer(promptWstr(title))),
 		wsOverlapped,
-		uintptr(x), uintptr(y), windowWidth, windowHeight,
-		0, 0, hinst, 0,
+		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		owner, 0, hinst, 0,
 	)
 	if hwnd == 0 {
 		return "", false
@@ -186,19 +191,22 @@ func PromptDialogWithLabels(title, instruction, defaultValue, okLabel, cancelLab
 	state.hwnd = hwnd
 	promptStates.Store(hwnd, state)
 	defer promptStates.Delete(hwnd)
+	restoreOwner := premiumModalOwner(owner)
+	defer restoreOwner()
 
-	font := premiumDialogFont(-15, 400)
+	font := premiumDialogFontForDPI(-15, dpi, 400)
 	if font != 0 {
 		defer promptDeleteObject.Call(font)
 	}
 
+	scale := func(value int) uintptr { return uintptr(premiumScale(value, dpi)) }
 	mk := func(class, text string, style uint32, x, y, w, h, id int, controlFont uintptr) uintptr {
 		ch, _, _ := promptCreateWindowExW.Call(
 			0,
 			uintptr(unsafe.Pointer(promptWstr(class))),
 			uintptr(unsafe.Pointer(promptWstr(text))),
 			uintptr(wsChild|wsVisible|style),
-			uintptr(x), uintptr(y), uintptr(w), uintptr(h),
+			scale(x), scale(y), scale(w), scale(h),
 			hwnd, uintptr(id), hinst, 0,
 		)
 		if ch != 0 && controlFont != 0 {
@@ -216,15 +224,15 @@ func PromptDialogWithLabels(title, instruction, defaultValue, okLabel, cancelLab
 		promptSendMessageW.Call(state.edit, promptEMSetLimitText, 1024, 0)
 	}
 	mk("STATIC", "", ssEtchedHorz, 28, 120, 544, 2, 0, font)
-	mk("BUTTON", okLabel, wsTabStop|bsDefPushButton, 374, 134, 94, 36, promptIDOK, font)
-	mk("BUTTON", cancelLabel, wsTabStop, 478, 134, 94, 36, promptIDCancel, font)
+	mk("BUTTON", okLabel, wsTabStop|bsDefPushButton, 374, 140, 94, 36, promptIDOK, font)
+	mk("BUTTON", cancelLabel, wsTabStop, 478, 140, 94, 36, promptIDCancel, font)
 
 	promptSetFocus.Call(state.edit)
 	promptShowWindow.Call(hwnd, 5)
 	promptUpdateWindow.Call(hwnd)
 
 	var m promptMsg
-	for {
+	for !state.closed {
 		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
 		if int32(r) <= 0 {
 			break

--- a/scripts/test_windows_modal_contract.py
+++ b/scripts/test_windows_modal_contract.py
@@ -51,11 +51,19 @@ class WindowsModalContractTests(unittest.TestCase):
         self.assertIn("premiumColor(246, 248, 251)", shell)
         self.assertNotIn("return premiumColor(255, 255, 255)", shell)
 
-    def test_compatibility_prompt_uses_configured_action_labels(self) -> None:
+    def test_compatibility_prompt_uses_runtime_localized_action_labels(self) -> None:
         prompt = read("internal/platform/prompt_windows.go")
         shell = read("internal/platform/dialog_premium_windows.go")
+        commands = read("internal/desktop/commands_windows.go")
+        catalogs = read("internal/i18n/catalogs.go")
+
         self.assertIn("dialogActionLabels()", prompt)
         self.assertIn("SetDialogActionLabels", shell)
+        self.assertIn(
+            'platform.SetDialogActionLabels(okLabel(a.languageCode()), a.tr("common.cancel"))',
+            commands,
+        )
+        self.assertIn('"common.cancel": "Otkaži"', catalogs)
 
 
 if __name__ == "__main__":

--- a/scripts/test_windows_modal_contract.py
+++ b/scripts/test_windows_modal_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsModalContractTests(unittest.TestCase):
+    def test_only_main_window_posts_quit_message(self) -> None:
+        main_window = read("internal/desktop/windows.go")
+        self.assertIn("case wmDestroy:", main_window)
+        self.assertIn("postQuitMessage.Call(0)", main_window)
+
+        for relative in (
+            "internal/platform/prompt_windows.go",
+            "internal/platform/language_windows.go",
+            "internal/platform/info_card_windows.go",
+        ):
+            source = read(relative)
+            self.assertNotIn("PostQuitMessage", source, relative)
+            self.assertNotIn("promptPostQuitMessage", source, relative)
+            self.assertIn("closed", source, relative)
+
+    def test_custom_dialogs_use_bounded_modal_loops(self) -> None:
+        prompt = read("internal/platform/prompt_windows.go")
+        option = read("internal/platform/language_windows.go")
+        info = read("internal/platform/info_card_windows.go")
+        shell = read("internal/platform/dialog_premium_windows.go")
+
+        self.assertIn("for !state.closed", prompt)
+        self.assertIn("for !state.closed", option)
+        self.assertIn("for !state.closed", info)
+        self.assertIn("premiumModalOwner(owner)", prompt)
+        self.assertIn("premiumModalOwner(owner)", option)
+        self.assertIn("premiumModalOwner(owner)", info)
+        self.assertIn("premiumDialogOuterSize", shell)
+        self.assertIn("AdjustWindowRectExForDpi", shell)
+        self.assertIn("GetDpiForWindow", shell)
+
+    def test_diagnostics_uses_application_owned_theme_shell(self) -> None:
+        diagnostics = read("internal/desktop/diagnostics_windows.go")
+        self.assertIn("platform.CompactInfoDialog", diagnostics)
+        self.assertNotIn("platform.InfoDialog(", diagnostics)
+
+    def test_light_dialog_surface_is_softened(self) -> None:
+        shell = read("internal/platform/dialog_premium_windows.go")
+        self.assertIn("premiumColor(246, 248, 251)", shell)
+        self.assertNotIn("return premiumColor(255, 255, 255)", shell)
+
+    def test_compatibility_prompt_uses_configured_action_labels(self) -> None:
+        prompt = read("internal/platform/prompt_windows.go")
+        shell = read("internal/platform/dialog_premium_windows.go")
+        self.assertIn("dialogActionLabels()", prompt)
+        self.assertIn("SetDialogActionLabels", shell)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Targeted Windows UI/runtime stability work based on the supplied Ghost FTP screenshots. No VERSION, release tag, protocol engine, transfer engine, packaging implementation or published 1.1.6 asset changes.

## Fixed lifecycle bug

Custom child/modal windows incorrectly called `PostQuitMessage(0)` from their own `WM_DESTROY`. Because the dialogs share the main Windows UI thread, closing Nova mapa, Preimenuj, Postavke/options or O programu could inject `WM_QUIT` into the application message loop and terminate all of Ghost FTP.

This PR makes the main desktop window the only owner of `WM_QUIT`. Prompt, option and information-card windows now maintain their own closed state and exit only their nested modal loop.

## UI/UX fixes from screenshots

- dialog dimensions now describe the client area and are converted to the correct outer Windows size, preventing the title bar/frame from clipping OK/Cancel buttons;
- dialog controls and fonts use DPI-aware scaling;
- dialogs center on the active Ghost FTP owner window when available;
- the owner window is disabled while an application-owned modal is open and is re-enabled/focused when the modal closes;
- Diagnostics now uses the application-owned themed information shell instead of a stock light TaskDialog in a Dark session;
- concise Diagnostics uses compact geometry while About retains the protected 760x460 multiline-heading client layout;
- compatibility PromptDialog actions are synchronized with the current Ghost FTP runtime language, fixing Croatian `Cancel` -> `Otkaži` while retaining localized `U redu`;
- shared Light appearance avoids dominant pure-white application surfaces;
- Dark appearance uses a slightly softer navy/charcoal hierarchy with clearer layer separation;
- no external icon/theme/font dependency is introduced. Existing Windows 11 Segoe Fluent Icons with the Windows 10 MDL2 fallback remain the native icon contract.

## Regression coverage

Adds `scripts/test_windows_modal_contract.py` to fail if child dialogs regain `PostQuitMessage`, lose bounded modal loops/DPI sizing, Diagnostics falls back to stock TaskDialog, or compatibility prompt actions stop following the runtime language catalog. Shared theme tests also prevent primary Light surfaces from regressing to pure white. Existing About release regression remains intact.

## Security/performance

- no telemetry, analytics or external network dependency;
- no credential handling changes;
- no weakening of FTPS/SFTP/path safety;
- no new UI framework/runtime;
- modal ownership prevents background main-window commands from being dispatched through the nested dialog loop while a modal decision is pending.

`VERSION` remains 1.1.6. This PR must merge only after every workflow triggered for the exact final head is `completed/success`. Any head change invalidates previous CI evidence.