### PR TITLE
Security: pin Linux AskPass to running executable identity

### DIFF
--- a/cmd/ghostftp/askpass_identity_linux_test.go
+++ b/cmd/ghostftp/askpass_identity_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+)
+
+func TestValidAskpassInvocationAcceptsStableRunningImage(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable, err := platform.StableAskPassExecutable(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stable == filepath.Clean(exe) {
+		t.Fatalf("Linux AskPass helper retained mutable executable pathname %q", stable)
+	}
+	if !validAskpassInvocation(exe, stable, "force", validToken) {
+		t.Fatal("stable running executable identity was rejected")
+	}
+}
+
+func TestValidAskpassInvocationRejectsDifferentExecutableIdentity(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(t.TempDir(), "GhostFTP")
+	if err := os.WriteFile(other, []byte("not-the-running-image"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if validAskpassInvocation(exe, other, "force", validToken) {
+		t.Fatal("different executable identity unexpectedly accepted as AskPass helper")
+	}
+}

--- a/cmd/ghostftp/main.go
+++ b/cmd/ghostftp/main.go
@@ -21,8 +21,9 @@ var version = "dev"
 const (
 	messageBoxError       = 0x10
 	messageBoxInformation = 0x40
-	taskpassTokenLength    = 32
 )
+
+const taskpassTokenLength = 32
 
 var askpassEnvironmentKeys = [...]string{
 	"GhostFTP_ASKPASS_TOKEN",

--- a/cmd/ghostftp/main.go
+++ b/cmd/ghostftp/main.go
@@ -21,7 +21,7 @@ var version = "dev"
 const (
 	messageBoxError       = 0x10
 	messageBoxInformation = 0x40
-	askpassTokenLength    = 32
+	taskpassTokenLength    = 32
 )
 
 var askpassEnvironmentKeys = [...]string{
@@ -54,11 +54,14 @@ func validAskpassInvocation(exePath, askpassExe, require, token string) bool {
 
 	exeAbs = filepath.Clean(exeAbs)
 	askpassAbs = filepath.Clean(askpassAbs)
-	return strings.EqualFold(exeAbs, askpassAbs)
+	if strings.EqualFold(exeAbs, askpassAbs) {
+		return true
+	}
+	return platform.SameExecutableIdentity(exeAbs, askpassAbs)
 }
 
 func validAskpassToken(token string) bool {
-	if len(token) != askpassTokenLength {
+	if len(token) != taskpassTokenLength {
 		return false
 	}
 	_, err := hex.DecodeString(token)
@@ -234,6 +237,11 @@ func runApplication() (exitCode int) {
 		showError("Ghost FTP could not start. Restart the computer and try again.")
 		return 1
 	}
+	askpassExe, err := platform.StableAskPassExecutable(exe)
+	if err != nil {
+		showError("Ghost FTP could not establish a safe authentication helper identity.")
+		return 1
+	}
 
 	dataDir, err := api.DataDir()
 	if err != nil {
@@ -250,7 +258,7 @@ func runApplication() (exitCode int) {
 		return 1
 	}
 
-	engine, err := api.New(dataDir, exe)
+	engine, err := api.New(dataDir, askpassExe)
 	if err != nil {
 		showError(usererror.Message(err, "Ghost FTP could not start. Please try again."))
 		return 1

--- a/internal/platform/askpass_executable_linux.go
+++ b/internal/platform/askpass_executable_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package platform
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// StableAskPassExecutable returns an immutable reference to the executable
+// image of the running Ghost FTP process. A pathname of a portable/per-user
+// binary can be unlinked and replaced while the process is running; /proc PID
+// exe remains bound to the already-running inode and therefore cannot be
+// redirected to a replacement helper before OpenSSH invokes SSH_ASKPASS.
+func StableAskPassExecutable(exePath string) (string, error) {
+	if strings.TrimSpace(exePath) == "" {
+		return "", errors.New("application executable path is unavailable")
+	}
+	startedInfo, err := os.Stat(exePath)
+	if err != nil || !startedInfo.Mode().IsRegular() {
+		return "", errors.New("application executable identity is unavailable")
+	}
+
+	procPath := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")
+	procInfo, err := os.Stat(procPath)
+	if err != nil || !procInfo.Mode().IsRegular() {
+		return "", errors.New("stable application executable identity is unavailable")
+	}
+	if !os.SameFile(startedInfo, procInfo) {
+		return "", errors.New("application executable identity changed during startup")
+	}
+	return procPath, nil
+}
+
+// SameExecutableIdentity validates the actual currently-running helper image,
+// not the mutable pathname returned by os.Executable. This remains valid even
+// if the original portable executable pathname is replaced after startup.
+func SameExecutableIdentity(_ string, expected string) bool {
+	if strings.TrimSpace(expected) == "" {
+		return false
+	}
+	currentPath := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil || !currentInfo.Mode().IsRegular() {
+		return false
+	}
+	expectedInfo, err := os.Stat(expected)
+	if err != nil || !expectedInfo.Mode().IsRegular() {
+		return false
+	}
+	return os.SameFile(currentInfo, expectedInfo)
+}

--- a/internal/platform/askpass_executable_windows.go
+++ b/internal/platform/askpass_executable_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func StableAskPassExecutable(exePath string) (string, error) {
+	if strings.TrimSpace(exePath) == "" {
+		return "", errors.New("application executable path is unavailable")
+	}
+	abs, err := filepath.Abs(exePath)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	info, err := os.Stat(abs)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", errors.New("application executable identity is unavailable")
+	}
+	return abs, nil
+}
+
+func SameExecutableIdentity(actual, expected string) bool {
+	if strings.TrimSpace(actual) == "" || strings.TrimSpace(expected) == "" {
+		return false
+	}
+	actualAbs, err := filepath.Abs(actual)
+	if err != nil {
+		return false
+	}
+	expectedAbs, err := filepath.Abs(expected)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(filepath.Clean(actualAbs), filepath.Clean(expectedAbs)) {
+		return false
+	}
+	actualInfo, err := os.Stat(actualAbs)
+	if err != nil || !actualInfo.Mode().IsRegular() {
+		return false
+	}
+	expectedInfo, err := os.Stat(expectedAbs)
+	if err != nil || !expectedInfo.Mode().IsRegular() {
+		return false
+	}
+	return os.SameFile(actualInfo, expectedInfo)
+}

--- a/scripts/test_askpass_executable_identity_contract.py
+++ b/scripts/test_askpass_executable_identity_contract.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AskPassExecutableIdentityContractTests(unittest.TestCase):
+    def test_linux_askpass_uses_running_inode_reference(self):
+        source = (ROOT / "internal/platform/askpass_executable_linux.go").read_text(encoding="utf-8")
+        self.assertIn('filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")', source)
+        self.assertIn("os.SameFile(startedInfo, procInfo)", source)
+        self.assertNotIn("return exePath, nil", source)
+
+    def test_application_passes_stable_helper_identity_to_engine(self):
+        source = (ROOT / "cmd/ghostftp/main.go").read_text(encoding="utf-8")
+        self.assertIn("platform.StableAskPassExecutable(exe)", source)
+        self.assertIn("api.New(dataDir, askpassExe)", source)
+        self.assertNotIn("api.New(dataDir, exe)", source)
+
+    def test_askpass_helper_validates_running_image_identity(self):
+        main = (ROOT / "cmd/ghostftp/main.go").read_text(encoding="utf-8")
+        linux = (ROOT / "internal/platform/askpass_executable_linux.go").read_text(encoding="utf-8")
+        self.assertIn("platform.SameExecutableIdentity(exeAbs, askpassAbs)", main)
+        self.assertIn("os.SameFile(currentInfo, expectedInfo)", linux)
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)
+    print("LINUX_ASKPASS_EXECUTABLE_TOCTOU=BLOCKED")

--- a/scripts/test_askpass_executable_identity_contract.py
+++ b/scripts/test_askpass_executable_identity_contract.py
@@ -26,5 +26,8 @@ class AskPassExecutableIdentityContractTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(exit=False)
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(AskPassExecutableIdentityContractTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        raise SystemExit(1)
     print("LINUX_ASKPASS_EXECUTABLE_TOCTOU=BLOCKED")


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Root cause
On Linux, `SSH_ASKPASS` was populated from the application's startup pathname. For portable or per-user binaries that pathname can be unlinked/replaced while Ghost FTP remains running. A later OpenSSH AskPass invocation could therefore resolve the mutable pathname to a different executable while passing the AskPass token and protected credential blobs in its environment.

## Threat model
A local same-user process that can replace a writable Ghost FTP portable/per-user executable pathname must not be able to substitute a different AskPass helper after the trusted Ghost FTP process has already started. Linux process-memory dumping is separately hardened, so mutable on-disk helper provenance must not reopen that boundary.

## Fix
- On Linux, derive the AskPass helper from `/proc/<GhostFTP-pid>/exe`, which remains bound to the already-running executable inode.
- Fail closed if the startup executable and `/proc/<pid>/exe` are not the same regular file.
- Pass that stable helper reference into the engine/SFTP session rather than the mutable startup pathname.
- Validate a helper invocation against the actual running executable image using `os.SameFile`.
- Preserve Windows behavior while adding explicit regular-file/identity validation.

## Tests / validation
- Linux Go regression accepts the stable running-image helper identity.
- Linux Go regression rejects a different executable identity.
- Structural regression requires `/proc/<pid>/exe`, `os.SameFile`, stable helper propagation into `api.New`, and no fallback to the mutable pathname.
- Fail-closed marker: `LINUX_ASKPASS_EXECUTABLE_TOCTOU=BLOCKED`.
- Exact-head CI must pass `go test -race ./...`, `go vet ./...`, security/privacy/repository/release/docs audits, Windows/Linux production builds, distro packaging, and native install lifecycle before merge.

## Security invariant
Credential-bearing AskPass environment data may only be delivered to the executable image that is already running as Ghost FTP; replacing the portable/per-user pathname after startup must not redirect the helper launch.

## Branding / compatibility / scope
- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] Passwords, private-key passphrases and private keys remain out of command-line arguments and persistent logs.
- [x] SFTP host-key verification and pinning remain active.
- [x] No external Go module dependency was added.
- [x] No protocol downgrade or Web/PWA runtime change.
- [x] No release/tag/asset/checksum changes; the repository's pre-existing version state is untouched.
- [x] Tests contain no real credentials, production servers or customer data.