### PR TITLE
Windows: replace chained settings prompts with one modern dialog

### DIFF
--- a/docs/REFERENCE-UI.md
+++ b/docs/REFERENCE-UI.md
@@ -1,6 +1,6 @@
 # Ghost FTP desktop reference UI
 
-This document defines the maintained visual and interaction contract for **Ghost FTP 1.1.1 Stable** and later compatible desktop releases.
+This document defines the maintained visual and interaction contract for **Ghost FTP 1.1.6 Stable** and later compatible desktop releases.
 
 It is a **source/runtime contract**, not a mockup specification. Controls shown by the application must map to real engine capabilities and real state. Decorative controls that imply unsupported backend behavior are not acceptable.
 
@@ -21,20 +21,20 @@ Windows Setup and Portable package the same application executable and therefore
 
 ## Appearance contract
 
-**Classic Light is the fresh-install, missing-state and invalid-state primary appearance in 1.1.1.** An explicitly persisted Dark selection remains respected on Windows. Appearance is one canonical decision rather than a collection of overlapping cosmetic switches.
+**Classic Light is the fresh-install, missing-state and invalid-state primary appearance in 1.1.6.** An explicitly persisted Dark selection remains respected on Windows. Appearance is one canonical decision rather than a collection of overlapping cosmetic switches.
+
+The 1.1.6-maintained palette deliberately avoids pure white as the dominant application surface. Classic Light uses cool neutral layers, while Dark uses a restrained navy/charcoal hierarchy so long file-management sessions remain readable without flattening panels into one undifferentiated background.
 
 ### Classic Light — primary
 
-Classic Light follows the clarity and information density associated with traditional professional FTP clients, but does not copy third-party artwork, branding or proprietary assets.
-
 | Role | RGB |
 | --- | --- |
-| Window | `243, 244, 246` (`#F3F4F6`) |
-| Panel | `255, 255, 255` (`#FFFFFF`) |
-| List | `255, 255, 255` (`#FFFFFF`) |
-| Border | `200, 205, 214` (`#C8CDD6`) |
-| Primary text | `31, 35, 40` (`#1F2328`) |
-| Muted text | `102, 112, 133` (`#667085`) |
+| Window | `238, 241, 245` (`#EEF1F5`) |
+| Panel | `246, 248, 251` (`#F6F8FB`) |
+| List | `250, 251, 253` (`#FAFBFD`) |
+| Border | `199, 206, 216` (`#C7CED8`) |
+| Primary text | `32, 37, 43` (`#20252B`) |
+| Muted text | `101, 112, 131` (`#657083`) |
 | Accent | `63, 99, 221` (`#3F63DD`) |
 | Strong accent | `37, 75, 199` (`#254BC7`) |
 | Success | `27, 127, 75` (`#1B7F4B`) |
@@ -44,28 +44,59 @@ Classic Light follows the clarity and information density associated with tradit
 
 ### Dark — explicit Windows choice
 
-The established dark appearance remains available on Windows and is preserved when the user explicitly selected it.
-
 | Role | RGB |
 | --- | --- |
-| Window | `8, 10, 15` (`#080A0F`) |
-| Panel | `15, 19, 28` (`#0F131C`) |
-| List | `21, 26, 37` (`#151A25`) |
-| Border | `37, 45, 60` (`#252D3C`) |
-| Primary text | `244, 247, 255` (`#F4F7FF`) |
-| Muted text | `142, 153, 173` (`#8E99AD`) |
-| Accent | `82, 119, 245` (`#5277F5`) |
-| Strong accent | `114, 147, 255` (`#7293FF`) |
+| Window | `11, 15, 23` (`#0B0F17`) |
+| Panel | `18, 24, 36` (`#121824`) |
+| List | `22, 29, 42` (`#161D2A`) |
+| Border | `44, 54, 72` (`#2C3648`) |
+| Primary text | `242, 245, 250` (`#F2F5FA`) |
+| Muted text | `151, 163, 184` (`#97A3B8`) |
+| Accent | `91, 124, 250` (`#5B7CFA`) |
+| Strong accent | `122, 152, 255` (`#7A98FF`) |
 | Success | `74, 215, 155` (`#4AD79B`) |
 | Warning | `242, 186, 85` (`#F2BA55`) |
-| Danger | `255, 100, 118` (`#FF6476`) |
-| Selection | `29, 42, 74` (`#1D2A4A`) |
+| Danger | `255, 104, 120` (`#FF6878`) |
+| Selection | `32, 47, 80` (`#202F50`) |
 
 Theme data is local source data only. No remote stylesheet, font service, theme API, analytics endpoint or browser runtime is loaded.
 
 On Windows, an explicit appearance choice is applied on the next start so title bar, menus, native controls, headers and owner-drawn controls are initialized consistently. Fresh/fallback state resolves to Classic Light before the native control tree is created.
 
 The Linux graphical frontend uses Classic Light as the canonical palette. It deliberately does not expose a runtime appearance toggle until complete native switching can be implemented without mixed-state rendering or race-prone global palette mutation.
+
+## Native dialog contract
+
+Ghost FTP-owned Windows dialogs must visually belong to the active application appearance and must not terminate the application message loop when they close.
+
+Maintained rules are:
+
+- only the main desktop window owns process-level `WM_QUIT`/`PostQuitMessage` lifecycle;
+- auxiliary Prompt, Option, Settings and information-card windows close only their own bounded modal loop;
+- application-owned dialogs use the active Ghost FTP owner window when available and temporarily disable that owner while a modal decision is pending;
+- dialog client dimensions are converted to true outer Windows dimensions so title bars and frames do not clip footer controls;
+- controls, fonts and geometry scale from the current Windows DPI;
+- dialog title bars follow the active Light/Dark state on supported Windows builds;
+- Diagnostics uses the Ghost FTP information shell rather than an unrelated bright stock surface during a Dark session;
+- action labels remain caller/localization-owned, so a selected locale must not fall back to English `Cancel` on an otherwise localized dialog.
+
+Closing **Nova mapa**, **Preimenuj**, **Postavke**, **Dijagnostika** or **O programu** with the title-bar X must close that surface only. It must not close the whole Ghost FTP application.
+
+## Settings surface
+
+Windows Settings is one application-owned modal surface rather than a wizard-like chain of unrelated prompts. It presents the current canonical settings together:
+
+- appearance;
+- parallel transfer count;
+- connection timeout;
+- automatic retry count;
+- retry delay;
+- destination conflict policy;
+- delete confirmation.
+
+Numeric values are validated against the same `internal/config` bounds used by persisted settings normalization. Invalid input keeps Settings open, shows localized corrective text and restores focus to the invalid field instead of discarding the rest of the user's pending choices.
+
+**OK** returns one complete candidate settings value to the desktop layer and the existing typed engine persists it. **Cancel** or title-bar **X** discards the pending dialog values and returns to the main workspace. The serialized settings schema is unchanged; compatibility mirror fields are not promoted into duplicate controls.
 
 ## Menu and action contract
 
