### PR TITLE
Harden child-process diagnostic privacy boundary

### DIFF
--- a/internal/remote/tool_error_privacy_test.go
+++ b/internal/remote/tool_error_privacy_test.go
@@ -10,7 +10,7 @@ func TestToolErrorPublicStringRedactsRawDiagnostics(t *testing.T) {
 	raw := "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase for secret-host.example"
 	err := &toolError{tool: "sftp", code: 255, message: raw}
 
-	if got, want := err.Error(), "sftp operation failed (exit code 255)"; got != want {
+	if got, want := err.Error(), "sftp credential settings invalid (exit code 255)"; got != want {
 		t.Fatalf("Error()=%q want %q", got, want)
 	}
 
@@ -22,10 +22,31 @@ func TestToolErrorPublicStringRedactsRawDiagnostics(t *testing.T) {
 	}
 }
 
+func TestToolErrorAuthenticationKeepsSafeSignalWithoutRawReply(t *testing.T) {
+	raw := "530 Login incorrect for private-user@secret-host.example"
+	err := &toolError{tool: "curl", code: 67, message: raw}
+	got := err.Error()
+	if !strings.Contains(strings.ToLower(got), "login") {
+		t.Fatalf("public error lost safe authentication signal: %q", got)
+	}
+	for _, sensitive := range []string{"530", "private-user", "secret-host.example"} {
+		if strings.Contains(strings.ToLower(got), strings.ToLower(sensitive)) {
+			t.Fatalf("public error leaked raw authentication diagnostic %q: %q", sensitive, got)
+		}
+	}
+}
+
 func TestToolErrorUnknownToolNameIsNotReflected(t *testing.T) {
 	err := &toolError{tool: "secret-host.example/private-user", code: -1, message: "opaque"}
 	if got, want := err.Error(), "network tool operation failed"; got != want {
 		t.Fatalf("Error()=%q want %q", got, want)
+	}
+}
+
+func TestNilToolErrorIsStableAndRedacted(t *testing.T) {
+	var err *toolError
+	if got, want := err.Error(), "network tool operation failed"; got != want {
+		t.Fatalf("nil Error()=%q want %q", got, want)
 	}
 }
 

--- a/internal/remote/tool_error_privacy_test.go
+++ b/internal/remote/tool_error_privacy_test.go
@@ -1,0 +1,64 @@
+package remote
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestToolErrorPublicStringRedactsRawDiagnostics(t *testing.T) {
+	raw := "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase for secret-host.example"
+	err := &toolError{tool: "sftp", code: 255, message: raw}
+
+	if got, want := err.Error(), "sftp operation failed (exit code 255)"; got != want {
+		t.Fatalf("Error()=%q want %q", got, want)
+	}
+
+	wrapped := fmt.Errorf("transfer failed: %w", err).Error()
+	for _, sensitive := range []string{"private-user", "customer-prod", "secret-host.example", "passphrase"} {
+		if strings.Contains(strings.ToLower(wrapped), strings.ToLower(sensitive)) {
+			t.Fatalf("generic wrapped error leaked child-process diagnostic %q: %q", sensitive, wrapped)
+		}
+	}
+}
+
+func TestToolErrorUnknownToolNameIsNotReflected(t *testing.T) {
+	err := &toolError{tool: "secret-host.example/private-user", code: -1, message: "opaque"}
+	if got, want := err.Error(), "network tool operation failed"; got != want {
+		t.Fatalf("Error()=%q want %q", got, want)
+	}
+}
+
+func TestToolErrorPrivateDiagnosticsStillDriveClassification(t *testing.T) {
+	err := &toolError{
+		tool:    "sftp",
+		code:    255,
+		message: "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase supplied to decrypt private key",
+	}
+	if got := err.UserErrorKind(); got != "sftp_settings" {
+		t.Fatalf("UserErrorKind()=%q want sftp_settings", got)
+	}
+	if strings.Contains(err.Error(), "private-user") || strings.Contains(err.Error(), "customer-prod") {
+		t.Fatalf("public error leaked private diagnostic: %q", err.Error())
+	}
+}
+
+func TestToolErrorPrivateDiagnosticsPreserveRetryClassification(t *testing.T) {
+	retryable := &toolError{
+		tool:    "sftp",
+		code:    255,
+		message: "Connection reset by peer at secret-host.example",
+	}
+	if !IsRetryable(retryable) {
+		t.Fatal("transient SFTP diagnostic must remain retryable after public error redaction")
+	}
+
+	nonRetryable := &toolError{
+		tool:    "sftp",
+		code:    255,
+		message: "Permission denied (publickey,password) for private-user@secret-host.example",
+	}
+	if IsRetryable(nonRetryable) {
+		t.Fatal("authentication diagnostic must remain non-retryable after public error redaction")
+	}
+}

--- a/internal/remote/util.go
+++ b/internal/remote/util.go
@@ -51,7 +51,30 @@ type toolError struct {
 	message string
 }
 
-func (e *toolError) Error() string { return e.message }
+// Error deliberately exposes only bounded structural information. Child-process
+// stderr can contain hosts, usernames, remote paths and private-key paths; it is
+// retained privately in message for classification but must never become the
+// generic error string consumed by UI, logs or future fallback paths.
+func (e *toolError) Error() string {
+	label := toolErrorPublicLabel(e.tool)
+	if e.code >= 0 {
+		return fmt.Sprintf("%s operation failed (exit code %d)", label, e.code)
+	}
+	return label + " operation failed"
+}
+
+func toolErrorPublicLabel(tool string) string {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "curl":
+		return "curl"
+	case "ssh":
+		return "ssh"
+	case "sftp":
+		return "sftp"
+	default:
+		return "network tool"
+	}
+}
 
 func newToolError(tool string, runErr error, message string) error {
 	code := -1
@@ -87,7 +110,13 @@ func IsRetryable(err error) bool {
 		}
 		return false
 	}
