### PR TITLE
Security: delete owned Windows shortcuts by verified handle

### DIFF
--- a/internal/platform/delete_verified_windows_test.go
+++ b/internal/platform/delete_verified_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package platform
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func digestText(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestVerifiedRegularFileSHA256(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owned.lnk")
+	if err := os.WriteFile(path, []byte("owned shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := verifiedRegularFileSHA256(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := digestText("owned shortcut")
+	if got != want {
+		t.Fatalf("digest mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestRemoveVerifiedRegularFileMatchingSHA256DeletesExactObject(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owned.lnk")
+	if err := os.WriteFile(path, []byte("owned shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removeVerifiedRegularFileMatchingSHA256(path, digestText("owned shortcut"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("expected owned shortcut to be removed")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("owned shortcut still exists: %v", err)
+	}
+}
+
+func TestRemoveVerifiedRegularFileMatchingSHA256PreservesMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "foreign.lnk")
+	if err := os.WriteFile(path, []byte("foreign shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removeVerifiedRegularFileMatchingSHA256(path, digestText("owned shortcut"))
+	if !errors.Is(err, errVerifiedOwnershipDigestMismatch) {
+		t.Fatalf("expected ownership mismatch, got %v", err)
+	}
+	if removed {
+		t.Fatal("foreign shortcut was reported removed")
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != "foreign shortcut" {
+		t.Fatalf("foreign shortcut was not preserved: %q %v", got, readErr)
+	}
+}
+
+func TestVerifiedRegularHandleBlocksPathReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owned.lnk")
+	replacement := filepath.Join(dir, "replacement.lnk")
+	if err := os.WriteFile(path, []byte("owned shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(replacement, []byte("foreign shortcut"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := openVerifiedRegularFile(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := os.Rename(replacement, path); err == nil {
+		t.Fatal("replacement unexpectedly succeeded while verified handle was pinned")
+	}
+	got, err := verifiedOpenFileSHA256(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != digestText("owned shortcut") {
+		t.Fatalf("pinned handle changed identity/content: %q", got)
+	}
+}
+
+func TestVerifiedRegularFileRejectsDirectory(t *testing.T) {
+	if _, err := verifiedRegularFileSHA256(t.TempDir()); err == nil {
+		t.Fatal("directory was accepted as a verified regular file")
+	}
+}

--- a/internal/platform/delete_windows.go
+++ b/internal/platform/delete_windows.go
@@ -3,20 +3,159 @@
 package platform
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
 	"os"
+	"strings"
 	"syscall"
 	"unsafe"
 )
 
+const (
+	genericReadAccess         = 0x80000000
+	deleteFileAccess          = 0x00010000
+	fileShareRead             = 0x00000001
+	openExisting              = 3
+	fileFlagOpenReparsePoint  = 0x00200000
+	fileAttributeDirectory    = 0x00000010
+	fileAttributeReparsePoint = 0x00000400
+	fileDispositionInfo       = 4
+)
+
+var kernel32Delete = syscall.NewLazyDLL("kernel32.dll")
+var moveFileExDelete = kernel32Delete.NewProc("MoveFileExW")
+var setFileInformationByHandleDelete = kernel32Delete.NewProc("SetFileInformationByHandle")
+
+func openVerifiedRegularFile(path string, allowDelete bool) (*os.File, error) {
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	access := uint32(genericReadAccess)
+	if allowDelete {
+		access |= deleteFileAccess
+	}
+	h, err := syscall.CreateFile(
+		p,
+		access,
+		fileShareRead,
+		nil,
+		openExisting,
+		fileFlagOpenReparsePoint,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(h, &info); err != nil {
+		_ = syscall.CloseHandle(h)
+		return nil, err
+	}
+	if info.FileAttributes&(fileAttributeDirectory|fileAttributeReparsePoint) != 0 {
+		_ = syscall.CloseHandle(h)
+		return nil, errors.New("path is not a safe regular file")
+	}
+
+	f := os.NewFile(uintptr(h), path)
+	if f == nil {
+		_ = syscall.CloseHandle(h)
+		return nil, errors.New("Windows file handle could not be attached")
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !stat.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, errors.New("path is not a safe regular file")
+	}
+	return f, nil
+}
+
+func verifiedOpenFileSHA256(f *os.File) (string, error) {
+	if f == nil {
+		return "", errors.New("verified file handle is unavailable")
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func verifiedRegularFileSHA256(path string) (string, error) {
+	f, err := openVerifiedRegularFile(path, false)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return verifiedOpenFileSHA256(f)
+}
+
+func deleteVerifiedOpenFile(f *os.File) error {
+	if f == nil {
+		return errors.New("verified file handle is unavailable")
+	}
+	deleteFile := uint32(1)
+	r, _, callErr := setFileInformationByHandleDelete.Call(
+		f.Fd(),
+		fileDispositionInfo,
+		uintptr(unsafe.Pointer(&deleteFile)),
+		unsafe.Sizeof(deleteFile),
+	)
+	if r == 0 {
+		if callErr != nil && callErr != syscall.Errno(0) {
+			return callErr
+		}
+		return errors.New("Windows could not delete the verified file object")
+	}
+	return nil
+}
+
+func removeVerifiedRegularFileMatchingSHA256(path, expectedDigest string) (bool, error) {
+	if strings.TrimSpace(expectedDigest) == "" {
+		return false, nil
+	}
+
+	f, err := openVerifiedRegularFile(path, true)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	actualDigest, err := verifiedOpenFileSHA256(f)
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(actualDigest, expectedDigest) {
+		return false, errors.New("verified file content does not match its ownership digest")
+	}
+	if err := deleteVerifiedOpenFile(f); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // ScheduleDeleteOnReboot asks Windows to remove a path at the next reboot.
 // It is used only as a fallback when an executable is still locked.
 func ScheduleDeleteOnReboot(path string) error {
-	moveFile := syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
 	p, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return err
 	}
-	r, _, callErr := moveFile.Call(uintptr(unsafe.Pointer(p)), 0, 0x4) // MOVEFILE_DELAY_UNTIL_REBOOT
+	r, _, callErr := moveFileExDelete.Call(uintptr(unsafe.Pointer(p)), 0, 0x4) // MOVEFILE_DELAY_UNTIL_REBOOT
 	if r == 0 {
 		if callErr != nil && callErr != syscall.Errno(0) {
 			return callErr

--- a/internal/platform/delete_windows.go
+++ b/internal/platform/delete_windows.go
@@ -24,6 +24,8 @@ const (
 	fileDispositionInfo       = 4
 )
 
+var errVerifiedOwnershipDigestMismatch = errors.New("verified file content does not match its ownership digest")
+
 var kernel32Delete = syscall.NewLazyDLL("kernel32.dll")
 var moveFileExDelete = kernel32Delete.NewProc("MoveFileExW")
 var setFileInformationByHandleDelete = kernel32Delete.NewProc("SetFileInformationByHandle")
@@ -140,7 +142,7 @@ func removeVerifiedRegularFileMatchingSHA256(path, expectedDigest string) (bool,
 		return false, err
 	}
 	if !strings.EqualFold(actualDigest, expectedDigest) {
-		return false, errors.New("verified file content does not match its ownership digest")
+		return false, errVerifiedOwnershipDigestMismatch
 	}
 	if err := deleteVerifiedOpenFile(f); err != nil {
 		return false, err

--- a/internal/platform/delete_windows.go
+++ b/internal/platform/delete_windows.go
@@ -107,7 +107,10 @@ func deleteVerifiedOpenFile(f *os.File) error {
 	if f == nil {
 		return errors.New("verified file handle is unavailable")
 	}
-	deleteFile := uint32(1)
+	// FILE_DISPOSITION_INFO contains one BOOLEAN field. Windows BOOLEAN is one
+	// byte, so keep the buffer layout exact instead of relying on the API to
+	// tolerate a wider integer representation.
+	deleteFile := byte(1)
 	r, _, callErr := setFileInformationByHandleDelete.Call(
 		f.Fd(),
 		fileDispositionInfo,

--- a/internal/platform/shortcut_windows.go
+++ b/internal/platform/shortcut_windows.go
@@ -191,13 +191,10 @@ func sameShortcutTarget(actual, expected string) bool {
 
 func removeShortcutMatchingDigest(path, expectedDigest string) (bool, error) {
 	removed, err := removeVerifiedRegularFileMatchingSHA256(path, expectedDigest)
-	if err != nil {
-		if strings.Contains(err.Error(), "ownership digest") {
-			return false, errors.New("shortcut je promijenjen nakon instalacije i neće biti obrisan")
-		}
-		return false, err
+	if errors.Is(err, errVerifiedOwnershipDigestMismatch) {
+		return false, errors.New("shortcut je promijenjen nakon instalacije i neće biti obrisan")
 	}
-	return removed, nil
+	return removed, err
 }
 
 func createOwnedShortcut(linkPath, target, workingDir, description, digestValue string) error {

--- a/internal/platform/shortcut_windows.go
+++ b/internal/platform/shortcut_windows.go
@@ -3,10 +3,7 @@
 package platform
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,8 +31,6 @@ var coUninitialize = ole32Shortcut.NewProc("CoUninitialize")
 var coCreateInstance = ole32Shortcut.NewProc("CoCreateInstance")
 var shell32Shortcut = syscall.NewLazyDLL("shell32.dll")
 var shGetFolderPathW = shell32Shortcut.NewProc("SHGetFolderPathW")
-var kernel32Shortcut = syscall.NewLazyDLL("kernel32.dll")
-var getFileAttributesShortcut = kernel32Shortcut.NewProc("GetFileAttributesW")
 var clsidShellLink = guid{0x00021401, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
 var iidIShellLinkW = guid{0x000214F9, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
 var iidIPersistFile = guid{0x0000010B, 0, 0, [8]byte{0xC0, 0, 0, 0, 0, 0, 0, 0x46}}
@@ -121,61 +116,8 @@ func createShellLink(linkPath, target, workingDir, description string) error {
 	return nil
 }
 
-func shortcutReparsePoint(path string) bool {
-	p, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return true
-	}
-	attrs, _, _ := getFileAttributesShortcut.Call(uintptr(unsafe.Pointer(p)))
-	const (
-		invalidFileAttributes = 0xffffffff
-		fileAttributeReparse  = 0x00000400
-	)
-	if uint32(attrs) == invalidFileAttributes {
-		return true
-	}
-	return uint32(attrs)&fileAttributeReparse != 0
-}
-
 func stableShortcutDigest(path string) (string, error) {
-	before, err := os.Lstat(path)
-	if err != nil {
-		return "", err
-	}
-	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 || shortcutReparsePoint(path) {
-		return "", errors.New("shortcut nije sigurna regularna datoteka")
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	opened, err := f.Stat()
-	if err != nil {
-		return "", err
-	}
-	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
-		return "", errors.New("shortcut se promijenio tijekom sigurnog otvaranja")
-	}
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	after, err := f.Stat()
-	if err != nil {
-		return "", err
-	}
-	current, err := os.Lstat(path)
-	if err != nil {
-		return "", err
-	}
-	if !os.SameFile(opened, after) || !os.SameFile(after, current) || current.Mode()&os.ModeSymlink != 0 || shortcutReparsePoint(path) {
-		return "", errors.New("shortcut se promijenio tijekom provjere")
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return verifiedRegularFileSHA256(path)
 }
 
 func readShellLinkTarget(linkPath string) (string, error) {
@@ -248,33 +190,14 @@ func sameShortcutTarget(actual, expected string) bool {
 }
 
 func removeShortcutMatchingDigest(path, expectedDigest string) (bool, error) {
-	if strings.TrimSpace(expectedDigest) == "" {
-		return false, nil
-	}
-	current, err := stableShortcutDigest(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
+	removed, err := removeVerifiedRegularFileMatchingSHA256(path, expectedDigest)
 	if err != nil {
+		if strings.Contains(err.Error(), "ownership digest") {
+			return false, errors.New("shortcut je promijenjen nakon instalacije i neće biti obrisan")
+		}
 		return false, err
 	}
-	if !strings.EqualFold(current, expectedDigest) {
-		return false, errors.New("shortcut je promijenjen nakon instalacije i neće biti obrisan")
-	}
-
-	// Re-read immediately before deletion so a normal replacement between the
-	// ownership check and cleanup is detected and preserved.
-	confirmed, err := stableShortcutDigest(path)
-	if err != nil {
-		return false, err
-	}
-	if !strings.EqualFold(confirmed, expectedDigest) {
-		return false, errors.New("shortcut se promijenio prije uklanjanja i neće biti obrisan")
-	}
-	if err := os.Remove(path); err != nil {
-		return false, err
-	}
-	return true, nil
+	return removed, nil
 }
 
 func createOwnedShortcut(linkPath, target, workingDir, description, digestValue string) error {

--- a/scripts/test_windows_shortcut_ownership_contract.py
+++ b/scripts/test_windows_shortcut_ownership_contract.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 class WindowsShortcutOwnershipContractTests(unittest.TestCase):
     def setUp(self):
         self.source = (ROOT / "internal" / "platform" / "shortcut_windows.go").read_text(encoding="utf-8")
+        self.delete_source = (ROOT / "internal" / "platform" / "delete_windows.go").read_text(encoding="utf-8")
 
     def test_created_shortcuts_are_bound_to_digest_markers(self):
         for marker in (
@@ -21,7 +22,9 @@ class WindowsShortcutOwnershipContractTests(unittest.TestCase):
     def test_uninstall_requires_matching_ownership_digest(self):
         self.assertIn("GetRegistryString(ghostFTPUninstallKey, digestValue)", self.source)
         self.assertIn("removeShortcutMatchingDigest(path, expected)", self.source)
-        self.assertIn("!strings.EqualFold(current, expectedDigest)", self.source)
+        self.assertIn("removeVerifiedRegularFileMatchingSHA256(path, expectedDigest)", self.source)
+        self.assertIn("!strings.EqualFold(actualDigest, expectedDigest)", self.delete_source)
+        self.assertIn("errVerifiedOwnershipDigestMismatch", self.delete_source)
         self.assertIn("shortcut je promijenjen nakon instalacije i neće biti obrisan", self.source)
 
     def test_foreign_same_name_shortcut_is_not_overwritten(self):
@@ -29,10 +32,13 @@ class WindowsShortcutOwnershipContractTests(unittest.TestCase):
         self.assertIn("!sameShortcutTarget(existingTarget, target)", self.source)
         self.assertIn("nije Ghost FTP shortcut i nije prepisan", self.source)
 
-    def test_shortcut_digest_rejects_redirects(self):
-        self.assertIn("before.Mode()&os.ModeSymlink", self.source)
-        self.assertIn("shortcutReparsePoint(path)", self.source)
-        self.assertIn("os.SameFile(before, opened)", self.source)
+    def test_shortcut_digest_rejects_redirects_and_pins_identity(self):
+        self.assertIn("return verifiedRegularFileSHA256(path)", self.source)
+        self.assertIn("fileFlagOpenReparsePoint", self.delete_source)
+        self.assertIn("fileAttributeReparsePoint", self.delete_source)
+        self.assertIn("GetFileInformationByHandle", self.delete_source)
+        self.assertIn("fileShareRead", self.delete_source)
+        self.assertIn("SetFileInformationByHandle", self.delete_source)
 
 
 if __name__ == "__main__":

--- a/scripts/test_windows_verified_cleanup_contract.py
+++ b/scripts/test_windows_verified_cleanup_contract.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsVerifiedCleanupContractTests(unittest.TestCase):
+    def test_verified_handle_blocks_replacement_and_deletes_same_object(self):
+        delete_impl = (ROOT / "internal/platform/delete_windows.go").read_text(encoding="utf-8")
+
+        self.assertIn("deleteFileAccess", delete_impl)
+        self.assertIn("fileShareRead", delete_impl)
+        self.assertIn("fileFlagOpenReparsePoint", delete_impl)
+        self.assertIn('NewProc("SetFileInformationByHandle")', delete_impl)
+        self.assertIn("fileDispositionInfo", delete_impl)
+        self.assertIn("openVerifiedRegularFile(path, true)", delete_impl)
+        self.assertIn("deleteVerifiedOpenFile(f)", delete_impl)
+        self.assertIn("errVerifiedOwnershipDigestMismatch", delete_impl)
+
+    def test_shortcut_digest_and_delete_use_verified_handle_helpers(self):
+        shortcut = (ROOT / "internal/platform/shortcut_windows.go").read_text(encoding="utf-8")
+
+        self.assertIn("return verifiedRegularFileSHA256(path)", shortcut)
+        self.assertIn("removeVerifiedRegularFileMatchingSHA256(path, expectedDigest)", shortcut)
+        self.assertIn("errors.Is(err, errVerifiedOwnershipDigestMismatch)", shortcut)
+        self.assertNotIn("os.Remove(path)", shortcut)
+        self.assertNotIn("confirmed, err := stableShortcutDigest(path)", shortcut)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False)
+    if not result.result.wasSuccessful():
+        raise SystemExit(1)
+    print("WINDOWS_VERIFIED_CLEANUP_HANDLE=PINNED")


### PR DESCRIPTION
## Root cause
Shortcut ownership was improved to use SHA-256 digests, but the final cleanup still had a narrow check-then-delete gap: Ghost FTP could verify the current `.lnk` content and then call pathname-based `os.Remove(path)`. A same-user process racing uninstall/rollback could replace the path after the last digest check and before deletion.

## Threat model
A local same-user process races Ghost FTP shortcut cleanup by renaming/replacing the Desktop or Start Menu `.lnk` between ownership verification and deletion. The application must never delete a different file object merely because it later appears at the same pathname.

## Fix
- Open shortcut files through `CreateFile` with `FILE_FLAG_OPEN_REPARSE_POINT` so redirects are inspected rather than followed.
- Allow only `FILE_SHARE_READ`, which prevents concurrent writers, renames and delete-sharing while the ownership check is active.
- Add `DELETE` access only for cleanup operations.
- Hash the pinned file handle, compare the recorded ownership digest, then call `SetFileInformationByHandle(FileDispositionInfo)` on that same handle.
- Replace pathname-based shortcut digesting with the same verified-handle reader.
- Preserve modified/foreign shortcuts via a typed ownership-digest mismatch error.

## Tests
- Verified-handle SHA-256 matches expected content.
- Exact owned shortcut is deleted.
- Digest mismatch preserves the foreign/modified shortcut.
- A pinned verified handle blocks pathname replacement.
- Directories are rejected as owned regular files.
- Python structural contract locks `FILE_SHARE_READ`, `FILE_FLAG_OPEN_REPARSE_POINT`, handle-based disposition deletion, and absence of pathname `os.Remove(path)` for shortcut cleanup.
- Full Core race/vet/security/privacy, Windows setup/portable, Linux build and distro lifecycle gates remain required.

## Invariant
Ghost FTP may delete a Windows shortcut only while the exact file object whose content matched the recorded Ghost FTP ownership digest remains pinned by an open non-reparse handle. Pathname equality after verification is never sufficient authority to delete.