@@ -172,6 +203,8 @@ The current Site Manager navigation evidence was regenerated by authentic UI wor
 The unchanged main-workspace hash demonstrates that the Site Manager navigation maintenance did not alter the primary workspace capture. The changed Site Manager hash binds the repository image to the verified left-navigation runtime update.
 
 These hashes bind the maintained screenshots to the verified capture. A future UI change must regenerate the images and update this evidence instead of retaining stale screenshot hashes.
+
+The unified Settings work in current source changes a public Windows surface. Until a fresh authentic production screenshot is generated and persisted by the maintained capture workflow, the historical screenshot hashes above remain historical evidence only and are not rewritten to imply that they prove the new Settings geometry.
 
 Mockups, image-generation output and manually composed approximations are not accepted as production UI evidence.
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,6 +1,6 @@
 # Ghost FTP settings
 
-Ghost FTP **1.1.1 Stable** treats settings as validated runtime policy, not decorative UI state. A persisted option is accepted only within the bounds enforced by `internal/config/settings.go`.
+Ghost FTP **1.1.6 Stable** treats settings as validated runtime policy, not decorative UI state. A persisted option is accepted only within the bounds enforced by `internal/config/settings.go`.
 
 ## Current persisted settings
 
@@ -16,14 +16,24 @@ Ghost FTP **1.1.1 Stable** treats settings as validated runtime policy, not deco
 
 Corrupt or unavailable state does not select a less-safe policy. Defaults remain bounded and conservative.
 
+## Windows settings surface
+
+The maintained Windows frontend presents the current settings in **one application-owned native Settings dialog** instead of forcing the user through a chain of independent prompts. Appearance, transfer concurrency, connection timeout, retry policy, destination conflict policy and delete confirmation are visible together before anything is committed.
+
+The dialog uses the same local Light/Dark shell as the main Ghost FTP application, is owner-modal, scales from the active Windows DPI and never owns the process-level `WM_QUIT` lifecycle. Closing it with **X** or **Cancel** closes only Settings and leaves the main application running.
+
+Numeric input is validated inside the same dialog against the canonical `internal/config` bounds. Invalid input keeps the dialog open, shows localized corrective text, returns keyboard focus to the invalid field and selects its value for correction. A successful **OK** returns one complete candidate settings value to the desktop layer, which persists it through the existing typed engine path. Partial step-by-step settings writes are not introduced.
+
+The unified surface does not change the serialized settings schema. `conflictPolicy` remains the one user-facing destination-conflict decision; legacy boolean mirrors remain compatibility state only.
+
 ## Appearance
 
 Ghost FTP deliberately exposes only one appearance decision rather than separate background, accent, icon, list and button color switches.
 
 ### Windows
 
-- `light` — **Classic Light**, the primary/fresh Ghost FTP appearance: a bright neutral two-pane workspace inspired by the clarity of traditional professional FTP clients while using Ghost FTP's own branding, iconography and palette.
-- `dark` — the optional established Ghost FTP dark workspace. If the user explicitly selects and saves it, normalization preserves that preference.
+- `light` — **Classic Light**, the primary/fresh Ghost FTP appearance: a soft neutral two-pane workspace that avoids dominant pure-white application surfaces while preserving native-control readability and Ghost FTP's own branding, iconography and palette.
+- `dark` — the optional established Ghost FTP dark workspace, using a restrained navy/charcoal hierarchy. If the user explicitly selects and saves it, normalization preserves that preference.
 
 The Windows selection is persisted locally and is applied on the next application start. This is intentional: native title bar, menu, combo, edit, list/header and owner-drawn control styling are selected before the complete window tree is created, preventing mixed-theme fragments and avoiding runtime repaint races.
 
@@ -31,7 +41,7 @@ Unknown or missing appearance state fails to Classic Light rather than Dark. Thi
 
 ### Linux
 
-The native Linux desktop uses the **Classic Light** palette as the canonical 1.1 workspace. No extra Linux appearance toggle is exposed until complete runtime switching can be provided without introducing redraw/race complexity. This keeps the settings surface honest and avoids a control whose backend behavior would differ from its label.
+The native Linux desktop uses the **Classic Light** palette as the canonical 1.1.6 workspace. No extra Linux appearance toggle is exposed until complete runtime switching can be provided without introducing redraw/race complexity. This keeps the settings surface honest and avoids a control whose backend behavior would differ from its label.
 
 Appearance changes do not load remote styles, fonts, images or theme services and do not create network traffic.
 

--- a/internal/desktop/settings_windows.go
+++ b/internal/desktop/settings_windows.go
@@ -3,7 +3,6 @@
 package desktop
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
@@ -48,26 +47,6 @@ func (a *app) setSettingsControlsEnabled(enabled bool) {
 	}
 }
 
