### PR TITLE
Redact ssh-keyscan diagnostics from user-facing errors

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -26,6 +26,8 @@ Fresh quick-connect defaults use FTPS; plain FTP remains an explicit unencrypted
 
 Connection failures are converted into privacy-safe categories and remediation text. The diagnostic layer is tested so user-facing errors do not intentionally reproduce passwords, passphrases or protected profile payloads.
 
+SFTP host-key discovery follows the same boundary: raw `ssh-keyscan` stderr is used only for local error classification and is not reproduced verbatim in the user-facing failure string. Hostnames, local paths and other tool-emitted details therefore do not need to be echoed merely to explain a failed fingerprint scan.
+
 When reporting a problem, users should still remove real hostnames or paths if those details are confidential.
 
 ## Saved profiles

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -203,7 +203,7 @@ func ScanFingerprint(ctx context.Context, host string, port int, _ string) (stri
 		if overflowErr := er.Err("odgovor"); overflowErr != nil {
 			return "", "", "", overflowErr
 		}
-		return "", "", "", fmt.Errorf("nije moguće dohvatiti SFTP host ključ: %s", strings.TrimSpace(er.String()))
+		return "", "", "", sshKeyscanFailure(err, er.String())
 	}
 	if err := out.Err("odgovor"); err != nil {
 		return "", "", "", err

--- a/internal/remote/ssh_keyscan_error.go
+++ b/internal/remote/ssh_keyscan_error.go
@@ -1,0 +1,13 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+)
+
+func sshKeyscanFailure(runErr error, diagnostic string) error {
+	if runErr == nil {
+		return errors.New("nije moguće dohvatiti SFTP host ključ")
+	}
+	return fmt.Errorf("nije moguće dohvatiti SFTP host ključ: %w", newToolError("sftp", runErr, diagnostic))
+}

--- a/internal/remote/ssh_keyscan_error_test.go
+++ b/internal/remote/ssh_keyscan_error_test.go
@@ -1,0 +1,47 @@
+package remote
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSSHKeyscanFailureRedactsRawDiagnostic(t *testing.T) {
+	raw := "ssh-keyscan: Could not resolve hostname secret-host.example for private-user: Name or service not known"
+	err := sshKeyscanFailure(errors.New("exit status 255"), raw)
+	got := err.Error()
+
+	if !strings.Contains(strings.ToLower(got), "host resolution failed") {
+		t.Fatalf("safe semantic resolution signal was lost: %q", got)
+	}
+	for _, sensitive := range []string{"secret-host.example", "private-user", "name or service not known"} {
+		if strings.Contains(strings.ToLower(got), strings.ToLower(sensitive)) {
+			t.Fatalf("ssh-keyscan diagnostic leaked %q: %q", sensitive, got)
+		}
+	}
+
+	var te *toolError
+	if !errors.As(err, &te) {
+		t.Fatalf("wrapped error must retain private tool classification: %T", err)
+	}
+	if got := te.UserErrorKind(); got != "resolve" {
+		t.Fatalf("UserErrorKind()=%q want resolve", got)
+	}
+}
+
+func TestSSHKeyscanFailureDoesNotEchoUnknownDiagnostic(t *testing.T) {
+	raw := "opaque failure at C:/Users/private-user/.ssh/config for secret-host.example"
+	err := sshKeyscanFailure(errors.New("exit status 1"), raw)
+	got := err.Error()
+	for _, sensitive := range []string{"private-user", ".ssh/config", "secret-host.example", "opaque failure"} {
+		if strings.Contains(strings.ToLower(got), strings.ToLower(sensitive)) {
+			t.Fatalf("unknown ssh-keyscan diagnostic leaked %q: %q", sensitive, got)
+		}
+	}
+}
+
+func TestSSHKeyscanFailureNilCauseIsStable(t *testing.T) {
+	if got, want := sshKeyscanFailure(nil, "secret-host.example").Error(), "nije moguće dohvatiti SFTP host ključ"; got != want {
+		t.Fatalf("Error()=%q want %q", got, want)
+	}
+}

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -105,12 +105,21 @@ def audit_credentials_and_network_tools() -> None:
         '"  GlobalKnownHostsFile none"', '"  VerifyHostKeyDNS no"', '"  UpdateHostKeys no"',
         '"  IdentityAgent none"', '"  ClearAllForwardings yes"', '"  ForwardAgent no"',
         "GhostFTP_ASKPASS_TOKEN=", "GhostFTP_PASSWORD_BLOB=", "GhostFTP_PASSPHRASE_BLOB=",