-	msg := strings.ToLower(err.Error())
+	msg := err.Error()
+	if te != nil {
+		// Raw child-process diagnostics stay private to the remote package for
+		// classification/retry decisions even though toolError.Error is redacted.
+		msg = te.message
+	}
+	msg = strings.ToLower(msg)
 	for _, marker := range []string{
 		"permission denied", "access denied", "authentication failed", "login denied", "login incorrect",
 		"host key verification failed", "fingerprint", "no such file", "not found", "not a directory",

--- a/internal/remote/util.go
+++ b/internal/remote/util.go
@@ -51,16 +51,23 @@ type toolError struct {
 	message string
 }
 
-// Error deliberately exposes only bounded structural information. Child-process
-// stderr can contain hosts, usernames, remote paths and private-key paths; it is
-// retained privately in message for classification but must never become the
-// generic error string consumed by UI, logs or future fallback paths.
+// Error deliberately exposes only bounded structural information and a stable,
+// locally generated semantic category. Child-process stderr can contain hosts,
+// usernames, remote paths and private-key paths; it remains private in message
+// for classification and retry decisions and is never reflected verbatim.
 func (e *toolError) Error() string {
-	label := toolErrorPublicLabel(e.tool)
-	if e.code >= 0 {
-		return fmt.Sprintf("%s operation failed (exit code %d)", label, e.code)
+	if e == nil {
+		return "network tool operation failed"
 	}
-	return label + " operation failed"
+	label := toolErrorPublicLabel(e.tool)
+	base := label + " operation failed"
+	if detail := toolErrorPublicDetail(e.UserErrorKind()); detail != "" {
+		base = label + " " + detail
+	}
+	if e.code >= 0 {
+		return fmt.Sprintf("%s (exit code %d)", base, e.code)
+	}
+	return base
 }
 
 func toolErrorPublicLabel(tool string) string {
@@ -73,6 +80,39 @@ func toolErrorPublicLabel(tool string) string {
 		return "sftp"
 	default:
 		return "network tool"
+	}
+}
+
+func toolErrorPublicDetail(kind string) string {
+	switch kind {
+	case "auth":
+		return "login failed"
+	case "permission":
+		return "permission denied"
+	case "not_found":
+		return "remote object not found"
+	case "resolve":
+		return "host resolution failed"
+	case "refused":
+		return "connection refused"
+	case "timeout":
+		return "operation timed out"
+	case "connection_lost":
+		return "connection lost"
+	case "tls":
+		return "TLS verification failed"
+	case "ftp_limit":
+		return "connection limit reached"
+	case "ftp_data":
+		return "data connection failed"
+	case "disk":
+		return "remote storage unavailable"
+	case "hostkey_changed":
+		return "host key verification failed"
+	case "sftp_settings":
+		return "credential settings invalid"
+	default:
+		return ""
 	}
 }
 

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -117,10 +117,13 @@ def audit_credentials_and_network_tools() -> None:
         '"http_proxy"', '"https_proxy"', '"ftp_proxy"', '"all_proxy"', '"no_proxy"', '"sslkeylogfile"',
         '"ssh_askpass"', '"ssh_auth_sock"', "crypto/rand", "func randomTransferToken()",
         "func (e *toolError) Error() string", "func toolErrorPublicLabel(tool string) string",
+        "func toolErrorPublicDetail(kind string) string", "e.UserErrorKind()",
         'return "network tool"', "msg = te.message",
     ))
     if "return e.message" in util:
         fail("raw child-process diagnostics must not be exposed by toolError.Error")
