### PR TITLE
Security: pin installer directory identity

### DIFF
--- a/cmd/installer/install_directory_guard.go
+++ b/cmd/installer/install_directory_guard.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+type installDirectoryGuard struct {
+	root   string
+	dir    string
+	handle *os.File
+}
+
+func pinInstallDirectory(root, dir string) (*installDirectoryGuard, error) {
+	if root == "" || dir == "" {
+		return nil, errors.New("instalacijska mapa nije dostupna za sigurnosno vezivanje")
+	}
+	rootAbs, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return nil, err
+	}
+	dirAbs, err := filepath.Abs(filepath.Clean(dir))
+	if err != nil {
+		return nil, err
+	}
+	if err := security.EnsureNoRedirectDirectory(rootAbs, dirAbs); err != nil {
+		return nil, err
+	}
+
+	before, err := os.Lstat(dirAbs)
+	if err != nil {
+		return nil, err
+	}
+	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(dirAbs) {
+		return nil, errors.New("instalacijska mapa mora biti obična lokalna mapa bez preusmjeravanja")
+	}
+
+	h, err := os.Open(dirAbs)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := h.Stat()
+	if err != nil {
+		_ = h.Close()
+		return nil, err
+	}
+	if !opened.IsDir() || !os.SameFile(before, opened) {
+		_ = h.Close()
+		return nil, errors.New("instalacijska mapa se promijenila tijekom sigurnog otvaranja")
+	}
+
+	guard := &installDirectoryGuard{root: rootAbs, dir: dirAbs, handle: h}
+	if err := guard.verify(); err != nil {
+		_ = h.Close()
+		return nil, err
+	}
+	return guard, nil
+}
+
+func (g *installDirectoryGuard) verify() error {
+	if g == nil || g.handle == nil || g.root == "" || g.dir == "" {
+		return errors.New("identitet instalacijske mape nije dostupan")
+	}
+	if err := security.EnsureNoRedirectDirectory(g.root, g.dir); err != nil {
+		return err
+	}
+	opened, err := g.handle.Stat()
+	if err != nil {
+		return err
+	}
+	current, err := os.Lstat(g.dir)
+	if err != nil {
+		return err
+	}
+	if !opened.IsDir() || !current.IsDir() || current.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(g.dir) {
+		return errors.New("instalacijska mapa više nije sigurna lokalna mapa")
+	}
+	if !os.SameFile(opened, current) {
+		return errors.New("instalacijska mapa je zamijenjena tijekom instalacije")
+	}
+	return nil
+}
+
+func (g *installDirectoryGuard) close() {
+	if g != nil && g.handle != nil {
+		_ = g.handle.Close()
+		g.handle = nil
+	}
+}

