### PR TITLE
Fix: preserve foreign Windows shortcuts

### DIFF
--- a/internal/platform/shortcut_ownership_windows_test.go
+++ b/internal/platform/shortcut_ownership_windows_test.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveShortcutMatchingDigestPreservesModifiedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Ghost FTP.lnk")
+	if err := os.WriteFile(path, []byte("owned-shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := stableShortcutDigest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("user-replacement"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removeShortcutMatchingDigest(path, digest)
+	if err == nil {
+		t.Fatal("modified shortcut was accepted as installer-owned")
+	}
+	if removed {
+		t.Fatal("modified shortcut was reported removed")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "user-replacement" {
+		t.Fatalf("modified shortcut changed: %q", got)
+	}
+}
+
+func TestRemoveShortcutMatchingDigestDeletesExactOwnedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Ghost FTP.lnk")
+	if err := os.WriteFile(path, []byte("owned-shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := stableShortcutDigest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removeShortcutMatchingDigest(path, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("exact owned shortcut was not removed")
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("owned shortcut still exists: %v", err)
+	}
+}
+
+func TestStableShortcutDigestRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.lnk")
+	if err := os.WriteFile(target, []byte("target"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "Ghost FTP.lnk")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := stableShortcutDigest(link); err == nil {
+		t.Fatal("symlink shortcut was accepted as owned regular file")
+	}
+}
+
+func TestSameShortcutTargetCanonicalizesCaseAndDots(t *testing.T) {
+	base := t.TempDir()
+	expected := filepath.Join(base, "GhostFTP.exe")
+	actual := filepath.Join(base, ".", "GhostFTP.exe")
+	if !sameShortcutTarget(actual, expected) {
+		t.Fatal("equivalent shortcut targets were not recognized")
+	}
+}

--- a/internal/platform/shortcut_windows.go
+++ b/internal/platform/shortcut_windows.go
@@ -28,19 +28,17 @@ const (
 	startMenuShortcutDigestValue = "StartMenuShortcutSHA256"
 )
 
-var (
-	ole32Shortcut            = syscall.NewLazyDLL("ole32.dll")
-	coInitializeEx           = ole32Shortcut.NewProc("CoInitializeEx")
-	coUninitialize           = ole32Shortcut.NewProc("CoUninitialize")
-	coCreateInstance         = ole32Shortcut.NewProc("CoCreateInstance")
-	shell32Shortcut          = syscall.NewLazyDLL("shell32.dll")
-	shGetFolderPathW         = shell32Shortcut.NewProc("SHGetFolderPathW")
-	kernel32Shortcut         = syscall.NewLazyDLL("kernel32.dll")
-	getFileAttributesShortcut = kernel32Shortcut.NewProc("GetFileAttributesW")
-	clsidShellLink           = guid{0x00021401, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
-	iidIShellLinkW           = guid{0x000214F9, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
-	iidIPersistFile          = guid{0x0000010B, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
-)
+var ole32Shortcut = syscall.NewLazyDLL("ole32.dll")
+var coInitializeEx = ole32Shortcut.NewProc("CoInitializeEx")
+var coUninitialize = ole32Shortcut.NewProc("CoUninitialize")
+var coCreateInstance = ole32Shortcut.NewProc("CoCreateInstance")
+var shell32Shortcut = syscall.NewLazyDLL("shell32.dll")
+var shGetFolderPathW = shell32Shortcut.NewProc("SHGetFolderPathW")
+var kernel32Shortcut = syscall.NewLazyDLL("kernel32.dll")
+var getFileAttributesShortcut = kernel32Shortcut.NewProc("GetFileAttributesW")
+var clsidShellLink = guid{0x00021401, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
+var iidIShellLinkW = guid{0x000214F9, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
+var iidIPersistFile = guid{0x0000010B, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
 
 func hresultFailed(v uintptr) bool { return int32(v) < 0 }
 

--- a/internal/platform/shortcut_windows.go
+++ b/internal/platform/shortcut_windows.go
@@ -3,12 +3,17 @@
 package platform
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"github.com/bren-wp/Ghost-FTP/internal/brand"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/brand"
 )
 
 type guid struct {
@@ -18,16 +23,23 @@ type guid struct {
 	Data4 [8]byte
 }
 
+const (
+	desktopShortcutDigestValue   = "DesktopShortcutSHA256"
+	startMenuShortcutDigestValue = "StartMenuShortcutSHA256"
+)
+
 var (
-	ole32Shortcut    = syscall.NewLazyDLL("ole32.dll")
-	coInitializeEx   = ole32Shortcut.NewProc("CoInitializeEx")
-	coUninitialize   = ole32Shortcut.NewProc("CoUninitialize")
-	coCreateInstance = ole32Shortcut.NewProc("CoCreateInstance")
-	shell32Shortcut  = syscall.NewLazyDLL("shell32.dll")
-	shGetFolderPathW = shell32Shortcut.NewProc("SHGetFolderPathW")
-	clsidShellLink   = guid{0x00021401, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
-	iidIShellLinkW   = guid{0x000214F9, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
-	iidIPersistFile  = guid{0x0000010B, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
+	ole32Shortcut            = syscall.NewLazyDLL("ole32.dll")
+	coInitializeEx           = ole32Shortcut.NewProc("CoInitializeEx")
+	coUninitialize           = ole32Shortcut.NewProc("CoUninitialize")
+	coCreateInstance         = ole32Shortcut.NewProc("CoCreateInstance")
+	shell32Shortcut          = syscall.NewLazyDLL("shell32.dll")
+	shGetFolderPathW         = shell32Shortcut.NewProc("SHGetFolderPathW")
+	kernel32Shortcut         = syscall.NewLazyDLL("kernel32.dll")
+	getFileAttributesShortcut = kernel32Shortcut.NewProc("GetFileAttributesW")
+	clsidShellLink           = guid{0x00021401, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
+	iidIShellLinkW           = guid{0x000214F9, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
+	iidIPersistFile          = guid{0x0000010B, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
 )
 
 func hresultFailed(v uintptr) bool { return int32(v) < 0 }
@@ -111,6 +123,218 @@ func createShellLink(linkPath, target, workingDir, description string) error {
 	return nil
 }
 
+func shortcutReparsePoint(path string) bool {
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return true
+	}
+	attrs, _, _ := getFileAttributesShortcut.Call(uintptr(unsafe.Pointer(p)))
+	const (
+		invalidFileAttributes = 0xffffffff
+		fileAttributeReparse  = 0x00000400
+	)
+	if uint32(attrs) == invalidFileAttributes {
+		return true
+	}
+	return uint32(attrs)&fileAttributeReparse != 0
+}
+
+func stableShortcutDigest(path string) (string, error) {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 || shortcutReparsePoint(path) {
+		return "", errors.New("shortcut nije sigurna regularna datoteka")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	opened, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return "", errors.New("shortcut se promijenio tijekom sigurnog otvaranja")
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	after, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	current, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(opened, after) || !os.SameFile(after, current) || current.Mode()&os.ModeSymlink != 0 || shortcutReparsePoint(path) {
+		return "", errors.New("shortcut se promijenio tijekom provjere")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func readShellLinkTarget(linkPath string) (string, error) {
+	const (
+		coinitApartmentThreaded = 0x2
+		clsctxInprocServer      = 0x1
+		slgpRawPath             = 0x4
+	)
+	hr, _, _ := coInitializeEx.Call(0, coinitApartmentThreaded)
+	if hresultFailed(hr) {
+		return "", syscall.Errno(uint32(hr))
+	}
+	defer coUninitialize.Call()
+
+	var link unsafe.Pointer
+	hr, _, _ = coCreateInstance.Call(
+		uintptr(unsafe.Pointer(&clsidShellLink)),
+		0,
+		clsctxInprocServer,
+		uintptr(unsafe.Pointer(&iidIShellLinkW)),
+		uintptr(unsafe.Pointer(&link)),
+	)
+	if hresultFailed(hr) || link == nil {
+		return "", errors.New("Windows Shell Link nije dostupan")
+	}
+	defer releaseCOM(link)
+
+	var persist unsafe.Pointer
+	if hr, _, _ = syscall.SyscallN(vtableMethod(link, 0), uintptr(link), uintptr(unsafe.Pointer(&iidIPersistFile)), uintptr(unsafe.Pointer(&persist))); hresultFailed(hr) || persist == nil {
+		return "", errors.New("IPersistFile nije dostupan")
+	}
+	defer releaseCOM(persist)
+
+	pathPtr, err := syscall.UTF16PtrFromString(linkPath)
+	if err != nil {
+		return "", err
+	}
+	if hr, _, _ = syscall.SyscallN(vtableMethod(persist, 5), uintptr(persist), uintptr(unsafe.Pointer(pathPtr)), 0); hresultFailed(hr) {
+		return "", syscall.Errno(uint32(hr))
+	}
+
+	buf := make([]uint16, 32768)
+	if hr, _, _ = syscall.SyscallN(
+		vtableMethod(link, 3),
+		uintptr(link),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0,
+		slgpRawPath,
+	); hresultFailed(hr) {
+		return "", syscall.Errno(uint32(hr))
+	}
+	target := syscall.UTF16ToString(buf)
+	if strings.TrimSpace(target) == "" {
+		return "", errors.New("shortcut nema valjanu ciljnu putanju")
+	}
+	return target, nil
+}
+
+func sameShortcutTarget(actual, expected string) bool {
+	actualAbs, err := filepath.Abs(filepath.Clean(actual))
+	if err != nil {
+		return false
+	}
+	expectedAbs, err := filepath.Abs(filepath.Clean(expected))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(actualAbs, expectedAbs)
+}
+
+func removeShortcutMatchingDigest(path, expectedDigest string) (bool, error) {
+	if strings.TrimSpace(expectedDigest) == "" {
+		return false, nil
+	}
+	current, err := stableShortcutDigest(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(current, expectedDigest) {
+		return false, errors.New("shortcut je promijenjen nakon instalacije i neće biti obrisan")
+	}
+
+	// Re-read immediately before deletion so a normal replacement between the
+	// ownership check and cleanup is detected and preserved.
+	confirmed, err := stableShortcutDigest(path)
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(confirmed, expectedDigest) {
+		return false, errors.New("shortcut se promijenio prije uklanjanja i neće biti obrisan")
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func createOwnedShortcut(linkPath, target, workingDir, description, digestValue string) error {
+	if _, err := os.Lstat(linkPath); err == nil {
+		digest, digestErr := stableShortcutDigest(linkPath)
+		if digestErr != nil {
+			return digestErr
+		}
+		recorded, recordedOK, recordedErr := GetRegistryString(ghostFTPUninstallKey, digestValue)
+		if recordedErr != nil {
+			return recordedErr
+		}
+		if recordedOK && strings.EqualFold(recorded, digest) {
+			return nil
+		}
+
+		// Migrate a legacy Ghost FTP shortcut only after independently proving
+		// that its stored target is the canonical application path. A foreign
+		// same-name shortcut is preserved and never adopted.
+		existingTarget, targetErr := readShellLinkTarget(linkPath)
+		if targetErr != nil || !sameShortcutTarget(existingTarget, target) {
+			_ = DeleteRegistryValue(ghostFTPUninstallKey, digestValue)
+			return errors.New("postojeći shortcut istog imena nije Ghost FTP shortcut i nije prepisan")
+		}
+		return SetRegistryString(ghostFTPUninstallKey, digestValue, digest)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := createShellLink(linkPath, target, workingDir, description); err != nil {
+		return err
+	}
+	digest, err := stableShortcutDigest(linkPath)
+	if err != nil {
+		return err
+	}
+	if err := SetRegistryString(ghostFTPUninstallKey, digestValue, digest); err != nil {
+		_, cleanupErr := removeShortcutMatchingDigest(linkPath, digest)
+		return errors.Join(err, cleanupErr)
+	}
+	return nil
+}
+
+func removeOwnedShortcut(path, digestValue string) error {
+	expected, ok, err := GetRegistryString(ghostFTPUninstallKey, digestValue)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	_, err = removeShortcutMatchingDigest(path, expected)
+	if err != nil {
+		return err
+	}
+	return DeleteRegistryValue(ghostFTPUninstallKey, digestValue)
+}
+
 func ShortcutPaths() (desktop, startMenu string, err error) {
 	const (
 		csidlPrograms         = 0x0002
@@ -133,14 +357,16 @@ func CreateShortcuts(appPath string) error {
 		return err
 	}
 	work := filepath.Dir(appPath)
-	if err = createShellLink(desktop, appPath, work, brand.ProductFull+" — "+brand.Company); err != nil {
-		return err
+	description := brand.ProductFull + " — " + brand.Company
+
+	var errs []error
+	if err := createOwnedShortcut(desktop, appPath, work, description, desktopShortcutDigestValue); err != nil {
+		errs = append(errs, err)
 	}
-	if err = createShellLink(start, appPath, work, brand.ProductFull+" — "+brand.Company); err != nil {
-		_ = os.Remove(desktop)
-		return err
+	if err := createOwnedShortcut(start, appPath, work, description, startMenuShortcutDigestValue); err != nil {
+		errs = append(errs, err)
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func RemoveShortcuts() error {
@@ -149,11 +375,13 @@ func RemoveShortcuts() error {
 		return err
 	}
 	var errs []error
-	for _, path := range []string{desktop, start} {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			errs = append(errs, err)
-		}
+	if err := removeOwnedShortcut(desktop, desktopShortcutDigestValue); err != nil {
+		errs = append(errs, err)
 	}
+	if err := removeOwnedShortcut(start, startMenuShortcutDigestValue); err != nil {
+		errs = append(errs, err)
+	}
+
 	startDir := filepath.Dir(start)
 	if err := os.Remove(startDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		// A non-empty company Start Menu folder is normal; do not remove

--- a/scripts/test_windows_shortcut_ownership_contract.py
+++ b/scripts/test_windows_shortcut_ownership_contract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsShortcutOwnershipContractTests(unittest.TestCase):
+    def setUp(self):
+        self.source = (ROOT / "internal" / "platform" / "shortcut_windows.go").read_text(encoding="utf-8")
+
+    def test_created_shortcuts_are_bound_to_digest_markers(self):
+        for marker in (
+            'desktopShortcutDigestValue   = "DesktopShortcutSHA256"',
+            'startMenuShortcutDigestValue = "StartMenuShortcutSHA256"',
+            "stableShortcutDigest(linkPath)",
+            "SetRegistryString(ghostFTPUninstallKey, digestValue, digest)",
+        ):
+            self.assertIn(marker, self.source)
+
+    def test_uninstall_requires_matching_ownership_digest(self):
+        self.assertIn("GetRegistryString(ghostFTPUninstallKey, digestValue)", self.source)
+        self.assertIn("removeShortcutMatchingDigest(path, expected)", self.source)
+        self.assertIn("!strings.EqualFold(current, expectedDigest)", self.source)
+        self.assertIn("shortcut je promijenjen nakon instalacije i neće biti obrisan", self.source)
+
+    def test_foreign_same_name_shortcut_is_not_overwritten(self):
+        self.assertIn("readShellLinkTarget(linkPath)", self.source)
+        self.assertIn("!sameShortcutTarget(existingTarget, target)", self.source)
+        self.assertIn("nije Ghost FTP shortcut i nije prepisan", self.source)
+
+    def test_shortcut_digest_rejects_redirects(self):
+        self.assertIn("before.Mode()&os.ModeSymlink", self.source)
+        self.assertIn("shortcutReparsePoint(path)", self.source)
+        self.assertIn("os.SameFile(before, opened)", self.source)
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(WindowsShortcutOwnershipContractTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        raise SystemExit(1)
+    print("WINDOWS_SHORTCUT_OWNERSHIP=PRESERVED")


### PR DESCRIPTION
## Root cause
Windows shortcut creation and removal were pathname-based. `CreateShortcuts` could overwrite an existing `.lnk` with the same Ghost FTP display name, while `RemoveShortcuts` deleted those paths without proving that Ghost FTP had created or still owned the current file. A pre-existing or later user-replaced shortcut could therefore be destroyed during install, rollback, or uninstall.

## Failure model
A user already has a Desktop or Start Menu shortcut with the same filename, or replaces/edits a Ghost FTP shortcut after installation. Setup/uninstall must preserve that file unless Ghost FTP can prove ownership of the exact current shortcut object/content.

## Fix
- Record SHA-256 ownership digests for Desktop and Start Menu shortcuts in the Ghost FTP Installed Apps registry key.
- Never overwrite a foreign same-name shortcut.
- Safely adopt a legacy unmarked Ghost FTP shortcut only after reading its raw Shell Link target and proving it points to the canonical application path.
- Revalidate regular-file identity and reject symlink/reparse shortcut paths while hashing.
- On uninstall, remove a shortcut only when its current digest still matches the recorded Ghost FTP ownership digest; modified/foreign shortcuts are preserved.
- If registry ownership recording fails after creating a shortcut, cleanup is constrained to the just-observed digest instead of blindly deleting the pathname.

## Tests
- Modified/replaced shortcut survives ownership cleanup.
- Exact digest-owned shortcut is removable.
- Symlink shortcut is rejected as an ownership object.
- Canonical target comparison regression.
- Python contract locks digest markers, target migration proof and no-overwrite/preserve behavior.
- Full Windows setup/portable, Core race/vet/audits, Linux build and distro lifecycle CI remain required.

## Invariant
Ghost FTP may create, adopt, or delete a Windows shortcut only when it can establish Ghost FTP ownership. A same-name path alone is never sufficient authority to overwrite or remove user content.