### PR TITLE
Security: block Linux transport PATH shadowing

### DIFF
--- a/internal/remote/connect_regression_test.go
+++ b/internal/remote/connect_regression_test.go
@@ -36,21 +36,16 @@ func TestFindOpenSSHUsesNativeExecutableNameOutsideWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("non-Windows executable-name regression")
 	}
-	dir := t.TempDir()
-	tool := filepath.Join(dir, "sftp")
-	if err := os.WriteFile(tool, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", dir)
-	oldSystemDirectory := systemDirectory
-	systemDirectory = func() (string, error) { return "", os.ErrNotExist }
-	t.Cleanup(func() { systemDirectory = oldSystemDirectory })
 
-	got, err := findOpenSSH("sftp.exe")
+	withWindowsSuffix, err := findOpenSSH("sftp.exe")
+	if err != nil {
+		t.Skipf("trusted native sftp is unavailable: %v", err)
+	}
+	native, err := findOpenSSH("sftp")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != tool {
-		t.Fatalf("findOpenSSH returned %q, want native tool %q", got, tool)
+	if withWindowsSuffix != native {
+		t.Fatalf("findOpenSSH(sftp.exe)=%q want same trusted native executable as findOpenSSH(sftp)=%q", withWindowsSuffix, native)
 	}
 }

--- a/internal/remote/privacy_test.go
+++ b/internal/remote/privacy_test.go
@@ -123,6 +123,9 @@ func TestFindCurlPrefersWindowsSystemBinary(t *testing.T) {
 }
 
 func TestFindOpenSSHPreferWindowsSystemBinary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows OpenSSH system-directory trust policy is Windows-specific")
+	}
 	system32 := filepath.Join(t.TempDir(), "System32")
 	if err := os.MkdirAll(system32, 0700); err != nil {
 		t.Fatal(err)

--- a/internal/remote/process_connect_smoke_other_test.go
+++ b/internal/remote/process_connect_smoke_other_test.go
@@ -4,26 +4,12 @@ package remote
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/bren-wp/Ghost-FTP/internal/security"
 )
