### PR TITLE
Security: pin config state directory identity

### DIFF
--- a/internal/config/state_directory_identity_other.go
+++ b/internal/config/state_directory_identity_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package config
+
+import "os"
+
+func sameStateDirectoryIdentity(before, after os.FileInfo) bool {
+	return before != nil && after != nil && os.SameFile(before, after)
+}

--- a/internal/config/state_directory_identity_windows.go
+++ b/internal/config/state_directory_identity_windows.go
@@ -2,8 +2,19 @@
 
 package config
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
 func sameStateDirectoryIdentity(before, after os.FileInfo) bool {
-	return before != nil && after != nil && os.SameFile(before, after)
+	if before == nil || after == nil || !os.SameFile(before, after) {
+		return false
+	}
+	beforeData, beforeOK := before.Sys().(*syscall.Win32FileAttributeData)
+	afterData, afterOK := after.Sys().(*syscall.Win32FileAttributeData)
+	if !beforeOK || !afterOK || beforeData == nil || afterData == nil {
+		return false
+	}
+	return beforeData.CreationTime == afterData.CreationTime
 }

--- a/internal/config/state_directory_identity_windows.go
+++ b/internal/config/state_directory_identity_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package config
+
+import "os"
+
+func sameStateDirectoryIdentity(before, after os.FileInfo) bool {
+	return before != nil && after != nil && os.SameFile(before, after)
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -9,17 +9,75 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/bren-wp/Ghost-FTP/internal/security"
 )
 
 const maxStateSize = 4 << 20
 
 type Store struct {
-	dir string
-	mu  sync.Mutex
+	dir         string
+	dirIdentity os.FileInfo
+	mu          sync.Mutex
 }
 
-func New(dir string) *Store  { return &Store{dir: dir} }
+// New captures the state-directory identity when the directory already exists.
+// Production startup validates the Ghost FTP data path immediately before
+// constructing the store; retaining that filesystem identity lets later state
+// operations reject a directory that was renamed/replaced after startup.
+//
+// If the directory does not exist (or is temporarily invalid), construction
+// remains side-effect free and the first successful operation establishes the
+// identity. This preserves recovery behavior for callers that repair an invalid
+// path and retry.
+func New(dir string) *Store {
+	s := &Store{dir: dir}
+	if info, err := stateDirectoryInfo(dir); err == nil {
+		s.dirIdentity = info
+	}
+	return s
+}
+
 func (s *Store) Dir() string { return s.dir }
