### PR TITLE
Windows: unify modal palette and keyboard behavior

### DIFF
--- a/internal/desktop/theme.go
+++ b/internal/desktop/theme.go
@@ -1,6 +1,9 @@
 package desktop
 
-import "github.com/bren-wp/Ghost-FTP/internal/model"
+import (
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/uipalette"
+)
 
 // Canonical desktop geometry primitives. Linux uses these values directly and
 // Windows applies its own DPI scaling around the same minimum workspace model.
@@ -15,66 +18,14 @@ const (
 	premiumPanelGap    = 12
 )
 
-// PremiumTheme is the canonical cross-platform Ghost FTP desktop palette.
-// Both supported appearances are local data-only palettes. They never load
-// fonts, images, telemetry, network resources or third-party theme engines at
-// runtime.
-type PremiumTheme struct {
-	Window       RGB
-	Panel        RGB
-	List         RGB
-	Border       RGB
-	Text         RGB
-	Muted        RGB
-	Accent       RGB
-	AccentStrong RGB
-	Success      RGB
-	Warn         RGB
-	Danger       RGB
-	Selection    RGB
-}
+// Keep the historical desktop names as aliases so Windows/Linux rendering and
+// existing tests continue to express the desktop contract while the actual RGB
+// source of truth lives in one dependency-neutral package shared with modals.
+type PremiumTheme = uipalette.Theme
+type RGB = uipalette.RGB
 
-type RGB struct {
-	R byte
-	G byte
-	B byte
-}
-
-// Dark uses a restrained navy/charcoal surface rather than near-black blocks.
-// This preserves contrast while reducing eye strain and keeps list/panel layers
-// visually separable without relying on heavy borders.
-var darkTheme = PremiumTheme{
-	Window:       RGB{0x0B, 0x0F, 0x17},
-	Panel:        RGB{0x12, 0x18, 0x24},
-	List:         RGB{0x16, 0x1D, 0x2A},
-	Border:       RGB{0x2C, 0x36, 0x48},
-	Text:         RGB{0xF2, 0xF5, 0xFA},
-	Muted:        RGB{0x97, 0xA3, 0xB8},
-	Accent:       RGB{0x5B, 0x7C, 0xFA},
-	AccentStrong: RGB{0x7A, 0x98, 0xFF},
-	Success:      RGB{0x4A, 0xD7, 0x9B},
-	Warn:         RGB{0xF2, 0xBA, 0x55},
-	Danger:       RGB{0xFF, 0x68, 0x78},
-	Selection:    RGB{0x20, 0x2F, 0x50},
-}
-
-// Light deliberately avoids pure white as the dominant application surface.
-// The slightly cool neutral hierarchy keeps long file-management sessions less
-// glaring while preserving native-control readability and clear selection.
-var lightTheme = PremiumTheme{
-	Window:       RGB{0xEE, 0xF1, 0xF5},
-	Panel:        RGB{0xF6, 0xF8, 0xFB},
-	List:         RGB{0xFA, 0xFB, 0xFD},
-	Border:       RGB{0xC7, 0xCE, 0xD8},
-	Text:         RGB{0x20, 0x25, 0x2B},
-	Muted:        RGB{0x65, 0x70, 0x83},
-	Accent:       RGB{0x3F, 0x63, 0xDD},
-	AccentStrong: RGB{0x25, 0x4B, 0xC7},
-	Success:      RGB{0x1B, 0x7F, 0x4B},
-	Warn:         RGB{0x9A, 0x67, 0x00},
-	Danger:       RGB{0xC6, 0x28, 0x28},
-	Selection:    RGB{0xDC, 0xE8, 0xFF},
-}
+var darkTheme = uipalette.Dark
+var lightTheme = uipalette.Light
 
 // Classic Light is the product-default desktop surface. Windows startup then
 // applies the user's persisted appearance before controls are created, so an