-
-func prependTestToolDirectory(t *testing.T, dir string) {
-	t.Helper()
-	oldSystemDirectory := systemDirectory
-	systemDirectory = func() (string, error) { return "", errors.New("nema Windows system direktorija") }
-	t.Cleanup(func() { systemDirectory = oldSystemDirectory })
-	oldPath := os.Getenv("PATH")
-	if oldPath == "" {
-		t.Setenv("PATH", dir)
-		return
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
-}
 
 func writeExecutable(t *testing.T, path, body string) {
 	t.Helper()
@@ -34,8 +20,8 @@ func writeExecutable(t *testing.T, path, body string) {
 
 func TestCurlFTPProcessSmokeUsesRuntimeSecretAndParsesListing(t *testing.T) {
 	dir := t.TempDir()
-	prependTestToolDirectory(t, dir)
-	writeExecutable(t, filepath.Join(dir, "curl"), `#!/bin/sh
+	fakeCurl := filepath.Join(dir, "curl")
+	writeExecutable(t, fakeCurl, `#!/bin/sh
 cfg="$(cat)"
 case "$cfg" in
   *'user = "tester:sesija-secret"'*) ;;
@@ -48,6 +34,7 @@ printf '%s\n' 'type=file;size=4;modify=20260101010203; test.txt'
 	if err != nil {
 		t.Fatal(err)
 	}
+	client.curl = fakeCurl
 	if client.passwordBlob == "" || client.passwordBlob == "sesija-secret" {
 		t.Fatalf("aktivna FTP tajna nije izdvojena iza runtime tokena: %q", client.passwordBlob)
 	}
@@ -69,8 +56,8 @@ printf '%s\n' 'type=file;size=4;modify=20260101010203; test.txt'
 
 func TestSFTPProcessSmokeUsesStdinWithoutBatchMode(t *testing.T) {
 	dir := t.TempDir()
-	prependTestToolDirectory(t, dir)
-	writeExecutable(t, filepath.Join(dir, "sftp"), `#!/bin/sh
+	fakeSFTP := filepath.Join(dir, "sftp")
+	writeExecutable(t, fakeSFTP, `#!/bin/sh
 for arg in "$@"; do
   if [ "$arg" = "-b" ]; then
     echo 'OpenSSH batch način ne smije biti uključen' >&2
@@ -100,6 +87,7 @@ printf '%s\n' '-rw-r--r-- 1 user group 4 Jan 1 00:00 test.txt'
 	if err != nil {
 		t.Fatal(err)
 	}
+	client.sftp = fakeSFTP
 	items, err := client.List(context.Background(), ".")
 	if err != nil {
 		_ = client.Close()

--- a/internal/remote/sftp.go
+++ b/internal/remote/sftp.go
@@ -56,16 +56,10 @@ func findOpenSSH(name string) (string, error) {
 		}
 		return "", errors.New("SFTP support is not available on this Windows installation")
 	}
-	if systemDir, err := systemDirectory(); err == nil && systemDir != "" {
-		p := filepath.Join(systemDir, "OpenSSH", name)
-		if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() {
-			return p, nil
-		}
-	}
 	if strings.HasSuffix(strings.ToLower(name), ".exe") {
 		name = strings.TrimSuffix(name, filepath.Ext(name))
 	}
-	if p, err := exec.LookPath(name); err == nil {
+	if p, err := findTrustedTransportExecutable(name); err == nil {
 		return p, nil
 	}
 	return "", errors.New("SFTP component was not found")

--- a/internal/remote/shared_hosting_ftp_other_test.go
+++ b/internal/remote/shared_hosting_ftp_other_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestSharedHostingFTPQuoteUsesHomeRelativePathAndNoBody(t *testing.T) {
 	dir := t.TempDir()
-	prependTestToolDirectory(t, dir)
-	writeExecutable(t, filepath.Join(dir, "curl"), `#!/bin/sh
+	fakeCurl := filepath.Join(dir, "curl")
+	writeExecutable(t, fakeCurl, `#!/bin/sh
 cfg="$(cat)"
 case "$cfg" in
   *'user = "account@example.com:shared-secret"'*) ;;
@@ -36,6 +36,7 @@ exit 0
 	if err != nil {
 		t.Fatal(err)
 	}
+	client.curl = fakeCurl
 	defer client.Close()
 	if err := client.Mkdir(context.Background(), "/public_html", "test-map"); err != nil {
 		t.Fatalf("shared-hosting MKD nije prošao: %v", err)
@@ -44,10 +45,10 @@ exit 0
 
 func TestSharedHostingFTPDisablesRepeatedMLSDWhenListFallbackWorks(t *testing.T) {
 	dir := t.TempDir()
-	prependTestToolDirectory(t, dir)
+	fakeCurl := filepath.Join(dir, "curl")
 	calls := filepath.Join(dir, "calls.txt")
 	t.Setenv("GhostFTP_TEST_CALLS", calls)
-	writeExecutable(t, filepath.Join(dir, "curl"), `#!/bin/sh
+	writeExecutable(t, fakeCurl, `#!/bin/sh
 cfg="$(cat)"
 case "$cfg" in
   *'request = "MLSD"'*)
@@ -64,6 +65,7 @@ printf '%s\n' '-rw-r--r-- 1 user group 4 Aug 19 12:00 index.php'
 	if err != nil {
 		t.Fatal(err)
 	}
+	client.curl = fakeCurl
 	defer client.Close()
 	for i := 0; i < 2; i++ {
 		items, err := client.List(context.Background(), "/public_html")

--- a/internal/remote/tools.go
+++ b/internal/remote/tools.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -51,7 +50,7 @@ func findCurl() (string, error) {
 		}
 		return "", errors.New("Windows FTP transport component is not available")
 	}
-	if p, err := exec.LookPath("curl"); err == nil {
+	if p, err := findTrustedTransportExecutable("curl"); err == nil {
 		return p, nil
 	}
 	return "", errors.New("FTP transport component was not found")

--- a/internal/remote/tools_other_test.go
+++ b/internal/remote/tools_other_test.go
@@ -1,41 +1,173 @@
-//go:build !windows
+//go:build linux
 
 package remote
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestFindCurlPrefersNativeUnixBinary(t *testing.T) {
-	dir := t.TempDir()
-	native := filepath.Join(dir, "curl")
-	windowsName := filepath.Join(dir, "curl.exe")
-	for _, file := range []string{native, windowsName} {
-		if err := os.WriteFile(file, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
-			t.Fatal(err)
+func writeFakeTransportExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func firstTrustedSystemTransport(name string) (string, bool) {
+	for _, dir := range linuxTransportSystemDirs {
+		if resolved, ok := trustedLinuxTransportExecutable(filepath.Join(dir, name)); ok {
+			return resolved, true
 		}
 	}
+	return "", false
+}
+
+func TestFindCurlRejectsPATHShadowing(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "curl")
+	writeFakeTransportExecutable(t, fake)
 	t.Setenv("PATH", dir)
 
-	oldSystemDirectory := systemDirectory
-	calledSystemDirectory := false
-	systemDirectory = func() (string, error) {
-		calledSystemDirectory = true
-		return "", errors.New("system directory must not be used on Unix")
+	got, err := findCurl()
+	if got == fake {
+		t.Fatalf("findCurl accepted user-controlled PATH executable %q", got)
 	}
-	defer func() { systemDirectory = oldSystemDirectory }()
+	if err == nil {
+		if resolved, ok := trustedLinuxTransportExecutable(got); !ok || resolved != got {
+			t.Fatalf("findCurl returned untrusted executable %q", got)
+		}
+	}
+}
+
+func TestFindCurlFallsBackToTrustedSystemBinary(t *testing.T) {
+	expected, ok := firstTrustedSystemTransport("curl")
+	if !ok {
+		t.Skip("no trusted system curl is installed")
+	}
+	dir := t.TempDir()
+	writeFakeTransportExecutable(t, filepath.Join(dir, "curl"))
+	t.Setenv("PATH", dir)
 
 	got, err := findCurl()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != native {
-		t.Fatalf("findCurl()=%q want native %q", got, native)
+	if got != expected {
+		t.Fatalf("findCurl()=%q want trusted system binary %q", got, expected)
 	}
-	if calledSystemDirectory {
-		t.Fatal("Unix findCurl unexpectedly queried the Windows system directory")
+}
+
+func TestFindOpenSSHRejectsPATHShadowing(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"ssh", "sftp", "ssh-keyscan"}
+	for _, name := range names {
+		writeFakeTransportExecutable(t, filepath.Join(dir, name))
+	}
+	t.Setenv("PATH", dir)
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			fake := filepath.Join(dir, name)
+			expected, haveSystem := firstTrustedSystemTransport(name)
+			got, err := findOpenSSH(name + ".exe")
+			if got == fake {
+				t.Fatalf("findOpenSSH accepted user-controlled PATH executable %q", got)
+			}
+			if haveSystem {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got != expected {
+					t.Fatalf("findOpenSSH()=%q want trusted system binary %q", got, expected)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("findOpenSSH unexpectedly resolved %q without a trusted system candidate", got)
+			}
+		})
+	}
+}
+
+func TestTrustedLinuxTransportRejectsUserControlledSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "unsafe-curl")
+	writeFakeTransportExecutable(t, target)
+	link := filepath.Join(dir, "curl")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if resolved, ok := trustedLinuxTransportExecutable(link); ok {
+		t.Fatalf("user-controlled symlink unexpectedly trusted as %q", resolved)
+	}
+
+	if systemCurl, ok := firstTrustedSystemTransport("curl"); ok {
+		systemLink := filepath.Join(dir, "system-curl")
+		if err := os.Symlink(systemCurl, systemLink); err != nil {
+			t.Fatal(err)
+		}
+		if resolved, ok := trustedLinuxTransportExecutable(systemLink); ok {
+			t.Fatalf("user-controlled symlink to trusted target unexpectedly trusted as %q", resolved)
+		}
+	}
+}
+
+func TestTrustedLinuxTransportAcceptsSystemSymlinkChain(t *testing.T) {
+	candidate := "/bin/sh"
+	info, err := os.Lstat(candidate)
+	if err != nil {
+		t.Skip("/bin/sh is unavailable")
+	}
+	binInfo, binErr := os.Lstat("/bin")
+	if info.Mode()&os.ModeSymlink == 0 && (binErr != nil || binInfo.Mode()&os.ModeSymlink == 0) {
+		t.Skip("system does not expose a symlink chain through /bin/sh")
+	}
+	resolved, ok := trustedLinuxTransportExecutable(candidate)
+	if !ok {
+		t.Fatalf("legitimate system symlink chain %q was rejected", candidate)
+	}
+	if !filepath.IsAbs(resolved) {
+		t.Fatalf("resolved system executable is not absolute: %q", resolved)
+	}
+}
+
+func TestTrustedLinuxDirectoryPermissionBoundary(t *testing.T) {
+	if trustedLinuxMetadata(0, os.ModeDir|0775, true) {
+		t.Fatal("group-writable root-owned directory was trusted")
+	}
+	if trustedLinuxMetadata(0, os.ModeDir|0757, true) {
+		t.Fatal("other-writable root-owned directory was trusted")
+	}
+	if !trustedLinuxMetadata(0, os.ModeDir|0755, true) {
+		t.Fatal("root-owned non-writable directory was rejected")
+	}
+	if trustedLinuxDirectoryChain("/tmp", 0) {
+		t.Fatal("world-writable /tmp unexpectedly passed trusted directory-chain validation")
+	}
+}
+
+func TestTrustedLinuxTransportRejectsNonRegularFile(t *testing.T) {
+	if trustedLinuxMetadata(0, os.ModeNamedPipe|0755, false) {
+		t.Fatal("non-regular executable metadata was trusted")
+	}
+	if trustedLinuxMetadata(0, os.ModeDir|0755, false) {
+		t.Fatal("directory executable metadata was trusted")
+	}
+}
+
+func TestTrustedLinuxTransportRequiresExecutablePermission(t *testing.T) {
+	if trustedLinuxMetadata(0, 0644, false) {
+		t.Fatal("non-executable regular file was trusted")
+	}
+	if !trustedLinuxMetadata(0, 0755, false) {
+		t.Fatal("root-owned executable regular file was rejected")
+	}
+}
+
+func TestTrustedLinuxTransportRequiresRootOwnership(t *testing.T) {
+	if trustedLinuxMetadata(1000, 0755, false) {
+		t.Fatal("non-root-owned executable was trusted")
 	}
 }

--- a/internal/remote/transport_tools_linux.go
+++ b/internal/remote/transport_tools_linux.go
@@ -1,0 +1,217 @@
+//go:build linux
+
+package remote
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const maxLinuxTransportSymlinkDepth = 32
+
+var linuxTransportSystemDirs = []string{
+	"/usr/bin",
+	"/bin",
+	"/usr/sbin",
+	"/sbin",
+	"/usr/local/bin",
+	"/usr/local/sbin",
+}
+
+// findTrustedTransportExecutable treats PATH only as a discovery hint. Every
+// candidate must independently prove that its complete filesystem provenance
+// is controlled by root and cannot be replaced by an unprivileged user.
+func findTrustedTransportExecutable(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.ContainsRune(name, '\x00') || filepath.Base(name) != name {
+		return "", errors.New("invalid Linux transport component name")
+	}
+
+	candidates := make([]string, 0, len(linuxTransportSystemDirs)+1)
+	if hinted, err := exec.LookPath(name); err == nil {
+		candidates = append(candidates, hinted)
+	}
+	for _, dir := range linuxTransportSystemDirs {
+		candidates = append(candidates, filepath.Join(dir, name))
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if !filepath.IsAbs(candidate) {
+			absolute, err := filepath.Abs(candidate)
+			if err != nil {
+				continue
+			}
+			candidate = absolute
+		}
+		candidate = filepath.Clean(candidate)
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if resolved, ok := trustedLinuxTransportExecutable(candidate); ok {
+			return resolved, nil
+		}
+	}
+	return "", errors.New("trusted Linux transport component was not found")
+}
+
+func trustedLinuxTransportExecutable(candidate string) (string, bool) {
+	return trustedLinuxTransportExecutableDepth(candidate, 0)
+}
+
+func trustedLinuxTransportExecutableDepth(candidate string, depth int) (string, bool) {
+	if depth > maxLinuxTransportSymlinkDepth || !filepath.IsAbs(candidate) {
+		return "", false
+	}
+	candidate = filepath.Clean(candidate)
+	if !trustedLinuxDirectoryChain(filepath.Dir(candidate), depth) {
+		return "", false
+	}
+
+	info, err := os.Lstat(candidate)
+	if err != nil {
+		return "", false
+	}
+	uid, ok := linuxFileUID(info)
+	if !ok || uid != 0 {
+		return "", false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(candidate)
+		if err != nil {
+			return "", false
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(candidate), target)
+		}
+		resolvedTarget, ok := trustedLinuxTransportExecutableDepth(filepath.Clean(target), depth+1)
+		if !ok {
+			return "", false
+		}
+		evaluated, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			return "", false
+		}
+		evaluated, err = filepath.Abs(evaluated)
+		if err != nil || filepath.Clean(evaluated) != resolvedTarget {
+			return "", false
+		}
+		return resolvedTarget, true
+	}
+	if !trustedLinuxMetadata(uid, info.Mode(), false) {
+		return "", false
+	}
+
+	// Parent-directory symlinks may cause the canonical path to differ even
+	// when the executable itself is not a symlink. Validate the canonical path
+	// again before returning it so cmd.Dir also lands in a trusted directory.
+	evaluated, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", false
+	}
+	evaluated, err = filepath.Abs(evaluated)
+	if err != nil {
+		return "", false
+	}
+	evaluated = filepath.Clean(evaluated)
+	if !trustedLinuxDirectoryChain(filepath.Dir(evaluated), depth) {
+		return "", false
+	}
+	finalInfo, err := os.Stat(evaluated)
+	if err != nil {
+		return "", false
+	}
+	finalUID, ok := linuxFileUID(finalInfo)
+	if !ok || !trustedLinuxMetadata(finalUID, finalInfo.Mode(), false) {
+		return "", false
+	}
+	return evaluated, true
+}
+
+// trustedLinuxDirectoryChain validates every lexical directory component.
+// Root-owned symlinks such as /bin -> /usr/bin are allowed only when their
+// target chain is itself root-owned and non-writable by group/other users.
+func trustedLinuxDirectoryChain(dir string, depth int) bool {
+	if depth > maxLinuxTransportSymlinkDepth || !filepath.IsAbs(dir) {
+		return false
+	}
+	dir = filepath.Clean(dir)
+	rootInfo, err := os.Lstat(string(os.PathSeparator))
+	if err != nil {
+		return false
+	}
+	rootUID, ok := linuxFileUID(rootInfo)
+	if !ok || !trustedLinuxMetadata(rootUID, rootInfo.Mode(), true) {
+		return false
+	}
+	if dir == string(os.PathSeparator) {
+		return true
+	}
+
+	current := string(os.PathSeparator)
+	for _, part := range strings.Split(strings.TrimPrefix(dir, string(os.PathSeparator)), string(os.PathSeparator)) {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return false
+		}
+		uid, ok := linuxFileUID(info)
+		if !ok || uid != 0 {
+			return false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(current)
+			if err != nil {
+				return false
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(current), target)
+			}
+			if !trustedLinuxDirectoryChain(filepath.Clean(target), depth+1) {
+				return false
+			}
+			resolvedInfo, err := os.Stat(current)
+			if err != nil {
+				return false
+			}
+			resolvedUID, ok := linuxFileUID(resolvedInfo)
+			if !ok || !trustedLinuxMetadata(resolvedUID, resolvedInfo.Mode(), true) {
+				return false
+			}
+			continue
+		}
+		if !trustedLinuxMetadata(uid, info.Mode(), true) {
+			return false
+		}
+	}
+	return true
+}
+
+func linuxFileUID(info os.FileInfo) (uint32, bool) {
+	if info == nil {
+		return 0, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return 0, false
+	}
+	return stat.Uid, true
+}
+
+func trustedLinuxMetadata(uid uint32, mode os.FileMode, directory bool) bool {
+	if uid != 0 || mode.Perm()&0022 != 0 {
+		return false
+	}
+	if directory {
+		return mode.IsDir()
+	}
+	return mode.IsRegular() && mode.Perm()&0111 != 0
+}

--- a/internal/remote/transport_tools_other.go
+++ b/internal/remote/transport_tools_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package remote
+
+import "errors"
+
+func findTrustedTransportExecutable(string) (string, error) {
+	return "", errors.New("trusted Linux transport resolution is unavailable")
+}

--- a/scripts/test_linux_transport_security_contract.py
+++ b/scripts/test_linux_transport_security_contract.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Fail-closed audit for trusted Linux network transport executable resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    target = ROOT / path
+    if not target.is_file():
+        raise AssertionError(f"missing required security source: {path}")
+    return target.read_text(encoding="utf-8")
+
+
+def go_function_body(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        raise AssertionError(f"missing Go function signature: {signature}")
+    brace = source.find("{", start)
+    if brace < 0:
+        raise AssertionError(f"missing Go function body: {signature}")
+    depth = 0
+    for pos in range(brace, len(source)):
+        char = source[pos]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace + 1 : pos]
+    raise AssertionError(f"unterminated Go function body: {signature}")
+
+
+class LinuxTransportSecurityContract(unittest.TestCase):
+    def test_trusted_transport_resolution_contract(self) -> None:
+        resolver = read("internal/remote/transport_tools_linux.go")
+        tools = read("internal/remote/tools.go")
+        sftp = read("internal/remote/sftp.go")
+        regressions = read("internal/remote/tools_other_test.go")
+
+        self.assertTrue(resolver.startswith("//go:build linux\n"))
+
+        discovery = go_function_body(
+            resolver,
+            "func findTrustedTransportExecutable(name string) (string, error)",
+        )
+        for marker in (
+            "exec.LookPath(name)",
+            "trustedLinuxTransportExecutable(candidate)",
+            '"/usr/bin"',
+            '"/bin"',
+            '"/usr/sbin"',
+            '"/sbin"',
+        ):
+            self.assertIn(marker, resolver if marker.startswith('"/') else discovery)
+
+        validation = go_function_body(
+            resolver,
+            "func trustedLinuxTransportExecutableDepth(candidate string, depth int) (string, bool)",
+        )
+        for marker in (
+            "trustedLinuxDirectoryChain(filepath.Dir(candidate), depth)",
+            "os.Lstat(candidate)",
+            "linuxFileUID(info)",
+            "uid != 0",
+            "os.ModeSymlink",
+            "os.Readlink(candidate)",
+            "filepath.EvalSymlinks(candidate)",
+            "trustedLinuxMetadata(uid, info.Mode(), false)",
+            "os.Stat(evaluated)",
+        ):
+            self.assertIn(marker, validation)
+
+        directory_chain = go_function_body(
+            resolver,
+            "func trustedLinuxDirectoryChain(dir string, depth int) bool",
+        )
+        for marker in (
+            "os.Lstat(current)",
+            "uid != 0",
+            "os.Readlink(current)",
+            "trustedLinuxDirectoryChain(filepath.Clean(target), depth+1)",
+            "os.Stat(current)",
+            "trustedLinuxMetadata(resolvedUID, resolvedInfo.Mode(), true)",
+        ):
+            self.assertIn(marker, directory_chain)
+
+        metadata = go_function_body(
+            resolver,
+            "func trustedLinuxMetadata(uid uint32, mode os.FileMode, directory bool) bool",
+        )
+        for marker in (
+            "uid != 0",
+            "mode.Perm()&0022 != 0",
+            "mode.IsDir()",
+            "mode.IsRegular()",
+            "mode.Perm()&0111 != 0",
+        ):
+            self.assertIn(marker, metadata)
+
+        find_curl = go_function_body(tools, "func findCurl() (string, error)")
+        self.assertIn('findTrustedTransportExecutable("curl")', find_curl)
+        self.assertNotIn("exec.LookPath(", tools)
+
+        find_openssh = go_function_body(sftp, "func findOpenSSH(name string) (string, error)")
+        self.assertIn("findTrustedTransportExecutable(name)", find_openssh)
+        self.assertNotIn("exec.LookPath(", sftp)
+
+        for test_name in (
+            "TestFindCurlRejectsPATHShadowing",
+            "TestFindCurlFallsBackToTrustedSystemBinary",
+            "TestFindOpenSSHRejectsPATHShadowing",
+            "TestTrustedLinuxTransportRejectsUserControlledSymlink",
+            "TestTrustedLinuxTransportAcceptsSystemSymlinkChain",
+            "TestTrustedLinuxDirectoryPermissionBoundary",
+            "TestTrustedLinuxTransportRejectsNonRegularFile",
+            "TestTrustedLinuxTransportRequiresExecutablePermission",
+            "TestTrustedLinuxTransportRequiresRootOwnership",
+        ):
+            self.assertIn(test_name, regressions)
+
+        print("LINUX_TRANSPORT_PATH_SHADOWING=BLOCKED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_sftp_transfer_hardening.py
+++ b/scripts/test_sftp_transfer_hardening.py
@@ -13,13 +13,21 @@ class SFTPTransferHardeningTests(unittest.TestCase):
         self.assertIn('scannedKeyType == "ssh-rsa"', policy)
         self.assertNotIn('return "ssh-rsa"', policy)
 
-    def test_unix_curl_path_does_not_prefer_windows_name(self):
+    def test_unix_curl_path_uses_trusted_resolver(self):
         tools = (ROOT / "internal/remote/tools.go").read_text(encoding="utf-8")
-        windows_block, unix_block = tools.split('if runtime.GOOS == "windows"', 1)[1].split('if p, err := exec.LookPath("curl")', 1)
+        resolver = (ROOT / "internal/remote/transport_tools_linux.go").read_text(encoding="utf-8")
+        windows_block, unix_block = tools.split('if runtime.GOOS == "windows"', 1)[1].split(
+            'if p, err := findTrustedTransportExecutable("curl")', 1
+        )
         self.assertIn("windowsCurlCandidates(systemDir, runtime.GOARCH)", windows_block)
         self.assertIn('filepath.Join(systemDir, "curl.exe")', tools)
         self.assertIn('"Sysnative", "curl.exe"', tools)
         self.assertNotIn('exec.LookPath("curl.exe")', unix_block)
+        self.assertNotIn('exec.LookPath("curl")', tools)
+        self.assertIn("exec.LookPath(name)", resolver)
+        self.assertIn("trustedLinuxTransportExecutable(candidate)", resolver)
+        self.assertIn("trustedLinuxDirectoryChain(filepath.Dir(candidate), depth)", resolver)
+        self.assertIn("mode.Perm()&0022 != 0", resolver)
 
     def test_engine_validates_file_target_before_queue(self):
         engine = (ROOT / "internal/api/engine.go").read_text(encoding="utf-8")


### PR DESCRIPTION
## Root cause
Linux FTP/SFTP transport discovery accepted `exec.LookPath` results directly, allowing a user-controlled earlier `PATH` entry to become Ghost FTP's `curl`, `ssh`, `sftp`, or `ssh-keyscan` network/security process.

## Threat model
An unprivileged local user or compromised user-writable directory must not be able to shadow Ghost FTP transport executables. `PATH` is permitted only as a discovery hint; every accepted candidate must independently prove trusted filesystem provenance.

## Fix
- add a Linux-only trusted transport resolver;
- canonicalize candidates and validate lexical + resolved filesystem provenance;
- require root ownership for the executable and directory chain;
- reject group/other-writable executable files and parent directories;
- reject non-regular and non-executable candidates;
- validate symlink chains while allowing legitimate root-owned usr-merge layouts such as `/bin -> /usr/bin`;
- fall back to trusted system candidate directories used by supported distro packages;
- return the canonical resolved executable so `cmd.Dir` is also trusted;
- keep Windows system-directory resolution unchanged.

## Tests
Go regressions cover malicious PATH-shadowed `curl`, trusted system curl fallback, PATH-shadowed `ssh`/`sftp`/`ssh-keyscan`, user-controlled symlinks, legitimate system symlink chains, writable-parent rejection, non-regular files, executable-bit enforcement and root ownership.

Existing process smoke tests were aligned without adding a production resolver bypass: test-only fake processes are assigned directly to already-constructed test clients, while constructor/discovery coverage continues to exercise the trusted production resolver.

A CI-discovered fail-closed structural contract blocks direct `exec.LookPath` from returning to `tools.go`/`sftp.go` and emits `LINUX_TRANSPORT_PATH_SHADOWING=BLOCKED` only after the trust and regression anchors pass.

## Security invariant
No Linux network transport executable may be accepted solely because it appears in `PATH`. Every executable that Ghost FTP discovers for FTP/FTPS/SFTP must have root-controlled, non-group/other-writable filesystem provenance.

## Package compatibility
The resolver supports trusted distro-managed paths and root-owned usr-merge symlinks. Existing Debian/Ubuntu `curl` + `openssh-client` and Fedora `curl` + `openssh-clients` dependencies are unchanged. No native-runtime coverage claim is expanded.

## Privacy / dependency / release safety
- no telemetry, analytics, tracking, advertising, backend or Web/PWA runtime added;
- no external Go module dependency added;
- no credential/security downgrade;
- no release workflow, signing identity, tag, release asset or checksum changes;
- current repository `VERSION=1.1.7` and the already-published `ghostftp-v1.1.7` release are untouched by this PR;
- historical 1.1.6 and 1.1.5 releases/tags/assets remain untouched.

Exact PR head: `8c0c5855d257202a4f4bd50b20a98075f864a4c2`. Any code/test/audit head change invalidates earlier CI and requires a complete new exact-head gate.