+
+func stateDirectoryInfo(dir string) (os.FileInfo, error) {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(dir) {
+		return nil, errors.New("state mapa mora biti obična lokalna mapa bez preusmjeravanja")
+	}
+	return info, nil
+}
+
+// ensureDirectoryIdentity establishes or revalidates the Store's directory
+// identity. Once bound, removal/recreation, symlink/junction substitution and a
+// replacement real directory all fail closed instead of silently redirecting
+// state reads or writes to a different filesystem object.
+func (s *Store) ensureDirectoryIdentity() error {
+	info, err := stateDirectoryInfo(s.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if s.dirIdentity != nil {
+			return errors.New("state mapa je uklonjena ili zamijenjena tijekom rada")
+		}
+		if err := os.MkdirAll(s.dir, 0700); err != nil {
+			return err
+		}
+		info, err = stateDirectoryInfo(s.dir)
+	}
+	if err != nil {
+		return err
+	}
+	if s.dirIdentity == nil {
+		s.dirIdentity = info
+		return nil
+	}
+	if !os.SameFile(s.dirIdentity, info) {
+		return errors.New("state mapa je zamijenjena drugim objektom datotečnog sustava")
+	}
+	return nil
+}
 
 func validateStateName(name string) error {
 	if name == "" || filepath.Base(name) != name || strings.ContainsAny(name, `/\\`) || name == "." || name == ".." {
@@ -57,23 +115,37 @@ func copyFallback(fallback, out any) error {
 	return decodeState(b, out)
 }
 
+func (s *Store) readBoundState(path string) ([]byte, error) {
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		return nil, err
+	}
+	data, err := readLimited(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 func (s *Store) Read(name string, fallback any, out any) (string, error) {
 	if err := validateStateName(name); err != nil {
 		return "fallback", err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := os.MkdirAll(s.dir, 0700); err != nil {
+	if err := s.ensureDirectoryIdentity(); err != nil {
 		return "fallback", err
 	}
 
 	path := filepath.Join(s.dir, name)
-	if data, err := readLimited(path); err == nil {
+	if data, err := s.readBoundState(path); err == nil {
 		if err = decodeState(data, out); err == nil {
 			return "current", nil
 		}
 	}
-	if data, err := readLimited(path + ".previous"); err == nil {
+	if data, err := s.readBoundState(path + ".previous"); err == nil {
 		if err = decodeState(data, out); err == nil {
 			return "previous", nil
 		}
@@ -81,6 +153,9 @@ func (s *Store) Read(name string, fallback any, out any) (string, error) {
 
 	// A damaged/missing state file must not prevent the desktop app from booting.
 	// Defaults are safe and the next successful write repairs the current state.
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		return "fallback", err
+	}
 	if err := copyFallback(fallback, out); err != nil {
 		return "fallback", err
 	}
@@ -197,13 +272,39 @@ func replaceSyncedGeneration(dir, tmp, dst string) error {
 	return syncStateDirectory(dir)
 }
 
+func (s *Store) writeBoundTemp(pattern string, data []byte) (string, error) {
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		return "", err
+	}
+	tmp, err := writeSyncedTemp(s.dir, pattern, data)
+	if err != nil {
+		return "", err
+	}
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	return tmp, nil
+}
+
+func (s *Store) replaceBoundGeneration(tmp, dst string) error {
+	if err := s.ensureDirectoryIdentity(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := replaceSyncedGeneration(s.dir, tmp, dst); err != nil {
+		return err
+	}
+	return s.ensureDirectoryIdentity()
+}
+
 func (s *Store) Write(name string, value any) error {
 	if err := validateStateName(name); err != nil {
 		return err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := os.MkdirAll(s.dir, 0700); err != nil {
+	if err := s.ensureDirectoryIdentity(); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(value, "", "  ")
@@ -219,19 +320,19 @@ func (s *Store) Write(name string, value any) error {
 	// Keep only a known-valid previous generation. The previous generation is
 	// synced before the new current generation is activated, preserving a
 	// recovery point if a crash happens between the two replacements.
-	if existing, e := readLimited(path); e == nil && json.Valid(existing) {
-		prevTmp, e := writeSyncedTemp(s.dir, "."+name+".previous-*.tmp", existing)
+	if existing, e := s.readBoundState(path); e == nil && json.Valid(existing) {
+		prevTmp, e := s.writeBoundTemp("."+name+".previous-*.tmp", existing)
 		if e != nil {
 			return e
 		}
-		if e = replaceSyncedGeneration(s.dir, prevTmp, path+".previous"); e != nil {
+		if e = s.replaceBoundGeneration(prevTmp, path+".previous"); e != nil {
 			return e
 		}
 	}
 
-	tmp, err := writeSyncedTemp(s.dir, "."+name+"-*.tmp", data)
+	tmp, err := s.writeBoundTemp("."+name+"-*.tmp", data)
 	if err != nil {
 		return err
 	}
-	return replaceSyncedGeneration(s.dir, tmp, path)
+	return s.replaceBoundGeneration(tmp, path)
 }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -73,7 +73,7 @@ func (s *Store) ensureDirectoryIdentity() error {
 		s.dirIdentity = info
 		return nil
 	}
-	if !os.SameFile(s.dirIdentity, info) {
+	if !sameStateDirectoryIdentity(s.dirIdentity, info) {
 		return errors.New("state mapa je zamijenjena drugim objektom datotečnog sustava")
 	}
 	return nil

--- a/internal/config/store_directory_identity_test.go
+++ b/internal/config/store_directory_identity_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreRejectsReplacementDirectoryAfterBinding(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "state")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	store := New(dir)
+
+	original := filepath.Join(base, "state-original")
+	if err := os.Rename(dir, original); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Write("state.json", testState{Value: 9}); err == nil {
+		t.Fatal("write unexpectedly accepted a replacement state directory")
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "state.json")); !os.IsNotExist(err) {
+		t.Fatalf("replacement directory received state data: %v", err)
+	}
+}
+
+func TestStoreRejectsSymlinkedDirectoryAfterBinding(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "state")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{\"value\":1}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := New(dir)
+
+	original := filepath.Join(base, "state-original")
+	if err := os.Rename(dir, original); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(base, "outside")
+	if err := os.Mkdir(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "state.json"), []byte("{\"value\":99}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, dir); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	var got testState
+	if _, err := store.Read("state.json", testState{Value: 7}, &got); err == nil {
+		t.Fatal("read unexpectedly accepted a symlinked replacement state directory")
+	}
+	if got.Value == 99 {
+		t.Fatal("state was read through the replacement symlink")
+	}
+}
+
+func TestStoreCanBindDirectoryAfterRecoverableInitialPathFailure(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "state")
+	if err := os.WriteFile(dir, []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := New(dir)
+
+	var got testState
+	if _, err := store.Read("state.json", testState{Value: 3}, &got); err == nil {
+		t.Fatal("expected invalid initial state path to fail")
+	}
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Write("state.json", testState{Value: 5}); err != nil {
+		t.Fatalf("repaired state directory did not bind: %v", err)
+	}
+	if _, err := store.Read("state.json", testState{}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Value != 5 {
+		t.Fatalf("value=%d want 5", got.Value)
+	}
+}

--- a/scripts/test_state_directory_identity_contract.py
+++ b/scripts/test_state_directory_identity_contract.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class StateDirectoryIdentityContractTests(unittest.TestCase):
+    def test_store_pins_directory_identity(self):
+        source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")
+        self.assertIn("dirIdentity os.FileInfo", source)
+        self.assertIn("os.SameFile(s.dirIdentity, info)", source)
+        self.assertIn("s.ensureDirectoryIdentity()", source)
+
+    def test_store_rejects_redirected_directory(self):
+        source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")
+        self.assertIn("security.IsReparsePoint(dir)", source)
+        self.assertIn("info.Mode()&os.ModeSymlink", source)
+
+    def test_read_and_write_use_bound_directory_helpers(self):
+        source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")
+        self.assertIn("s.readBoundState(path)", source)
+        self.assertIn("s.writeBoundTemp", source)
+        self.assertIn("s.replaceBoundGeneration", source)
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(StateDirectoryIdentityContractTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        raise SystemExit(1)
+    print("STATE_DIRECTORY_IDENTITY_REPLACEMENT=BLOCKED")

--- a/scripts/test_state_directory_identity_contract.py
+++ b/scripts/test_state_directory_identity_contract.py
@@ -9,13 +9,19 @@ class StateDirectoryIdentityContractTests(unittest.TestCase):
     def test_store_pins_directory_identity(self):
         source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")
         self.assertIn("dirIdentity os.FileInfo", source)
-        self.assertIn("os.SameFile(s.dirIdentity, info)", source)
+        self.assertIn("sameStateDirectoryIdentity(s.dirIdentity, info)", source)
         self.assertIn("s.ensureDirectoryIdentity()", source)
 
     def test_store_rejects_redirected_directory(self):
         source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")
         self.assertIn("security.IsReparsePoint(dir)", source)
         self.assertIn("info.Mode()&os.ModeSymlink", source)
+
+    def test_windows_identity_has_independent_generation_signal(self):
+        source = (ROOT / "internal/config/state_directory_identity_windows.go").read_text(encoding="utf-8")
+        self.assertIn("os.SameFile(before, after)", source)
+        self.assertIn("syscall.Win32FileAttributeData", source)
+        self.assertIn("beforeData.CreationTime == afterData.CreationTime", source)
 
     def test_read_and_write_use_bound_directory_helpers(self):
         source = (ROOT / "internal/config/store.go").read_text(encoding="utf-8")

--- a/scripts/test_state_durability.py
+++ b/scripts/test_state_durability.py
@@ -18,10 +18,20 @@ class StateDurabilitySourceTests(unittest.TestCase):
             "func replaceSyncedGeneration(",
             "replaceFile(tmp, dst)",
             "syncStateDirectory(dir)",
-            'replaceSyncedGeneration(s.dir, prevTmp, path+".previous")',
-            "replaceSyncedGeneration(s.dir, tmp, path)",
+            "func (s *Store) replaceBoundGeneration(",
+            "replaceSyncedGeneration(s.dir, tmp, dst)",
+            's.replaceBoundGeneration(prevTmp, path+".previous")',
+            "s.replaceBoundGeneration(tmp, path)",
         ):
             self.assertIn(marker, store)
+
+    def test_bound_replace_revalidates_directory_identity(self) -> None:
+        store = self.read("internal/config/store.go")
+        start = store.index("func (s *Store) replaceBoundGeneration(")
+        end = store.index("func (s *Store) Write(", start)
+        bound_replace = store[start:end]
+        self.assertGreaterEqual(bound_replace.count("s.ensureDirectoryIdentity()"), 2)
+        self.assertIn("replaceSyncedGeneration(s.dir, tmp, dst)", bound_replace)
 
     def test_unix_replace_has_directory_sync(self) -> None:
         other = self.read("internal/config/replace_other.go")


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Root cause
Ghost FTP validates its application-data directory during startup, but `config.Store` retained only the pathname. Later `Read`/`Write` operations reopened files through that pathname. If the data directory was renamed/replaced while the application remained running, state operations could silently move to a symlink/junction/reparse target or to a different real directory.

## Threat model
A local filesystem actor able to replace the Ghost FTP state directory after startup must not redirect subsequent settings/profile-state reads or writes into a different filesystem object. The startup no-redirect check must remain meaningful for the lifetime of the Store.

## Fix
- Capture the safe state-directory filesystem identity when `Store` is constructed and the directory already exists.
- Revalidate the leaf as a real directory with no symlink/junction/reparse redirection.
- Bind a previously missing/repaired directory on its first successful operation.
- Once bound, reject removal/recreation or replacement with a different directory.
- Use `os.SameFile` on Unix-like platforms; on Windows require both `os.SameFile` and the stable directory creation-time generation signal to reject an immediately recreated directory even if an identifier is recycled.
- Revalidate around state reads, temp writes and generation replacement operations.
- Preserve existing recoverable-initial-path behavior.

## Regression coverage
- Reject replacement with a different real directory and prove no state is written there on Linux and Windows.
- Reject replacement with a symlink and prove redirected state is not read.
- Preserve retry after an initially invalid path is legitimately repaired.
- Preserve durable temp-file sync and atomic replacement semantics through the hardened bound-generation wrapper.
- Structural contract marker: `STATE_DIRECTORY_IDENTITY_REPLACEMENT=BLOCKED`.

## Validation
Exact head `5c7bc4ca2800971123663b6f35c7395f1bd79521` passed:
- Core quality/security/documentation, including gofmt, `go test -race ./...`, `go vet ./...`, all repository/security/privacy/release audits and Python regressions.
- Windows x64/x86 production build, including the Windows replacement-directory regression, artifact verification and Authenticode smoke test.
- Linux amd64/arm64/i386 production build.
- Debian/Ubuntu/Fedora/portable package build and metadata/binary parity.
- Debian 13, Ubuntu 26.04 LTS and Fedora 44 native install/remove/GUI lifecycle.

## Scope
- No protocol behavior change.
- No telemetry or new dependency.
- No release/tag/asset/checksum changes.
- No version change.