### PR TITLE
Windows: theme decision dialogs and localize profile privacy flow

### DIFF
--- a/internal/desktop/connection_profiles_windows.go
+++ b/internal/desktop/connection_profiles_windows.go
@@ -4,14 +4,15 @@ package desktop
 
 import (
 	"context"
-	"github.com/bren-wp/Ghost-FTP/internal/model"
-	"github.com/bren-wp/Ghost-FTP/internal/platform"
-	"github.com/bren-wp/Ghost-FTP/internal/profilebinding"
-	"github.com/bren-wp/Ghost-FTP/internal/remote"
 	"strconv"
 	"strings"
 	"time"
 	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+	"github.com/bren-wp/Ghost-FTP/internal/profilebinding"
+	"github.com/bren-wp/Ghost-FTP/internal/remote"
 )
 
 func (a *app) cancelConnectionAttempt() {
@@ -418,8 +419,10 @@ func (a *app) selectProfile() {
 }
 
 func (a *app) saveCurrentProfile() {
+	language := a.languageCode()
+	profileTitle := "Ghost FTP — " + a.tr("profile.save")
 	if a.connected || a.connectionBusy {
-		platform.InfoDialog("Ghost FTP", "Profile changes are unavailable during a connection", "Wait for the connection attempt to finish or disconnect before saving profile changes.")
+		platform.InfoDialog("Ghost FTP", profileBusyHeading(language), profileBusyBody(language))
 		return
 	}
 	existing, editing := a.currentProfile()
@@ -427,13 +430,19 @@ func (a *app) saveCurrentProfile() {
 	if editing {
 		defaultName = existing.Name
 	}
-	name, ok := platform.PromptDialog("Ghost FTP — profile", "Profile name:", defaultName)
+	name, ok := platform.PromptDialogWithLabels(
+		profileTitle,
+		profileNameLabel(language),
+		defaultName,
+		okLabel(language),
+		a.tr("common.cancel"),
+	)
 	if !ok {
 		return
 	}
 	name = strings.TrimSpace(name)
 	if name == "" {
-		platform.ErrorDialog("Ghost FTP — profile", "Profile name is required", "Enter a name that identifies this connection.")
+		platform.ErrorDialog(profileTitle, profileNameRequiredHeading(language), profileNameRequiredBody(language))
 		return
 	}
 	protocol := a.protocolValue()
@@ -442,9 +451,9 @@ func (a *app) saveCurrentProfile() {
 	port, err := validateRawConnectionInput(protocol, host, getText(a.port), username)
 	if err != nil {
 		if err == errInvalidConnectionPort {
-			platform.ErrorDialog("Ghost FTP — profile", a.tr("connection.invalid_port"), a.tr("connection.invalid_port_body"))
+			platform.ErrorDialog(profileTitle, a.tr("connection.invalid_port"), a.tr("connection.invalid_port_body"))
 		} else {
-			platform.ErrorDialog("Ghost FTP — profile", a.tr("connection.invalid_data"), a.userMessage(err, "connection.invalid_data_body"))
+			platform.ErrorDialog(profileTitle, a.tr("connection.invalid_data"), a.userMessage(err, "connection.invalid_data_body"))
 		}
 		return
 	}
@@ -468,7 +477,7 @@ func (a *app) saveCurrentProfile() {
 	}
 
 	if password != "" || passphrase != "" {
-		words := credentialConsentText(a.languageCode())
+		words := credentialConsentText(language)
 		if !platform.ConfirmDialog(words.Title, words.Question, words.Body) {
 			password = ""
 			passphrase = ""
@@ -487,11 +496,11 @@ func (a *app) saveCurrentProfile() {
 		retainPassphrase := existing.HasPassphrase && !clearPassphrase
 		autoRemoved := clearPassword || clearPassphrase
 		if retainPassword || retainPassphrase {
-			message := "This profile already contains stored credentials that still belong to the same identity.\n\nYes = retain them.\nNo = remove them from the Ghost FTP profile store."
+			message := profileRetainBody(language)
 			if autoRemoved {
-				message = "Credentials that no longer belong to the changed server, account or private key will be removed automatically.\n\n" + message
+				message = profileAutoRemovedPrefix(language) + "\n\n" + message
 			}
-			if !platform.ConfirmDialog("Ghost FTP — privacy", "Retain stored credentials?", message) {
+			if !platform.ConfirmDialog("Ghost FTP — "+profilePrivacyTitle(language), profileRetainHeading(language), message) {
 				if retainPassword {
 					clearPassword = true
 				}
@@ -501,9 +510,9 @@ func (a *app) saveCurrentProfile() {
 			}
 		} else if autoRemoved {
 			platform.InfoDialog(
-				"Ghost FTP — profile security",
-				"Old credentials will not be transferred",
-				"The server, port, username or private key changed. For safety, old stored credentials are removed from this profile. Enter them again if you want to store credentials for the new identity.",
+				"Ghost FTP — "+profilePrivacyTitle(language),
+				profileOldCredentialsHeading(language),
+				profileOldCredentialsBody(language),
 			)
 		}
 	}
@@ -533,7 +542,7 @@ func (a *app) saveCurrentProfile() {
 		payload.Passphrase = ""
 		a.dispatch(func() {
 			if err != nil {
-				platform.ErrorDialog("Ghost FTP — profile", a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
+				platform.ErrorDialog(profileTitle, a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
 				return
 			}
 			a.selectedProfileID = saved.ID
@@ -559,7 +568,7 @@ func (a *app) removeCurrentProfile() {
 		platform.InfoDialog("Ghost FTP", a.tr("profile.delete"), a.tr("disconnect.question"))
 		return
 	}
-	if !platform.ConfirmDialog("Ghost FTP — profiles", a.tr("profile.delete"), p.Name) {
+	if !platform.ConfirmDialog("Ghost FTP — "+a.tr("profile.delete"), a.tr("profile.delete"), p.Name) {
 		return
 	}
 	id := p.ID
@@ -567,7 +576,7 @@ func (a *app) removeCurrentProfile() {
 		err := a.engine.RemoveProfile(id)
 		a.dispatch(func() {
 			if err != nil {
-				platform.ErrorDialog("Ghost FTP — profiles", a.tr("profile.delete"), a.userMessage(err, "error.generic"))
+				platform.ErrorDialog("Ghost FTP — "+a.tr("profile.delete"), a.tr("profile.delete"), a.userMessage(err, "error.generic"))
 				return
 			}
 			a.selectedProfileID = ""

--- a/internal/desktop/dialog_localization_windows.go
+++ b/internal/desktop/dialog_localization_windows.go
@@ -18,12 +18,23 @@ func noLabel(language string) string {
 	})
 }
 
-// syncPlatformDialogLocalization updates every application-owned native action
-// label as one atomic UI-language decision. It is called at startup, whenever
-// the runtime language changes, and before command flows that may complete
-// asynchronously and show a later security confirmation.
-func (a *app) syncPlatformDialogLocalization() {
-	language := a.languageCode()
-	platform.SetDialogActionLabels(okLabel(language), a.tr("common.cancel"))
-	platform.SetDialogDecisionLabels(yesLabel(language), noLabel(language))
+// installDialogLabelProvider keeps the platform layer independent from the
+// desktop translation catalog while resolving labels at the moment a dialog is
+// opened. That makes startup, runtime locale switches and asynchronous security
+// confirmations use the same current language without a second i18n state.
+func init() {
+	platform.SetDialogLabelProvider(func() (string, string, string, string) {
+		language := "en"
+		cancelLabel := "Cancel"
+		apps.Range(func(_, value any) bool {
+			a, ok := value.(*app)
+			if !ok || a == nil {
+				return true
+			}
+			language = a.languageCode()
+			cancelLabel = a.tr("common.cancel")
+			return false
+		})
+		return okLabel(language), cancelLabel, yesLabel(language), noLabel(language)
+	})
 }

--- a/internal/desktop/dialog_localization_windows.go
+++ b/internal/desktop/dialog_localization_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package desktop
+
+import "github.com/bren-wp/Ghost-FTP/internal/platform"
+
+func yesLabel(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Yes", "Da", "Ja", "Oui", "Sí", "Evet", "Ναι", "Sim", "是", "Да", "हाँ", "はい",
+		"Sì", "Tak", "Ja", "Ano", "Так", "Ja", "Da", "Igen", "Ja", "Kyllä", "Ja", "예",
+	})
+}
+
+func noLabel(language string) string {
+	return localizedPrompt(language, [24]string{
+		"No", "Ne", "Nein", "Non", "No", "Hayır", "Όχι", "Não", "否", "Нет", "नहीं", "いいえ",
+		"No", "Nie", "Nee", "Ne", "Ні", "Nej", "Nu", "Nem", "Nej", "Ei", "Nei", "아니요",
+	})
+}
+
+// syncPlatformDialogLocalization updates every application-owned native action
+// label as one atomic UI-language decision. It is called at startup, whenever
+// the runtime language changes, and before command flows that may complete
+// asynchronously and show a later security confirmation.
+func (a *app) syncPlatformDialogLocalization() {
+	language := a.languageCode()
+	platform.SetDialogActionLabels(okLabel(language), a.tr("common.cancel"))
+	platform.SetDialogDecisionLabels(yesLabel(language), noLabel(language))
+}

--- a/internal/desktop/localized_prompts_windows_test.go
+++ b/internal/desktop/localized_prompts_windows_test.go
@@ -3,6 +3,7 @@
 package desktop
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bren-wp/Ghost-FTP/internal/i18n"
@@ -23,17 +24,33 @@ func TestNativeWindowsPromptsCoverCanonicalLanguages(t *testing.T) {
 			value string
 		}{
 			{"ok", okLabel(code)},
+			{"yes", yesLabel(code)},
+			{"no", noLabel(code)},
 			{"close question", closeQuestion(code)},
 			{"close body", closeBody(code)},
 			{"private-key title", privateKeyDialogTitle(code)},
 			{"private-key filter", privateKeyFilterLabel(code)},
 			{"all-files filter", allFilesFilterLabel(code)},
 			{"directory title", directoryDialogTitle(code)},
+			{"profile busy heading", profileBusyHeading(code)},
+			{"profile busy body", profileBusyBody(code)},
+			{"profile name label", profileNameLabel(code)},
+			{"profile name required heading", profileNameRequiredHeading(code)},
+			{"profile name required body", profileNameRequiredBody(code)},
+			{"profile privacy title", profilePrivacyTitle(code)},
+			{"profile retain heading", profileRetainHeading(code)},
+			{"profile retain body", profileRetainBody(code)},
+			{"profile auto-remove prefix", profileAutoRemovedPrefix(code)},
+			{"profile old-credential heading", profileOldCredentialsHeading(code)},
+			{"profile old-credential body", profileOldCredentialsBody(code)},
 		}
 		for _, item := range values {
-			if item.value == "" {
+			if strings.TrimSpace(item.value) == "" {
 				t.Fatalf("%s prompt is empty for %s", item.name, code)
 			}
+		}
+		if !strings.Contains(profileRetainBody(code), yesLabel(code)) || !strings.Contains(profileRetainBody(code), noLabel(code)) {
+			t.Fatalf("profile retain prompt does not match decision labels for %s", code)
 		}
 		if code != "en" {
 			if closeQuestion(code) == englishClose {
@@ -54,12 +71,25 @@ func TestNativeWindowsPromptsUseEnglishFallbackForUnknownLocale(t *testing.T) {
 		english string
 	}{
 		{"ok", okLabel(unknown), okLabel("en")},
+		{"yes", yesLabel(unknown), yesLabel("en")},
+		{"no", noLabel(unknown), noLabel("en")},
 		{"close question", closeQuestion(unknown), closeQuestion("en")},
 		{"close body", closeBody(unknown), closeBody("en")},
 		{"private-key title", privateKeyDialogTitle(unknown), privateKeyDialogTitle("en")},
 		{"private-key filter", privateKeyFilterLabel(unknown), privateKeyFilterLabel("en")},
 		{"all-files filter", allFilesFilterLabel(unknown), allFilesFilterLabel("en")},
 		{"directory title", directoryDialogTitle(unknown), directoryDialogTitle("en")},
+		{"profile busy heading", profileBusyHeading(unknown), profileBusyHeading("en")},
+		{"profile busy body", profileBusyBody(unknown), profileBusyBody("en")},
+		{"profile name label", profileNameLabel(unknown), profileNameLabel("en")},
+		{"profile name required heading", profileNameRequiredHeading(unknown), profileNameRequiredHeading("en")},
+		{"profile name required body", profileNameRequiredBody(unknown), profileNameRequiredBody("en")},
+		{"profile privacy title", profilePrivacyTitle(unknown), profilePrivacyTitle("en")},
+		{"profile retain heading", profileRetainHeading(unknown), profileRetainHeading("en")},
+		{"profile retain body", profileRetainBody(unknown), profileRetainBody("en")},
+		{"profile auto-remove prefix", profileAutoRemovedPrefix(unknown), profileAutoRemovedPrefix("en")},
+		{"profile old-credential heading", profileOldCredentialsHeading(unknown), profileOldCredentialsHeading("en")},
+		{"profile old-credential body", profileOldCredentialsBody(unknown), profileOldCredentialsBody("en")},
 	}
 	for _, check := range checks {
 		if check.got != check.english {

--- a/internal/desktop/profile_dialog_text_windows.go
+++ b/internal/desktop/profile_dialog_text_windows.go
@@ -1,0 +1,213 @@
+//go:build windows
+
+package desktop
+
+import "fmt"
+
+func profileBusyHeading(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Profile changes are unavailable during a connection",
+		"Promjene profila nisu dostupne tijekom veze",
+		"Profiländerungen sind während einer Verbindung nicht verfügbar",
+		"Les modifications de profil sont indisponibles pendant une connexion",
+		"Los cambios de perfil no están disponibles durante una conexión",
+		"Bağlantı sırasında profil değişiklikleri kullanılamaz",
+		"Οι αλλαγές προφίλ δεν είναι διαθέσιμες κατά τη σύνδεση",
+		"As alterações de perfil não estão disponíveis durante uma ligação",
+		"连接期间无法更改配置文件",
+		"Изменение профиля недоступно во время подключения",
+		"कनेक्शन के दौरान प्रोफ़ाइल बदलाव उपलब्ध नहीं हैं",
+		"接続中はプロファイルを変更できません",
+		"Le modifiche al profilo non sono disponibili durante una connessione",
+		"Zmiany profilu są niedostępne podczas połączenia",
+		"Profielwijzigingen zijn niet beschikbaar tijdens een verbinding",
+		"Změny profilu nejsou během připojení dostupné",
+		"Зміни профілю недоступні під час з’єднання",
+		"Profiländringar är inte tillgängliga under en anslutning",
+		"Modificările profilului nu sunt disponibile în timpul unei conexiuni",
+		"A profil módosítása kapcsolat közben nem érhető el",
+		"Profilændringer er ikke tilgængelige under en forbindelse",
+		"Profiilin muutokset eivät ole käytettävissä yhteyden aikana",
+		"Profilendringer er ikke tilgjengelige under en tilkobling",
+		"연결 중에는 프로필을 변경할 수 없습니다",
+	})
+}
+
+func profileBusyBody(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Wait for the connection attempt to finish or disconnect before saving profile changes.",
+		"Pričekajte završetak pokušaja povezivanja ili prekinite vezu prije spremanja promjena profila.",
+		"Warten Sie, bis der Verbindungsversuch beendet ist, oder trennen Sie die Verbindung, bevor Sie Profiländerungen speichern.",
+		"Attendez la fin de la tentative de connexion ou déconnectez-vous avant d’enregistrer les modifications du profil.",
+		"Espere a que finalice el intento de conexión o desconéctese antes de guardar los cambios del perfil.",
+		"Profil değişikliklerini kaydetmeden önce bağlantı denemesinin tamamlanmasını bekleyin veya bağlantıyı kesin.",
+		"Περιμένετε να ολοκληρωθεί η προσπάθεια σύνδεσης ή αποσυνδεθείτε πριν αποθηκεύσετε αλλαγές στο προφίλ.",
+		"Aguarde a conclusão da tentativa de ligação ou desligue antes de guardar alterações ao perfil.",
+		"请等待连接尝试完成，或先断开连接，再保存配置文件更改。",
+		"Дождитесь завершения попытки подключения или отключитесь перед сохранением изменений профиля.",
+		"प्रोफ़ाइल बदलाव सहेजने से पहले कनेक्शन प्रयास पूरा होने दें या डिस्कनेक्ट करें।",
+		"接続試行の完了を待つか切断してから、プロファイルの変更を保存してください。",
+		"Attendi il termine del tentativo di connessione oppure disconnettiti prima di salvare le modifiche al profilo.",
+		"Poczekaj na zakończenie próby połączenia lub rozłącz się przed zapisaniem zmian profilu.",
+		"Wacht tot de verbindingspoging is voltooid of verbreek de verbinding voordat u profielwijzigingen opslaat.",
+		"Před uložením změn profilu počkejte na dokončení pokusu o připojení nebo se odpojte.",
+		"Дочекайтеся завершення спроби з’єднання або від’єднайтеся перед збереженням змін профілю.",
+		"Vänta tills anslutningsförsöket är klart eller koppla från innan profiländringar sparas.",
+		"Așteptați finalizarea încercării de conectare sau deconectați-vă înainte de a salva modificările profilului.",
+		"A profilmódosítások mentése előtt várja meg a kapcsolódási kísérlet végét, vagy bontsa a kapcsolatot.",
+		"Vent til forbindelsesforsøget er afsluttet, eller afbryd forbindelsen, før profilændringer gemmes.",
+		"Odota yhteysyrityksen valmistumista tai katkaise yhteys ennen profiilimuutosten tallentamista.",
+		"Vent til tilkoblingsforsøket er ferdig, eller koble fra før du lagrer profilendringer.",
+		"프로필 변경 사항을 저장하기 전에 연결 시도가 끝날 때까지 기다리거나 연결을 끊으세요.",
+	})
+}
+
+func profileNameLabel(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Profile name:", "Naziv profila:", "Profilname:", "Nom du profil :", "Nombre del perfil:", "Profil adı:",
+		"Όνομα προφίλ:", "Nome do perfil:", "配置文件名称：", "Имя профиля:", "प्रोफ़ाइल नाम:", "プロファイル名:",
+		"Nome profilo:", "Nazwa profilu:", "Profielnaam:", "Název profilu:", "Назва профілю:", "Profilnamn:",
+		"Numele profilului:", "Profil neve:", "Profilnavn:", "Profiilin nimi:", "Profilnavn:", "프로필 이름:",
+	})
+}
+
+func profileNameRequiredHeading(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Profile name is required", "Naziv profila je obavezan", "Ein Profilname ist erforderlich", "Le nom du profil est obligatoire",
+		"El nombre del perfil es obligatorio", "Profil adı gereklidir", "Απαιτείται όνομα προφίλ", "O nome do perfil é obrigatório",
+		"必须填写配置文件名称", "Необходимо указать имя профиля", "प्रोफ़ाइल नाम आवश्यक है", "プロファイル名は必須です",
+		"Il nome del profilo è obbligatorio", "Nazwa profilu jest wymagana", "Een profielnaam is vereist", "Název profilu je povinný",
+		"Потрібно вказати назву профілю", "Profilnamn krävs", "Numele profilului este obligatoriu", "A profil neve kötelező",
+		"Profilnavn er påkrævet", "Profiilin nimi vaaditaan", "Profilnavn er påkrevd", "프로필 이름이 필요합니다",
+	})
+}
+
+func profileNameRequiredBody(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Enter a name that identifies this connection.", "Unesite naziv po kojem ćete prepoznati ovu vezu.", "Geben Sie einen Namen ein, der diese Verbindung identifiziert.",
+		"Saisissez un nom permettant d’identifier cette connexion.", "Introduzca un nombre que identifique esta conexión.", "Bu bağlantıyı tanımlayan bir ad girin.",
+		"Εισαγάγετε ένα όνομα που προσδιορίζει αυτή τη σύνδεση.", "Introduza um nome que identifique esta ligação.", "请输入用于识别此连接的名称。",
+		"Введите имя, по которому можно определить это подключение.", "इस कनेक्शन की पहचान करने वाला नाम दर्ज करें।", "この接続を識別できる名前を入力してください。",
+		"Inserisci un nome che identifichi questa connessione.", "Wprowadź nazwę identyfikującą to połączenie.", "Voer een naam in waarmee deze verbinding kan worden herkend.",
+		"Zadejte název, podle kterého toto připojení poznáte.", "Введіть назву, за якою можна розпізнати це з’єднання.", "Ange ett namn som identifierar den här anslutningen.",
+		"Introduceți un nume care identifică această conexiune.", "Adjon meg egy nevet, amely azonosítja ezt a kapcsolatot.", "Indtast et navn, der identificerer denne forbindelse.",
+		"Anna nimi, josta tämä yhteys tunnistetaan.", "Skriv inn et navn som identifiserer denne tilkoblingen.", "이 연결을 식별할 이름을 입력하세요.",
+	})
+}
+
+func profilePrivacyTitle(language string) string {
+	return localizedPrompt(language, [24]string{
+		"privacy", "privatnost", "Datenschutz", "confidentialité", "privacidad", "gizlilik", "απόρρητο", "privacidade", "隐私", "конфиденциальность", "गोपनीयता", "プライバシー",
+		"privacy", "prywatność", "privacy", "soukromí", "конфіденційність", "integritet", "confidențialitate", "adatvédelem", "privatliv", "tietosuoja", "personvern", "개인정보 보호",
+	})
+}
+
+func profileRetainHeading(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Retain stored credentials?", "Zadržati spremljene vjerodajnice?", "Gespeicherte Anmeldedaten beibehalten?", "Conserver les identifiants enregistrés ?",
+		"¿Conservar las credenciales guardadas?", "Kayıtlı kimlik bilgileri korunsun mu?", "Διατήρηση αποθηκευμένων διαπιστευτηρίων;", "Manter as credenciais guardadas?",
+		"保留已保存的凭据？", "Сохранить сохранённые учётные данные?", "सहेजे गए क्रेडेंशियल रखें?", "保存済みの認証情報を保持しますか？",
+		"Mantenere le credenziali salvate?", "Zachować zapisane dane logowania?", "Opgeslagen aanmeldgegevens behouden?", "Ponechat uložené přihlašovací údaje?",
+		"Зберегти збережені облікові дані?", "Behålla sparade autentiseringsuppgifter?", "Păstrați datele de autentificare salvate?", "Megtartja a mentett hitelesítő adatokat?",
+		"Behold gemte legitimationsoplysninger?", "Säilytetäänkö tallennetut tunnistetiedot?", "Beholde lagret påloggingsinformasjon?", "저장된 자격 증명을 유지할까요?",
+	})
+}
+
+func profileRetainBody(language string) string {
+	template := localizedPrompt(language, [24]string{
+		"This profile already contains stored credentials that still belong to the same identity.\n\n%s = retain them.\n%s = remove them from the Ghost FTP profile store.",
+		"Ovaj profil već sadrži spremljene vjerodajnice koje i dalje pripadaju istom identitetu.\n\n%s = zadrži ih.\n%s = ukloni ih iz spremišta profila Ghost FTP-a.",
+		"Dieses Profil enthält bereits gespeicherte Anmeldedaten, die weiterhin zur selben Identität gehören.\n\n%s = beibehalten.\n%s = aus dem Ghost-FTP-Profilspeicher entfernen.",
+		"Ce profil contient déjà des identifiants enregistrés qui appartiennent toujours à la même identité.\n\n%s = les conserver.\n%s = les supprimer du stockage de profils Ghost FTP.",
+		"Este perfil ya contiene credenciales guardadas que siguen perteneciendo a la misma identidad.\n\n%s = conservarlas.\n%s = eliminarlas del almacén de perfiles de Ghost FTP.",
+		"Bu profil, hâlâ aynı kimliğe ait kayıtlı kimlik bilgileri içeriyor.\n\n%s = koru.\n%s = Ghost FTP profil deposundan kaldır.",
+		"Αυτό το προφίλ περιέχει ήδη αποθηκευμένα διαπιστευτήρια που εξακολουθούν να ανήκουν στην ίδια ταυτότητα.\n\n%s = διατήρηση.\n%s = αφαίρεση από το χώρο αποθήκευσης προφίλ Ghost FTP.",
+		"Este perfil já contém credenciais guardadas que continuam a pertencer à mesma identidade.\n\n%s = manter.\n%s = remover do armazenamento de perfis do Ghost FTP.",
+		"此配置文件已包含仍属于同一身份的已保存凭据。\n\n%s = 保留。\n%s = 从 Ghost FTP 配置文件存储中删除。",
+		"В этом профиле уже есть сохранённые учётные данные, которые по-прежнему относятся к той же учётной записи.\n\n%s = сохранить.\n%s = удалить из хранилища профиля Ghost FTP.",
+		"इस प्रोफ़ाइल में पहले से सहेजे गए क्रेडेंशियल हैं जो अभी भी उसी पहचान से संबंधित हैं।\n\n%s = उन्हें रखें।\n%s = उन्हें Ghost FTP प्रोफ़ाइल स्टोर से हटाएँ।",
+		"このプロファイルには、同じ認証対象に属する保存済みの認証情報があります。\n\n%s = 保持。\n%s = Ghost FTP のプロファイルストアから削除。",
+		"Questo profilo contiene già credenziali salvate che appartengono ancora alla stessa identità.\n\n%s = mantenerle.\n%s = rimuoverle dall'archivio profili di Ghost FTP.",
+		"Ten profil zawiera już zapisane dane logowania, które nadal należą do tej samej tożsamości.\n\n%s = zachowaj je.\n%s = usuń je z magazynu profilu Ghost FTP.",
+		"Dit profiel bevat al opgeslagen aanmeldgegevens die nog bij dezelfde identiteit horen.\n\n%s = behouden.\n%s = verwijderen uit de profielopslag van Ghost FTP.",
+		"Tento profil již obsahuje uložené přihlašovací údaje, které stále patří ke stejné identitě.\n\n%s = ponechat.\n%s = odstranit z úložiště profilu Ghost FTP.",
+		"Цей профіль уже містить збережені облікові дані, які й надалі належать до тієї самої ідентичності.\n\n%s = зберегти їх.\n%s = видалити зі сховища профілю Ghost FTP.",
+		"Den här profilen innehåller redan sparade autentiseringsuppgifter som fortfarande tillhör samma identitet.\n\n%s = behåll dem.\n%s = ta bort dem från Ghost FTP:s profillagring.",
+		"Acest profil conține deja date de autentificare salvate care aparțin în continuare aceleiași identități.\n\n%s = păstrați-le.\n%s = eliminați-le din stocarea profilului Ghost FTP.",
+		"Ez a profil már tartalmaz olyan mentett hitelesítő adatokat, amelyek továbbra is ugyanahhoz az identitáshoz tartoznak.\n\n%s = megtartás.\n%s = eltávolítás a Ghost FTP profiltárolójából.",
+		"Denne profil indeholder allerede gemte legitimationsoplysninger, som stadig tilhører den samme identitet.\n\n%s = behold dem.\n%s = fjern dem fra Ghost FTP-profildataene.",
+		"Tässä profiilissa on jo tallennettuja tunnistetietoja, jotka kuuluvat edelleen samaan identiteettiin.\n\n%s = säilytä ne.\n%s = poista ne Ghost FTP:n profiilivarastosta.",
+		"Denne profilen inneholder allerede lagret påloggingsinformasjon som fortsatt tilhører samme identitet.\n\n%s = behold den.\n%s = fjern den fra Ghost FTP-profillageret.",
+		"이 프로필에는 동일한 자격에 계속 속하는 저장된 자격 증명이 이미 있습니다.\n\n%s = 유지.\n%s = Ghost FTP 프로필 저장소에서 제거.",
+	})
+	return fmt.Sprintf(template, yesLabel(language), noLabel(language))
+}
+
+func profileAutoRemovedPrefix(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Credentials that no longer belong to the changed server, account or private key will be removed automatically.",
+		"Vjerodajnice koje više ne pripadaju promijenjenom poslužitelju, računu ili privatnom ključu bit će automatski uklonjene.",
+		"Anmeldedaten, die nicht mehr zum geänderten Server, Konto oder privaten Schlüssel gehören, werden automatisch entfernt.",
+		"Les identifiants qui ne correspondent plus au serveur, au compte ou à la clé privée modifiés seront supprimés automatiquement.",
+		"Las credenciales que ya no correspondan al servidor, la cuenta o la clave privada modificados se eliminarán automáticamente.",
+		"Değiştirilen sunucuya, hesaba veya özel anahtara artık ait olmayan kimlik bilgileri otomatik olarak kaldırılacaktır.",
+		"Τα διαπιστευτήρια που δεν ανήκουν πλέον στον αλλαγμένο διακομιστή, λογαριασμό ή ιδιωτικό κλειδί θα αφαιρεθούν αυτόματα.",
+		"As credenciais que já não pertencem ao servidor, conta ou chave privada alterados serão removidas automaticamente.",
+		"不再属于已更改服务器、帐户或私钥的凭据将自动删除。",
+		"Учётные данные, которые больше не относятся к изменённому серверу, учётной записи или закрытому ключу, будут удалены автоматически.",
+		"बदले गए सर्वर, खाते या निजी कुंजी से अब संबंधित न रहने वाले क्रेडेंशियल अपने आप हटा दिए जाएंगे।",
+		"変更後のサーバー、アカウント、または秘密鍵に属さない認証情報は自動的に削除されます。",
+		"Le credenziali che non appartengono più al server, all'account o alla chiave privata modificati verranno rimosse automaticamente.",
+		"Dane logowania, które nie należą już do zmienionego serwera, konta lub klucza prywatnego, zostaną usunięte automatycznie.",
+		"Aanmeldgegevens die niet meer bij de gewijzigde server, account of privésleutel horen, worden automatisch verwijderd.",
+		"Přihlašovací údaje, které již nepatří ke změněnému serveru, účtu nebo soukromému klíči, budou automaticky odstraněny.",
+		"Облікові дані, які більше не належать зміненому серверу, обліковому запису або приватному ключу, буде видалено автоматично.",
+		"Autentiseringsuppgifter som inte längre hör till den ändrade servern, kontot eller privata nyckeln tas bort automatiskt.",
+		"Datele de autentificare care nu mai aparțin serverului, contului sau cheii private modificate vor fi eliminate automat.",
+		"A módosított szerverhez, fiókhoz vagy privát kulcshoz már nem tartozó hitelesítő adatok automatikusan törlődnek.",
+		"Legitimationsoplysninger, der ikke længere tilhører den ændrede server, konto eller private nøgle, fjernes automatisk.",
+		"Muuttuneeseen palvelimeen, tiliin tai yksityiseen avaimeen enää kuulumattomat tunnistetiedot poistetaan automaattisesti.",
+		"Påloggingsinformasjon som ikke lenger tilhører den endrede serveren, kontoen eller private nøkkelen, fjernes automatisk.",
+		"변경된 서버, 계정 또는 개인 키에 더 이상 속하지 않는 자격 증명은 자동으로 제거됩니다.",
+	})
+}
+
+func profileOldCredentialsHeading(language string) string {
+	return localizedPrompt(language, [24]string{
+		"Old credentials will not be transferred", "Stare vjerodajnice neće se prenijeti", "Alte Anmeldedaten werden nicht übernommen", "Les anciens identifiants ne seront pas transférés",
+		"Las credenciales antiguas no se transferirán", "Eski kimlik bilgileri aktarılmayacak", "Τα παλιά διαπιστευτήρια δεν θα μεταφερθούν", "As credenciais antigas não serão transferidas",
+		"旧凭据不会转移", "Старые учётные данные не будут перенесены", "पुराने क्रेडेंशियल स्थानांतरित नहीं किए जाएंगे", "以前の認証情報は引き継がれません",
+		"Le vecchie credenziali non verranno trasferite", "Stare dane logowania nie zostaną przeniesione", "Oude aanmeldgegevens worden niet overgenomen", "Staré přihlašovací údaje nebudou přeneseny",
+		"Старі облікові дані не буде перенесено", "Gamla autentiseringsuppgifter överförs inte", "Datele de autentificare vechi nu vor fi transferate", "A régi hitelesítő adatok nem kerülnek át",
+		"Gamle legitimationsoplysninger overføres ikke", "Vanhoja tunnistetietoja ei siirretä", "Gammel påloggingsinformasjon overføres ikke", "이전 자격 증명은 이전되지 않습니다",
+	})
+}
+
+func profileOldCredentialsBody(language string) string {
+	return localizedPrompt(language, [24]string{
+		"The server, port, username or private key changed. For safety, old stored credentials are removed from this profile. Enter them again if you want to store credentials for the new identity.",
+		"Promijenjen je poslužitelj, port, korisničko ime ili privatni ključ. Radi sigurnosti stare spremljene vjerodajnice uklanjaju se iz ovog profila. Unesite ih ponovno ako želite spremiti vjerodajnice za novi identitet.",
+		"Server, Port, Benutzername oder privater Schlüssel wurden geändert. Aus Sicherheitsgründen werden alte gespeicherte Anmeldedaten aus diesem Profil entfernt. Geben Sie sie erneut ein, wenn Sie Anmeldedaten für die neue Identität speichern möchten.",
+		"Le serveur, le port, le nom d’utilisateur ou la clé privée a changé. Par sécurité, les anciens identifiants enregistrés sont supprimés de ce profil. Saisissez-les à nouveau si vous souhaitez enregistrer des identifiants pour la nouvelle identité.",
+		"El servidor, el puerto, el nombre de usuario o la clave privada han cambiado. Por seguridad, las credenciales guardadas anteriormente se eliminan de este perfil. Vuelva a introducirlas si desea guardar credenciales para la nueva identidad.",
+		"Sunucu, bağlantı noktası, kullanıcı adı veya özel anahtar değişti. Güvenlik için eski kayıtlı kimlik bilgileri bu profilden kaldırılır. Yeni kimlik için kimlik bilgilerini kaydetmek istiyorsanız yeniden girin.",
+		"Ο διακομιστής, η θύρα, το όνομα χρήστη ή το ιδιωτικό κλειδί άλλαξε. Για λόγους ασφαλείας, τα παλιά αποθηκευμένα διαπιστευτήρια αφαιρούνται από αυτό το προφίλ. Εισαγάγετέ τα ξανά αν θέλετε να αποθηκεύσετε διαπιστευτήρια για τη νέα ταυτότητα.",
+		"O servidor, a porta, o nome de utilizador ou a chave privada mudou. Por segurança, as credenciais anteriormente guardadas são removidas deste perfil. Introduza-as novamente se quiser guardar credenciais para a nova identidade.",
+		"服务器、端口、用户名或私钥已更改。为安全起见，旧的已保存凭据将从此配置文件中删除。如果要为新身份保存凭据，请重新输入。",
+		"Сервер, порт, имя пользователя или закрытый ключ изменились. В целях безопасности старые сохранённые учётные данные удаляются из этого профиля. Введите их снова, если хотите сохранить данные для новой учётной записи.",
+		"सर्वर, पोर्ट, उपयोगकर्ता नाम या निजी कुंजी बदल गई है। सुरक्षा के लिए पुराने सहेजे गए क्रेडेंशियल इस प्रोफ़ाइल से हटा दिए जाते हैं। नई पहचान के लिए क्रेडेंशियल सहेजना हो तो उन्हें फिर से दर्ज करें।",
+		"サーバー、ポート、ユーザー名、または秘密鍵が変更されました。安全のため、以前に保存された認証情報はこのプロファイルから削除されます。新しい認証対象の情報を保存する場合は、もう一度入力してください。",
+		"Il server, la porta, il nome utente o la chiave privata sono cambiati. Per sicurezza, le vecchie credenziali salvate vengono rimosse da questo profilo. Inseriscile di nuovo se vuoi salvare credenziali per la nuova identità.",
+		"Serwer, port, nazwa użytkownika lub klucz prywatny uległy zmianie. Ze względów bezpieczeństwa stare zapisane dane logowania są usuwane z tego profilu. Wprowadź je ponownie, jeśli chcesz zapisać dane dla nowej tożsamości.",
+		"De server, poort, gebruikersnaam of privésleutel is gewijzigd. Voor de veiligheid worden oude opgeslagen aanmeldgegevens uit dit profiel verwijderd. Voer ze opnieuw in als u aanmeldgegevens voor de nieuwe identiteit wilt opslaan.",
+		"Server, port, uživatelské jméno nebo soukromý klíč se změnily. Z bezpečnostních důvodů budou staré uložené přihlašovací údaje z tohoto profilu odstraněny. Pokud chcete uložit údaje pro novou identitu, zadejte je znovu.",
+		"Сервер, порт, ім’я користувача або приватний ключ змінилися. З міркувань безпеки старі збережені облікові дані буде видалено з цього профілю. Введіть їх знову, якщо хочете зберегти дані для нової ідентичності.",
+		"Servern, porten, användarnamnet eller den privata nyckeln har ändrats. Av säkerhetsskäl tas gamla sparade autentiseringsuppgifter bort från profilen. Ange dem igen om du vill spara uppgifter för den nya identiteten.",
+		"Serverul, portul, numele de utilizator sau cheia privată s-a schimbat. Pentru siguranță, datele de autentificare vechi salvate sunt eliminate din acest profil. Introduceți-le din nou dacă doriți să salvați date pentru noua identitate.",
+		"A szerver, a port, a felhasználónév vagy a privát kulcs megváltozott. Biztonsági okból a régi mentett hitelesítő adatok törlődnek ebből a profilból. Adja meg őket újra, ha az új identitáshoz szeretne adatokat menteni.",
+		"Serveren, porten, brugernavnet eller den private nøgle er ændret. Af sikkerhedshensyn fjernes gamle gemte legitimationsoplysninger fra denne profil. Indtast dem igen, hvis du vil gemme oplysninger for den nye identitet.",
+		"Palvelin, portti, käyttäjänimi tai yksityinen avain muuttui. Turvallisuuden vuoksi vanhat tallennetut tunnistetiedot poistetaan tästä profiilista. Syötä ne uudelleen, jos haluat tallentaa tunnistetiedot uudelle identiteetille.",
+		"Serveren, porten, brukernavnet eller den private nøkkelen er endret. Av sikkerhetsgrunner fjernes gammel lagret påloggingsinformasjon fra denne profilen. Skriv den inn på nytt hvis du vil lagre informasjon for den nye identiteten.",
+		"서버, 포트, 사용자 이름 또는 개인 키가 변경되었습니다. 보안을 위해 이전에 저장된 자격 증명은 이 프로필에서 제거됩니다. 새 자격에 대한 정보를 저장하려면 다시 입력하세요.",
+	})
+}

--- a/internal/platform/decision_card_windows.go
+++ b/internal/platform/decision_card_windows.go
@@ -15,14 +15,14 @@ const (
 )
 
 const (
-	decisionIDYes = 6 // IDYES
-	decisionIDNo  = 7 // IDNO
+	decisionIDYes      = 6 // IDYES
+	decisionIDNo       = 7 // IDNO
 	decisionSSNoPrefix = 0x00000080
 	decisionEtchedHorz = 0x00000010
-	decisionWSChild = 0x40000000
-	decisionWSVisible = 0x10000000
-	decisionWSTabStop = 0x00010000
-	decisionDefButton = 0x00000001
+	decisionWSChild    = 0x40000000
+	decisionWSVisible  = 0x10000000
+	decisionWSTabStop  = 0x00010000
+	decisionDefButton  = 0x00000001
 )
 
 type decisionCardState struct {
@@ -208,14 +208,14 @@ func decisionCardDialog(title, instruction, content string, kind int) (result in
 	makeControl("STATIC", "", decisionEtchedHorz, 36, 238, 608, 2, 0, bodyFont)
 
 	if kind == decisionCardKindConfirm {
-		yesLabel, noLabel := dialogDecisionLabels()
+		_, _, yesLabel, noLabel := resolvedDialogLabels()
 		yesButton := makeControl("BUTTON", yesLabel, decisionWSTabStop|decisionDefButton, 430, 254, 102, 38, decisionIDYes, bodyFont)
 		makeControl("BUTTON", noLabel, decisionWSTabStop, 542, 254, 102, 38, decisionIDNo, bodyFont)
 		if yesButton != 0 {
 			promptSetFocus.Call(yesButton)
 		}
 	} else {
-		okLabel, _ := dialogActionLabels()
+		okLabel, _, _, _ := resolvedDialogLabels()
 		okButton := makeControl("BUTTON", okLabel, decisionWSTabStop|decisionDefButton, 542, 254, 102, 38, promptIDOK, bodyFont)
 		if okButton != 0 {
 			promptSetFocus.Call(okButton)

--- a/internal/platform/decision_card_windows.go
+++ b/internal/platform/decision_card_windows.go
@@ -1,0 +1,229 @@
+//go:build windows
+
+package platform
+
+import (
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	decisionCardKindInfo = iota
+	decisionCardKindError
+	decisionCardKindConfirm
+)
+
+const (
+	decisionIDYes = 6 // IDYES
+	decisionIDNo  = 7 // IDNO
+	decisionSSNoPrefix = 0x00000080
+	decisionEtchedHorz = 0x00000010
+	decisionWSChild = 0x40000000
+	decisionWSVisible = 0x10000000
+	decisionWSTabStop = 0x00010000
+	decisionDefButton = 0x00000001
+)
+
+type decisionCardState struct {
+	kind    int
+	heading uintptr
+	result  int
+	closed  bool
+}
+
+var (
+	decisionCardStates sync.Map
+	decisionCardOnce   sync.Once
+	decisionCardClass  = "GhostFTP.DecisionCardDialog"
+	decisionCardProc   = syscall.NewCallback(decisionCardWndProc)
+
+	decisionLabelsMu sync.RWMutex
+	decisionYesLabel = "Yes"
+	decisionNoLabel  = "No"
+)
+
+// SetDialogDecisionLabels keeps Yes/No actions in the application's selected
+// locale without coupling the platform package to the desktop i18n catalog.
+func SetDialogDecisionLabels(yesLabel, noLabel string) {
+	if yesLabel == "" {
+		yesLabel = "Yes"
+	}
+	if noLabel == "" {
+		noLabel = "No"
+	}
+	decisionLabelsMu.Lock()
+	decisionYesLabel = yesLabel
+	decisionNoLabel = noLabel
+	decisionLabelsMu.Unlock()
+}
+
+func dialogDecisionLabels() (string, string) {
+	decisionLabelsMu.RLock()
+	defer decisionLabelsMu.RUnlock()
+	return decisionYesLabel, decisionNoLabel
+}
+
+func decisionCardHeadingColor(kind int) uintptr {
+	theme := premiumDialogTheme()
+	switch kind {
+	case decisionCardKindError:
+		return premiumPaletteColor(theme.Danger)
+	case decisionCardKindInfo:
+		return premiumPaletteColor(theme.AccentStrong)
+	default:
+		return premiumPaletteColor(theme.Text)
+	}
+}
+
+func decisionCardWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
+	if value, ok := decisionCardStates.Load(hwnd); ok {
+		state := value.(*decisionCardState)
+		switch message {
+		case promptWMCommand:
+			id := int(wParam & 0xffff)
+			if state.kind == decisionCardKindConfirm {
+				switch id {
+				case decisionIDYes:
+					state.result = decisionIDYes
+					promptDestroyWindow.Call(hwnd)
+					return 0
+				case decisionIDNo, promptIDCancel:
+					state.result = decisionIDNo
+					promptDestroyWindow.Call(hwnd)
+					return 0
+				}
+			} else if id == promptIDOK || id == promptIDCancel {
+				state.result = promptIDOK
+				promptDestroyWindow.Call(hwnd)
+				return 0
+			}
+		case premiumWMCtlColorEdit, premiumWMCtlColorListBox, premiumWMCtlColorBtn:
+			return premiumDialogControlColor(wParam)
+		case premiumWMCtlColorStatic:
+			if lParam == state.heading && state.heading != 0 {
+				premiumSetTextColor.Call(wParam, decisionCardHeadingColor(state.kind))
+				premiumSetBkColor.Call(wParam, premiumDialogSurfaceColor())
+				return premiumDialogBackgroundBrush()
+			}
+			return premiumDialogControlColor(wParam)
+		case promptWMClose:
+			if state.kind == decisionCardKindConfirm {
+				state.result = decisionIDNo
+			} else {
+				state.result = promptIDOK
+			}
+			promptDestroyWindow.Call(hwnd)
+			return 0
+		case promptWMDestroy:
+			state.closed = true
+			return 0
+		}
+	}
+	r, _, _ := promptDefWindowProcW.Call(hwnd, uintptr(message), wParam, lParam)
+	return r
+}
+
+// decisionCardDialog is the application-owned primary path for ConfirmDialog,
+// InfoDialog and ErrorDialog. Returning ok=false means Win32 could not create
+// the custom surface and the caller should use the stock Windows fallback.
+func decisionCardDialog(title, instruction, content string, kind int) (result int, ok bool) {
+	hinst, _, _ := promptGetModuleHandleW.Call(0)
+	decisionCardOnce.Do(func() {
+		cursor, _, _ := promptLoadCursorW.Call(0, 32512)
+		wc := promptWndClassEx{
+			CbSize:     uint32(unsafe.Sizeof(promptWndClassEx{})),
+			WndProc:    decisionCardProc,
+			Instance:   hinst,
+			Cursor:     cursor,
+			Background: premiumDialogBackgroundBrush(),
+			ClassName:  promptWstr(decisionCardClass),
+		}
+		promptRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc)))
+	})
+
+	const (
+		wsOverlapped = 0x00C80000
+		clientWidth  = 680
+		clientHeight = 320
+	)
+	owner := premiumDialogOwner()
+	dpi := premiumDialogDPI(owner)
+	windowWidth, windowHeight := premiumDialogOuterSize(clientWidth, clientHeight, wsOverlapped, 0, dpi)
+	x, y := premiumDialogPosition(owner, windowWidth, windowHeight)
+	hwnd, _, _ := promptCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(promptWstr(decisionCardClass))),
+		uintptr(unsafe.Pointer(promptWstr(title))),
+		wsOverlapped,
+		uintptr(x), uintptr(y), uintptr(windowWidth), uintptr(windowHeight),
+		owner, 0, hinst, 0,
+	)
+	if hwnd == 0 {
+		return 0, false
+	}
+	applyPremiumDialogWindow(hwnd)
+
+	state := &decisionCardState{kind: kind}
+	if kind == decisionCardKindConfirm {
+		state.result = decisionIDNo
+	} else {
+		state.result = promptIDOK
+	}
+	decisionCardStates.Store(hwnd, state)
+	defer decisionCardStates.Delete(hwnd)
+	restoreOwner := premiumModalOwner(owner)
+	defer restoreOwner()
+
+	bodyFont := premiumDialogFontForDPI(-15, dpi, 400)
+	if bodyFont != 0 {
+		defer promptDeleteObject.Call(bodyFont)
+	}
+	headingFont := premiumDialogFontForDPI(-22, dpi, 600)
+	if headingFont != 0 {
+		defer promptDeleteObject.Call(headingFont)
+	}
+
+	scale := func(value int) uintptr { return uintptr(premiumScale(value, dpi)) }
+	makeControl := func(class, text string, style uint32, x, y, width, height, id int, font uintptr) uintptr {
+		child, _, _ := promptCreateWindowExW.Call(
+			0,
+			uintptr(unsafe.Pointer(promptWstr(class))),
+			uintptr(unsafe.Pointer(promptWstr(text))),
+			uintptr(decisionWSChild|decisionWSVisible|style),
+			scale(x), scale(y), scale(width), scale(height),
+			hwnd, uintptr(id), hinst, 0,
+		)
+		if child != 0 && font != 0 {
+			promptSendMessageW.Call(child, promptWMSetFont, font, 1)
+		}
+		if child != 0 {
+			applyPremiumDialogControl(child, class)
+		}
+		return child
+	}
+
+	state.heading = makeControl("STATIC", instruction, decisionSSNoPrefix, 36, 28, 608, 58, 0, headingFont)
+	makeControl("STATIC", content, decisionSSNoPrefix, 36, 96, 608, 126, 0, bodyFont)
+	makeControl("STATIC", "", decisionEtchedHorz, 36, 238, 608, 2, 0, bodyFont)
+
+	if kind == decisionCardKindConfirm {
+		yesLabel, noLabel := dialogDecisionLabels()
+		yesButton := makeControl("BUTTON", yesLabel, decisionWSTabStop|decisionDefButton, 430, 254, 102, 38, decisionIDYes, bodyFont)
+		makeControl("BUTTON", noLabel, decisionWSTabStop, 542, 254, 102, 38, decisionIDNo, bodyFont)
+		if yesButton != 0 {
+			promptSetFocus.Call(yesButton)
+		}
+	} else {
+		okLabel, _ := dialogActionLabels()
+		okButton := makeControl("BUTTON", okLabel, decisionWSTabStop|decisionDefButton, 542, 254, 102, 38, promptIDOK, bodyFont)
+		if okButton != 0 {
+			promptSetFocus.Call(okButton)
+		}
+	}
+
+	promptShowWindow.Call(hwnd, 5)
+	promptUpdateWindow.Call(hwnd)
+	premiumRunDialogLoop(hwnd, func() bool { return state.closed })
+	return state.result, true
+}

--- a/internal/platform/dialog_label_provider_windows.go
+++ b/internal/platform/dialog_label_provider_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package platform
+
+import "sync"
+
+type dialogLabelProvider func() (okLabel, cancelLabel, yesLabel, noLabel string)
+
+var (
+	dialogLabelProviderMu sync.RWMutex
+	dialogLabelsProvider dialogLabelProvider
+)
+
+// SetDialogLabelProvider installs a desktop-owned resolver for application
+// dialog action labels. The callback is evaluated when a dialog opens, so
+// runtime language changes are reflected without duplicating the i18n catalog
+// inside the platform package.
+func SetDialogLabelProvider(provider func() (string, string, string, string)) {
+	dialogLabelProviderMu.Lock()
+	dialogLabelsProvider = provider
+	dialogLabelProviderMu.Unlock()
+}
+
+func resolvedDialogLabels() (okLabel, cancelLabel, yesLabel, noLabel string) {
+	dialogLabelProviderMu.RLock()
+	provider := dialogLabelsProvider
+	dialogLabelProviderMu.RUnlock()
+	if provider != nil {
+		okLabel, cancelLabel, yesLabel, noLabel = provider()
+	}
+	if okLabel == "" || cancelLabel == "" {
+		fallbackOK, fallbackCancel := dialogActionLabels()
+		if okLabel == "" {
+			okLabel = fallbackOK
+		}
+		if cancelLabel == "" {
+			cancelLabel = fallbackCancel
+		}
+	}
+	if yesLabel == "" || noLabel == "" {
+		fallbackYes, fallbackNo := dialogDecisionLabels()
+		if yesLabel == "" {
+			yesLabel = fallbackYes
+		}
+		if noLabel == "" {
+			noLabel = fallbackNo
+		}
+	}
+	return okLabel, cancelLabel, yesLabel, noLabel
+}

--- a/internal/platform/dialog_label_provider_windows.go
+++ b/internal/platform/dialog_label_provider_windows.go
@@ -8,7 +8,7 @@ type dialogLabelProvider func() (okLabel, cancelLabel, yesLabel, noLabel string)
 
 var (
 	dialogLabelProviderMu sync.RWMutex
-	dialogLabelsProvider dialogLabelProvider
+	dialogLabelsProvider  dialogLabelProvider
 )
 
 // SetDialogLabelProvider installs a desktop-owned resolver for application

--- a/internal/platform/windows.go
+++ b/internal/platform/windows.go
@@ -262,14 +262,22 @@ func taskDialogCall(title, instruction, content string, buttons uintptr) (int, b
 }
 
 func ConfirmDialog(title, instruction, content string) bool {
+	if pressed, ok := decisionCardDialog(title, instruction, content, decisionCardKindConfirm); ok {
+		return pressed == decisionIDYes
+	}
+	// Stock Windows surfaces are a robustness fallback only. The normal desktop
+	// path is the application-owned Ghost FTP decision card above.
 	const yesNo = 0x0002 | 0x0004
 	if pressed, ok := taskDialogCall(title, instruction, content, yesNo); ok {
-		return pressed == 6
+		return pressed == decisionIDYes
 	}
-	return MessageBox(title, instruction+"\n\n"+content, 0x24) == 6
+	return MessageBox(title, instruction+"\n\n"+content, 0x24) == decisionIDYes
 }
 
 func InfoDialog(title, instruction, content string) {
+	if _, ok := decisionCardDialog(title, instruction, content, decisionCardKindInfo); ok {
+		return
+	}
 	const okButton = 0x0001
 	if _, ok := taskDialogCall(title, instruction, content, okButton); ok {
 		return
@@ -278,6 +286,9 @@ func InfoDialog(title, instruction, content string) {
 }
 
 func ErrorDialog(title, instruction, content string) {
+	if _, ok := decisionCardDialog(title, instruction, content, decisionCardKindError); ok {
+		return
+	}
 	const okButton = 0x0001
 	if _, ok := taskDialogCall(title, instruction, content, okButton); ok {
 		return

--- a/scripts/test_windows_decision_dialog_contract.py
+++ b/scripts/test_windows_decision_dialog_contract.py
@@ -21,10 +21,17 @@ class WindowsDecisionDialogContractTests(unittest.TestCase):
         self.assertIn(
             "decisionCardDialog(title, instruction, content, decisionCardKindError)", source
         )
-        # Stock Windows dialogs remain a fail-safe only after the custom path.
-        self.assertIn("taskDialogCall", source)
-        self.assertIn("MessageBox(title", source)
-        self.assertLess(source.index("decisionCardDialog"), source.index("taskDialogCall(title"))
+
+        # Stock Windows dialogs remain a fail-safe only after the custom path in
+        # each public API, regardless of helper declaration order in the file.
+        confirm = source[source.index("func ConfirmDialog"):source.index("func InfoDialog")]
+        info = source[source.index("func InfoDialog"):source.index("func ErrorDialog")]
+        error = source[source.index("func ErrorDialog"):source.index("func MessageBox")]
+        for block in (confirm, info, error):
+            self.assertIn("decisionCardDialog", block)
+            self.assertIn("taskDialogCall", block)
+            self.assertIn("MessageBox(title", block)
+            self.assertLess(block.index("decisionCardDialog"), block.index("taskDialogCall"))
 
     def test_decision_card_reuses_shared_theme_dpi_owner_and_keyboard_shell(self) -> None:
         card = read("internal/platform/decision_card_windows.go")

--- a/scripts/test_windows_decision_dialog_contract.py
+++ b/scripts/test_windows_decision_dialog_contract.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsDecisionDialogContractTests(unittest.TestCase):
+    def test_confirm_info_and_error_prefer_application_owned_decision_card(self) -> None:
+        source = read("internal/platform/windows.go")
+        self.assertIn(
+            "decisionCardDialog(title, instruction, content, decisionCardKindConfirm)", source
+        )
+        self.assertIn(
+            "decisionCardDialog(title, instruction, content, decisionCardKindInfo)", source
+        )
+        self.assertIn(
+            "decisionCardDialog(title, instruction, content, decisionCardKindError)", source
+        )
+        # Stock Windows dialogs remain a fail-safe only after the custom path.
+        self.assertIn("taskDialogCall", source)
+        self.assertIn("MessageBox(title", source)
+        self.assertLess(source.index("decisionCardDialog"), source.index("taskDialogCall(title"))
+
+    def test_decision_card_reuses_shared_theme_dpi_owner_and_keyboard_shell(self) -> None:
+        card = read("internal/platform/decision_card_windows.go")
+        self.assertIn("premiumDialogTheme()", card)
+        self.assertIn("theme.Danger", card)
+        self.assertIn("theme.AccentStrong", card)
+        self.assertIn("premiumDialogDPI(owner)", card)
+        self.assertIn("premiumDialogOuterSize", card)
+        self.assertIn("premiumModalOwner(owner)", card)
+        self.assertIn("premiumRunDialogLoop(hwnd", card)
+        self.assertIn("decisionIDYes", card)
+        self.assertIn("decisionIDNo", card)
+        self.assertIn("promptIDOK", card)
+        self.assertNotIn("PostQuitMessage", card)
+
+    def test_runtime_labels_are_resolved_from_the_active_desktop_locale(self) -> None:
+        provider = read("internal/platform/dialog_label_provider_windows.go")
+        desktop = read("internal/desktop/dialog_localization_windows.go")
+        card = read("internal/platform/decision_card_windows.go")
+
+        self.assertIn("SetDialogLabelProvider", provider)
+        self.assertIn("resolvedDialogLabels", provider)
+        self.assertIn("platform.SetDialogLabelProvider", desktop)
+        self.assertIn("apps.Range", desktop)
+        self.assertIn("a.languageCode()", desktop)
+        self.assertIn('a.tr("common.cancel")', desktop)
+        self.assertIn("[24]string", desktop)
+        self.assertIn("resolvedDialogLabels()", card)
+
+    def test_profile_privacy_flow_has_no_old_hardcoded_english_copy(self) -> None:
+        flow = read("internal/desktop/connection_profiles_windows.go")
+        localized = read("internal/desktop/profile_dialog_text_windows.go")
+
+        for old_copy in (
+            "Profile changes are unavailable during a connection",
+            "Profile name is required",
+            "Retain stored credentials?",
+            "This profile already contains stored credentials",
+            "Old credentials will not be transferred",
+            "Credentials that no longer belong to the changed server",
+        ):
+            self.assertNotIn(old_copy, flow)
+
+        for helper in (
+            "profileBusyHeading(language)",
+            "profileBusyBody(language)",
+            "profileNameLabel(language)",
+            "profileNameRequiredHeading(language)",
+            "profileNameRequiredBody(language)",
+            "profileRetainBody(language)",
+            "profileAutoRemovedPrefix(language)",
+            "profileRetainHeading(language)",
+            "profileOldCredentialsHeading(language)",
+            "profileOldCredentialsBody(language)",
+        ):
+            self.assertIn(helper, flow)
+
+        # Every profile/privacy helper is explicitly tied to the same 24-language
+        # native-dialog contract used elsewhere on Windows.
+        self.assertGreaterEqual(localized.count("localizedPrompt(language, [24]string{"), 11)
+        self.assertIn("yesLabel(language)", localized)
+        self.assertIn("noLabel(language)", localized)
+
+    def test_profile_credential_clear_semantics_remain_explicit(self) -> None:
+        flow = read("internal/desktop/connection_profiles_windows.go")
+        for marker in (
+            "profilebinding.AccountMatches(",
+            "profilebinding.PrivateKeyMatches(",
+            "clearPassword = existing.HasPassword && !sameAccount",
+            "clearPassphrase = existing.HasPassphrase && !samePrivateKey",
+            "ClearPassword:   clearPassword",
+            "ClearPassphrase: clearPassphrase",
+        ):
+            self.assertIn(marker, flow)
+
+    def test_phase_keeps_release_version_unchanged(self) -> None:
+        self.assertEqual(read("VERSION").strip(), "1.1.6")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_modal_contract.py
+++ b/scripts/test_windows_modal_contract.py
@@ -20,6 +20,7 @@ class WindowsModalContractTests(unittest.TestCase):
             "internal/platform/language_windows.go",
             "internal/platform/info_card_windows.go",
             "internal/platform/settings_dialog_windows.go",
+            "internal/platform/decision_card_windows.go",
         ):
             source = read(relative)
             self.assertNotIn("PostQuitMessage", source, relative)
@@ -40,6 +41,7 @@ class WindowsModalContractTests(unittest.TestCase):
             "internal/platform/language_windows.go",
             "internal/platform/info_card_windows.go",
             "internal/platform/settings_dialog_windows.go",
+            "internal/platform/decision_card_windows.go",
         ):
             source = read(relative)
             self.assertIn("premiumRunDialogLoop(hwnd", source, relative)

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -43,6 +43,7 @@ class WindowsModalSharedContractTests(unittest.TestCase):
             "internal/platform/language_windows.go",
             "internal/platform/settings_dialog_windows.go",
             "internal/platform/info_card_windows.go",
+            "internal/platform/decision_card_windows.go",
         ):
             source = read(relative)
             self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
@@ -60,6 +61,15 @@ class WindowsModalSharedContractTests(unittest.TestCase):
         self.assertIn("infoCardIDClose = 1 // IDOK", source)
         self.assertIn("id == infoCardIDClose || id == promptIDCancel", source)
         self.assertIn("wsTabStop|bsDefPushButton", source)
+        self.assertNotIn("PostQuitMessage", source)
+
+    def test_decision_cards_use_native_yes_no_and_ok_commands(self) -> None:
+        source = read("internal/platform/decision_card_windows.go")
+        self.assertIn("decisionIDYes", source)
+        self.assertIn("decisionIDNo", source)
+        self.assertIn("promptIDOK", source)
+        self.assertIn("promptIDCancel", source)
+        self.assertIn("resolvedDialogLabels()", source)
         self.assertNotIn("PostQuitMessage", source)
 
 


### PR DESCRIPTION
## Phase 4D

Unifies the remaining application-owned Windows decision surfaces with the Ghost FTP desktop theme and closes the profile/privacy localization gap without changing release or credential semantics.

### UI
- make ConfirmDialog, InfoDialog and ErrorDialog prefer a Ghost FTP-owned DecisionCard
- reuse the canonical Light/Dark uipalette, owner modality, DPI sizing and shared IsDialogMessageW loop
- preserve stock TaskDialog/MessageBox only as a creation-failure fallback
- preserve native IDYES/IDNO and IDOK/IDCANCEL semantics

### Localization
- resolve decision action labels from the active desktop locale when each dialog opens
- add Yes/No coverage for all 24 canonical languages
- localize the full Windows save-profile/privacy/security flow for all 24 languages
- keep retain/remove/automatic credential-clearing behavior unchanged

### Regression coverage
- include DecisionCard in the shared modal lifecycle/keyboard contracts
- lock primary/fallback routing and runtime label resolution
- execute profile/privacy helper coverage for all canonical Windows languages
- assert the credential-binding/clear markers remain explicit

### Guardrails
- VERSION remains 1.1.6
- no transport/protocol/release/installer changes
- no credential-store or ProfileInput semantic changes