### PR TITLE
Security: bind legacy uninstaller cleanup to ownership proof

### DIFF
--- a/cmd/installer/legacy_uninstaller.go
+++ b/cmd/installer/legacy_uninstaller.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+)
+
+type legacyUninstallerProof struct {
+	path    string
+	digest  string
+	warning string
+	owned   bool
+}
+
+func sameCanonicalLegacyCommand(raw, expectedPath string) bool {
+	command := strings.TrimSpace(raw)
+	if len(command) >= 2 && command[0] == '"' && command[len(command)-1] == '"' {
+		command = command[1 : len(command)-1]
+	}
+	if command == "" {
+		return false
+	}
+
+	actual, err := filepath.Abs(filepath.Clean(command))
+	if err != nil {
+		return false
+	}
+	expected, err := filepath.Abs(filepath.Clean(expectedPath))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(actual, expected)
+}
+
+func captureLegacyUninstallerProof(dir string, snapshot registrySnapshot) legacyUninstallerProof {
+	legacyPath := filepath.Join(dir, "Uninstall.exe")
+	registered, ok := snapshot.stringValue(uninstallKey, "UninstallString")
+	if !ok || !sameCanonicalLegacyCommand(registered, legacyPath) {
+		if _, err := os.Lstat(legacyPath); err == nil {
+			return legacyUninstallerProof{
+				warning: "A legacy Uninstall.exe file was preserved because the previous Installed Apps registration did not prove Ghost FTP ownership.",
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return legacyUninstallerProof{
+				warning: "The legacy Uninstall.exe path could not be checked safely and was not removed.",
+			}
+		}
+		return legacyUninstallerProof{}
+	}
+
+	digest, err := platform.VerifiedRegularFileSHA256(legacyPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return legacyUninstallerProof{}
+	}
+	if err != nil {
+		return legacyUninstallerProof{
+			warning: "A registered legacy Uninstall.exe file was preserved because its file identity could not be verified safely.",
+		}
+	}
+	return legacyUninstallerProof{path: legacyPath, digest: digest, owned: true}
+}
+
+func cleanupLegacyUninstaller(proof legacyUninstallerProof) string {
+	if proof.warning != "" {
+		return "\n\n" + proof.warning
+	}
+	if !proof.owned || proof.path == "" || proof.digest == "" {
+		return ""
+	}
+
+	removed, err := platform.RemoveVerifiedRegularFileMatchingSHA256(proof.path, proof.digest)
+	if err != nil {
+		return "\n\nThe legacy Uninstall.exe file was preserved because it changed after ownership verification or could not be removed safely."
+	}
+	if !removed {
+		return ""
+	}
+	return ""
+}

--- a/cmd/installer/legacy_uninstaller.go
+++ b/cmd/installer/legacy_uninstaller.go
@@ -21,18 +21,12 @@ func sameCanonicalLegacyCommand(raw, expectedPath string) bool {
 	if len(command) >= 2 && command[0] == '"' && command[len(command)-1] == '"' {
 		command = command[1 : len(command)-1]
 	}
-	if command == "" {
+	if command == "" || !filepath.IsAbs(command) || !filepath.IsAbs(expectedPath) {
 		return false
 	}
 
-	actual, err := filepath.Abs(filepath.Clean(command))
-	if err != nil {
-		return false
-	}
-	expected, err := filepath.Abs(filepath.Clean(expectedPath))
-	if err != nil {
-		return false
-	}
+	actual := filepath.Clean(command)
+	expected := filepath.Clean(expectedPath)
 	return strings.EqualFold(actual, expected)
 }
 

--- a/cmd/installer/legacy_uninstaller_test.go
+++ b/cmd/installer/legacy_uninstaller_test.go
@@ -21,6 +21,9 @@ func TestSameCanonicalLegacyCommand(t *testing.T) {
 	if sameCanonicalLegacyCommand(filepath.Join(dir, "Other.exe"), legacy) {
 		t.Fatal("foreign executable path was accepted")
 	}
+	if sameCanonicalLegacyCommand("Uninstall.exe", legacy) {
+		t.Fatal("relative legacy executable path was accepted as ownership evidence")
+	}
 }
 
 func TestCaptureLegacyUninstallerProofRequiresRegistryOwnership(t *testing.T) {

--- a/cmd/installer/legacy_uninstaller_test.go
+++ b/cmd/installer/legacy_uninstaller_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSameCanonicalLegacyCommand(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, "Uninstall.exe")
+
+	for _, raw := range []string{legacy, `"` + legacy + `"`, "  \"" + legacy + "\"  "} {
+		if !sameCanonicalLegacyCommand(raw, legacy) {
+			t.Fatalf("expected canonical legacy command to match: %q", raw)
+		}
+	}
+	if sameCanonicalLegacyCommand(`"`+legacy+`" /S`, legacy) {
+		t.Fatal("legacy command with extra arguments was accepted")
+	}
+	if sameCanonicalLegacyCommand(filepath.Join(dir, "Other.exe"), legacy) {
+		t.Fatal("foreign executable path was accepted")
+	}
+}
+
+func TestCaptureLegacyUninstallerProofRequiresRegistryOwnership(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, "Uninstall.exe")
+	if err := os.WriteFile(legacy, []byte("foreign"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	proof := captureLegacyUninstallerProof(dir, registrySnapshot{})
+	if proof.owned {
+		t.Fatal("unregistered legacy file was treated as owned")
+	}
+	if proof.warning == "" {
+		t.Fatal("unregistered legacy file did not produce a preservation warning")
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "foreign" {
+		t.Fatalf("unregistered legacy file was not preserved: %q %v", got, err)
+	}
+}
+
+func TestCaptureLegacyUninstallerProofBindsDigest(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, "Uninstall.exe")
+	if err := os.WriteFile(legacy, []byte("legacy ghost ftp uninstaller"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := registrySnapshot{strings: []registryStringSnapshot{{
+		key: uninstallKey, name: "UninstallString", value: `"` + legacy + `"`, existed: true,
+	}}}
+	proof := captureLegacyUninstallerProof(dir, snapshot)
+	if !proof.owned || proof.path != legacy || proof.digest == "" {
+		t.Fatalf("registered legacy ownership was not captured: %+v", proof)
+	}
+}
+
+func TestRegistrySnapshotStringValueRequiresExistingEntry(t *testing.T) {
+	snapshot := registrySnapshot{strings: []registryStringSnapshot{
+		{key: uninstallKey, name: "UninstallString", value: "old", existed: true},
+		{key: uninstallKey, name: "DisplayName", value: "ignored", existed: false},
+	}}
+	if got, ok := snapshot.stringValue(uninstallKey, "UninstallString"); !ok || got != "old" {
+		t.Fatalf("unexpected captured value: %q %v", got, ok)
+	}
+	if _, ok := snapshot.stringValue(uninstallKey, "DisplayName"); ok {
+		t.Fatal("non-existing registry snapshot entry was exposed as evidence")
+	}
+}

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
 	"github.com/bren-wp/Ghost-FTP/internal/platform"

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -295,26 +295,6 @@ func register(appPath string) error {
 	return nil
 }
 
-func cleanupLegacyUninstaller(dir string) string {
-	var warnings []string
-	legacyPath := filepath.Join(dir, "Uninstall.exe")
-	info, err := os.Lstat(legacyPath)
-	if err == nil {
-		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(legacyPath) {
-			warnings = append(warnings, "A legacy Uninstall.exe entry was not removed because it is not a safe regular file.")
-		} else if err := os.Remove(legacyPath); err != nil {
-			warnings = append(warnings, "The legacy Uninstall.exe file could not be removed. Close applications using it and delete it manually.")
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		warnings = append(warnings, "The legacy Uninstall.exe path could not be checked safely.")
-	}
-
-	if len(warnings) == 0 {
-		return ""
-	}
-	return "\n\n" + strings.Join(warnings, " ")
-}
-
 func installerTitle() string {
 	return brand.ProductName + " Setup"
 }
@@ -416,6 +396,7 @@ func runInstaller() (exitCode int) {
 		)
 		return 1
 	}
+	legacyUninstaller := captureLegacyUninstallerProof(dir, registryBackup)
 
 	freshInstall := !appBackup.existed()
 	transactionCommitted := false
@@ -488,7 +469,7 @@ func runInstaller() (exitCode int) {
 	}
 
 	transactionCommitted = true
-	legacyCleanupWarning := cleanupLegacyUninstaller(dir)
+	legacyCleanupWarning := cleanupLegacyUninstaller(legacyUninstaller)
 
 	languageWarning := ""
 	if err := persistInstallerLanguage(installLanguage); err != nil {

--- a/cmd/installer/registry_snapshot.go
+++ b/cmd/installer/registry_snapshot.go
@@ -65,6 +65,15 @@ func captureRegistrySnapshot() (registrySnapshot, error) {
 	return out, nil
 }
 
+func (s registrySnapshot) stringValue(key, name string) (string, bool) {
+	for _, item := range s.strings {
+		if item.key == key && item.name == name && item.existed {
+			return item.value, true
+		}
+	}
+	return "", false
+}
+
 func (s registrySnapshot) restore() error {
 	var errs []error
 	for _, item := range s.strings {

--- a/internal/platform/delete_other.go
+++ b/internal/platform/delete_other.go
@@ -2,4 +2,60 @@
 
 package platform
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+)
+
+func VerifiedRegularFileSHA256(path string) (string, error) {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("path is not a safe regular file")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	opened, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return "", errors.New("file changed during verified open")
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	after, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	current, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(opened, after) || !os.SameFile(after, current) || current.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("file changed during verification")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func RemoveVerifiedRegularFileMatchingSHA256(string, string) (bool, error) {
+	// This exact-object deletion primitive is intentionally Windows-only. The
+	// Linux package lifecycle does not use the Windows legacy Uninstall.exe
+	// migration; fail closed rather than emulate it with pathname deletion.
+	return false, errors.New("verified legacy Windows file deletion is unavailable on Linux")
+}
+
 func ScheduleDeleteOnReboot(string) error { return nil }

--- a/internal/platform/delete_windows.go
+++ b/internal/platform/delete_windows.go
@@ -103,6 +103,12 @@ func verifiedRegularFileSHA256(path string) (string, error) {
 	return verifiedOpenFileSHA256(f)
 }
 
+// VerifiedRegularFileSHA256 hashes a regular non-reparse file through a pinned
+// Windows handle. It never follows a symlink/junction/reparse point.
+func VerifiedRegularFileSHA256(path string) (string, error) {
+	return verifiedRegularFileSHA256(path)
+}
+
 func deleteVerifiedOpenFile(f *os.File) error {
 	if f == nil {
 		return errors.New("verified file handle is unavailable")
@@ -151,6 +157,12 @@ func removeVerifiedRegularFileMatchingSHA256(path, expectedDigest string) (bool,
 		return false, err
 	}
 	return true, nil
+}
+
+// RemoveVerifiedRegularFileMatchingSHA256 deletes only the exact regular,
+// non-reparse Windows file whose pinned-handle digest matches expectedDigest.
+func RemoveVerifiedRegularFileMatchingSHA256(path, expectedDigest string) (bool, error) {
+	return removeVerifiedRegularFileMatchingSHA256(path, expectedDigest)
 }
 
 // ScheduleDeleteOnReboot asks Windows to remove a path at the next reboot.

--- a/scripts/test_windows_legacy_uninstaller_cleanup_contract.py
+++ b/scripts/test_windows_legacy_uninstaller_cleanup_contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsLegacyUninstallerCleanupContractTests(unittest.TestCase):
+    def test_registry_and_digest_proof_precede_cleanup(self):
+        helper = (ROOT / "cmd/installer/legacy_uninstaller.go").read_text(encoding="utf-8")
+        main = (ROOT / "cmd/installer/main.go").read_text(encoding="utf-8")
+        snapshot = (ROOT / "cmd/installer/registry_snapshot.go").read_text(encoding="utf-8")
+
+        self.assertIn('snapshot.stringValue(uninstallKey, "UninstallString")', helper)
+        self.assertIn("sameCanonicalLegacyCommand(registered, legacyPath)", helper)
+        self.assertIn("platform.VerifiedRegularFileSHA256(legacyPath)", helper)
+        self.assertIn("platform.RemoveVerifiedRegularFileMatchingSHA256(proof.path, proof.digest)", helper)
+        self.assertIn("func (s registrySnapshot) stringValue", snapshot)
+        self.assertIn("legacyUninstaller := captureLegacyUninstallerProof(dir, registryBackup)", main)
+        self.assertIn("cleanupLegacyUninstaller(legacyUninstaller)", main)
+
+    def test_pathname_only_legacy_delete_is_gone(self):
+        main = (ROOT / "cmd/installer/main.go").read_text(encoding="utf-8")
+        helper = (ROOT / "cmd/installer/legacy_uninstaller.go").read_text(encoding="utf-8")
+
+        self.assertNotIn("os.Remove(legacyPath)", main)
+        self.assertNotIn("security.IsReparsePoint(legacyPath)", main)
+        self.assertNotIn("os.Remove(proof.path)", helper)
+        self.assertIn("previous Installed Apps registration did not prove Ghost FTP ownership", helper)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False)
+    if not result.result.wasSuccessful():
+        raise SystemExit(1)
+    print("WINDOWS_LEGACY_UNINSTALLER_CLEANUP=OWNERSHIP_BOUND")


### PR DESCRIPTION
## Root cause
The installer’s legacy `Uninstall.exe` cleanup checked a pathname with `Lstat`/reparse validation and then later deleted that pathname with `os.Remove`. A same-user process could replace the file between the check and deletion. The old logic also treated any safe regular file named `Uninstall.exe` inside the install directory as Ghost FTP-owned without proving that the previous installation had registered it.

## Threat model
A local same-user process, or a pre-existing foreign file, occupies/replaces `<InstallDir>\Uninstall.exe` during an upgrade. Setup must not delete that file unless the previous Ghost FTP installation proved ownership before registry migration and the file content still matches that captured object.

## Fix
- Read the pre-upgrade `UninstallString` from the existing registry snapshot.
- Accept ownership only when that value is exactly the canonical legacy `Uninstall.exe` path (quoted or unquoted, with no extra arguments).
- Before replacing Installed Apps registration, hash the legacy file through the non-reparse verified-handle primitive introduced by PR #199.
- After transaction commit, delete only through `RemoveVerifiedRegularFileMatchingSHA256`, which pins a non-reparse Windows handle, revalidates the captured digest, and disposes that same file object by handle.
- Preserve any legacy file when registry ownership is absent, path identity is unsafe, content changed, or deletion cannot be proven safe.
- Linux exposes only the verification shape needed for cross-platform compilation and fails closed for the Windows-only deletion primitive.

## Tests
- Canonical quoted/unquoted legacy registration matches; added arguments and foreign executable paths are rejected.
- An unregistered same-name file is preserved and produces an ownership warning.
- Registered legacy ownership captures a digest before migration.
- Registry snapshot evidence only exposes values that actually existed.
- Python contract forbids pathname `os.Remove(legacyPath)` and requires registry + digest + verified-handle deletion flow.
- Full Core race/vet/security/privacy, Windows setup/portable, Linux build, distro packages and Debian/Ubuntu/Fedora lifecycle gates remain required.

## Invariant
Ghost FTP may remove a legacy `Uninstall.exe` only when the pre-upgrade Windows Installed Apps registration identified that exact canonical legacy path and the file still matches the digest captured through a safe non-reparse handle before registration migration. Pathname/name alone is never deletion authority.