--- a/internal/desktop/theme_test.go
+++ b/internal/desktop/theme_test.go
@@ -37,7 +37,7 @@ func TestClassicLightThemeKeepsReadableContrastDirection(t *testing.T) {
 }
 
 func TestClassicLightAvoidsPureWhitePrimarySurfaces(t *testing.T) {
-	pureWhite := RGB{0xFF, 0xFF, 0xFF}
+	pureWhite := RGB{R: 0xFF, G: 0xFF, B: 0xFF}
 	for name, surface := range map[string]RGB{
 		"window": lightTheme.Window,
 		"panel":  lightTheme.Panel,

--- a/internal/platform/dialog_loop_windows.go
+++ b/internal/platform/dialog_loop_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package platform
+
+import "unsafe"
+
+var premiumIsDialogMessageW = user32.NewProc("IsDialogMessageW")
+
+// premiumRunDialogLoop is the one nested message-loop contract for all
+// application-owned Ghost FTP modal windows. IsDialogMessageW supplies native
+// Tab/Shift+Tab traversal and default/cancel button semantics even though these
+// surfaces are registered top-level windows rather than DialogBox resources.
+func premiumRunDialogLoop(hwnd uintptr, closed func() bool) {
+	var message promptMsg
+	for !closed() {
+		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
+		if int32(r) <= 0 {
+			break
+		}
+		handled, _, _ := premiumIsDialogMessageW.Call(hwnd, uintptr(unsafe.Pointer(&message)))
+		if handled != 0 {
+			continue
+		}
+		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&message)))
+		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
+	}
+}

--- a/internal/platform/dialog_premium_windows.go
+++ b/internal/platform/dialog_premium_windows.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/uipalette"
 )
 
 var premiumGetSystemMetrics = user32.NewProc("GetSystemMetrics")
@@ -83,26 +85,29 @@ func premiumColor(r, g, b byte) uintptr {
 	return uintptr(r) | uintptr(g)<<8 | uintptr(b)<<16
 }
 