+    if "base = label + e.message" in util or "fmt.Sprintf(\"%s %s\", label, e.message)" in util:
+        fail("raw child-process diagnostics must not be concatenated into public tool errors")
     require("internal/transfer/manager.go", (
         "recover() != nil",
         "ConnectionIdentity() (string, error)",
@@ -176,6 +179,7 @@ def main() -> None:
     print("TELEMETRY_VENDOR_MARKERS=BLOCKED")
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
     print("RAW_TOOL_DIAGNOSTICS_USER_SURFACE=BLOCKED")
+    print("SAFE_TOOL_ERROR_CLASSIFICATION=PRESERVED")
     print("DOWNLOAD_LOCAL_ROOT_PROPAGATION=ENFORCED")
     print("DOWNLOAD_ROOT_RELATIVE_COMMIT=ENFORCED")
 

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -113,7 +113,14 @@ def audit_credentials_and_network_tools() -> None:
             fail(f"SFTP must not write AskPass secrets to disk: {forbidden}")
 
     require("cmd/ghostftp/main.go", ("GhostFTP_ASKPASS_TOKEN", "GhostFTP_PASSWORD_BLOB", "GhostFTP_PASSPHRASE_BLOB", "TrustedAskPassParent", "selectAskpassSecret"))
-    require("internal/remote/util.go", ('"http_proxy"', '"https_proxy"', '"ftp_proxy"', '"all_proxy"', '"no_proxy"', '"sslkeylogfile"', '"ssh_askpass"', '"ssh_auth_sock"', "crypto/rand", "func randomTransferToken()"))
+    util = require("internal/remote/util.go", (
+        '"http_proxy"', '"https_proxy"', '"ftp_proxy"', '"all_proxy"', '"no_proxy"', '"sslkeylogfile"',
+        '"ssh_askpass"', '"ssh_auth_sock"', "crypto/rand", "func randomTransferToken()",
+        "func (e *toolError) Error() string", "func toolErrorPublicLabel(tool string) string",
+        'return "network tool"', "msg = te.message",
+    ))
+    if "return e.message" in util:
+        fail("raw child-process diagnostics must not be exposed by toolError.Error")
     require("internal/transfer/manager.go", (
         "recover() != nil",
         "ConnectionIdentity() (string, error)",
@@ -168,6 +175,7 @@ def main() -> None:
     print("FIXED_RUNTIME_HTTP_URLS=BLOCKED")
     print("TELEMETRY_VENDOR_MARKERS=BLOCKED")
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
+    print("RAW_TOOL_DIAGNOSTICS_USER_SURFACE=BLOCKED")
     print("DOWNLOAD_LOCAL_ROOT_PROPAGATION=ENFORCED")
     print("DOWNLOAD_ROOT_RELATIVE_COMMIT=ENFORCED")
 


### PR DESCRIPTION
## Authorization

- [x] Explicitly requested Ghost FTP code, stability, security and privacy hardening.
- [x] Existing published 1.1.7 release/tag/assets/checksums remain immutable.

## Summary

- Prevent raw `curl` / `ssh` / `sftp` child-process diagnostics from escaping through generic `toolError.Error()` strings.
- Keep raw child-process text private inside `internal/remote` only for classification and retry decisions.
- Preserve safe, locally generated semantic error signals such as login failure, timeout, DNS resolution, TLS verification, permissions, missing remote objects and host-key failure.
- Do not reflect unknown tool names into public error strings.
- Make the public tool error path nil-safe.
- Add regression coverage that injects synthetic hostnames, usernames, private-key paths and passphrase-related diagnostics and verifies they are not exposed.
- Harden `scripts/audit_privacy.py` so this privacy boundary fails closed if raw diagnostics are reintroduced later.

## Regression found and resolved

The first candidate correctly redacted raw diagnostics but also removed the safe authentication signal required by the real FTP wrong-password integration test. The fix does **not** restore raw server output. Instead, an internally classified authentication failure now renders the locally generated phrase `login failed`, while the raw `530` reply, username and hostname remain private.

## Security and privacy

- [x] No telemetry, analytics, advertising or tracking added.
- [x] No runtime network destination added.
- [x] No external Go dependency added.
- [x] Raw child-process stderr is not exposed through the generic public error string.
- [x] Internal retry/classification behavior still uses the private diagnostic when needed.
- [x] SFTP host-key verification/pinning is unchanged.
- [x] Existing path, symlink, junction and reparse-point protections are unchanged.

## Scope

Exactly three files are changed:

- `internal/remote/util.go`
- `internal/remote/tool_error_privacy_test.go`
- `scripts/audit_privacy.py`

No VERSION, tag, release workflow, published 1.1.7 asset, checksum or GHCR object is modified.

## Merge gate

Do not merge until all workflows triggered for exact final head `643254dd9ef774a1db75d64de05f4494820bb84b` are `completed/success`. Any code-head change invalidates previous green results. After merge, verify push workflows again on the exact resulting `main` SHA.