-func (a *app) promptNumber(instructionKey string, current, min, max int) (int, bool) {
-	title := a.tr("settings.title")
-	value, ok := platform.PromptDialogWithLabels(
-		title,
-		a.tr(instructionKey),
-		strconv.Itoa(current),
-		okLabel(a.languageCode()),
-		a.tr("common.cancel"),
-	)
-	if !ok {
-		return current, false
-	}
-	number, err := strconv.Atoi(strings.TrimSpace(value))
-	if err != nil || number < min || number > max {
-		platform.ErrorDialog(title, a.tr("settings.invalid_value"), a.tr("settings.enter_range", min, max))
-		return current, false
-	}
-	return number, true
-}
-
 func conflictPolicyIndex(settings model.Settings) int {
 	switch settings.ConflictPolicy {
 	case model.ConflictPolicySkip:
@@ -108,48 +87,6 @@ func applyConflictPolicySelection(settings *model.Settings, index int) {
 	}
 }
 
-func (a *app) promptAppearance(settings model.Settings) (model.Settings, bool) {
-	words := appearanceText(a.languageCode())
-	index, ok := platform.SelectOptionDialog(
-		a.tr("settings.title"),
-		words.Hint,
-		brand.ProductName+" · "+words.Title,
-		okLabel(a.languageCode()),
-		a.tr("common.cancel"),
-		[]string{words.Dark, words.Light},
-		appearanceIndex(settings.Appearance),
-	)
-	if !ok {
-		return settings, false
-	}
-	applyAppearanceSelection(&settings, index)
-	return settings, true
-}
-
-func (a *app) promptConflictPolicy(settings model.Settings) (model.Settings, bool) {
-	title := a.tr("settings.title")
-	options := []string{
-		a.tr("settings.skip_existing"),
-		a.tr("settings.overwrite"),
-		a.tr("settings.overwrite") + " + " + a.tr("settings.backup_title"),
-	}
-	instruction := a.tr("settings.skip_body") + "\n" + a.tr("settings.backup_body")
-	index, ok := platform.SelectOptionDialog(
-		title,
-		instruction,
-		brand.ProductName+" · "+a.tr("settings.title"),
-		okLabel(a.languageCode()),
-		a.tr("common.cancel"),
-		options,
-		conflictPolicyIndex(settings),
-	)
-	if !ok {
-		return settings, false
-	}
-	applyConflictPolicySelection(&settings, index)
-	return settings, true
-}
-
 func normalizeSettingsForPrompt(settings model.Settings) model.Settings {
 	defaults := config.DefaultSettings()
 	if settings.Appearance == "" {
@@ -170,71 +107,69 @@ func normalizeSettingsForPrompt(settings model.Settings) model.Settings {
 	return settings
 }
 
+func settingsNumber(label string, value, min, max int, invalid string) platform.SettingsDialogNumber {
+	return platform.SettingsDialogNumber{
+		Label:       label,
+		Value:       value,
+		Min:         min,
+		Max:         max,
+		InvalidText: invalid,
+	}
+}
+
 func (a *app) openSettings() {
 	if a.connectionBusy {
 		return
 	}
+
 	settings := normalizeSettingsForPrompt(a.settings)
+	language := a.languageCode()
+	appearance := appearanceText(language)
+	conflictOptions := []string{
+		a.tr("settings.skip_existing"),
+		a.tr("settings.overwrite"),
+		a.tr("settings.overwrite") + " + " + a.tr("settings.backup_title"),
+	}
 
-	var ok bool
-	settings, ok = a.promptAppearance(settings)
-	if !ok {
+	parallelLabel := a.tr("settings.parallel")
+	timeoutLabel := a.tr("settings.timeout")
+	retriesLabel := a.tr("settings.retries")
+	retryDelayLabel := a.tr("settings.retry_delay")
+	result, ok := platform.SettingsDialog(platform.SettingsDialogConfig{
+		Title:             a.tr("settings.title"),
+		Heading:           brand.ProductName,
+		Intro:             a.tr("settings.title") + " · FTP • FTPS • SFTP",
+		AppearanceLabel:   appearance.Title,
+		AppearanceOptions: []string{appearance.Dark, appearance.Light},
+		AppearanceIndex:   appearanceIndex(settings.Appearance),
+		Numbers: []platform.SettingsDialogNumber{
+			settingsNumber(parallelLabel, settings.Parallelism, config.MinParallelism, config.MaxParallelism, parallelLabel+" "+a.tr("settings.enter_range", config.MinParallelism, config.MaxParallelism)),
+			settingsNumber(timeoutLabel, settings.ConnectionTimeoutSeconds, config.MinConnectionTimeoutSeconds, config.MaxConnectionTimeoutSeconds, timeoutLabel+" "+a.tr("settings.enter_range", config.MinConnectionTimeoutSeconds, config.MaxConnectionTimeoutSeconds)),
+			settingsNumber(retriesLabel, settings.AutoRetryCount, config.MinAutoRetryCount, config.MaxAutoRetryCount, retriesLabel+" "+a.tr("settings.enter_range", config.MinAutoRetryCount, config.MaxAutoRetryCount)),
+			settingsNumber(retryDelayLabel, settings.RetryDelaySeconds, config.MinRetryDelaySeconds, config.MaxRetryDelaySeconds, retryDelayLabel+" "+a.tr("settings.enter_range", config.MinRetryDelaySeconds, config.MaxRetryDelaySeconds)),
+		},
+		ConflictLabel:   a.tr("settings.skip_title"),
+		ConflictOptions: conflictOptions,
+		ConflictIndex:   conflictPolicyIndex(settings),
+		ConfirmDelete:   a.tr("settings.confirm_delete_title"),
+		ConfirmDeleteOn: settings.ConfirmDelete,
+		Footer:          appearance.Hint,
+		ApplyLabel:      okLabel(language),
+		CancelLabel:     a.tr("common.cancel"),
+	})
+	if !ok || len(result.Numbers) != 4 {
 		return
 	}
 
-	parallel, ok := a.promptNumber(
-		"settings.parallel",
-		settings.Parallelism,
-		config.MinParallelism,
-		config.MaxParallelism,
-	)
-	if !ok {
-		return
-	}
-	settings.Parallelism = parallel
-
-	connectTimeout, ok := a.promptNumber(
-		"settings.timeout",
-		settings.ConnectionTimeoutSeconds,
-		config.MinConnectionTimeoutSeconds,
-		config.MaxConnectionTimeoutSeconds,
-	)
-	if !ok {
-		return
-	}
-	settings.ConnectionTimeoutSeconds = connectTimeout
-
-	retries, ok := a.promptNumber(
-		"settings.retries",
-		settings.AutoRetryCount,
-		config.MinAutoRetryCount,
-		config.MaxAutoRetryCount,
-	)
-	if !ok {
-		return
-	}
-	settings.AutoRetryCount = retries
-	if retries > 0 {
-		delay, ok := a.promptNumber(
-			"settings.retry_delay",
-			settings.RetryDelaySeconds,
-			config.MinRetryDelaySeconds,
-			config.MaxRetryDelaySeconds,
-		)
-		if !ok {
-			return
-		}
-		settings.RetryDelaySeconds = delay
-	}
-
-	settings, ok = a.promptConflictPolicy(settings)
-	if !ok {
-		return
-	}
+	applyAppearanceSelection(&settings, result.AppearanceIndex)
+	settings.Parallelism = result.Numbers[0]
+	settings.ConnectionTimeoutSeconds = result.Numbers[1]
+	settings.AutoRetryCount = result.Numbers[2]
+	settings.RetryDelaySeconds = result.Numbers[3]
+	applyConflictPolicySelection(&settings, result.ConflictIndex)
+	settings.ConfirmDelete = result.ConfirmDelete
 
 	title := a.tr("settings.title")
-	settings.ConfirmDelete = platform.ConfirmDialog(title, a.tr("settings.confirm_delete_title"), a.tr("settings.confirm_delete_body"))
-
 	a.setSettingsControlsEnabled(false)
 	a.goSafe(func() {
 		saved, err := a.engine.SetSettings(settings)

--- a/internal/platform/settings_dialog_windows.go
+++ b/internal/platform/settings_dialog_windows.go
@@ -1,0 +1,354 @@
+//go:build windows
+
+package platform
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	settingsIDAppearance = 4101
+	settingsIDNumberBase = 4110
+	settingsIDConflict   = 4120
+	settingsIDConfirm    = 4121
+	settingsIDApply      = 4122
+	settingsIDCancel     = 4123
+	settingsIDError      = 4124
+
+	settingsCBAdd       = 0x0143
+	settingsCBGet       = 0x0147
+	settingsCBSet       = 0x014E
+	settingsBMGetCheck  = 0x00F0
+	settingsBMSetCheck  = 0x00F1
+	settingsBSTChecked  = 1
+	settingsEMSetSel    = 0x00B1
+	settingsESNumber    = 0x2000
+	settingsAutoCheck   = 0x00000003
+	settingsWSBorder    = 0x00800000
+	settingsWSChild     = 0x40000000
+	settingsWSVisible   = 0x10000000
+	settingsWSTabStop   = 0x00010000
+	settingsWSVScroll   = 0x00200000
+	settingsCBSDropList = 0x0003
+	settingsDefButton   = 0x00000001
+	settingsEtchedHorz  = 0x00000010
+)
+
+// SettingsDialogNumber describes one bounded integer preference. InvalidText is
+// caller-owned so validation remains localized without coupling platform code to
+// Ghost FTP's translation catalog.
+type SettingsDialogNumber struct {
+	Label       string
+	Value       int
+	Min         int
+	Max         int
+	InvalidText string
+}
+
+// SettingsDialogConfig contains presentation text and current values for the
+// application-owned Windows settings surface. The desktop layer owns all labels
+// and business meaning; this package owns only native rendering and interaction.
+type SettingsDialogConfig struct {
+	Title             string
+	Heading           string
+	Intro             string
+	AppearanceLabel   string
+	AppearanceOptions []string
+	AppearanceIndex   int
+	Numbers           []SettingsDialogNumber
+	ConflictLabel     string
+	ConflictOptions   []string
+	ConflictIndex     int
+	ConfirmDelete     string
+	ConfirmDeleteOn   bool
+	Footer            string
+	ApplyLabel        string
+	CancelLabel       string
+}
+
+type SettingsDialogResult struct {
+	AppearanceIndex int
+	Numbers         []int
+	ConflictIndex   int
+	ConfirmDelete   bool
+}
+
+type settingsDialogState struct {
+	appearance uintptr
+	numbers    []uintptr
+	conflict   uintptr
+	confirm    uintptr
+	errorLabel uintptr
+	config     SettingsDialogConfig
+	result     SettingsDialogResult
+	accepted   bool
+	closed     bool
+}
+
+var (
+	settingsStates         sync.Map
+	settingsOnce           sync.Once
+	settingsClass          = "GhostFTP.SettingsDialog"
+	settingsProc           = syscall.NewCallback(settingsWndProc)
+	settingsSetWindowTextW = user32.NewProc("SetWindowTextW")
+)
+
+func settingsSetText(hwnd uintptr, text string) {
+	if hwnd == 0 {
+		return
+	}
+	settingsSetWindowTextW.Call(hwnd, uintptr(unsafe.Pointer(promptWstr(text))))
+}
+
+func settingsComboIndex(hwnd uintptr, fallback int) int {
+	if hwnd == 0 {
+		return fallback
+	}
+	value, _, _ := promptSendMessageW.Call(hwnd, settingsCBGet, 0, 0)
+	if int32(value) < 0 {
+		return fallback
+	}
+	return int(value)
+}
+
+func settingsWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
+	if v, ok := settingsStates.Load(hwnd); ok {
+		state := v.(*settingsDialogState)
+		switch message {
+		case promptWMCommand:
+			id := int(wParam & 0xffff)
+			switch id {
+			case settingsIDApply:
+				values := make([]int, len(state.numbers))
+				for index, edit := range state.numbers {
+					field := state.config.Numbers[index]
+					value, err := strconv.Atoi(strings.TrimSpace(promptText(edit)))
+					if err != nil || value < field.Min || value > field.Max {
+						message := field.InvalidText
+						if message == "" {
+							message = field.Label
+						}
+						settingsSetText(state.errorLabel, message)
+						promptSetFocus.Call(edit)
+						promptSendMessageW.Call(edit, settingsEMSetSel, 0, ^uintptr(0))
+						return 0
+					}
+					values[index] = value
+				}
+
+				state.result.AppearanceIndex = settingsComboIndex(state.appearance, state.config.AppearanceIndex)
+				state.result.Numbers = values
+				state.result.ConflictIndex = settingsComboIndex(state.conflict, state.config.ConflictIndex)
+				checked, _, _ := promptSendMessageW.Call(state.confirm, settingsBMGetCheck, 0, 0)
+				state.result.ConfirmDelete = checked == settingsBSTChecked
+				state.accepted = true
+				promptDestroyWindow.Call(hwnd)
+				return 0
+			case settingsIDCancel:
+				promptDestroyWindow.Call(hwnd)
+				return 0
+			}
+		case premiumWMCtlColorEdit, premiumWMCtlColorListBox, premiumWMCtlColorBtn, premiumWMCtlColorStatic:
+			return premiumDialogControlColor(wParam)
+		case promptWMClose:
+			promptDestroyWindow.Call(hwnd)
+			return 0
+		case promptWMDestroy:
+			state.closed = true
+			return 0
+		}
+	}
+	r, _, _ := promptDefWindowProcW.Call(hwnd, uintptr(message), wParam, lParam)
+	return r
+}
+
+func normalizedSettingsIndex(index, count int) int {
+	if count <= 0 {
+		return 0
+	}
+	if index < 0 || index >= count {
+		return 0
+	}
+	return index
+}
+
+// SettingsDialog presents all frequently changed desktop preferences in one
+// bounded modal instead of forcing the user through a chain of independent
+// prompts. It is DPI-aware, owner-modal and follows the active Ghost FTP theme.
+func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
+	fallback := SettingsDialogResult{
+		AppearanceIndex: normalizedSettingsIndex(config.AppearanceIndex, len(config.AppearanceOptions)),
+		ConflictIndex:   normalizedSettingsIndex(config.ConflictIndex, len(config.ConflictOptions)),
+		ConfirmDelete:   config.ConfirmDeleteOn,
+		Numbers:         make([]int, len(config.Numbers)),
+	}
+	for index, field := range config.Numbers {
+		fallback.Numbers[index] = field.Value
+	}
+	if len(config.AppearanceOptions) == 0 || len(config.ConflictOptions) == 0 || len(config.Numbers) == 0 || len(config.Numbers) > 6 {
+		return fallback, false
+	}
+	if config.ApplyLabel == "" {
+		config.ApplyLabel = "OK"
+	}
+	if config.CancelLabel == "" {
+		config.CancelLabel = "Cancel"
+	}
+	config.AppearanceIndex = fallback.AppearanceIndex
+	config.ConflictIndex = fallback.ConflictIndex
+
+	hinst, _, _ := promptGetModuleHandleW.Call(0)
+	settingsOnce.Do(func() {
+		cursor, _, _ := promptLoadCursorW.Call(0, 32512)
+		wc := promptWndClassEx{
+			CbSize:     uint32(unsafe.Sizeof(promptWndClassEx{})),
+			WndProc:    settingsProc,
+			Instance:   hinst,
+			Cursor:     cursor,
+			Background: premiumDialogBackgroundBrush(),
+			ClassName:  promptWstr(settingsClass),
+		}
+		promptRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc)))
+	})
+
+	const (
+		wsOverlapped = 0x00C80000
+		clientWidth  = 760
+		clientHeight = 600
+	)
+	owner := premiumDialogOwner()
+	dpi := premiumDialogDPI(owner)
+	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
+	hwnd, _, _ := promptCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(promptWstr(settingsClass))),
+		uintptr(unsafe.Pointer(promptWstr(config.Title))),
+		wsOverlapped,
+		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		owner, 0, hinst, 0,
+	)
+	if hwnd == 0 {
+		return fallback, false
+	}
+	applyPremiumDialogWindow(hwnd)
+
+	state := &settingsDialogState{config: config, result: fallback}
+	settingsStates.Store(hwnd, state)
+	defer settingsStates.Delete(hwnd)
+	restoreOwner := premiumModalOwner(owner)
+	defer restoreOwner()
+
+	font := premiumDialogFontForDPI(-15, dpi, 400)
+	if font != 0 {
+		defer promptDeleteObject.Call(font)
+	}
+	headingFont := premiumDialogFontForDPI(-25, dpi, 600)
+	if headingFont != 0 {
+		defer promptDeleteObject.Call(headingFont)
+	}
+	captionFont := premiumDialogFontForDPI(-13, dpi, 400)
+	if captionFont != 0 {
+		defer promptDeleteObject.Call(captionFont)
+	}
+
+	scale := func(value int) uintptr { return uintptr(premiumScale(value, dpi)) }
+	makeControl := func(class, text string, style uint32, x, y, w, h, id int, controlFont uintptr) uintptr {
+		child, _, _ := promptCreateWindowExW.Call(
+			0,
+			uintptr(unsafe.Pointer(promptWstr(class))),
+			uintptr(unsafe.Pointer(promptWstr(text))),
+			uintptr(settingsWSChild|settingsWSVisible|style),
+			scale(x), scale(y), scale(w), scale(h),
+			hwnd, uintptr(id), hinst, 0,
+		)
+		if child != 0 && controlFont != 0 {
+			promptSendMessageW.Call(child, promptWMSetFont, controlFont, 1)
+		}
+		if child != 0 {
+			applyPremiumDialogControl(child, class)
+		}
+		return child
+	}
+
+	makeControl("STATIC", config.Heading, 0, 36, 22, 688, 38, 0, headingFont)
+	makeControl("STATIC", config.Intro, 0, 36, 66, 688, 34, 0, font)
+	makeControl("STATIC", config.AppearanceLabel, 0, 36, 112, 688, 22, 0, captionFont)
+	state.appearance = makeControl("COMBOBOX", "", settingsWSTabStop|settingsWSVScroll|settingsCBSDropList, 36, 137, 688, 240, settingsIDAppearance, font)
+	for _, option := range config.AppearanceOptions {
+		promptSendMessageW.Call(state.appearance, settingsCBAdd, 0, uintptr(unsafe.Pointer(promptWstr(option))))
+	}
+	promptSendMessageW.Call(state.appearance, settingsCBSet, uintptr(config.AppearanceIndex), 0)
+
+	const leftX = 36
+	const rightX = 390
+	const fieldWidth = 334
+	const editWidth = 160
+	for index, field := range config.Numbers {
+		row := index / 2
+		column := index % 2
+		xPos := leftX
+		if column == 1 {
+			xPos = rightX
+		}
+		yLabel := 192 + row*72
+		makeControl("STATIC", field.Label, 0, xPos, yLabel, fieldWidth, 24, 0, captionFont)
+		edit := makeControl(
+			"EDIT",
+			strconv.Itoa(field.Value),
+			settingsWSBorder|settingsWSTabStop|settingsESNumber,
+			xPos, yLabel+27, editWidth, 31,
+			settingsIDNumberBase+index,
+			font,
+		)
+		if edit != 0 {
+			promptSendMessageW.Call(edit, promptEMSetLimitText, 5, 0)
+		}
+		state.numbers = append(state.numbers, edit)
+	}
+
+	separatorY := 192 + ((len(config.Numbers)+1)/2)*72 + 4
+	makeControl("STATIC", "", settingsEtchedHorz, 36, separatorY, 688, 2, 0, font)
+	conflictLabelY := separatorY + 18
+	makeControl("STATIC", config.ConflictLabel, 0, 36, conflictLabelY, 688, 24, 0, captionFont)
+	state.conflict = makeControl("COMBOBOX", "", settingsWSTabStop|settingsWSVScroll|settingsCBSDropList, 36, conflictLabelY+27, 688, 240, settingsIDConflict, font)
+	for _, option := range config.ConflictOptions {
+		promptSendMessageW.Call(state.conflict, settingsCBAdd, 0, uintptr(unsafe.Pointer(promptWstr(option))))
+	}
+	promptSendMessageW.Call(state.conflict, settingsCBSet, uintptr(config.ConflictIndex), 0)
+
+	confirmY := conflictLabelY + 70
+	state.confirm = makeControl("BUTTON", config.ConfirmDelete, settingsWSTabStop|settingsAutoCheck, 36, confirmY, 688, 28, settingsIDConfirm, font)
+	if config.ConfirmDeleteOn {
+		promptSendMessageW.Call(state.confirm, settingsBMSetCheck, settingsBSTChecked, 0)
+	}
+
+	makeControl("STATIC", "", settingsEtchedHorz, 36, 500, 688, 2, 0, font)
+	makeControl("STATIC", config.Footer, 0, 36, 514, 470, 38, 0, captionFont)
+	state.errorLabel = makeControl("STATIC", "", 0, 36, 552, 470, 24, settingsIDError, captionFont)
+	applyButton := makeControl("BUTTON", config.ApplyLabel, settingsWSTabStop|settingsDefButton, 516, 530, 98, 38, settingsIDApply, font)
+	makeControl("BUTTON", config.CancelLabel, settingsWSTabStop, 624, 530, 100, 38, settingsIDCancel, font)
+
+	if state.appearance != 0 {
+		promptSetFocus.Call(state.appearance)
+	} else if applyButton != 0 {
+		promptSetFocus.Call(applyButton)
+	}
+	promptShowWindow.Call(hwnd, 5)
+	promptUpdateWindow.Call(hwnd)
+
+	var msg promptMsg
+	for !state.closed {
+		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
+		if int32(r) <= 0 {
+			break
+		}
+		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
+		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
+	}
+	return state.result, state.accepted
+}