-func premiumDialogSurfaceColor() uintptr {
+func premiumPaletteColor(value uipalette.RGB) uintptr {
+	return premiumColor(value.R, value.G, value.B)
+}
+
+func premiumDialogTheme() uipalette.Theme {
 	if premiumDialogDark.Load() {
-		return premiumColor(15, 19, 28)
+		return uipalette.Dark
 	}
-	// A restrained neutral surface avoids the glaring pure-white flash that the
-	// previous application-owned Light dialogs produced next to the main window.
-	return premiumColor(246, 248, 251)
+	return uipalette.Light
+}
+
+func premiumDialogSurfaceColor() uintptr {
+	return premiumPaletteColor(premiumDialogTheme().Panel)
 }
 
 func premiumDialogTextColor() uintptr {
-	if premiumDialogDark.Load() {
-		return premiumColor(244, 247, 255)
-	}
-	return premiumColor(31, 35, 40)
+	return premiumPaletteColor(premiumDialogTheme().Text)
 }
 
 func premiumDialogBackgroundBrush() uintptr {
 	if premiumDialogDark.Load() {
 		premiumDarkBrushOnce.Do(func() {
-			premiumDarkBrush, _, _ = premiumCreateSolidBrush.Call(premiumColor(15, 19, 28))
+			premiumDarkBrush, _, _ = premiumCreateSolidBrush.Call(premiumPaletteColor(uipalette.Dark.Panel))
 		})
 		if premiumDarkBrush != 0 {
 			return premiumDarkBrush
@@ -110,7 +115,7 @@ func premiumDialogBackgroundBrush() uintptr {
 		return 6
 	}
 	premiumLightBrushOnce.Do(func() {
-		premiumLightBrush, _, _ = premiumCreateSolidBrush.Call(premiumColor(246, 248, 251))
+		premiumLightBrush, _, _ = premiumCreateSolidBrush.Call(premiumPaletteColor(uipalette.Light.Panel))
 	})
 	if premiumLightBrush != 0 {
 		return premiumLightBrush
@@ -118,10 +123,9 @@ func premiumDialogBackgroundBrush() uintptr {
 	return 6
 }
 
-// premiumDialogControlColor is shared by the prompt/option/about card window
-// procedures. It prevents static labels and edit/list backgrounds from falling
-// back to an unrelated stock brush while the active application appearance is
-// Dark or the softened application-owned Light palette is active.
+// premiumDialogControlColor is shared by the application-owned prompt,
+// settings and information-card window procedures. It prevents static labels
+// and edit/list backgrounds from falling back to an unrelated stock brush.
 func premiumDialogControlColor(hdc uintptr) uintptr {
 	if hdc != 0 {
 		premiumSetTextColor.Call(hdc, premiumDialogTextColor())
@@ -194,9 +198,7 @@ func premiumScale(value int, dpi uint32) int {
 }
 
 // premiumDialogOuterSize converts a desired client-area size into the actual
-// top-level window size. The old code treated the requested outer size as if it
-// were the client size, so the Windows title bar and frame consumed the footer
-// and clipped action buttons on current Windows builds and DPI settings.
+// top-level window size so title bars and frames cannot consume footer space.
 func premiumDialogOuterSize(clientWidth, clientHeight int, style uint32, exStyle uint32, dpi uint32) (int, int) {
 	r := premiumRect{
 		Right:  int32(premiumScale(clientWidth, dpi)),
@@ -263,8 +265,7 @@ func premiumDialogPosition(owner uintptr, width, height int) (int, int) {
 }
 
 // premiumModalOwner makes the custom top-level window actually modal. Without
-// this, the nested message loop still dispatched clicks and keyboard commands
-// to the main Ghost FTP window behind the dialog.
+// this, the nested message loop still dispatches input to the main window.
 func premiumModalOwner(owner uintptr) func() {
 	if owner == 0 {
 		return func() {}
@@ -301,9 +302,7 @@ func premiumDialogFont(height int32, weight uintptr) uintptr {
 }
 
 // applyPremiumDialogWindow uses best-effort DWM hints only. Failure is ignored
-// so the same binary remains usable on Windows builds that do not expose a
-// particular modern composition attribute. The title bar follows the active
-// appearance instead of being forced dark while the dialog body remains light.
+// so the same binary remains usable on Windows builds without an attribute.
 func applyPremiumDialogWindow(hwnd uintptr) {
 	if hwnd == 0 {
 		return

--- a/internal/platform/info_card_windows.go
+++ b/internal/platform/info_card_windows.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-const infoCardIDClose = 2 // IDCANCEL: Escape and the default Close button share one path.
+const infoCardIDClose = 1 // IDOK: the visible default Close/OK button.
 
 type infoCardState struct {
 	closed bool
@@ -26,7 +26,11 @@ func infoCardWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintp
 		state := v.(*infoCardState)
 		switch message {
 		case promptWMCommand:
-			if int(wParam&0xffff) == infoCardIDClose {
+			id := int(wParam & 0xffff)
+			// Enter activates the visible IDOK button; Escape is translated by the
+			// shared dialog manager into IDCANCEL even though no second button is
+			// required on an information-only surface.
+			if id == infoCardIDClose || id == promptIDCancel {
 				promptDestroyWindow.Call(hwnd)
 				return 0
 			}

--- a/internal/platform/info_card_windows.go
+++ b/internal/platform/info_card_windows.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-const infoCardIDClose = 3201
+const infoCardIDClose = 2 // IDCANCEL: Escape and the default Close button share one path.
 
 type infoCardState struct {
 	closed bool
@@ -171,14 +171,5 @@ func infoCardDialog(title, heading, body, closeLabel string, compact bool) {
 
 	promptShowWindow.Call(hwnd, 5)
 	promptUpdateWindow.Call(hwnd)
-
-	var message promptMsg
-	for !state.closed {
-		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
-		if int32(r) <= 0 {
-			break
-		}
-		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&message)))
-		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
-	}
+	premiumRunDialogLoop(hwnd, func() bool { return state.closed })
 }

--- a/internal/platform/language_windows.go
+++ b/internal/platform/language_windows.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	languageIDCombo   = 2101
-	languageIDInstall = 2102
-	languageIDCancel  = 2103
+	languageIDInstall = 1 // IDOK
+	languageIDCancel  = 2 // IDCANCEL
 	languageCBAdd     = 0x0143
 	languageCBGet     = 0x0147
 	languageCBSet     = 0x014E
@@ -66,7 +66,7 @@ func languageWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintp
 
 // SelectOptionDialog shows a bounded native Windows selector with no framework
 // dependency. The caller owns labels and validation while this platform shell
-// owns consistent Light/Dark rendering.
+// owns consistent Light/Dark rendering and native keyboard navigation.
 func SelectOptionDialog(title, instruction, footer, acceptLabel, cancelLabel string, options []string, defaultIndex int) (int, bool) {
 	if len(options) == 0 {
 		return 0, false
@@ -184,15 +184,7 @@ func SelectOptionDialog(title, instruction, footer, acceptLabel, cancelLabel str
 	promptShowWindow.Call(hwnd, 5)
 	promptUpdateWindow.Call(hwnd)
 
-	var msg promptMsg
-	for !state.closed {
-		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
-		if int32(r) <= 0 {
-			break
-		}
-		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
-		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
-	}
+	premiumRunDialogLoop(hwnd, func() bool { return state.closed })
 	return state.selected, state.accepted
 }
 

--- a/internal/platform/prompt_windows.go
+++ b/internal/platform/prompt_windows.go
@@ -231,14 +231,6 @@ func PromptDialogWithLabels(title, instruction, defaultValue, okLabel, cancelLab
 	promptShowWindow.Call(hwnd, 5)
 	promptUpdateWindow.Call(hwnd)
 
-	var m promptMsg
-	for !state.closed {
-		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&m)), 0, 0, 0)
-		if int32(r) <= 0 {
-			break
-		}
-		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
-		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&m)))
-	}
+	premiumRunDialogLoop(hwnd, func() bool { return state.closed })
 	return state.value, state.accepted
 }

--- a/internal/platform/settings_dialog_windows.go
+++ b/internal/platform/settings_dialog_windows.go
@@ -92,12 +92,11 @@ type settingsDialogState struct {
 }
 
 var (
-	settingsStates           sync.Map
-	settingsOnce             sync.Once
-	settingsClass            = "GhostFTP.SettingsDialog"
-	settingsProc             = syscall.NewCallback(settingsWndProc)
-	settingsSetWindowTextW   = user32.NewProc("SetWindowTextW")
-	settingsIsDialogMessageW = user32.NewProc("IsDialogMessageW")
+	settingsStates         sync.Map
+	settingsOnce           sync.Once
+	settingsClass          = "GhostFTP.SettingsDialog"
+	settingsProc           = syscall.NewCallback(settingsWndProc)
+	settingsSetWindowTextW = user32.NewProc("SetWindowTextW")
 )
 
 func settingsSetText(hwnd uintptr, text string) {
@@ -351,21 +350,6 @@ func SettingsDialog(config SettingsDialogConfig) (SettingsDialogResult, bool) {
 	promptShowWindow.Call(hwnd, 5)
 	promptUpdateWindow.Call(hwnd)
 
-	var msg promptMsg
-	for !state.closed {
-		r, _, _ := promptGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
-		if int32(r) <= 0 {
-			break
-		}
-		// This is a registered top-level window rather than DialogBox-created
-		// resource. Route messages through the dialog manager so WS_TABSTOP,
-		// Shift+Tab, standard IDOK/IDCANCEL and control-specific keyboard behavior
-		// work for keyboard-only users before normal dispatch.
-		if handled, _, _ := settingsIsDialogMessageW.Call(hwnd, uintptr(unsafe.Pointer(&msg))); handled != 0 {
-			continue
-		}
-		promptTranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
-		promptDispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
-	}
+	premiumRunDialogLoop(hwnd, func() bool { return state.closed })
 	return state.result, state.accepted
 }

--- a/internal/uipalette/palette.go
+++ b/internal/uipalette/palette.go
@@ -1,0 +1,59 @@
+package uipalette
+
+// RGB is one local sRGB color in the Ghost FTP desktop palette.
+type RGB struct {
+	R byte
+	G byte
+	B byte
+}
+
+// Theme is the canonical cross-platform Ghost FTP desktop palette. Keeping
+// these values in a dependency-neutral package prevents the desktop workspace
+// and application-owned platform dialogs from drifting into subtly different
+// Light/Dark products.
+type Theme struct {
+	Window       RGB
+	Panel        RGB
+	List         RGB
+	Border       RGB
+	Text         RGB
+	Muted        RGB
+	Accent       RGB
+	AccentStrong RGB
+	Success      RGB
+	Warn         RGB
+	Danger       RGB
+	Selection    RGB
+}
+
+// Dark uses a restrained navy/charcoal hierarchy rather than near-black blocks.
+var Dark = Theme{
+	Window:       RGB{0x0B, 0x0F, 0x17},
+	Panel:        RGB{0x12, 0x18, 0x24},
+	List:         RGB{0x16, 0x1D, 0x2A},
+	Border:       RGB{0x2C, 0x36, 0x48},
+	Text:         RGB{0xF2, 0xF5, 0xFA},
+	Muted:        RGB{0x97, 0xA3, 0xB8},
+	Accent:       RGB{0x5B, 0x7C, 0xFA},
+	AccentStrong: RGB{0x7A, 0x98, 0xFF},
+	Success:      RGB{0x4A, 0xD7, 0x9B},
+	Warn:         RGB{0xF2, 0xBA, 0x55},
+	Danger:       RGB{0xFF, 0x68, 0x78},
+	Selection:    RGB{0x20, 0x2F, 0x50},
+}
+
+// Light deliberately avoids pure white as the dominant application surface.
+var Light = Theme{
+	Window:       RGB{0xEE, 0xF1, 0xF5},
+	Panel:        RGB{0xF6, 0xF8, 0xFB},
+	List:         RGB{0xFA, 0xFB, 0xFD},
+	Border:       RGB{0xC7, 0xCE, 0xD8},
+	Text:         RGB{0x20, 0x25, 0x2B},
+	Muted:        RGB{0x65, 0x70, 0x83},
+	Accent:       RGB{0x3F, 0x63, 0xDD},
+	AccentStrong: RGB{0x25, 0x4B, 0xC7},
+	Success:      RGB{0x1B, 0x7F, 0x4B},
+	Warn:         RGB{0x9A, 0x67, 0x00},
+	Danger:       RGB{0xC6, 0x28, 0x28},
+	Selection:    RGB{0xDC, 0xE8, 0xFF},
+}

--- a/internal/uipalette/palette_test.go
+++ b/internal/uipalette/palette_test.go
@@ -1,0 +1,34 @@
+package uipalette
+
+import "testing"
+
+func TestCanonicalPalettesRemainDistinct(t *testing.T) {
+	if Light == Dark {
+		t.Fatal("Light and Dark palettes unexpectedly match")
+	}
+	if Light.Panel == Dark.Panel || Light.Text == Dark.Text || Light.Selection == Dark.Selection {
+		t.Fatal("critical Light/Dark roles are not visually distinct")
+	}
+}
+
+func TestClassicLightAvoidsPureWhitePrimarySurfaces(t *testing.T) {
+	pureWhite := RGB{0xFF, 0xFF, 0xFF}
+	for name, value := range map[string]RGB{
+		"window": Light.Window,
+		"panel":  Light.Panel,
+		"list":   Light.List,
+	} {
+		if value == pureWhite {
+			t.Fatalf("Classic Light %s surface regressed to pure white", name)
+		}
+	}
+}
+
+func TestMaintainedModalRolesMatchDesktopContract(t *testing.T) {
+	if Dark.Panel != (RGB{0x12, 0x18, 0x24}) || Dark.Text != (RGB{0xF2, 0xF5, 0xFA}) {
+		t.Fatal("canonical Dark panel/text contract changed unexpectedly")
+	}
+	if Light.Panel != (RGB{0xF6, 0xF8, 0xFB}) || Light.Text != (RGB{0x20, 0x25, 0x2B}) {
+		t.Fatal("canonical Light panel/text contract changed unexpectedly")
+	}
+}

--- a/scripts/test_active_ui_docs_contract.py
+++ b/scripts/test_active_ui_docs_contract.py
@@ -20,7 +20,7 @@ class ActiveUIDocumentationContractTests(unittest.TestCase):
 
     def test_reference_ui_uses_current_soft_light_palette(self) -> None:
         reference = read("docs/REFERENCE-UI.md")
-        theme = read("internal/desktop/theme.go")
+        theme = read("internal/uipalette/palette.go")
 
         for marker in (
             "`#EEF1F5`",

--- a/scripts/test_windows_modal_contract.py
+++ b/scripts/test_windows_modal_contract.py
@@ -19,27 +19,41 @@ class WindowsModalContractTests(unittest.TestCase):
             "internal/platform/prompt_windows.go",
             "internal/platform/language_windows.go",
             "internal/platform/info_card_windows.go",
+            "internal/platform/settings_dialog_windows.go",
         ):
             source = read(relative)
             self.assertNotIn("PostQuitMessage", source, relative)
             self.assertNotIn("promptPostQuitMessage", source, relative)
             self.assertIn("closed", source, relative)
 
-    def test_custom_dialogs_use_bounded_modal_loops(self) -> None:
-        prompt = read("internal/platform/prompt_windows.go")
-        option = read("internal/platform/language_windows.go")
-        info = read("internal/platform/info_card_windows.go")
+    def test_custom_dialogs_use_one_bounded_modal_loop(self) -> None:
+        loop = read("internal/platform/dialog_loop_windows.go")
         shell = read("internal/platform/dialog_premium_windows.go")
 
-        self.assertIn("for !state.closed", prompt)
-        self.assertIn("for !state.closed", option)
-        self.assertIn("for !state.closed", info)
-        self.assertIn("premiumModalOwner(owner)", prompt)
-        self.assertIn("premiumModalOwner(owner)", option)
-        self.assertIn("premiumModalOwner(owner)", info)
+        self.assertIn("for !closed()", loop)
+        self.assertIn("premiumIsDialogMessageW.Call(hwnd", loop)
+        self.assertIn("promptTranslateMessage.Call", loop)
+        self.assertIn("promptDispatchMessageW.Call", loop)
+
+        for relative in (
+            "internal/platform/prompt_windows.go",
+            "internal/platform/language_windows.go",
+            "internal/platform/info_card_windows.go",
+            "internal/platform/settings_dialog_windows.go",
+        ):
+            source = read(relative)
+            self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
+            self.assertIn("premiumModalOwner(owner)", source, relative)
+
         self.assertIn("premiumDialogOuterSize", shell)
         self.assertIn("AdjustWindowRectExForDpi", shell)
         self.assertIn("GetDpiForWindow", shell)
+
+    def test_option_dialog_uses_standard_enter_and_escape_commands(self) -> None:
+        option = read("internal/platform/language_windows.go")
+        self.assertIn("languageIDInstall = 1 // IDOK", option)
+        self.assertIn("languageIDCancel  = 2 // IDCANCEL", option)
+        self.assertIn("wsTabStop|bsDefPushButton", option)
 
     def test_diagnostics_uses_application_owned_theme_shell(self) -> None:
         diagnostics = read("internal/desktop/diagnostics_windows.go")
@@ -48,8 +62,10 @@ class WindowsModalContractTests(unittest.TestCase):
 
     def test_light_dialog_surface_is_softened(self) -> None:
         shell = read("internal/platform/dialog_premium_windows.go")
-        self.assertIn("premiumColor(246, 248, 251)", shell)
-        self.assertNotIn("return premiumColor(255, 255, 255)", shell)
+        palette = read("internal/uipalette/palette.go")
+        self.assertIn("premiumPaletteColor(uipalette.Light.Panel)", shell)
+        self.assertIn("Panel:        RGB{0xF6, 0xF8, 0xFB}", palette)
+        self.assertNotIn("RGB{0xFF, 0xFF, 0xFF}", palette)
 
     def test_compatibility_prompt_uses_runtime_localized_action_labels(self) -> None:
         prompt = read("internal/platform/prompt_windows.go")

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsModalSharedContractTests(unittest.TestCase):
+    def test_desktop_and_platform_read_one_palette_source(self) -> None:
+        desktop = read("internal/desktop/theme.go")
+        platform = read("internal/platform/dialog_premium_windows.go")
+        palette = read("internal/uipalette/palette.go")
+
+        self.assertIn('"github.com/bren-wp/Ghost-FTP/internal/uipalette"', desktop)
+        self.assertIn('"github.com/bren-wp/Ghost-FTP/internal/uipalette"', platform)
+        self.assertIn("var darkTheme = uipalette.Dark", desktop)
+        self.assertIn("var lightTheme = uipalette.Light", desktop)
+        self.assertIn("return uipalette.Dark", platform)
+        self.assertIn("return uipalette.Light", platform)
+        self.assertIn("var Dark = Theme{", palette)
+        self.assertIn("var Light = Theme{", palette)
+
+    def test_platform_modals_do_not_keep_the_old_dark_palette_copy(self) -> None:
+        source = read("internal/platform/dialog_premium_windows.go")
+        self.assertNotIn("premiumColor(15, 19, 28)", source)
+        self.assertNotIn("premiumColor(244, 247, 255)", source)
+        self.assertIn("uipalette.Dark.Panel", source)
+        self.assertIn("uipalette.Light.Panel", source)
+
+    def test_is_dialog_message_is_owned_by_one_shared_loop(self) -> None:
+        loop = read("internal/platform/dialog_loop_windows.go")
+        self.assertIn('premiumIsDialogMessageW = user32.NewProc("IsDialogMessageW")', loop)
+        self.assertIn("premiumIsDialogMessageW.Call(hwnd", loop)
+        self.assertIn("promptTranslateMessage.Call", loop)
+        self.assertIn("promptDispatchMessageW.Call", loop)
+
+        for relative in (
+            "internal/platform/prompt_windows.go",
+            "internal/platform/settings_dialog_windows.go",
+            "internal/platform/info_card_windows.go",
+        ):
+            source = read(relative)
+            self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
+            self.assertNotIn('NewProc("IsDialogMessageW")', source, relative)
+
+    def test_info_cards_use_standard_escape_close_command(self) -> None:
+        source = read("internal/platform/info_card_windows.go")
+        self.assertIn("infoCardIDClose = 2 // IDCANCEL", source)
+        self.assertIn("wsTabStop|bsDefPushButton", source)
+        self.assertNotIn("PostQuitMessage", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -40,12 +40,20 @@ class WindowsModalSharedContractTests(unittest.TestCase):
 
         for relative in (
             "internal/platform/prompt_windows.go",
+            "internal/platform/language_windows.go",
             "internal/platform/settings_dialog_windows.go",
             "internal/platform/info_card_windows.go",
         ):
             source = read(relative)
             self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
             self.assertNotIn('NewProc("IsDialogMessageW")', source, relative)
+
+    def test_option_selector_uses_native_enter_and_escape_commands(self) -> None:
+        source = read("internal/platform/language_windows.go")
+        self.assertIn("languageIDInstall = 1 // IDOK", source)
+        self.assertIn("languageIDCancel  = 2 // IDCANCEL", source)
+        self.assertIn("wsTabStop|bsDefPushButton", source)
+        self.assertNotIn("PostQuitMessage", source)
 
     def test_info_cards_use_native_enter_and_escape_commands(self) -> None:
         source = read("internal/platform/info_card_windows.go")

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -47,9 +47,10 @@ class WindowsModalSharedContractTests(unittest.TestCase):
             self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
             self.assertNotIn('NewProc("IsDialogMessageW")', source, relative)
 
-    def test_info_cards_use_standard_escape_close_command(self) -> None:
+    def test_info_cards_use_native_enter_and_escape_commands(self) -> None:
         source = read("internal/platform/info_card_windows.go")
-        self.assertIn("infoCardIDClose = 2 // IDCANCEL", source)
+        self.assertIn("infoCardIDClose = 1 // IDOK", source)
+        self.assertIn("id == infoCardIDClose || id == promptIDCancel", source)
         self.assertIn("wsTabStop|bsDefPushButton", source)
         self.assertNotIn("PostQuitMessage", source)
 

--- a/scripts/test_windows_settings_dialog_contract.py
+++ b/scripts/test_windows_settings_dialog_contract.py
@@ -48,7 +48,7 @@ class WindowsSettingsDialogContractTests(unittest.TestCase):
         self.assertIn("premiumDialogDPI(owner)", source)
         self.assertIn("premiumModalOwner(owner)", source)
         self.assertIn("applyPremiumDialogWindow(hwnd)", source)
-        self.assertIn("for !state.closed", source)
+        self.assertIn("premiumRunDialogLoop(hwnd", source)
         self.assertNotIn("PostQuitMessage", source)
         self.assertNotIn("promptPostQuitMessage", source)
 
@@ -59,14 +59,17 @@ class WindowsSettingsDialogContractTests(unittest.TestCase):
         self.assertIn("promptSetFocus.Call(edit)", source)
         self.assertIn("return 0", source)
 
-    def test_keyboard_navigation_uses_win32_dialog_manager_and_standard_commands(self) -> None:
-        source = read("internal/platform/settings_dialog_windows.go")
-        self.assertIn('settingsIsDialogMessageW = user32.NewProc("IsDialogMessageW")', source)
-        self.assertIn("settingsIDApply      = 1 // IDOK", source)
-        self.assertIn("settingsIDCancel     = 2 // IDCANCEL", source)
-        self.assertIn("settingsIsDialogMessageW.Call(hwnd", source)
-        self.assertIn("if handled", source)
-        self.assertIn("continue", source)
+    def test_keyboard_navigation_uses_shared_win32_dialog_manager_and_standard_commands(self) -> None:
+        settings = read("internal/platform/settings_dialog_windows.go")
+        loop = read("internal/platform/dialog_loop_windows.go")
+        self.assertIn("settingsIDApply      = 1 // IDOK", settings)
+        self.assertIn("settingsIDCancel     = 2 // IDCANCEL", settings)
+        self.assertIn("premiumRunDialogLoop(hwnd", settings)
+        self.assertNotIn("settingsIsDialogMessageW", settings)
+        self.assertIn('premiumIsDialogMessageW = user32.NewProc("IsDialogMessageW")', loop)
+        self.assertIn("premiumIsDialogMessageW.Call(hwnd", loop)
+        self.assertIn("if handled != 0", loop)
+        self.assertIn("continue", loop)
 
     def test_numeric_labels_reserve_two_lines_for_long_locales(self) -> None:
         source = read("internal/platform/settings_dialog_windows.go")


### PR DESCRIPTION
## Scope

Phase 4C Windows UI infrastructure cleanup. This PR keeps `VERSION` at 1.1.6 and does not change protocol/transfer engines, credential persistence, installer payloads, release assets or Linux packaging behavior.

## One canonical palette

Desktop rendering and application-owned Windows modals previously carried separate copies of Light/Dark RGB values. The modal shell still used an older Dark panel/text pair, so About, Diagnostics, Prompt, Option/Language and Settings could look subtly different from the main workspace.

This PR introduces dependency-neutral `internal/uipalette` as the single source for the maintained Light/Dark palette. `internal/desktop` keeps compatibility aliases for its existing theme contract, while `internal/platform` reads the exact same palette for application-owned modal surfaces.

No remote theme service, font, framework, image dependency or runtime network resource is introduced.

## Shared native modal keyboard loop

Prompt, Option/Language, Settings and Info/About/Diagnostics are registered application-owned top-level Win32 windows rather than DialogBox resources. Their nested loops are now routed through one `premiumRunDialogLoop` helper that owns `IsDialogMessageW` and then falls through to normal Translate/Dispatch.

This gives one maintained implementation for Tab / Shift+Tab traversal, default-button Enter behavior, Escape/IDCANCEL behavior and normal control-specific keyboard handling.

Settings and Option/Language use standard `IDOK`/`IDCANCEL`. Information cards use IDOK for their visible default Close/OK button and explicitly accept IDCANCEL generated by Escape, without adding a fake second button.

The child/modal lifecycle contract is unchanged: only the main application window may own process-level `WM_QUIT`.

## Regression coverage

Adds/updates Go and Python regression coverage for one shared Light/Dark palette source, Classic Light remaining non-pure-white, the maintained modal panel/text roles, removal of old duplicated modal RGB values, one shared `IsDialogMessageW` owner, all four active custom modal families using the shared loop, native Enter/Escape semantics, and preservation of Settings validation/DPI/localization geometry contracts. Existing documentation regressions now follow the canonical palette source rather than the former desktop-local copy.

A separate follow-up will handle the larger profile/privacy i18n block and replacement of remaining stock TaskDialog/MessageBox surfaces; those changes are intentionally not mixed into this infrastructure PR.

`VERSION` remains 1.1.6. Merge only after every workflow triggered for the exact final head is `completed/success`; any head change invalidates earlier CI evidence.