-        "sanitizedToolEnv(os.Environ())",
+        "sanitizedToolEnv(os.Environ())", "sshKeyscanFailure(err, er.String())",
         "prepareLocalDownloadTarget(local, options.LocalRoot, options.SkipExisting)",
     ))
     for forbidden in ("GhostFTP_ASKPASS_FILE", "askpassFile", "os.WriteFile(askpass"):
         if forbidden in sftp:
             fail(f"SFTP must not write AskPass secrets to disk: {forbidden}")
+    if 'fmt.Errorf("nije moguće dohvatiti SFTP host ključ: %s"' in sftp:
+        fail("ssh-keyscan stderr must not be copied into a user-facing error")
+
+    keyscan_error = require("internal/remote/ssh_keyscan_error.go", (
+        "func sshKeyscanFailure(runErr error, diagnostic string) error",
+        'newToolError("sftp", runErr, diagnostic)',
+    ))
+    if 'fmt.Errorf("nije moguće dohvatiti SFTP host ključ: %s"' in keyscan_error:
+        fail("ssh-keyscan helper must preserve the redacted tool-error boundary")
 
     require("cmd/ghostftp/main.go", ("GhostFTP_ASKPASS_TOKEN", "GhostFTP_PASSWORD_BLOB", "GhostFTP_PASSPHRASE_BLOB", "TrustedAskPassParent", "selectAskpassSecret"))
     util = require("internal/remote/util.go", (
@@ -180,6 +189,7 @@ def main() -> None:
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
     print("RAW_TOOL_DIAGNOSTICS_USER_SURFACE=BLOCKED")
     print("SAFE_TOOL_ERROR_CLASSIFICATION=PRESERVED")
+    print("SSH_KEYSCAN_DIAGNOSTICS_USER_SURFACE=REDACTED")
     print("DOWNLOAD_LOCAL_ROOT_PROPAGATION=ENFORCED")
     print("DOWNLOAD_ROOT_RELATIVE_COMMIT=ENFORCED")
 


### PR DESCRIPTION
## Authorization

- [x] Explicitly requested continued Ghost FTP security, privacy, stability and quality hardening.
- [x] Existing published 1.1.7 release/tag/assets/checksums remain immutable.

## Problem

`ScanFingerprint()` was the remaining direct child-process diagnostic leak: when `ssh-keyscan` failed, its raw stderr was embedded directly into the returned error. That diagnostic may contain the user-selected hostname, local SSH paths or other tool-emitted details and could therefore reach the UI outside the redacted `toolError` boundary introduced in earlier hardening.

## Fix

- Route failed `ssh-keyscan` diagnostics through a dedicated `sshKeyscanFailure()` helper.
- Preserve safe semantic classification through `toolError` while never reproducing raw stderr verbatim.
- Keep context cancellation/timeout handling and bounded stderr behavior unchanged.
- Add regression coverage for host-resolution classification, unknown diagnostic redaction and nil-cause stability.
- Extend the fail-closed privacy audit so direct raw `ssh-keyscan` stderr formatting cannot be reintroduced silently.
- Document the SFTP host-key discovery privacy boundary.

## Scope

Exactly five files:

- `internal/remote/sftp.go`
- `internal/remote/ssh_keyscan_error.go`
- `internal/remote/ssh_keyscan_error_test.go`
- `scripts/audit_privacy.py`
- `docs/PRIVACY.md`

No VERSION, release workflow, tag, published asset, checksum, telemetry, network destination or external dependency change.

## Security and privacy

- [x] Raw `ssh-keyscan` stderr is no longer copied into user-facing errors.
- [x] Safe resolution/error semantics remain available for remediation.
- [x] SFTP host-key verification/pinning behavior remains unchanged.
- [x] No telemetry/analytics/tracking added.
- [x] No credential persistence or command-line secret behavior changed.

## Exact-head validation

Final PR head: `b2d30369d0976f8a01b3e5ae9b8cec546f72dc00`

- [x] Ghost FTP CI — success
- [x] Windows x64/x86 production build — success
- [x] Linux amd64/arm64/i386 production build — success
- [x] Core quality/security/docs + Python regression suite — success
- [x] Linux distro packages — success
- [x] Debian 13 amd64 lifecycle — success
- [x] Ubuntu 26.04 LTS amd64 lifecycle — success
- [x] Fedora 44 x86_64 lifecycle — success

Do not merge if the head changes. After merge, verify all push workflows on the exact resulting `main` SHA.