### PR TITLE
Stop retaining raw child-process diagnostics in tool errors

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -26,7 +26,9 @@ Fresh quick-connect defaults use FTPS; plain FTP remains an explicit unencrypted
 
 Connection failures are converted into privacy-safe categories and remediation text. The diagnostic layer is tested so user-facing errors do not intentionally reproduce passwords, passphrases or protected profile payloads.
 
-SFTP host-key discovery follows the same boundary: raw `ssh-keyscan` stderr is used only for local error classification and is not reproduced verbatim in the user-facing failure string. Hostnames, local paths and other tool-emitted details therefore do not need to be echoed merely to explain a failed fingerprint scan.
+Raw `curl`, `sftp` and related child-process diagnostics are reduced to a stable semantic category and a conservative retry decision while the bounded process output is still in scope. The retained `toolError` contains only the normalized tool identifier, exit code, semantic category and retry flag; it does not retain the raw diagnostic string for later parsing. This shortens the in-memory lifetime of hostnames, usernames, remote paths or private-key paths that a system networking tool may have emitted.
+
+SFTP host-key discovery follows the same boundary: raw `ssh-keyscan` stderr is used only for transient local error classification and is not reproduced verbatim in the user-facing failure string or retained inside the resulting tool error. Hostnames, local paths and other tool-emitted details therefore do not need to be echoed merely to explain a failed fingerprint scan.
 
 When reporting a problem, users should still remove real hostnames or paths if those details are confidential.
 

--- a/internal/remote/ftp_command_privacy_regression_test.go
+++ b/internal/remote/ftp_command_privacy_regression_test.go
@@ -1,27 +1,36 @@
 package remote
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
 