--- a/internal/platform/settings_dialog_windows.go
+++ b/internal/platform/settings_dialog_windows.go
@@ -11,12 +11,14 @@ import (
 )
 
 const (
+	// Use the standard Win32 dialog command IDs so IsDialogMessageW can route
+	// Enter/Escape consistently even though this surface is application-owned.
+	settingsIDApply      = 1 // IDOK
+	settingsIDCancel     = 2 // IDCANCEL
 	settingsIDAppearance = 4101
 	settingsIDNumberBase = 4110
 	settingsIDConflict   = 4120
 	settingsIDConfirm    = 4121
-	settingsIDApply      = 4122
-	settingsIDCancel     = 4123
 	settingsIDError      = 4124
 
 	settingsCBAdd       = 0x0143
@@ -90,11 +92,12 @@ type settingsDialogState struct {
 }
 
 var (
-	settingsStates         sync.Map
-	settingsOnce           sync.Once
-	settingsClass          = "GhostFTP.SettingsDialog"
-	settingsProc           = syscall.NewCallback(settingsWndProc)
-	settingsSetWindowTextW = user32.NewProc("SetWindowTextW")
+	settingsStates           sync.Map
+	settingsOnce             sync.Once
+	settingsClass            = "GhostFTP.SettingsDialog"
+	settingsProc             = syscall.NewCallback(settingsWndProc)
+	settingsSetWindowTextW   = user32.NewProc("SetWindowTextW")
+	settingsIsDialogMessageW = user32.NewProc("IsDialogMessageW")
 )
 
 func settingsSetText(hwnd uintptr, text string) {
@@ -284,10 +287,14 @@ func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
 	}
 	promptSendMessageW.Call(state.appearance, settingsCBSet, uintptr(config.AppearanceIndex), 0)
 
-	const leftX = 36
-	const rightX = 390
-	const fieldWidth = 334
-	const editWidth = 160
+	const (
+		leftX           = 36
+		rightX          = 390
+		fieldWidth      = 334
+		editWidth       = 160
+		numberLabelH    = 42
+		numberRowHeight = 82
+	)
 	for index, field := range config.Numbers {
 		row := index / 2
 		column := index % 2
@@ -295,13 +302,16 @@ func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
 		if column == 1 {
 			xPos = rightX
 		}
-		yLabel := 192 + row*72
-		makeControl("STATIC", field.Label, 0, xPos, yLabel, fieldWidth, 24, 0, captionFont)
+		yLabel := 192 + row*numberRowHeight
+		// Reserve two visible text lines for long localized labels. The maintained
+		// 24-language catalog contains descriptions that do not fit 334 px in one
+		// line, and clipping their wrapped second line would hide setting meaning.
+		makeControl("STATIC", field.Label, 0, xPos, yLabel, fieldWidth, numberLabelH, 0, captionFont)
 		edit := makeControl(
 			"EDIT",
 			strconv.Itoa(field.Value),
 			settingsWSBorder|settingsWSTabStop|settingsESNumber,
-			xPos, yLabel+27, editWidth, 31,
+			xPos, yLabel+45, editWidth, 31,
 			settingsIDNumberBase+index,
 			font,
 		)
@@ -311,7 +321,7 @@ func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
 		state.numbers = append(state.numbers, edit)
 	}
 
-	separatorY := 192 + ((len(config.Numbers)+1)/2)*72 + 4
+	separatorY := 192 + ((len(config.Numbers)+1)/2)*numberRowHeight + 4
 	makeControl("STATIC", "", settingsEtchedHorz, 36, separatorY, 688, 2, 0, font)
 	conflictLabelY := separatorY + 18
 	makeControl("STATIC", config.ConflictLabel, 0, 36, conflictLabelY, 688, 24, 0, captionFont)
@@ -346,6 +356,13 @@ func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
 		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
 		if int32(r) <= 0 {
 			break
+		}
+		// This is a registered top-level window rather than DialogBox-created
+		// resource. Route messages through the dialog manager so WS_TABSTOP,
+		// Shift+Tab, standard IDOK/IDCANCEL and control-specific keyboard behavior
+		// work for keyboard-only users before normal dispatch.
+		if handled, _, _ := settingsIsDialogMessageW.Call(hwnd, uintptr(unsafe.Pointer(&msg))); handled != 0 {
+			continue
 		}
 		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
 		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))

