### PR TITLE
Security: bind integrated Windows uninstall to executable identity

### DIFF
--- a/cmd/installer/registry_snapshot.go
+++ b/cmd/installer/registry_snapshot.go
@@ -33,6 +33,7 @@ var installerStringRegistryValues = []struct{ key, name string }{
 	{uninstallKey, "InstallLocation"},
 	{uninstallKey, "DisplayIcon"},
 	{uninstallKey, "UninstallString"},
+	{uninstallKey, installedExecutableDigestValue},
 	{uninstallKey, "QuietUninstallString"},
 	{uninstallKey, "URLInfoAbout"},
 }

--- a/cmd/installer/uninstall_constants.go
+++ b/cmd/installer/uninstall_constants.go
@@ -1,0 +1,3 @@
+package main
+
+const installedExecutableDigestValue = "InstalledExecutableSHA256"

--- a/cmd/installer/uninstall_registration_windows.go
+++ b/cmd/installer/uninstall_registration_windows.go
@@ -10,7 +10,14 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 )
 
+const installedExecutableDigestValue = "InstalledExecutableSHA256"
+
 func registerIntegratedUninstall(appPath, currentVersion string) error {
+	digest, err := platform.VerifiedRegularFileSHA256(appPath)
+	if err != nil {
+		return fmt.Errorf("installed executable ownership digest could not be verified: %w", err)
+	}
+
 	quoted := fmt.Sprintf("\"%s\" --uninstall", appPath)
 	values := []struct {
 		name  string
@@ -22,6 +29,7 @@ func registerIntegratedUninstall(appPath, currentVersion string) error {
 		{"InstallLocation", filepath.Dir(appPath)},
 		{"DisplayIcon", appPath + ",0"},
 		{"UninstallString", quoted},
+		{installedExecutableDigestValue, digest},
 		{"URLInfoAbout", brand.Website},
 	}
 	for _, item := range values {

--- a/cmd/installer/uninstall_registration_windows.go
+++ b/cmd/installer/uninstall_registration_windows.go
@@ -10,8 +10,6 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 )
 
-const installedExecutableDigestValue = "InstalledExecutableSHA256"
-
 func registerIntegratedUninstall(appPath, currentVersion string) error {
 	digest, err := platform.VerifiedRegularFileSHA256(appPath)
 	if err != nil {

--- a/internal/platform/integrated_uninstall_windows.go
+++ b/internal/platform/integrated_uninstall_windows.go
@@ -18,17 +18,15 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
 )
 
-const (
-	ghostFTPUninstallKey              = `Software\Microsoft\Windows\CurrentVersion\Uninstall\GhostFTP`
-	ghostFTPAppPathsKey               = `Software\Microsoft\Windows\CurrentVersion\App Paths\GhostFTP.exe`
-	ghostFTPInstalledDigestValue      = "InstalledExecutableSHA256"
-	integratedUninstallFinalizeArg    = "--uninstall-finalize"
-	integratedUninstallDigestEnv      = "GHOSTFTP_UNINSTALL_SHA256"
-	integratedUninstallHelperPrefix   = ".ghostftp-uninstall-"
-	processSynchronizeAccess  uintptr = 0x00100000
-	waitObject0               uintptr = 0x00000000
-	waitInfinite              uintptr = 0xffffffff
-)
+const ghostFTPUninstallKey = `Software\Microsoft\Windows\CurrentVersion\Uninstall\GhostFTP`
+const ghostFTPAppPathsKey = `Software\Microsoft\Windows\CurrentVersion\App Paths\GhostFTP.exe`
+const ghostFTPInstalledDigestValue = "InstalledExecutableSHA256"
+const integratedUninstallFinalizeArg = "--uninstall-finalize"
+const integratedUninstallDigestEnv = "GHOSTFTP_UNINSTALL_SHA256"
+const integratedUninstallHelperPrefix = ".ghostftp-uninstall-"
+const processSynchronizeAccess uintptr = 0x00100000
+const waitObject0 uintptr = 0x00000000
+const waitInfinite uintptr = 0xffffffff
 
 var kernel32IntegratedUninstall = syscall.NewLazyDLL("kernel32.dll")
 var openProcessIntegratedUninstall = kernel32IntegratedUninstall.NewProc("OpenProcess")

--- a/internal/platform/integrated_uninstall_windows.go
+++ b/internal/platform/integrated_uninstall_windows.go
@@ -3,67 +3,298 @@
 package platform
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
-	"unsafe"
 
 	"github.com/bren-wp/Ghost-FTP/internal/brand"
 )
 
 const (
-	ghostFTPUninstallKey     = `Software\Microsoft\Windows\CurrentVersion\Uninstall\GhostFTP`
-	ghostFTPAppPathsKey      = `Software\Microsoft\Windows\CurrentVersion\App Paths\GhostFTP.exe`
-	moveFileDelayUntilReboot = 0x4
+	ghostFTPUninstallKey              = `Software\Microsoft\Windows\CurrentVersion\Uninstall\GhostFTP`
+	ghostFTPAppPathsKey               = `Software\Microsoft\Windows\CurrentVersion\App Paths\GhostFTP.exe`
+	ghostFTPInstalledDigestValue      = "InstalledExecutableSHA256"
+	integratedUninstallFinalizeArg    = "--uninstall-finalize"
+	integratedUninstallDigestEnv      = "GHOSTFTP_UNINSTALL_SHA256"
+	integratedUninstallHelperPrefix   = ".ghostftp-uninstall-"
+	processSynchronizeAccess  uintptr = 0x00100000
+	waitObject0               uintptr = 0x00000000
+	waitInfinite              uintptr = 0xffffffff
 )
 
-var moveFileExUninstall = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
+var kernel32IntegratedUninstall = syscall.NewLazyDLL("kernel32.dll")
+var openProcessIntegratedUninstall = kernel32IntegratedUninstall.NewProc("OpenProcess")
+var waitForSingleObjectIntegratedUninstall = kernel32IntegratedUninstall.NewProc("WaitForSingleObject")
 
-func scheduleDeleteOnReboot(path string) error {
-	p, err := syscall.UTF16PtrFromString(path)
+func canonicalWindowsPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("path is unavailable")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func sameCanonicalWindowsPath(a, b string) bool {
+	left, err := canonicalWindowsPath(a)
+	if err != nil {
+		return false
+	}
+	right, err := canonicalWindowsPath(b)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(left, right)
+}
+
+func validSHA256Digest(value string) bool {
+	decoded, err := hex.DecodeString(strings.TrimSpace(value))
+	return err == nil && len(decoded) == sha256.Size
+}
+
+func installedGhostFTPExecutablePath() (string, error) {
+	dir, err := InstallDir()
+	if err != nil {
+		return "", err
+	}
+	return canonicalWindowsPath(filepath.Join(dir, "GhostFTP.exe"))
+}
+
+func verifyIntegratedUninstallExecutable(exe string) (string, string, error) {
+	expected, err := installedGhostFTPExecutablePath()
+	if err != nil {
+		return "", "", err
+	}
+	actual, err := canonicalWindowsPath(exe)
+	if err != nil {
+		return "", "", err
+	}
+	if !SameExecutableIdentity(actual, expected) {
+		return "", "", errors.New("running executable does not match the installed Ghost FTP file object")
+	}
+
+	registeredPath, ok, err := GetRegistryString(ghostFTPAppPathsKey, "")
+	if err != nil || !ok || !sameCanonicalWindowsPath(registeredPath, expected) {
+		return "", "", errors.New("Windows App Paths registration does not prove executable ownership")
+	}
+
+	registeredLocation, ok, err := GetRegistryString(ghostFTPUninstallKey, "InstallLocation")
+	if err != nil || !ok || !sameCanonicalWindowsPath(registeredLocation, filepath.Dir(expected)) {
+		return "", "", errors.New("Windows Installed Apps location does not prove executable ownership")
+	}
+
+	registeredCommand, ok, err := GetRegistryString(ghostFTPUninstallKey, "UninstallString")
+	expectedCommand := fmt.Sprintf("\"%s\" --uninstall", expected)
+	if err != nil || !ok || !strings.EqualFold(strings.TrimSpace(registeredCommand), expectedCommand) {
+		return "", "", errors.New("Windows Installed Apps command does not prove executable ownership")
+	}
+
+	digest, ok, err := GetRegistryString(ghostFTPUninstallKey, ghostFTPInstalledDigestValue)
+	if err != nil || !ok || !validSHA256Digest(digest) {
+		return "", "", errors.New("installed executable ownership digest is unavailable")
+	}
+	digest = strings.ToLower(strings.TrimSpace(digest))
+
+	actualDigest, err := VerifiedRegularFileSHA256(actual)
+	if err != nil || !strings.EqualFold(actualDigest, digest) {
+		return "", "", errors.New("installed executable no longer matches its ownership digest")
+	}
+	return expected, digest, nil
+}
+
+func isInstalledGhostFTPExecutable(exe string) bool {
+	_, _, err := verifyIntegratedUninstallExecutable(exe)
+	return err == nil
+}
+
+func helperEnvironment(expectedDigest string) []string {
+	prefix := strings.ToUpper(integratedUninstallDigestEnv + "=")
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, item := range os.Environ() {
+		if strings.HasPrefix(strings.ToUpper(item), prefix) {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env, integratedUninstallDigestEnv+"="+expectedDigest)
+}
+
+func prepareIntegratedUninstallHelper(exe, expectedDigest string) (string, *os.File, error) {
+	source, err := openVerifiedRegularFile(exe, false)
+	if err != nil {
+		return "", nil, err
+	}
+	defer source.Close()
+
+	digest, err := verifiedOpenFileSHA256(source)
+	if err != nil || !strings.EqualFold(digest, expectedDigest) {
+		return "", nil, errors.New("running executable changed before uninstall helper creation")
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return "", nil, err
+	}
+
+	dir := filepath.Dir(exe)
+	helper, err := os.CreateTemp(dir, integratedUninstallHelperPrefix+"*.exe")
+	if err != nil {
+		return "", nil, err
+	}
+	helperPath := helper.Name()
+	cleanup := func() {
+		_ = helper.Close()
+		_ = os.Remove(helperPath)
+	}
+
+	if _, err := io.Copy(helper, source); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := helper.Sync(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := helper.Close(); err != nil {
+		_ = os.Remove(helperPath)
+		return "", nil, err
+	}
+
+	pinned, err := openVerifiedRegularFile(helperPath, false)
+	if err != nil {
+		_ = os.Remove(helperPath)
+		return "", nil, err
+	}
+	helperDigest, err := verifiedOpenFileSHA256(pinned)
+	if err != nil || !strings.EqualFold(helperDigest, expectedDigest) {
+		_ = pinned.Close()
+		_ = os.Remove(helperPath)
+		return "", nil, errors.New("uninstall helper integrity verification failed")
+	}
+	return helperPath, pinned, nil
+}
+
+func launchIntegratedUninstallHelper(exe, expectedDigest string) error {
+	helperPath, pinned, err := prepareIntegratedUninstallHelper(exe, expectedDigest)
 	if err != nil {
 		return err
 	}
-	r, _, callErr := moveFileExUninstall.Call(uintptr(unsafe.Pointer(p)), 0, moveFileDelayUntilReboot)
-	if r == 0 {
+
+	cmd := exec.Command(helperPath, integratedUninstallFinalizeArg, strconv.Itoa(os.Getpid()))
+	cmd.Env = helperEnvironment(expectedDigest)
+	startErr := cmd.Start()
+	_ = pinned.Close()
+	if startErr != nil {
+		_ = os.Remove(helperPath)
+		return startErr
+	}
+	return cmd.Process.Release()
+}
+
+func waitForUninstallParent(pid uint32) error {
+	h, _, callErr := openProcessIntegratedUninstall.Call(processSynchronizeAccess, 0, uintptr(pid))
+	if h == 0 {
 		if callErr != nil && callErr != syscall.Errno(0) {
 			return callErr
 		}
-		return errors.New("Windows could not schedule final application-file cleanup")
+		return errors.New("uninstall parent process is unavailable")
+	}
+	defer syscall.CloseHandle(syscall.Handle(h))
+
+	result, _, callErr := waitForSingleObjectIntegratedUninstall.Call(h, waitInfinite)
+	if result != waitObject0 {
+		if callErr != nil && callErr != syscall.Errno(0) {
+			return callErr
+		}
+		return errors.New("uninstall parent process wait failed")
 	}
 	return nil
 }
 
-func isInstalledGhostFTPExecutable(exe string) bool {
-	dir, err := InstallDir()
-	if err != nil {
-		return false
+func handleIntegratedUninstallFinalizer(args []string) (bool, int) {
+	if len(args) != 3 || !strings.EqualFold(strings.TrimSpace(args[1]), integratedUninstallFinalizeArg) {
+		return false, 0
 	}
-	expected := filepath.Clean(filepath.Join(dir, "GhostFTP.exe"))
-	actual, err := filepath.Abs(exe)
+
+	exe, err := os.Executable()
 	if err != nil {
-		return false
+		return true, 1
 	}
-	return strings.EqualFold(filepath.Clean(actual), expected)
+	exe, err = canonicalWindowsPath(exe)
+	if err != nil {
+		return true, 1
+	}
+	expected, err := installedGhostFTPExecutablePath()
+	if err != nil || sameCanonicalWindowsPath(exe, expected) {
+		return true, 1
+	}
+	if !sameCanonicalWindowsPath(filepath.Dir(exe), filepath.Dir(expected)) || !strings.HasPrefix(strings.ToLower(filepath.Base(exe)), integratedUninstallHelperPrefix) {
+		return true, 1
+	}
+
+	digest := strings.TrimSpace(os.Getenv(integratedUninstallDigestEnv))
+	_ = os.Unsetenv(integratedUninstallDigestEnv)
+	if !validSHA256Digest(digest) {
+		return true, 1
+	}
+	helperDigest, err := VerifiedRegularFileSHA256(exe)
+	if err != nil || !strings.EqualFold(helperDigest, digest) {
+		return true, 1
+	}
+
+	parent, err := strconv.ParseUint(strings.TrimSpace(args[2]), 10, 32)
+	if err != nil || parent == 0 || uint32(parent) == uint32(os.Getpid()) {
+		return true, 1
+	}
+	if err := waitForUninstallParent(uint32(parent)); err != nil {
+		return true, 1
+	}
+
+	removed, err := RemoveVerifiedRegularFileMatchingSHA256(expected, digest)
+	if err != nil || !removed {
+		return true, 1
+	}
+
+	// Best-effort cleanup of the short-lived helper. The installed application
+	// has already been deleted object-bound at this point. If Windows still has
+	// the helper image mapped, only the random helper pathname is deferred.
+	if _, err := RemoveVerifiedRegularFileMatchingSHA256(exe, digest); err != nil {
+		_ = ScheduleDeleteOnReboot(exe)
+	}
+	return true, 0
 }
 
 // HandleIntegratedUninstall implements the Windows Installed Apps uninstall
-// entry without shipping a second Uninstall.exe. The installed GhostFTP.exe is
-// invoked with --uninstall and removes only application-owned installation
-// artifacts. User profiles/settings are deliberately preserved by default.
+// entry without shipping a second permanent Uninstall.exe. The installed
+// GhostFTP.exe is invoked with --uninstall, proves registry and digest ownership,
+// and launches a verified short-lived copy of itself to delete the exact
+// installed file object after the interactive parent process exits.
 func HandleIntegratedUninstall(args []string) (handled bool, exitCode int) {
+	if handled, exitCode := handleIntegratedUninstallFinalizer(args); handled {
+		return true, exitCode
+	}
 	if len(args) != 2 || !strings.EqualFold(strings.TrimSpace(args[1]), "--uninstall") {
 		return false, 0
 	}
 
 	exe, err := os.Executable()
-	if err != nil || !isInstalledGhostFTPExecutable(exe) {
+	if err != nil {
+		return true, 1
+	}
+	_, digest, err := verifyIntegratedUninstallExecutable(exe)
+	if err != nil {
 		ErrorDialog(
 			brand.ProductName+" Setup",
 			"Uninstall is unavailable",
-			"Only the installed Ghost FTP application can run the integrated uninstaller. Portable copies are never removed by this command.",
+			"The installed Ghost FTP application could not prove its installation ownership. Portable copies and replaced executables are never removed by this command.",
 		)
 		return true, 1
 	}
@@ -76,6 +307,15 @@ func HandleIntegratedUninstall(args []string) (handled bool, exitCode int) {
 		return true, 0
 	}
 
+	if err := launchIntegratedUninstallHelper(exe, digest); err != nil {
+		ErrorDialog(
+			brand.ProductName+" Setup",
+			"Uninstall could not start safely",
+			"Ghost FTP could not prepare verified final cleanup. No installation registration was removed. Close other applications and try again.",
+		)
+		return true, 1
+	}
+
 	var warnings []string
 	if err := RemoveShortcuts(); err != nil {
 		warnings = append(warnings, "Some shortcuts could not be removed.")
@@ -86,11 +326,8 @@ func HandleIntegratedUninstall(args []string) (handled bool, exitCode int) {
 	if err := DeleteRegistryKey(ghostFTPUninstallKey); err != nil {
 		warnings = append(warnings, "The Windows Installed Apps entry could not be removed.")
 	}
-	if err := scheduleDeleteOnReboot(exe); err != nil {
-		warnings = append(warnings, "The application executable could not be scheduled for final deletion. Delete it manually after closing Ghost FTP.")
-	}
 
-	message := "Ghost FTP was uninstalled. Saved profiles and settings were preserved."
+	message := "Ghost FTP uninstall is completing. Saved profiles and settings were preserved. The verified application executable will be removed after this window closes."
 	if len(warnings) > 0 {
 		message += "\n\n" + strings.Join(warnings, " ")
 	}

--- a/internal/platform/integrated_uninstall_windows.go
+++ b/internal/platform/integrated_uninstall_windows.go
@@ -196,7 +196,12 @@ func launchIntegratedUninstallHelper(exe, expectedDigest string) error {
 		_ = os.Remove(helperPath)
 		return startErr
 	}
-	return cmd.Process.Release()
+
+	// Once Start succeeds the helper owns final cleanup. Process.Release is only
+	// local bookkeeping; a bookkeeping failure must not make the parent pretend
+	// the helper did not start and then leave two conflicting uninstall paths.
+	_ = cmd.Process.Release()
+	return nil
 }
 
 func waitForUninstallParent(pid uint32) error {

--- a/internal/platform/integrated_uninstall_windows_test.go
+++ b/internal/platform/integrated_uninstall_windows_test.go
@@ -1,0 +1,76 @@
+//go:build windows
+
+package platform
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidSHA256Digest(t *testing.T) {
+	valid := hex.EncodeToString(make([]byte, sha256.Size))
+	if !validSHA256Digest(valid) {
+		t.Fatal("valid SHA-256 digest was rejected")
+	}
+	for _, value := range []string{"", "00", strings.Repeat("z", sha256.Size*2), strings.Repeat("0", sha256.Size*2-2)} {
+		if validSHA256Digest(value) {
+			t.Fatalf("invalid SHA-256 digest was accepted: %q", value)
+		}
+	}
+}
+
+func TestHelperEnvironmentReplacesExistingDigest(t *testing.T) {
+	const old = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const next = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	t.Setenv(integratedUninstallDigestEnv, old)
+
+	env := helperEnvironment(next)
+	count := 0
+	for _, item := range env {
+		if strings.HasPrefix(strings.ToUpper(item), strings.ToUpper(integratedUninstallDigestEnv+"=")) {
+			count++
+			if item != integratedUninstallDigestEnv+"="+next {
+				t.Fatalf("unexpected helper digest environment: %q", item)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one helper digest environment value, got %d", count)
+	}
+}
+
+func TestSameCanonicalWindowsPath(t *testing.T) {
+	dir := t.TempDir()
+	left := filepath.Join(dir, "GhostFTP.exe")
+	right := filepath.Join(dir, ".", "GhostFTP.exe")
+	if !sameCanonicalWindowsPath(left, right) {
+		t.Fatalf("canonical Windows paths did not match: %q %q", left, right)
+	}
+	if sameCanonicalWindowsPath(left, filepath.Join(dir, "Other.exe")) {
+		t.Fatal("foreign executable path matched installed path")
+	}
+}
+
+func TestFinalizerRejectsMalformedInvocationBeforeCleanup(t *testing.T) {
+	for _, args := range [][]string{
+		{"GhostFTP.exe"},
+		{"GhostFTP.exe", integratedUninstallFinalizeArg},
+		{"GhostFTP.exe", integratedUninstallFinalizeArg, "0"},
+		{"GhostFTP.exe", integratedUninstallFinalizeArg, "not-a-pid"},
+	} {
+		handled, _ := handleIntegratedUninstallFinalizer(args)
+		if len(args) == 1 && handled {
+			t.Fatal("non-finalizer invocation was handled as finalizer")
+		}
+	}
+
+	// Keep the compiler honest about os import on Windows while also documenting
+	// that the helper mode never accepts its own PID as a parent identifier.
+	if os.Getpid() <= 0 {
+		t.Fatal("invalid process id")
+	}
+}

--- a/scripts/test_windows_uninstall_contract.py
+++ b/scripts/test_windows_uninstall_contract.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 class WindowsUninstallContractTests(unittest.TestCase):
     def setUp(self):
+        self.constants = (ROOT / "cmd/installer/uninstall_constants.go").read_text(encoding="utf-8")
         self.registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
         self.snapshot = (ROOT / "cmd/installer/registry_snapshot.go").read_text(encoding="utf-8")
         self.runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
@@ -23,7 +24,7 @@ class WindowsUninstallContractTests(unittest.TestCase):
         self.assertIn("InfoDialog(", self.runtime)
 
     def test_installer_records_and_rolls_back_executable_ownership_digest(self):
-        self.assertIn('const installedExecutableDigestValue = "InstalledExecutableSHA256"', self.registration)
+        self.assertIn('const installedExecutableDigestValue = "InstalledExecutableSHA256"', self.constants)
         self.assertIn("platform.VerifiedRegularFileSHA256(appPath)", self.registration)
         self.assertIn("{installedExecutableDigestValue, digest}", self.registration)
         self.assertIn("{uninstallKey, installedExecutableDigestValue}", self.snapshot)
@@ -38,7 +39,7 @@ class WindowsUninstallContractTests(unittest.TestCase):
         self.assertIn("installed executable no longer matches its ownership digest", self.runtime)
 
     def test_final_cleanup_is_verified_helper_and_object_bound(self):
-        self.assertIn('integratedUninstallFinalizeArg    = "--uninstall-finalize"', self.runtime)
+        self.assertIn('const integratedUninstallFinalizeArg = "--uninstall-finalize"', self.runtime)
         self.assertIn("prepareIntegratedUninstallHelper", self.runtime)
         self.assertIn("openVerifiedRegularFile(exe, false)", self.runtime)
         self.assertIn("verifiedOpenFileSHA256(source)", self.runtime)

--- a/scripts/test_windows_uninstall_contract.py
+++ b/scripts/test_windows_uninstall_contract.py
@@ -6,24 +6,61 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WindowsUninstallContractTests(unittest.TestCase):
+    def setUp(self):
+        self.registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
+        self.snapshot = (ROOT / "cmd/installer/registry_snapshot.go").read_text(encoding="utf-8")
+        self.runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
+
     def test_interactive_uninstaller_is_not_advertised_as_quiet(self):
-        registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
-        runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
+        self.assertIn('fmt.Sprintf("\\\"%s\\\" --uninstall", appPath)', self.registration)
+        self.assertNotIn('{"QuietUninstallString", quoted}', self.registration)
+        self.assertIn('DeleteRegistryValue(uninstallKey, "QuietUninstallString")', self.registration)
 
-        self.assertIn('fmt.Sprintf("\\\"%s\\\" --uninstall", appPath)', registration)
-        self.assertNotIn('{"QuietUninstallString", quoted}', registration)
-        self.assertIn('DeleteRegistryValue(uninstallKey, "QuietUninstallString")', registration)
-
-        # The current integrated uninstall command is deliberately interactive,
+        # The integrated uninstall command is deliberately interactive,
         # so a Windows QuietUninstallString would be a false OS integration contract.
-        self.assertIn('strings.TrimSpace(args[1]), "--uninstall"', runtime)
-        self.assertIn("ConfirmDialog(", runtime)
-        self.assertIn("InfoDialog(", runtime)
+        self.assertIn('strings.TrimSpace(args[1]), "--uninstall"', self.runtime)
+        self.assertIn("ConfirmDialog(", self.runtime)
+        self.assertIn("InfoDialog(", self.runtime)
 
-    def test_stale_quiet_value_remains_inside_registry_rollback_snapshot(self):
-        snapshot = (ROOT / "cmd/installer/registry_snapshot.go").read_text(encoding="utf-8")
-        self.assertIn('{uninstallKey, "QuietUninstallString"}', snapshot)
+    def test_installer_records_and_rolls_back_executable_ownership_digest(self):
+        self.assertIn('const installedExecutableDigestValue = "InstalledExecutableSHA256"', self.registration)
+        self.assertIn("platform.VerifiedRegularFileSHA256(appPath)", self.registration)
+        self.assertIn("{installedExecutableDigestValue, digest}", self.registration)
+        self.assertIn("{uninstallKey, installedExecutableDigestValue}", self.snapshot)
+
+    def test_runtime_requires_registry_and_digest_ownership(self):
+        self.assertIn('GetRegistryString(ghostFTPAppPathsKey, "")', self.runtime)
+        self.assertIn('GetRegistryString(ghostFTPUninstallKey, "InstallLocation")', self.runtime)
+        self.assertIn('GetRegistryString(ghostFTPUninstallKey, "UninstallString")', self.runtime)
+        self.assertIn("ghostFTPInstalledDigestValue", self.runtime)
+        self.assertIn("SameExecutableIdentity(actual, expected)", self.runtime)
+        self.assertIn("VerifiedRegularFileSHA256(actual)", self.runtime)
+        self.assertIn("installed executable no longer matches its ownership digest", self.runtime)
+
+    def test_final_cleanup_is_verified_helper_and_object_bound(self):
+        self.assertIn('integratedUninstallFinalizeArg    = "--uninstall-finalize"', self.runtime)
+        self.assertIn("prepareIntegratedUninstallHelper", self.runtime)
+        self.assertIn("openVerifiedRegularFile(exe, false)", self.runtime)
+        self.assertIn("verifiedOpenFileSHA256(source)", self.runtime)
+        self.assertIn("waitForUninstallParent", self.runtime)
+        self.assertIn("RemoveVerifiedRegularFileMatchingSHA256(expected, digest)", self.runtime)
+        self.assertNotIn("scheduleDeleteOnReboot(exe)", self.runtime)
+        self.assertNotIn("moveFileDelayUntilReboot", self.runtime)
+        self.assertNotIn('NewProc("MoveFileExW")', self.runtime)
+
+    def test_finalizer_digest_is_not_put_on_command_line(self):
+        self.assertIn("helperEnvironment(expectedDigest)", self.runtime)
+        self.assertIn("integratedUninstallDigestEnv", self.runtime)
+        self.assertIn("strconv.Itoa(os.Getpid())", self.runtime)
+        self.assertNotIn("exec.Command(helperPath, integratedUninstallFinalizeArg, strconv.Itoa(os.Getpid()), expectedDigest)", self.runtime)
+
+    def test_stale_values_remain_inside_registry_rollback_snapshot(self):
+        self.assertIn('{uninstallKey, "QuietUninstallString"}', self.snapshot)
+        self.assertIn("{uninstallKey, installedExecutableDigestValue}", self.snapshot)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    result = unittest.main(exit=False)
+    if not result.result.wasSuccessful():
+        raise SystemExit(1)
+    print("WINDOWS_INTEGRATED_UNINSTALL=OWNERSHIP_BOUND")


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] Repository license and contribution requirements remain unchanged.

## Root cause
The integrated Windows uninstall path authenticated the running application primarily by its expected pathname and scheduled final `GhostFTP.exe` cleanup with a reboot-time pathname operation. A pathname can later refer to a different file object, so this was not strong enough ownership proof for destructive cleanup and could also leave per-user uninstall cleanup dependent on reboot behavior.

## Fix
- Installer stores `InstalledExecutableSHA256` in the Ghost FTP Installed Apps registry key after verifying the installed executable through the existing non-reparse verified-handle SHA-256 primitive.
- Registry rollback snapshots include that ownership marker.
- Integrated uninstall now requires expected installed file identity, App Paths registration, Installed Apps `InstallLocation`, the exact interactive `UninstallString`, and the verified executable SHA-256 marker to agree before destructive work.
- After confirmation, the installed process creates a short-lived verified copy of the same executable, pins and hashes it before launch, and passes the expected digest through the child environment rather than command-line arguments.
- The helper waits for the interactive parent to exit, then deletes only the exact installed `GhostFTP.exe` object whose pinned-handle digest still matches.
- There is no permanent `Uninstall.exe` and no reboot pathname fallback for the installed application executable. Reboot cleanup is retained only as best-effort cleanup for the random short-lived helper itself if Windows still has that helper image mapped.

## Security and privacy
- No telemetry, analytics, tracking, advertising SDK or external crash reporting added.
- No new external network destination or Go dependency added.
- No secret is passed in command-line arguments; the SHA-256 ownership digest is not secret and is passed through the child environment.
- Existing SFTP host-key verification, local confinement and verified-handle deletion primitives remain unchanged.

## Regression coverage
- Windows Go tests cover digest validation, helper environment replacement, canonical path checks and malformed helper invocation handling.
- Python contract requires registry/digest ownership, verified helper creation and exact-object final cleanup and rejects the old pathname reboot-delete pattern for the installed executable.
- Full Core race/vet/security/privacy, Windows x64/x86 setup/portable build, Authenticode, Linux production build, distro packages and Debian/Ubuntu/Fedora lifecycle gates remain mandatory.

## Invariant
An integrated uninstall may delete the installed application executable only after registry ownership and executable content identity agree, and final deletion must target the verified file object rather than an untrusted pathname.