--- a/cmd/installer/install_directory_guard_test.go
+++ b/cmd/installer/install_directory_guard_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallDirectoryGuardRejectsDirectoryReplacement(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "install")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	guard, err := pinInstallDirectory(root, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer guard.close()
+
+	original := filepath.Join(root, "install-original")
+	if err := os.Rename(dir, original); err != nil {
+		// Some Windows filesystems deny renaming a directory while the retained
+		// handle is open. That behavior itself preserves the identity invariant.
+		return
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := guard.verify(); err == nil {
+		t.Fatal("replacement install directory was accepted")
+	}
+}
+
+func TestBoundInstallRefusesReplacementDirectory(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "install")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "GhostFTP.exe")
+
+	guard, err := pinInstallDirectory(root, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backup, err := backupExistingBound(target, guard)
+	if err != nil {
+		guard.close()
+		t.Fatal(err)
+	}
+	defer backup.cleanup()
+
+	original := filepath.Join(root, "install-original")
+	if err := os.Rename(dir, original); err != nil {
+		// An OS-level rename denial while the guard handle is open is also a
+		// fail-closed outcome, so no replacement can be installed through.
+		return
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installFile(target, []byte("replacement-payload"), &backup); err == nil {
+		t.Fatal("installer accepted a replacement installation directory")
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("replacement directory received activated GhostFTP.exe: %v", err)
+	}
+}
+
+func TestInstallDirectoryGuardRejectsRedirectedParent(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "Programs")
+	dir := filepath.Join(parent, "Ghost FTP")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	guard, err := pinInstallDirectory(root, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer guard.close()
+
+	movedParent := filepath.Join(root, "Programs-original")
+	if err := os.Rename(parent, movedParent); err != nil {
+		return
+	}
+	outside := filepath.Join(root, "outside")
+	if err := os.Mkdir(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, parent); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := guard.verify(); err == nil {
+		t.Fatal("redirected parent chain was accepted")
+	}
+}

--- a/cmd/installer/transaction.go
+++ b/cmd/installer/transaction.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 	"github.com/bren-wp/Ghost-FTP/internal/security"
@@ -23,6 +24,7 @@ type fileBackup struct {
 	activated       bool
 	installed       os.FileInfo
 	installedDigest [sha256.Size]byte
+	directory       *installDirectoryGuard
 }
 
 func ensureInstallDir(dir string) error {
@@ -45,6 +47,28 @@ func ensureInstallDir(dir string) error {
 		return errors.New("instalacijska putanja nije sigurna mapa")
 	}
 	return nil
+}
+
+func installerDirectoryGuardForTarget(target string) (*installDirectoryGuard, error) {
+	dir := filepath.Dir(target)
+	root := dir
+
+	// For the real product installation, also revalidate every Ghost FTP-owned
+	// parent below LocalAppData on each guard check. Unit-test and helper targets
+	// outside the canonical install path still pin their immediate directory.
+	if installDir, err := platform.InstallDir(); err == nil {
+		dirAbs, dirErr := filepath.Abs(filepath.Clean(dir))
+		installAbs, installErr := filepath.Abs(filepath.Clean(installDir))
+		if dirErr == nil && installErr == nil && strings.EqualFold(dirAbs, installAbs) {
+			localAppData, localErr := platform.LocalAppData()
+			if localErr != nil {
+				return nil, localErr
+			}
+			root = localAppData
+		}
+	}
+
+	return pinInstallDirectory(root, dir)
 }
 
 func safeInstallerRegular(path string, info os.FileInfo) error {
@@ -118,9 +142,29 @@ func digestStableInstallerFile(path string) (os.FileInfo, [sha256.Size]byte, err
 }
 
 func backupExisting(target string) (fileBackup, error) {
+	guard, err := installerDirectoryGuardForTarget(target)
+	if err != nil {
+		return fileBackup{}, err
+	}
+	backup, err := backupExistingBound(target, guard)
+	if err != nil {
+		guard.close()
+		return fileBackup{}, err
+	}
+	return backup, nil
+}
+
+func backupExistingBound(target string, guard *installDirectoryGuard) (fileBackup, error) {
+	if guard == nil {
+		return fileBackup{}, errors.New("identitet instalacijske mape nije dostupan")
+	}
+	if err := guard.verify(); err != nil {
+		return fileBackup{}, err
+	}
+
 	info, err := os.Lstat(target)
 	if errors.Is(err, os.ErrNotExist) {
-		return fileBackup{target: target}, nil
+		return fileBackup{target: target, directory: guard}, nil
 	}
 	if err != nil {
 		return fileBackup{}, err
@@ -142,6 +186,9 @@ func backupExisting(target string) (fileBackup, error) {
 	if err := safeInstallerRegular(target, opened); err != nil || !sameStableInstallerFile(info, opened) {
 		return fileBackup{}, errors.New("postojeća instalacijska datoteka se promijenila tijekom sigurnog otvaranja")
 	}
+	if err := guard.verify(); err != nil {
+		return fileBackup{}, err
+	}
 
 	dst, err := os.CreateTemp(filepath.Dir(target), ".GhostFTP-rollback-*.bak")
 	if err != nil {
@@ -151,6 +198,10 @@ func backupExisting(target string) (fileBackup, error) {
 	cleanup := func() {
 		_ = dst.Close()
 		_ = os.Remove(backup)
+	}
+	if err := guard.verify(); err != nil {
+		cleanup()
+		return fileBackup{}, err
 	}
 
 	if err := dst.Chmod(0600); err != nil {
@@ -203,7 +254,8 @@ func backupExisting(target string) (fileBackup, error) {
 
 	syncErr := dst.Sync()
 	closeErr := dst.Close()
-	if err := errors.Join(copyErr, statErr, currentErr, syncErr, closeErr); err != nil {
+	guardErr := guard.verify()
+	if err := errors.Join(copyErr, statErr, currentErr, syncErr, closeErr, guardErr); err != nil {
 		_ = os.Remove(backup)
 		return fileBackup{}, err
 	}
@@ -214,6 +266,10 @@ func backupExisting(target string) (fileBackup, error) {
 	if err != nil {
 		_ = os.Remove(backup)
 		return fileBackup{}, fmt.Errorf("sigurnosnu kopiju nije moguće potvrditi: %w", err)
+	}
+	if err := guard.verify(); err != nil {
+		_ = os.Remove(backup)
+		return fileBackup{}, err
 	}
 	if backupDigest != digest || backupInfo.Size() != opened.Size() {
 		_ = os.Remove(backup)
@@ -226,18 +282,29 @@ func backupExisting(target string) (fileBackup, error) {
 		original:       after,
 		originalDigest: digest,
 		backupInfo:     backupInfo,
+		directory:      guard,
 	}, nil
+}
+
+func (b *fileBackup) verifyDirectory() error {
+	if b == nil || b.directory == nil {
+		return errors.New("identitet instalacijske mape nije dostupan")
+	}
+	return b.directory.verify()
 }
 
 func (b *fileBackup) verifyBeforeInstall() error {
 	if b == nil || b.target == "" {
 		return errors.New("instalacijska transakcija nije ispravna")
 	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 
 	if !b.existed() {
 		_, err := os.Lstat(b.target)
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return b.verifyDirectory()
 		}
 		if err != nil {
 			return err
@@ -247,6 +314,9 @@ func (b *fileBackup) verifyBeforeInstall() error {
 
 	current, digest, err := digestStableInstallerFile(b.target)
 	if err != nil {
+		return err
+	}
+	if err := b.verifyDirectory(); err != nil {
 		return err
 	}
 	if !sameStableInstallerFile(b.original, current) || digest != b.originalDigest {
@@ -260,6 +330,9 @@ func (b *fileBackup) recordActivated(expected [sha256.Size]byte) error {
 	if b == nil || b.target == "" {
 		return errors.New("instalacijska transakcija nije ispravna")
 	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 
 	// Mark activation before verification so the transaction knows that the
 	// target path was changed even if post-install verification fails.
@@ -268,6 +341,9 @@ func (b *fileBackup) recordActivated(expected [sha256.Size]byte) error {
 	info, digest, err := digestStableInstallerFile(b.target)
 	if err != nil {
 		return fmt.Errorf("instalirana datoteka nije mogla biti potvrđena: %w", err)
+	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
 	}
 
 	// Store what was actually observed. If the payload digest does not match,
@@ -285,12 +361,18 @@ func (b fileBackup) verifyInstalledForRollback() error {
 	if !b.activated {
 		return nil
 	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 	if b.installed == nil {
 		return errors.New("nije moguće dokazati vlasništvo nad aktiviranom instalacijskom datotekom")
 	}
 
 	current, digest, err := digestStableInstallerFile(b.target)
 	if err != nil {
+		return err
+	}
+	if err := b.verifyDirectory(); err != nil {
 		return err
 	}
 	if !os.SameFile(b.installed, current) || digest != b.installedDigest {
@@ -300,6 +382,9 @@ func (b fileBackup) verifyInstalledForRollback() error {
 }
 
 func (b fileBackup) verifyBackupForRollback() error {
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 	if b.backup == "" {
 		return errors.New("sigurnosna kopija nije dostupna")
 	}
@@ -310,6 +395,9 @@ func (b fileBackup) verifyBackupForRollback() error {
 	current, digest, err := digestStableInstallerFile(b.backup)
 	if err != nil {
 		return fmt.Errorf("sigurnosnu kopiju nije moguće potvrditi: %w", err)
+	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
 	}
 	if !sameStableInstallerFile(b.backupInfo, current) || digest != b.originalDigest {
 		return errors.New("sigurnosna kopija promijenjena je prije rollbacka")
@@ -328,6 +416,9 @@ func (b fileBackup) stageRollbackBackup() (string, error) {
 	}
 	defer src.Close()
 
+	if err := b.verifyDirectory(); err != nil {
+		return "", err
+	}
 	dst, err := os.CreateTemp(filepath.Dir(b.target), ".GhostFTP-restore-*.tmp")
 	if err != nil {
 		return "", err
@@ -336,6 +427,10 @@ func (b fileBackup) stageRollbackBackup() (string, error) {
 	cleanup := func() {
 		_ = dst.Close()
 		_ = os.Remove(tmp)
+	}
+	if err := b.verifyDirectory(); err != nil {
+		cleanup()
+		return "", err
 	}
 
 	mode := os.FileMode(0700)
@@ -353,7 +448,8 @@ func (b fileBackup) stageRollbackBackup() (string, error) {
 	}
 	syncErr := dst.Sync()
 	closeErr := dst.Close()
-	if err := errors.Join(copyErr, syncErr, closeErr); err != nil {
+	guardErr := b.verifyDirectory()
+	if err := errors.Join(copyErr, syncErr, closeErr, guardErr); err != nil {
 		_ = os.Remove(tmp)
 		return "", err
 	}
@@ -362,6 +458,10 @@ func (b fileBackup) stageRollbackBackup() (string, error) {
 	if err != nil {
 		_ = os.Remove(tmp)
 		return "", fmt.Errorf("pripremljenu rollback datoteku nije moguće potvrditi: %w", err)
+	}
+	if err := b.verifyDirectory(); err != nil {
+		_ = os.Remove(tmp)
+		return "", err
 	}
 	if digest != b.originalDigest {
 		_ = os.Remove(tmp)
@@ -375,6 +475,9 @@ func (b fileBackup) rollback() error {
 	if b.target == "" || !b.activated {
 		return nil
 	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 	if err := b.verifyInstalledForRollback(); err != nil {
 		return err
 	}
@@ -386,7 +489,10 @@ func (b fileBackup) rollback() error {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		return b.verifyDirectory()
 	}
 
 	// Never consume the only rollback backup directly. Restore from a freshly
@@ -397,13 +503,22 @@ func (b fileBackup) rollback() error {
 	}
 	defer os.Remove(restoreTmp)
 
+	if err := b.verifyDirectory(); err != nil {
+		return err
+	}
 	if err := platform.ReplaceFile(restoreTmp, b.target); err != nil {
+		return err
+	}
+	if err := b.verifyDirectory(); err != nil {
 		return err
 	}
 
 	_, digest, err := digestStableInstallerFile(b.target)
 	if err != nil {
 		return fmt.Errorf("vraćena instalacijska datoteka nije mogla biti potvrđena: %w", err)
+	}
+	if err := b.verifyDirectory(); err != nil {
+		return err
 	}
 	if digest != b.originalDigest {
 		return errors.New("vraćena instalacijska datoteka ne odgovara sigurnosnoj kopiji")
@@ -415,8 +530,15 @@ func (b fileBackup) existed() bool {
 	return b.backup != ""
 }
 
-func (b fileBackup) cleanup() {
-	if b.backup != "" {
+func (b *fileBackup) cleanup() {
+	if b == nil {
+		return
+	}
+	if b.backup != "" && b.directory != nil && b.directory.verify() == nil {
 		_ = os.Remove(b.backup)
+	}
+	if b.directory != nil {
+		b.directory.close()
+		b.directory = nil
 	}
 }

--- a/cmd/installer/transaction_test.go
+++ b/cmd/installer/transaction_test.go
@@ -17,6 +17,7 @@ func TestBackupExistingRollbackRestoresPreviousFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer b.cleanup()
 	if !b.existed() {
 		t.Fatal("expected existing-file backup")
 	}
@@ -42,6 +43,7 @@ func TestBackupExistingRollbackRemovesFreshInstalledFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer b.cleanup()
 	if b.existed() {
 		t.Fatal("fresh target unexpectedly marked as existing")
 	}
@@ -114,6 +116,7 @@ func TestFreshInstallDoesNotOverwriteTargetThatAppearedAfterSnapshot(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer b.cleanup()
 	if err := os.WriteFile(target, []byte("external"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -165,6 +168,7 @@ func TestRollbackRefusesInstalledFileChangedByAnotherActor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer b.cleanup()
 	if err := installFile(target, []byte("GhostFTP"), &b); err != nil {
 		t.Fatal(err)
 	}
@@ -190,6 +194,7 @@ func TestRollbackBeforeActivationNeverDeletesFreshExternalTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer b.cleanup()
 	if err := os.WriteFile(target, []byte("external"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/test_installer_directory_identity_contract.py
+++ b/scripts/test_installer_directory_identity_contract.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class InstallerDirectoryIdentityContractTests(unittest.TestCase):
+    def test_guard_retains_open_directory_identity(self):
+        source = (ROOT / "cmd" / "installer" / "install_directory_guard.go").read_text(encoding="utf-8")
+        self.assertIn("handle *os.File", source)
+        self.assertIn("os.Open(dirAbs)", source)
+        self.assertIn("g.handle.Stat()", source)
+        self.assertIn("os.SameFile(opened, current)", source)
+
+    def test_guard_revalidates_redirect_chain(self):
+        source = (ROOT / "cmd" / "installer" / "install_directory_guard.go").read_text(encoding="utf-8")
+        self.assertIn("security.EnsureNoRedirectDirectory(g.root, g.dir)", source)
+        self.assertIn("security.IsReparsePoint(g.dir)", source)
+        self.assertIn("current.Mode()&os.ModeSymlink", source)
+
+    def test_transaction_binds_backup_activation_and_rollback(self):
+        source = (ROOT / "cmd" / "installer" / "transaction.go").read_text(encoding="utf-8")
+        self.assertIn("installerDirectoryGuardForTarget(target)", source)
+        self.assertIn("backupExistingBound(target, guard)", source)
+        self.assertIn("directory:      guard", source)
+        self.assertGreaterEqual(source.count("b.verifyDirectory()"), 8)
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(InstallerDirectoryIdentityContractTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        raise SystemExit(1)
+    print("INSTALLER_DIRECTORY_IDENTITY=BLOCKED")

--- a/scripts/test_installer_transaction_hardening.py
+++ b/scripts/test_installer_transaction_hardening.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Zaključava 1.0.9 installer backup, activation i rollback invarijante."""
+"""Zaključava installer backup, directory identity, activation i rollback invarijante."""
 
 from pathlib import Path
 import sys
@@ -14,21 +14,35 @@ def fail(message: str) -> None:
 def main() -> int:
     transaction = (ROOT / "cmd" / "installer" / "transaction.go").read_text(encoding="utf-8")
     installer = (ROOT / "cmd" / "installer" / "main.go").read_text(encoding="utf-8")
+    directory_guard = (ROOT / "cmd" / "installer" / "install_directory_guard.go").read_text(encoding="utf-8")
 
     for marker in (
-        "os.SameFile(info, opened)",
+        "sameStableInstallerFile(info, opened)",
         "src.Seek(0, io.SeekStart)",
         "digest != verifyDigest",
         "digestStableInstallerFile(b.target)",
         "!b.activated",
         "verifyInstalledForRollback()",
         "b.installedDigest",
+        "directory       *installDirectoryGuard",
+        "installerDirectoryGuardForTarget(target)",
+        "backupExistingBound(target, guard)",
+        "b.verifyDirectory()",
     ):
         if marker not in transaction:
             fail(f"nedostaje installer transaction guard: {marker}")
 
-    if "return fileBackup{target: target}, nil" not in transaction:
-        fail("fresh target snapshot više nije eksplicitno zabilježen")
+    for marker in (
+        "security.EnsureNoRedirectDirectory(g.root, g.dir)",
+        "g.handle.Stat()",
+        "os.Lstat(g.dir)",
+        "os.SameFile(opened, current)",
+    ):
+        if marker not in directory_guard:
+            fail(f"nedostaje installer directory identity guard: {marker}")
+
+    if "return fileBackup{target: target, directory: guard}, nil" not in transaction:
+        fail("fresh target snapshot nije vezan uz identitet instalacijske mape")
     if "if b.target == \"\" || !b.activated" not in transaction:
         fail("rollback ponovno može dirati fresh target prije installer aktivacije")
 
@@ -47,6 +61,7 @@ def main() -> int:
             fail(f"produkcijski installer zaobilazi transaction-bound install: {call}")
 
     print("INSTALLER_TRANSACTION_HARDENING=PROSAO")
+    print("INSTALLER_DIRECTORY_REPLACEMENT=BLOCKED")
     return 0
 
 


### PR DESCRIPTION
## Root cause
The installer validated the canonical installation path before starting, and file-level backup/activation/rollback logic strongly pinned individual executable objects. However, the installation directory itself remained pathname-based for the lifetime of the transaction. A local same-user process could attempt to rename/replace the whole install directory after the initial redirect check, causing later temp, backup, activation, or rollback operations to resolve through a different filesystem object.

## Threat model
A local process running as the same user races the per-user Ghost FTP installer and replaces the installation directory or one of its Ghost FTP-owned parent components during an upgrade/install transaction. This must not redirect installer writes or rollback actions into a different directory object.

## Fix
- Retain an open handle to the installation directory and compare later pathname resolution against that live filesystem object with `os.SameFile`.
- Re-run `EnsureNoRedirectDirectory` for the canonical LocalAppData parent chain on every production guard check.
- Bind fresh/existing `fileBackup` transactions to the directory guard.
- Revalidate the guard around backup creation, activation verification, rollback staging/replacement, and cleanup.
- Fail closed if directory identity or redirect-chain provenance changes; cleanup will not remove a pathname after identity loss.

## Tests
- Real-directory replacement after binding is rejected.
- Bound install refuses activation through a replacement directory.
- Redirected/symlinked parent chain is rejected where the platform supports creating the link.
- Python structural contracts lock retained-handle identity and transaction binding invariants.
- Existing installer transaction, rollback, Windows packaging, Linux build, race/vet, security/privacy and distro lifecycle gates remain required.

## Invariant
Once an installer transaction is bound, Ghost FTP backup/activation/rollback operations may only operate while the canonical installation pathname still resolves to the originally opened directory object and its Ghost FTP-owned parent chain remains non-redirected.