--- a/scripts/test_active_ui_docs_contract.py
+++ b/scripts/test_active_ui_docs_contract.py
@@ -14,8 +14,9 @@ class ActiveUIDocumentationContractTests(unittest.TestCase):
         version = read("VERSION").strip()
         for relative in ("docs/SETTINGS.md", "docs/REFERENCE-UI.md"):
             text = read(relative)
-            self.assertIn(f"Ghost FTP **{version} Stable**", text, relative)
-            self.assertNotIn("Ghost FTP **1.1.1 Stable**", text, relative)
+            self.assertIn("Ghost FTP", text, relative)
+            self.assertIn(f"{version} Stable", text, relative)
+            self.assertNotIn("1.1.1 Stable", text, relative)
 
     def test_reference_ui_uses_current_soft_light_palette(self) -> None:
         reference = read("docs/REFERENCE-UI.md")

--- a/scripts/test_active_ui_docs_contract.py
+++ b/scripts/test_active_ui_docs_contract.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class ActiveUIDocumentationContractTests(unittest.TestCase):
+    def test_settings_and_reference_ui_follow_current_version(self) -> None:
+        version = read("VERSION").strip()
+        for relative in ("docs/SETTINGS.md", "docs/REFERENCE-UI.md"):
+            text = read(relative)
+            self.assertIn(f"Ghost FTP **{version} Stable**", text, relative)
+            self.assertNotIn("Ghost FTP **1.1.1 Stable**", text, relative)
+
+    def test_reference_ui_uses_current_soft_light_palette(self) -> None:
+        reference = read("docs/REFERENCE-UI.md")
+        theme = read("internal/desktop/theme.go")
+
+        for marker in (
+            "`#EEF1F5`",
+            "`#F6F8FB`",
+            "`#FAFBFD`",
+            "`#0B0F17`",
+            "`#121824`",
+            "`#161D2A`",
+        ):
+            self.assertIn(marker, reference)
+
+        self.assertIn("deliberately avoids pure white as the dominant application surface", reference)
+        self.assertIn("Light deliberately avoids pure white as the dominant application surface", theme)
+        self.assertNotIn("Panel | `255, 255, 255` (`#FFFFFF`)", reference)
+        self.assertNotIn("List | `255, 255, 255` (`#FFFFFF`)", reference)
+
+    def test_reference_ui_documents_modal_lifecycle_and_unified_settings(self) -> None:
+        reference = read("docs/REFERENCE-UI.md")
+        settings = read("docs/SETTINGS.md")
+
+        self.assertIn("only the main desktop window owns process-level `WM_QUIT`/`PostQuitMessage` lifecycle", reference)
+        self.assertIn("Closing **Nova mapa**, **Preimenuj**, **Postavke**, **Dijagnostika** or **O programu**", reference)
+        self.assertIn("Windows Settings is one application-owned modal surface", reference)
+        self.assertIn("one application-owned native Settings dialog", settings)
+        self.assertIn("Invalid input keeps the dialog open", settings)
+
+    def test_screenshot_evidence_is_not_rewritten_without_authentic_capture(self) -> None:
+        reference = read("docs/REFERENCE-UI.md")
+        self.assertIn("authentic UI workflow run **#122**", reference)
+        self.assertIn("3b1e82695bcd3cbd87c15ed62ef20fe7c5870d4120d22dba6b44fe69141cce90", reference)
+        self.assertIn("5817a0fc4012c4a4f1042c8d0cea809e6907e53680659e2d55390dd61ff88eea", reference)
+        self.assertIn("historical evidence only", reference)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_settings_dialog_contract.py
+++ b/scripts/test_windows_settings_dialog_contract.py
@@ -59,6 +59,23 @@ class WindowsSettingsDialogContractTests(unittest.TestCase):
         self.assertIn("promptSetFocus.Call(edit)", source)
         self.assertIn("return 0", source)
 