-func TestFTPCommandUnsupportedUsesPrivateToolDiagnostic(t *testing.T) {
-	err := &toolError{
-		tool:    "curl",
-		code:    22,
-		message: "500 Unknown command MLSD on secret-host.example for private-user",
-	}
+func TestFTPCommandUnsupportedUsesTransientPrivateDiagnostic(t *testing.T) {
+	raw := "500 Unknown command MLSD on secret-host.example for private-user"
+	err := requireToolError(t, newToolError("curl", errors.New("tool process failed"), raw))
 	if !ftpCommandUnsupported(err) {
 		t.Fatal("redacted curl error must still classify an unsupported MLSD command")
 	}
-	if got := err.Error(); got == err.message {
-		t.Fatal("unsupported-command classification must not expose the raw curl diagnostic")
+	if err.UserErrorKind() != "ftp_unsupported" {
+		t.Fatalf("UserErrorKind()=%q want ftp_unsupported", err.UserErrorKind())
+	}
+	stored := fmt.Sprintf("%+v", *err)
+	for _, sensitive := range []string{"500", "secret-host.example", "private-user"} {
+		if strings.Contains(strings.ToLower(stored), strings.ToLower(sensitive)) {
+			t.Fatalf("toolError retained unsupported-command diagnostic %q: %q", sensitive, stored)
+		}
 	}
 }
 
 func TestFTPCommandUnsupportedDoesNotMisclassifyPrivateAuthOrTransportDiagnostic(t *testing.T) {
-	for _, err := range []*toolError{
-		{tool: "curl", code: 67, message: "530 Login incorrect for private-user@secret-host.example"},
-		{tool: "curl", code: 28, message: "Connection timed out to secret-host.example"},
-		{tool: "curl", code: 7, message: "425 Can't open data connection"},
+	for _, raw := range []string{
+		"530 Login incorrect for private-user@secret-host.example",
+		"Connection timed out to secret-host.example",
+		"425 Can't open data connection",
 	} {
+		err := requireToolError(t, newToolError("curl", errors.New("tool process failed"), raw))
 		if ftpCommandUnsupported(err) {
 			t.Fatalf("private diagnostic was misclassified as unsupported command: kind=%q", err.UserErrorKind())
 		}

--- a/internal/remote/remote_cleanup_hardening_test.go
+++ b/internal/remote/remote_cleanup_hardening_test.go
@@ -41,7 +41,7 @@ func TestCleanupFailureRejectsSpoofedMissingText(t *testing.T) {
 
 func TestCleanupFailureAcceptsStructuredCurlMissingResult(t *testing.T) {
 	original := errors.New("upload failed")
-	missing := &toolError{tool: "curl", code: 78, message: "server text is irrelevant"}
+	missing := &toolError{tool: "curl", code: 78, kind: "not_found"}
 	err := cleanupFailure(original, "/www", ".GhostFTP-part-test", func(context.Context, string, string, bool) error {
 		return missing
 	})
@@ -52,12 +52,12 @@ func TestCleanupFailureAcceptsStructuredCurlMissingResult(t *testing.T) {
 
 func TestCleanupFailureRejectsSFTPMissingText(t *testing.T) {
 	original := errors.New("upload failed")
-	missingText := &toolError{tool: "sftp", code: 1, message: "No such file"}
+	missingText := &toolError{tool: "sftp", code: 1, kind: "not_found"}
 	err := cleanupFailure(original, "/www", ".GhostFTP-part-test", func(context.Context, string, string, bool) error {
 		return missingText
 	})
 	if !isRemoteResidualArtifactError(err) {
-		t.Fatalf("SFTP diagnostic text is not structured proof of absence: %v", err)
+		t.Fatalf("SFTP missing classification is not structured proof of absence: %v", err)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestCommittedCleanupFailureMarksCommittedState(t *testing.T) {
 }
 
 func TestResidualCleanupErrorBlocksAutomaticRetry(t *testing.T) {
-	transport := &toolError{tool: "curl", code: 56, message: "recv failure"}
+	transport := &toolError{tool: "curl", code: 56, kind: "connection_lost", retryable: true}
 	if !IsRetryable(transport) {
 		t.Fatal("transport interruption should be retryable before cleanup uncertainty")
 	}

--- a/internal/remote/tool_diagnostics.go
+++ b/internal/remote/tool_diagnostics.go
@@ -2,16 +2,37 @@ package remote
 
 import "strings"
 
-// UserErrorKind exposes only a stable, non-secret semantic category to the UI
-// error mapper. Raw child-process output remains inside the remote package and
-// must never be rendered directly to users.
+// UserErrorKind exposes only the stable, non-secret semantic category captured
+// when the child-process failure was created. Raw diagnostic text is classified
+// transiently and is not retained in toolError.
 func (e *toolError) UserErrorKind() string {
 	if e == nil {
 		return ""
 	}
-	s := strings.ToLower(strings.Join(strings.Fields(e.message), " "))
+	return e.kind
+}
 
-	switch strings.ToLower(strings.TrimSpace(e.tool)) {
+func normalizeToolName(tool string) string {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "curl":
+		return "curl"
+	case "ssh":
+		return "ssh"
+	case "sftp":
+		return "sftp"
+	default:
+		return ""
+	}
+}
+
+func normalizeDiagnostic(diagnostic string) string {
+	return strings.ToLower(strings.Join(strings.Fields(diagnostic), " "))
+}
+
+func classifyToolDiagnostic(tool string, code int, diagnostic string) string {
+	s := normalizeDiagnostic(diagnostic)
+
+	switch normalizeToolName(tool) {
 	case "curl":
 		// Protocol replies are more specific than curl's process exit code and
 		// should win when both are available.
@@ -36,7 +57,7 @@ func (e *toolError) UserErrorKind() string {
 			return "tls"
 		}
 
-		switch e.code {
+		switch code {
 		case 6:
 			return "resolve"
 		case 9:
@@ -80,8 +101,6 @@ func (e *toolError) UserErrorKind() string {
 			"unprotected private key file",
 			"bad permissions: ignore key",
 		) || (strings.Contains(s, "load key") && strings.Contains(s, "invalid format")):
-			// Existing localized SFTP copy is intentionally used here rather than
-			// exposing the OpenSSH key path, parser details or passphrase prompt.
 			return "sftp_settings"
 		case containsDiagnosticMarker(s,
 			"authentication failed",
@@ -99,6 +118,44 @@ func (e *toolError) UserErrorKind() string {
 	}
 
 	return ""
+}
+
+// classifyToolRetryable captures the exact retry decision while the bounded
+// child-process diagnostic is still in scope. The raw text does not need to
+// survive inside the returned error object.
+func classifyToolRetryable(tool string, code int, diagnostic string) bool {
+	if normalizeToolName(tool) == "curl" {
+		// Preserve the established curl contract: exit code is authoritative for
+		// automatic retry, independent of the diagnostic wording.
+		switch code {
+		case 6, 7, 18, 28, 52, 55, 56:
+			return true
+		default:
+			return false
+		}
+	}
+
+	msg := strings.ToLower(diagnostic)
+	for _, marker := range []string{
+		"permission denied", "access denied", "authentication failed", "login denied", "login incorrect",
+		"host key verification failed", "fingerprint", "no such file", "not found", "not a directory",
+		"is a directory", "file exists", "already exists", "invalid argument", "unsupported", "not implemented",
+	} {
+		if strings.Contains(msg, marker) {
+			return false
+		}
+	}
+	for _, marker := range []string{
+		"connection reset", "connection timed out", "operation timed out", "connection timeout",
+		"failed to connect", "couldn't connect", "could not connect", "connection refused", "connection closed",
+		"broken pipe", "network is unreachable", "no route to host", "temporary failure in name resolution",
+		"could not resolve", "recv failure", "send failure", "partial file", "server returned nothing",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsDiagnosticMarker(s string, markers ...string) bool {

--- a/internal/remote/tool_diagnostics_test.go
+++ b/internal/remote/tool_diagnostics_test.go
@@ -4,28 +4,27 @@ import "testing"
 
 func TestCurlToolErrorUserErrorKind(t *testing.T) {
 	tests := []struct {
-		name    string
-		code    int
-		message string
-		want    string
+		name       string
+		code       int
+		diagnostic string
+		want       string
 	}{
-		{name: "resolve code", code: 6, message: "opaque curl failure", want: "resolve"},
-		{name: "timeout code", code: 28, message: "opaque curl failure", want: "timeout"},
-		{name: "tls verification code", code: 60, message: "opaque curl failure", want: "tls"},
-		{name: "login code", code: 67, message: "opaque curl failure", want: "auth"},
-		{name: "remote missing code", code: 78, message: "opaque curl failure", want: "not_found"},
-		{name: "partial transfer code", code: 18, message: "opaque curl failure", want: "connection_lost"},
-		{name: "ftp limit reply wins", code: 7, message: "421 Too many connections from this IP", want: "ftp_limit"},
-		{name: "ftp data reply wins", code: 7, message: "425 Can't open data connection", want: "ftp_data"},
-		{name: "ftp login reply wins", code: 7, message: "530 Login incorrect", want: "auth"},
-		{name: "refused message", code: 7, message: "Failed to connect: Connection refused", want: "refused"},
-		{name: "unknown code stays unclassified", code: 99, message: "opaque curl failure", want: ""},
+		{name: "resolve code", code: 6, diagnostic: "opaque curl failure", want: "resolve"},
+		{name: "timeout code", code: 28, diagnostic: "opaque curl failure", want: "timeout"},
+		{name: "tls verification code", code: 60, diagnostic: "opaque curl failure", want: "tls"},
+		{name: "login code", code: 67, diagnostic: "opaque curl failure", want: "auth"},
+		{name: "remote missing code", code: 78, diagnostic: "opaque curl failure", want: "not_found"},
+		{name: "partial transfer code", code: 18, diagnostic: "opaque curl failure", want: "connection_lost"},
+		{name: "ftp limit reply wins", code: 7, diagnostic: "421 Too many connections from this IP", want: "ftp_limit"},
+		{name: "ftp data reply wins", code: 7, diagnostic: "425 Can't open data connection", want: "ftp_data"},
+		{name: "ftp login reply wins", code: 7, diagnostic: "530 Login incorrect", want: "auth"},
+		{name: "refused message", code: 7, diagnostic: "Failed to connect: Connection refused", want: "refused"},
+		{name: "unknown code stays unclassified", code: 99, diagnostic: "opaque curl failure", want: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := &toolError{tool: "curl", code: tc.code, message: tc.message}
-			if got := err.UserErrorKind(); got != tc.want {
-				t.Fatalf("UserErrorKind()=%q want %q", got, tc.want)
+			if got := classifyToolDiagnostic("curl", tc.code, tc.diagnostic); got != tc.want {
+				t.Fatalf("classifyToolDiagnostic()=%q want %q", got, tc.want)
 			}
 		})
 	}
@@ -33,39 +32,64 @@ func TestCurlToolErrorUserErrorKind(t *testing.T) {
 
 func TestSFTPToolErrorUserErrorKind(t *testing.T) {
 	tests := []struct {
-		name    string
-		message string
-		want    string
+		name       string
+		diagnostic string
+		want       string
 	}{
-		{name: "host key changed", message: "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!", want: "hostkey_changed"},
-		{name: "host key verification", message: "Host key verification failed.", want: "hostkey_changed"},
-		{name: "resolve", message: "ssh: Could not resolve hostname server.invalid: Name or service not known", want: "resolve"},
-		{name: "refused", message: "ssh: connect to host example port 22: Connection refused", want: "refused"},
-		{name: "timeout", message: "ssh: connect to host example port 22: Connection timed out", want: "timeout"},
-		{name: "connection lost", message: "Connection reset by peer", want: "connection_lost"},
-		{name: "missing remote file", message: "stat remote: No such file or directory", want: "not_found"},
-		{name: "public key auth", message: "Permission denied (publickey,password).", want: "auth"},
-		{name: "keyboard interactive auth", message: "Permission denied (keyboard-interactive).", want: "auth"},
-		{name: "bad passphrase", message: "Load key C:/secret/key: incorrect passphrase supplied to decrypt private key", want: "sftp_settings"},
-		{name: "invalid key format", message: "Load key C:/secret/key: invalid format", want: "sftp_settings"},
-		{name: "libcrypto key failure", message: "Load key /home/user/key: error in libcrypto", want: "sftp_settings"},
-		{name: "private key permissions", message: "WARNING: UNPROTECTED PRIVATE KEY FILE! Bad permissions: ignore key", want: "sftp_settings"},
-		{name: "generic permission", message: "remote open: Permission denied", want: "permission"},
-		{name: "unknown output stays unclassified", message: "opaque sftp failure", want: ""},
+		{name: "host key changed", diagnostic: "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!", want: "hostkey_changed"},
+		{name: "host key verification", diagnostic: "Host key verification failed.", want: "hostkey_changed"},
+		{name: "resolve", diagnostic: "ssh: Could not resolve hostname server.invalid: Name or service not known", want: "resolve"},
+		{name: "refused", diagnostic: "ssh: connect to host example port 22: Connection refused", want: "refused"},
+		{name: "timeout", diagnostic: "ssh: connect to host example port 22: Connection timed out", want: "timeout"},
+		{name: "connection lost", diagnostic: "Connection reset by peer", want: "connection_lost"},
+		{name: "missing remote file", diagnostic: "stat remote: No such file or directory", want: "not_found"},
+		{name: "public key auth", diagnostic: "Permission denied (publickey,password).", want: "auth"},
+		{name: "keyboard interactive auth", diagnostic: "Permission denied (keyboard-interactive).", want: "auth"},
+		{name: "bad passphrase", diagnostic: "Load key C:/secret/key: incorrect passphrase supplied to decrypt private key", want: "sftp_settings"},
+		{name: "invalid key format", diagnostic: "Load key C:/secret/key: invalid format", want: "sftp_settings"},
+		{name: "libcrypto key failure", diagnostic: "Load key /home/user/key: error in libcrypto", want: "sftp_settings"},
+		{name: "private key permissions", diagnostic: "WARNING: UNPROTECTED PRIVATE KEY FILE! Bad permissions: ignore key", want: "sftp_settings"},
+		{name: "generic permission", diagnostic: "remote open: Permission denied", want: "permission"},
+		{name: "unknown output stays unclassified", diagnostic: "opaque sftp failure", want: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := &toolError{tool: "sftp", code: 255, message: tc.message}
-			if got := err.UserErrorKind(); got != tc.want {
-				t.Fatalf("UserErrorKind()=%q want %q", got, tc.want)
+			if got := classifyToolDiagnostic("sftp", 255, tc.diagnostic); got != tc.want {
+				t.Fatalf("classifyToolDiagnostic()=%q want %q", got, tc.want)
 			}
 		})
 	}
 }
 
 func TestToolErrorUnknownToolHasNoUserClassification(t *testing.T) {
-	err := &toolError{tool: "other", code: 6, message: "Could not resolve host"}
-	if got := err.UserErrorKind(); got != "" {
-		t.Fatalf("UserErrorKind()=%q", got)
+	if got := classifyToolDiagnostic("other", 6, "Could not resolve host"); got != "" {
+		t.Fatalf("classifyToolDiagnostic()=%q", got)
+	}
+}
+
+func TestToolDiagnosticRetryClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		tool       string
+		code       int
+		diagnostic string
+		want       bool
+	}{
+		{name: "curl connect code", tool: "curl", code: 7, diagnostic: "opaque", want: true},
+		{name: "curl timeout code", tool: "curl", code: 28, diagnostic: "opaque", want: true},
+		{name: "curl auth code", tool: "curl", code: 67, diagnostic: "connection reset", want: false},
+		{name: "sftp reset", tool: "sftp", code: 255, diagnostic: "Connection reset by peer", want: true},
+		{name: "sftp resolve", tool: "sftp", code: 255, diagnostic: "Could not resolve hostname secret-host.example", want: true},
+		{name: "sftp auth", tool: "sftp", code: 255, diagnostic: "Permission denied (publickey,password)", want: false},
+		{name: "sftp missing", tool: "sftp", code: 255, diagnostic: "No such file", want: false},
+		{name: "unknown transient", tool: "other", code: 1, diagnostic: "server returned nothing", want: true},
+		{name: "unknown opaque", tool: "other", code: 1, diagnostic: "opaque failure", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyToolRetryable(tc.tool, tc.code, tc.diagnostic); got != tc.want {
+				t.Fatalf("classifyToolRetryable()=%v want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/remote/tool_error_privacy_test.go
+++ b/internal/remote/tool_error_privacy_test.go
@@ -1,45 +1,68 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 )
 
-func TestToolErrorPublicStringRedactsRawDiagnostics(t *testing.T) {
-	raw := "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase for secret-host.example"
-	err := &toolError{tool: "sftp", code: 255, message: raw}
+func requireToolError(t *testing.T, err error) *toolError {
+	t.Helper()
+	var te *toolError
+	if !errors.As(err, &te) || te == nil {
+		t.Fatalf("expected toolError, got %T: %v", err, err)
+	}
+	return te
+}
 
-	if got, want := err.Error(), "sftp credential settings invalid (exit code 255)"; got != want {
+func TestToolErrorPublicStringRedactsAndDoesNotRetainRawDiagnostics(t *testing.T) {
+	raw := "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase for secret-host.example"
+	err := newToolError("sftp", errors.New("tool process failed"), raw)
+	te := requireToolError(t, err)
+
+	if got, want := te.Error(), "sftp credential settings invalid"; got != want {
 		t.Fatalf("Error()=%q want %q", got, want)
 	}
 
-	wrapped := fmt.Errorf("transfer failed: %w", err).Error()
+	wrapped := fmt.Errorf("transfer failed: %w", te).Error()
+	stored := fmt.Sprintf("%+v", *te)
 	for _, sensitive := range []string{"private-user", "customer-prod", "secret-host.example", "passphrase"} {
-		if strings.Contains(strings.ToLower(wrapped), strings.ToLower(sensitive)) {
-			t.Fatalf("generic wrapped error leaked child-process diagnostic %q: %q", sensitive, wrapped)
+		for label, value := range map[string]string{"public error": wrapped, "retained toolError": stored} {
+			if strings.Contains(strings.ToLower(value), strings.ToLower(sensitive)) {
+				t.Fatalf("%s leaked child-process diagnostic %q: %q", label, sensitive, value)
+			}
 		}
 	}
 }
 
 func TestToolErrorAuthenticationKeepsSafeSignalWithoutRawReply(t *testing.T) {
 	raw := "530 Login incorrect for private-user@secret-host.example"
-	err := &toolError{tool: "curl", code: 67, message: raw}
+	err := requireToolError(t, newToolError("curl", errors.New("tool process failed"), raw))
 	got := err.Error()
 	if !strings.Contains(strings.ToLower(got), "login") {
 		t.Fatalf("public error lost safe authentication signal: %q", got)
+	}
+	if err.UserErrorKind() != "auth" {
+		t.Fatalf("UserErrorKind()=%q want auth", err.UserErrorKind())
 	}
 	for _, sensitive := range []string{"530", "private-user", "secret-host.example"} {
 		if strings.Contains(strings.ToLower(got), strings.ToLower(sensitive)) {
 			t.Fatalf("public error leaked raw authentication diagnostic %q: %q", sensitive, got)
 		}
+		if strings.Contains(strings.ToLower(fmt.Sprintf("%+v", *err)), strings.ToLower(sensitive)) {
+			t.Fatalf("toolError retained raw authentication diagnostic %q", sensitive)
+		}
 	}
 }
 
-func TestToolErrorUnknownToolNameIsNotReflected(t *testing.T) {
-	err := &toolError{tool: "secret-host.example/private-user", code: -1, message: "opaque"}
+func TestToolErrorUnknownToolNameIsNotRetainedOrReflected(t *testing.T) {
+	err := requireToolError(t, newToolError("secret-host.example/private-user", errors.New("tool process failed"), "opaque"))
 	if got, want := err.Error(), "network tool operation failed"; got != want {
 		t.Fatalf("Error()=%q want %q", got, want)
+	}
+	if err.tool != "" {
+		t.Fatalf("unknown tool identifier must be discarded, got %q", err.tool)
 	}
 }
 
@@ -51,35 +74,27 @@ func TestNilToolErrorIsStableAndRedacted(t *testing.T) {
 }
 
 func TestToolErrorPrivateDiagnosticsStillDriveClassification(t *testing.T) {
-	err := &toolError{
-		tool:    "sftp",
-		code:    255,
-		message: "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase supplied to decrypt private key",
-	}
+	raw := "Load key C:/Users/private-user/.ssh/customer-prod: incorrect passphrase supplied to decrypt private key"
+	err := requireToolError(t, newToolError("sftp", errors.New("tool process failed"), raw))
 	if got := err.UserErrorKind(); got != "sftp_settings" {
 		t.Fatalf("UserErrorKind()=%q want sftp_settings", got)
 	}
-	if strings.Contains(err.Error(), "private-user") || strings.Contains(err.Error(), "customer-prod") {
-		t.Fatalf("public error leaked private diagnostic: %q", err.Error())
+	stored := fmt.Sprintf("%+v", *err)
+	for _, sensitive := range []string{"private-user", "customer-prod", "passphrase"} {
+		if strings.Contains(strings.ToLower(stored), strings.ToLower(sensitive)) {
+			t.Fatalf("toolError retained private diagnostic %q: %q", sensitive, stored)
+		}
 	}
 }
 
 func TestToolErrorPrivateDiagnosticsPreserveRetryClassification(t *testing.T) {
-	retryable := &toolError{
-		tool:    "sftp",
-		code:    255,
-		message: "Connection reset by peer at secret-host.example",
-	}
+	retryable := newToolError("sftp", errors.New("tool process failed"), "Connection reset by peer at secret-host.example")
 	if !IsRetryable(retryable) {
-		t.Fatal("transient SFTP diagnostic must remain retryable after public error redaction")
+		t.Fatal("transient SFTP diagnostic must remain retryable after diagnostic retention hardening")
 	}
 
-	nonRetryable := &toolError{
-		tool:    "sftp",
-		code:    255,
-		message: "Permission denied (publickey,password) for private-user@secret-host.example",
-	}
+	nonRetryable := newToolError("sftp", errors.New("tool process failed"), "Permission denied (publickey,password) for private-user@secret-host.example")
 	if IsRetryable(nonRetryable) {
-		t.Fatal("authentication diagnostic must remain non-retryable after public error redaction")
+		t.Fatal("authentication diagnostic must remain non-retryable after diagnostic retention hardening")
 	}
 }

--- a/internal/remote/util.go
+++ b/internal/remote/util.go
@@ -46,15 +46,16 @@ func (g *deleteGuard) step(depth int) error {
 }
 
 type toolError struct {
-	tool    string
-	code    int
-	message string
+	tool      string
+	code      int
+	kind      string
+	retryable bool
 }
 
-// Error deliberately exposes only bounded structural information and a stable,
-// locally generated semantic category. Child-process stderr can contain hosts,
-// usernames, remote paths and private-key paths; it remains private in message
-// for classification and retry decisions and is never reflected verbatim.
+// Error exposes only bounded structural information and a stable, locally
+// generated semantic category. Child-process stderr can contain hosts,
+// usernames, remote paths and private-key paths; newToolError classifies that
+// text transiently and never retains it in this error object.
 func (e *toolError) Error() string {
 	if e == nil {
 		return "network tool operation failed"
@@ -71,7 +72,7 @@ func (e *toolError) Error() string {
 }
 
 func toolErrorPublicLabel(tool string) string {
-	switch strings.ToLower(strings.TrimSpace(tool)) {
+	switch normalizeToolName(tool) {
 	case "curl":
 		return "curl"
 	case "ssh":
@@ -121,13 +122,20 @@ func toolErrorPublicDetail(kind string) string {
 func newToolError(tool string, runErr error, message string) error {
 	code := -1
 	var exitErr *exec.ExitError
-	if errors.As(runErr, &exitErr) {
+	if runErr != nil && errors.As(runErr, &exitErr) {
 		code = exitErr.ExitCode()
 	}
-	if strings.TrimSpace(message) == "" {
-		message = runErr.Error()
+	diagnostic := strings.TrimSpace(message)
+	if diagnostic == "" && runErr != nil {
+		diagnostic = runErr.Error()
 	}
-	return &toolError{tool: tool, code: code, message: message}
+	tool = normalizeToolName(tool)
+	return &toolError{
+		tool:      tool,
+		code:      code,
+		kind:      classifyToolDiagnostic(tool, code, diagnostic),
+		retryable: classifyToolRetryable(tool, code, diagnostic),
+	}
 }
 
 // IsRetryable is deliberately conservative. Automatic retry is useful only for
@@ -145,20 +153,10 @@ func IsRetryable(err error) bool {
 		return false
 	}
 	var te *toolError
-	if errors.As(err, &te) && te.tool == "curl" {
-		switch te.code {
-		case 6, 7, 18, 28, 52, 55, 56:
-			return true
-		}
-		return false
+	if errors.As(err, &te) && te != nil {
+		return te.retryable
 	}
-	msg := err.Error()
-	if te != nil {
-		// Raw child-process diagnostics stay private to the remote package for
-		// classification/retry decisions even though toolError.Error is redacted.
-		msg = te.message
-	}
-	msg = strings.ToLower(msg)
+	msg := strings.ToLower(err.Error())
 	for _, marker := range []string{
 		"permission denied", "access denied", "authentication failed", "login denied", "login incorrect",
 		"host key verification failed", "fingerprint", "no such file", "not found", "not a directory",

--- a/internal/remote/util_test.go
+++ b/internal/remote/util_test.go
@@ -392,8 +392,8 @@ func TestFTPCommandUnsupportedClassification(t *testing.T) {
 
 func TestIsRetryableConservativeClassification(t *testing.T) {
 	for _, err := range []error{
-		&toolError{tool: "curl", code: 7, message: "Failed to connect"},
-		&toolError{tool: "curl", code: 28, message: "Operation timed out"},
+		&toolError{tool: "curl", code: 7, retryable: true},
+		&toolError{tool: "curl", code: 28, retryable: true},
 		errors.New("connection reset by peer"),
 	} {
 		if !IsRetryable(err) {
@@ -401,7 +401,7 @@ func TestIsRetryableConservativeClassification(t *testing.T) {
 		}
 	}
 	for _, err := range []error{
-		&toolError{tool: "curl", code: 67, message: "Login denied"},
+		&toolError{tool: "curl", code: 67, kind: "auth", retryable: false},
 		errors.New("permission denied"),
 		errors.New("host key verification failed"),
 		errors.New("no such file"),

--- a/scripts/audit_privacy.py
+++ b/scripts/audit_privacy.py
@@ -69,6 +69,8 @@ def audit_runtime_sources() -> None:
         for marker in FORBIDDEN_VENDOR_MARKERS:
             if marker in lower:
                 fail(f"telemetry/vendor marker {marker!r} found in {rel}")
+        if rel.as_posix() != "internal/remote/util.go" and "toolError{" in text:
+            fail(f"runtime toolError must be constructed through newToolError: {rel}")
 
 
 def audit_credentials_and_network_tools() -> None:
@@ -127,12 +129,24 @@ def audit_credentials_and_network_tools() -> None:
         '"ssh_askpass"', '"ssh_auth_sock"', "crypto/rand", "func randomTransferToken()",
         "func (e *toolError) Error() string", "func toolErrorPublicLabel(tool string) string",
         "func toolErrorPublicDetail(kind string) string", "e.UserErrorKind()",
-        'return "network tool"', "msg = te.message",
+        'return "network tool"', "kind      string", "retryable bool",
+        "classifyToolDiagnostic(tool, code, diagnostic)", "classifyToolRetryable(tool, code, diagnostic)",
+        "return te.retryable",
     ))
-    if "return e.message" in util:
-        fail("raw child-process diagnostics must not be exposed by toolError.Error")
-    if "base = label + e.message" in util or "fmt.Sprintf(\"%s %s\", label, e.message)" in util:
-        fail("raw child-process diagnostics must not be concatenated into public tool errors")
+    tool_diagnostics = require("internal/remote/tool_diagnostics.go", (
+        "func classifyToolDiagnostic(tool string, code int, diagnostic string) string",
+        "func classifyToolRetryable(tool string, code int, diagnostic string) bool",
+        "return e.kind",
+    ))
+    tool_error_match = re.search(r"type toolError struct \{(?P<body>.*?)\n\}", util, re.DOTALL)
+    if tool_error_match is None:
+        fail("toolError structure was not found")
+    if "message" in tool_error_match.group("body") or "diagnostic" in tool_error_match.group("body"):
+        fail("toolError must not retain raw child-process diagnostic text")
+    for forbidden in ("return e.message", "base = label + e.message", 'fmt.Sprintf("%s %s", label, e.message)', "te.message", "e.message"):
+        if forbidden in util or forbidden in tool_diagnostics:
+            fail(f"raw child-process diagnostic retention/exposure must remain blocked: {forbidden}")
+
     require("internal/transfer/manager.go", (
         "recover() != nil",
         "ConnectionIdentity() (string, error)",
@@ -188,6 +202,7 @@ def main() -> None:
     print("TELEMETRY_VENDOR_MARKERS=BLOCKED")
     print("RUNTIME_CREDENTIAL_FILES=BLOCKED")
     print("RAW_TOOL_DIAGNOSTICS_USER_SURFACE=BLOCKED")
+    print("RAW_TOOL_DIAGNOSTICS_ERROR_RETENTION=BLOCKED")
     print("SAFE_TOOL_ERROR_CLASSIFICATION=PRESERVED")
     print("SSH_KEYSCAN_DIAGNOSTICS_USER_SURFACE=REDACTED")
     print("DOWNLOAD_LOCAL_ROOT_PROPAGATION=ENFORCED")


### PR DESCRIPTION
## Authorization

- [x] Explicitly requested continued Ghost FTP privacy, security, stability and quality hardening.
- [x] Existing published 1.1.7 release/tag/assets/checksums remain immutable.

## Problem

Earlier hardening stopped raw `curl`/`sftp`/`ssh-keyscan` diagnostics from reaching user-facing error strings, but `toolError` still retained the complete raw diagnostic text in memory so `UserErrorKind()` and `IsRetryable()` could parse it later. Networking-tool stderr can contain hostnames, usernames, remote paths or private-key paths, so retaining that text longer than classification requires is unnecessary privacy exposure and memory overhead.

## Fix

- Remove the raw diagnostic/message field from `toolError`.
- Classify diagnostics exactly once while bounded child-process output is in scope.
- Retain only normalized tool identity, exit code, safe semantic `kind`, and conservative `retryable` decision.
- Preserve curl exit-code retry behavior and message-over-code semantic precedence.
- Preserve SFTP auth, host-key, path, transport and settings classifications.
- Keep generic non-tool retry classification unchanged.
- Preserve MLSD unsupported-command fallback without retained raw stderr.
- Add tests proving sensitive host/user/key-path fragments are absent from the retained error object.
- Update cleanup hardening tests to consume structured semantic state rather than removed diagnostic text.
- Extend the fail-closed privacy audit to reject a future diagnostic/message field in `toolError` and direct production construction outside `newToolError`.
- Document the shortened in-memory diagnostic lifetime.

## Scope

Exactly nine files:

- `internal/remote/util.go`
- `internal/remote/tool_diagnostics.go`
- `internal/remote/tool_diagnostics_test.go`
- `internal/remote/tool_error_privacy_test.go`
- `internal/remote/ftp_command_privacy_regression_test.go`
- `internal/remote/util_test.go`
- `internal/remote/remote_cleanup_hardening_test.go`
- `scripts/audit_privacy.py`
- `docs/PRIVACY.md`

No VERSION, release workflow, tag, published asset, checksum, telemetry, network destination or external dependency change.

## Merge gate

Current candidate head: `0242d27c051bb78dfbadecd782f9f9c519225c29`.

Do not merge until every workflow triggered for the exact final head is `completed/success`. Any head change invalidates previous green results. After merge, verify push workflows on the exact resulting `main` SHA.