### PR TITLE
Security: preserve unowned Start Menu parent directory

### DIFF
--- a/internal/platform/shortcut_windows.go
+++ b/internal/platform/shortcut_windows.go
@@ -300,13 +300,8 @@ func RemoveShortcuts() error {
 		errs = append(errs, err)
 	}
 
-	startDir := filepath.Dir(start)
-	if err := os.Remove(startDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-		// A non-empty company Start Menu folder is normal; do not remove
-		// unrelated shortcuts that may belong to other GhostFTP products.
-		if entries, readErr := os.ReadDir(startDir); readErr != nil || len(entries) == 0 {
-			errs = append(errs, err)
-		}
-	}
+	// Ownership records authorize removal of the exact shortcut files only.
+	// The parent company Start Menu directory can predate Ghost FTP or be shared
+	// by another product, so preserve it even when it becomes empty.
 	return errors.Join(errs...)
 }

--- a/scripts/test_windows_shortcut_ownership_contract.py
+++ b/scripts/test_windows_shortcut_ownership_contract.py
@@ -40,6 +40,13 @@ class WindowsShortcutOwnershipContractTests(unittest.TestCase):
         self.assertIn("fileShareRead", self.delete_source)
         self.assertIn("SetFileInformationByHandle", self.delete_source)
 
+    def test_uninstall_preserves_unowned_start_menu_parent_directory(self):
+        remove_shortcuts = self.source.split("func RemoveShortcuts() error {", 1)[1]
+        self.assertNotIn("os.Remove(startDir)", remove_shortcuts)
+        self.assertNotIn("os.ReadDir(startDir)", remove_shortcuts)
+        self.assertNotIn("os.Remove(filepath.Dir(start))", remove_shortcuts)
+        self.assertIn("preserve it even when it becomes empty", remove_shortcuts)
+
 
 if __name__ == "__main__":
     suite = unittest.defaultTestLoader.loadTestsFromTestCase(WindowsShortcutOwnershipContractTests)


### PR DESCRIPTION
## Root cause
`RemoveShortcuts()` correctly proves ownership of the exact Desktop and Start Menu `.lnk` files, but then separately attempted to delete the Start Menu company parent directory with `os.Remove(startDir)`. The parent directory has no Ghost FTP ownership marker and may predate Ghost FTP or be shared by another product.

## Threat model
An existing or shared empty company Start Menu directory is present when Ghost FTP uninstall/rollback removes its owned shortcut. Shortcut ownership must not be treated as authority to delete the directory object containing that shortcut.

## Fix
- Continue deleting only exact `.lnk` files whose ownership digest matches.
- Remove the parent-directory `os.Remove(startDir)` cleanup entirely.
- Preserve the company Start Menu directory even when it becomes empty.
- Keep all existing verified-handle shortcut deletion and foreign-shortcut preservation behavior unchanged.

## Regression coverage
- Extend the Windows shortcut ownership structural contract to reject `os.Remove(startDir)`, `os.ReadDir(startDir)`, and direct parent removal in `RemoveShortcuts()`.
- Require the production invariant comment that the parent directory is preserved even when empty.
- Full Core race/vet/security/privacy, Windows setup/portable, Linux build, distro packages and Debian/Ubuntu/Fedora lifecycle gates remain required.

## Invariant
Ownership of a Ghost FTP shortcut authorizes removal of that exact shortcut file only. It never authorizes deletion of the parent Start Menu directory.