### PR TITLE
Preserve MLSD fallback classification after diagnostic redaction

### DIFF
--- a/internal/remote/ftp_command_privacy_regression_test.go
+++ b/internal/remote/ftp_command_privacy_regression_test.go
@@ -1,0 +1,29 @@
+package remote
+
+import "testing"
+
+func TestFTPCommandUnsupportedUsesPrivateToolDiagnostic(t *testing.T) {
+	err := &toolError{
+		tool:    "curl",
+		code:    22,
+		message: "500 Unknown command MLSD on secret-host.example for private-user",
+	}
+	if !ftpCommandUnsupported(err) {
+		t.Fatal("redacted curl error must still classify an unsupported MLSD command")
+	}
+	if got := err.Error(); got == err.message {
+		t.Fatal("unsupported-command classification must not expose the raw curl diagnostic")
+	}
+}
+
+func TestFTPCommandUnsupportedDoesNotMisclassifyPrivateAuthOrTransportDiagnostic(t *testing.T) {
+	for _, err := range []*toolError{
+		{tool: "curl", code: 67, message: "530 Login incorrect for private-user@secret-host.example"},
+		{tool: "curl", code: 28, message: "Connection timed out to secret-host.example"},
+		{tool: "curl", code: 7, message: "425 Can't open data connection"},
+	} {
+		if ftpCommandUnsupported(err) {
+			t.Fatalf("private diagnostic was misclassified as unsupported command: kind=%q", err.UserErrorKind())
+		}
+	}
+}

--- a/internal/remote/tool_diagnostics.go
+++ b/internal/remote/tool_diagnostics.go
@@ -16,6 +16,8 @@ func (e *toolError) UserErrorKind() string {
 		// Protocol replies are more specific than curl's process exit code and
 		// should win when both are available.
 		switch {
+		case containsDiagnosticMarker(s, "500 ", "500-", "502 ", "502-", "504 ", "504-", "unknown command", "command not understood", "not implemented", "unsupported command"):
+			return "ftp_unsupported"
 		case containsDiagnosticMarker(s, "421 too many connections", "421 service not available", "421 connection", "too many connections"):
 			return "ftp_limit"
 		case containsDiagnosticMarker(s, "425 can't open data connection", "425 cannot open data connection", "425 failed to establish connection", "426 connection closed", "426 transfer aborted"):

--- a/internal/remote/util.go
+++ b/internal/remote/util.go
@@ -101,6 +101,8 @@ func toolErrorPublicDetail(kind string) string {
 		return "connection lost"
 	case "tls":
 		return "TLS verification failed"
+	case "ftp_unsupported":
+		return "unsupported command"
 	case "ftp_limit":
 		return "connection limit reached"
 	case "ftp_data":


### PR DESCRIPTION
## Authorization

- [x] Explicitly requested continued Ghost FTP code, stability, performance and privacy hardening.
- [x] Existing published 1.1.7 release/tag/assets/checksums remain immutable.

## Problem

PR #189 correctly stopped raw curl/ssh/sftp stderr from escaping through generic public error strings. `ftpCommandUnsupported()` still relied on `err.Error()` to detect FTP `500/502/504` / unsupported-command responses. With redacted `toolError.Error()`, that private protocol signal could be lost, weakening MLSD fallback/cache behavior when MLSD is unsupported and the subsequent plain LIST attempt also fails.

## Fix

- Classify unsupported FTP command replies privately as stable semantic kind `ftp_unsupported`.
- Render only the locally generated public phrase `unsupported command`; raw server reply, hostname and username remain private.
- Preserve the existing `ftpCommandUnsupported()` contract without exposing private diagnostic text.
- Add regression tests proving a redacted `toolError` still drives unsupported-command fallback while auth, timeout and data-channel failures are not misclassified.

## Scope

Exactly three files:

- `internal/remote/ftp_command_privacy_regression_test.go`
- `internal/remote/tool_diagnostics.go`
- `internal/remote/util.go`

No VERSION, release workflow, tag, published asset, checksum, telemetry, network destination or external dependency change.

## Privacy

- [x] Raw child-process diagnostics remain private.
- [x] No hostname/user/server reply is reflected by the new public semantic.
- [x] No telemetry/analytics/tracking added.
- [x] Existing SFTP host-key and filesystem security behavior unchanged.

## Merge gate

Do not merge until every workflow triggered for exact final PR head `a1bd303f4760673df09711bd0794cec15a325152` is `completed/success`. Any code-head change invalidates prior green results. After merge, verify push workflows on the exact resulting `main` SHA.