+    def test_keyboard_navigation_uses_win32_dialog_manager_and_standard_commands(self) -> None:
+        source = read("internal/platform/settings_dialog_windows.go")
+        self.assertIn('settingsIsDialogMessageW = user32.NewProc("IsDialogMessageW")', source)
+        self.assertIn("settingsIDApply      = 1 // IDOK", source)
+        self.assertIn("settingsIDCancel     = 2 // IDCANCEL", source)
+        self.assertIn("settingsIsDialogMessageW.Call(hwnd", source)
+        self.assertIn("if handled", source)
+        self.assertIn("continue", source)
+
+    def test_numeric_labels_reserve_two_lines_for_long_locales(self) -> None:
+        source = read("internal/platform/settings_dialog_windows.go")
+        self.assertIn("numberLabelH    = 42", source)
+        self.assertIn("numberRowHeight = 82", source)
+        self.assertIn("fieldWidth, numberLabelH", source)
+        self.assertIn("row*numberRowHeight", source)
+        self.assertNotIn("fieldWidth, 24, 0, captionFont", source)
+
     def test_platform_settings_dialog_does_not_import_application_model_or_config(self) -> None:
         source = read("internal/platform/settings_dialog_windows.go")
         self.assertNotIn("internal/model", source)

--- a/scripts/test_windows_settings_dialog_contract.py
+++ b/scripts/test_windows_settings_dialog_contract.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsSettingsDialogContractTests(unittest.TestCase):
+    def test_desktop_settings_are_presented_in_one_application_owned_dialog(self) -> None:
+        source = read("internal/desktop/settings_windows.go")
+        self.assertIn("platform.SettingsDialog(platform.SettingsDialogConfig{", source)
+        self.assertNotIn("func (a *app) promptNumber", source)
+        self.assertNotIn("func (a *app) promptAppearance", source)
+        self.assertNotIn("func (a *app) promptConflictPolicy", source)
+        self.assertNotIn("platform.PromptDialogWithLabels(", source)
+        self.assertNotIn("platform.SelectOptionDialog(", source)
+
+    def test_unified_dialog_preserves_all_existing_settings_fields(self) -> None:
+        source = read("internal/desktop/settings_windows.go")
+        for marker in (
+            "settings.Parallelism = result.Numbers[0]",
+            "settings.ConnectionTimeoutSeconds = result.Numbers[1]",
+            "settings.AutoRetryCount = result.Numbers[2]",
+            "settings.RetryDelaySeconds = result.Numbers[3]",
+            "applyConflictPolicySelection(&settings, result.ConflictIndex)",
+            "settings.ConfirmDelete = result.ConfirmDelete",
+            "applyAppearanceSelection(&settings, result.AppearanceIndex)",
+        ):
+            self.assertIn(marker, source)
+
+    def test_validation_uses_canonical_config_bounds(self) -> None:
+        source = read("internal/desktop/settings_windows.go")
+        for marker in (
+            "config.MinParallelism, config.MaxParallelism",
+            "config.MinConnectionTimeoutSeconds, config.MaxConnectionTimeoutSeconds",
+            "config.MinAutoRetryCount, config.MaxAutoRetryCount",
+            "config.MinRetryDelaySeconds, config.MaxRetryDelaySeconds",
+        ):
+            self.assertIn(marker, source)
+
+    def test_settings_modal_is_dpi_aware_owner_modal_and_never_posts_quit(self) -> None:
+        source = read("internal/platform/settings_dialog_windows.go")
+        self.assertIn("premiumDialogOuterSize", source)
+        self.assertIn("premiumDialogDPI(owner)", source)
+        self.assertIn("premiumModalOwner(owner)", source)
+        self.assertIn("applyPremiumDialogWindow(hwnd)", source)
+        self.assertIn("for !state.closed", source)
+        self.assertNotIn("PostQuitMessage", source)
+        self.assertNotIn("promptPostQuitMessage", source)
+
+    def test_invalid_numeric_value_stays_inside_settings_dialog(self) -> None:
+        source = read("internal/platform/settings_dialog_windows.go")
+        self.assertIn("value < field.Min || value > field.Max", source)
+        self.assertIn("settingsSetText(state.errorLabel, message)", source)
+        self.assertIn("promptSetFocus.Call(edit)", source)
+        self.assertIn("return 0", source)
+
+    def test_platform_settings_dialog_does_not_import_application_model_or_config(self) -> None:
+        source = read("internal/platform/settings_dialog_windows.go")
+        self.assertNotIn("internal/model", source)
+        self.assertNotIn("internal/config", source)
+        self.assertNotIn("internal/i18n", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Phase 4B Windows UX improvement based on the supplied Ghost FTP screenshots and follow-up stability audit. This PR does not change VERSION, published 1.1.6 assets, protocol/transfer engines, credential storage, installer payload format or Linux packaging.

## Unified Windows Settings

Ghost FTP Settings previously forced users through a chain of separate dialogs for appearance, parallel transfers, timeout, retry count, retry delay, conflict policy and delete confirmation. Cancelling late in the sequence discarded the whole interaction and each step used a separate modal surface.

This PR replaces that sequence with one application-owned Win32 Settings dialog that shows the current values together:

- appearance;
- parallel transfer count;
- connection timeout;
- automatic retry count;
- retry delay;
- existing-file conflict policy;
- confirm-before-delete toggle.

The dialog uses the existing Ghost FTP Light/Dark shell, Segoe UI, owner modality, DWM rounded-corner hint and DPI-aware client sizing. No external UI framework, font, icon package or runtime dependency is introduced.

## Keyboard, localization and validation

The Settings window is a registered application-owned Win32 window rather than a DialogBox resource, so its modal loop explicitly routes messages through `IsDialogMessageW`. Apply/Cancel use the standard `IDOK`/`IDCANCEL` command IDs, providing native Tab/Shift+Tab traversal and reliable Enter/Escape semantics for keyboard-only users.

Long numeric-setting labels reserve two visible lines with locale-safe row spacing so maintained German/Finnish/Russian and other longer catalog strings are not clipped.

Numeric values are validated against the existing canonical `internal/config` min/max bounds. Invalid input does not close Settings: an in-dialog localized validation message is shown, the invalid field receives focus and its value is selected for correction.

The returned values are applied to the existing `model.Settings` fields and saved through the same `engine.SetSettings` path as before, including existing conflict-policy compatibility flags and next-start appearance semantics.

The Settings child window never posts `WM_QUIT`; X/Cancel close only Settings and return to the main application.

## Documentation synchronization

The active Settings and Reference UI documents are updated from stale 1.1.1 wording to the current 1.1.6 runtime contract. Reference UI now records the actual shared palette from `internal/desktop/theme.go`:

- soft Classic Light surfaces rather than dominant pure white;
- restrained navy/charcoal Dark hierarchy;
- child-dialog lifecycle and DPI rules;
- unified Settings behavior and inline validation.

Existing authentic screenshot hashes are deliberately preserved. The documentation explicitly marks them as historical evidence until a fresh production capture is generated for the new Settings geometry.

## Regression coverage

Adds regression coverage to lock:

- one unified Settings modal instead of chained Prompt/Option dialogs;
- preservation of every existing setting field;
- canonical config bounds;
- DPI-aware owner-modal behavior;
- no `PostQuitMessage` in the child dialog;
- Win32 dialog-manager keyboard routing with standard OK/Cancel IDs;
- two-line locale-safe numeric-label layout;
- in-dialog validation;
- platform-layer independence from model/config/i18n packages;
- current 1.1.6 Settings/Reference UI documentation;
- current soft-light/dark palette markers;
- preservation of authentic screenshot evidence without fabricated hashes.

`VERSION` remains 1.1.6. Merge only after every workflow triggered for the exact final head is `completed/success`; any head change invalidates earlier CI evidence.