### PR TITLE
Fix: keep Windows workspace inside monitor work area

### DIFF
--- a/internal/desktop/window_geometry.go
+++ b/internal/desktop/window_geometry.go
@@ -1,0 +1,66 @@
+package desktop
+
+const preferredWindowHorizontalMargin = 48
+const preferredWindowVerticalMargin = 72
+
+type logicalWindowBounds struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+func responsiveAxisSize(workSize, preferredSize, minimumSize, margin int) int {
+	if workSize <= 0 {
+		return preferredSize
+	}
+	// On constrained displays, accessibility wins over the normal breathing
+	// room: use the whole work area rather than forcing the canonical minimum
+	// beyond a physical screen edge.
+	if workSize < minimumSize {
+		return workSize
+	}
+	available := workSize - margin
+	if available < minimumSize {
+		available = minimumSize
+	}
+	if preferredSize > available {
+		return available
+	}
+	return preferredSize
+}
+
+func responsiveWindowBoundsForWorkArea(workX, workY, workWidth, workHeight int) logicalWindowBounds {
+	width := responsiveAxisSize(workWidth, premiumStartWidth, premiumMinWidth, preferredWindowHorizontalMargin)
+	height := responsiveAxisSize(workHeight, premiumStartHeight, premiumMinHeight, preferredWindowVerticalMargin)
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+	return logicalWindowBounds{
+		X:      workX + (workWidth-width)/2,
+		Y:      workY + (workHeight-height)/2,
+		Width:  width,
+		Height: height,
+	}
+}
+
+func responsiveMinimumTrackSize(workWidth, workHeight int) (width, height int) {
+	width = premiumMinWidth
+	height = premiumMinHeight
+	if workWidth > 0 && width > workWidth {
+		width = workWidth
+	}
+	if workHeight > 0 && height > workHeight {
+		height = workHeight
+	}
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+	return
+}

--- a/internal/desktop/window_geometry_test.go
+++ b/internal/desktop/window_geometry_test.go
@@ -14,8 +14,8 @@ func TestResponsiveWindowBoundsUsesCanonicalStartSizeOnLargeWorkArea(t *testing.
 
 func TestResponsiveWindowBoundsNeverExceedsConstrainedWorkArea(t *testing.T) {
 	for _, tc := range []struct {
-		name          string
-		x, y, w, h    int
+		name       string
+		x, y, w, h int
 	}{
 		{name: "small laptop", w: 800, h: 600},
 		{name: "short desktop", w: 1024, h: 600},

--- a/internal/desktop/window_geometry_test.go
+++ b/internal/desktop/window_geometry_test.go
@@ -1,0 +1,52 @@
+package desktop
+
+import "testing"
+
+func TestResponsiveWindowBoundsUsesCanonicalStartSizeOnLargeWorkArea(t *testing.T) {
+	got := responsiveWindowBoundsForWorkArea(0, 0, 1920, 1080)
+	if got.Width != premiumStartWidth || got.Height != premiumStartHeight {
+		t.Fatalf("unexpected preferred size: %+v", got)
+	}
+	if got.X != (1920-premiumStartWidth)/2 || got.Y != (1080-premiumStartHeight)/2 {
+		t.Fatalf("window was not centered in work area: %+v", got)
+	}
+}
+
+func TestResponsiveWindowBoundsNeverExceedsConstrainedWorkArea(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		x, y, w, h    int
+	}{
+		{name: "small laptop", w: 800, h: 600},
+		{name: "short desktop", w: 1024, h: 600},
+		{name: "offset monitor", x: -1280, y: 40, w: 900, h: 650},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := responsiveWindowBoundsForWorkArea(tc.x, tc.y, tc.w, tc.h)
+			if got.Width > tc.w || got.Height > tc.h {
+				t.Fatalf("window exceeds work area: work=%dx%d got=%+v", tc.w, tc.h, got)
+			}
+			if got.X < tc.x || got.Y < tc.y || got.X+got.Width > tc.x+tc.w || got.Y+got.Height > tc.y+tc.h {
+				t.Fatalf("window is outside work area: work=(%d,%d %dx%d) got=%+v", tc.x, tc.y, tc.w, tc.h, got)
+			}
+		})
+	}
+}
+
+func TestResponsiveWindowBoundsPreservesMinimumWhenWorkAreaCanFitIt(t *testing.T) {
+	got := responsiveWindowBoundsForWorkArea(0, 0, premiumMinWidth+20, premiumMinHeight+20)
+	if got.Width < premiumMinWidth || got.Height < premiumMinHeight {
+		t.Fatalf("canonical minimum was discarded despite available space: %+v", got)
+	}
+}
+
+func TestResponsiveMinimumTrackSizeClampsToWorkArea(t *testing.T) {
+	w, h := responsiveMinimumTrackSize(800, 600)
+	if w != 800 || h != 600 {
+		t.Fatalf("constrained minimum mismatch: got %dx%d", w, h)
+	}
+	w, h = responsiveMinimumTrackSize(1920, 1080)
+	if w != premiumMinWidth || h != premiumMinHeight {
+		t.Fatalf("normal minimum mismatch: got %dx%d", w, h)
+	}
+}

--- a/internal/desktop/window_geometry_windows.go
+++ b/internal/desktop/window_geometry_windows.go
@@ -14,6 +14,7 @@ type responsiveMonitorInfo struct {
 }
 
 var monitorFromWindowResponsive = user32.NewProc("MonitorFromWindow")
+var monitorFromRectResponsive = user32.NewProc("MonitorFromRect")
 var getMonitorInfoWResponsive = user32.NewProc("GetMonitorInfoW")
 
 func (a *app) logicalFromPhysical(value int32) int {
@@ -77,10 +78,14 @@ func (a *app) responsiveMinTrackSize() (width, height int) {
 }
 
 func (a *app) clampSuggestedWindowRectToWorkArea(value rect) rect {
-	if a == nil || a.hwnd == 0 {
+	if a == nil {
 		return value
 	}
-	monitor, _, _ := monitorFromWindowResponsive.Call(a.hwnd, monitorDefaultToNearest)
+	// WM_DPICHANGED supplies a rectangle for the destination monitor. Resolve
+	// that rectangle directly rather than the window's pre-move HWND position,
+	// otherwise a cross-monitor DPI transition can be clamped back to the old
+	// monitor before MoveWindow applies the suggested bounds.
+	monitor, _, _ := monitorFromRectResponsive.Call(uintptr(unsafe.Pointer(&value)), monitorDefaultToNearest)
 	if monitor == 0 {
 		return value
 	}

--- a/internal/desktop/window_geometry_windows.go
+++ b/internal/desktop/window_geometry_windows.go
@@ -1,0 +1,118 @@
+//go:build windows
+
+package desktop
+
+import "unsafe"
+
+const monitorDefaultToNearest = 2
+
+type responsiveMonitorInfo struct {
+	Size    uint32
+	Monitor rect
+	Work    rect
+	Flags   uint32
+}
+
+var monitorFromWindowResponsive = user32.NewProc("MonitorFromWindow")
+var getMonitorInfoWResponsive = user32.NewProc("GetMonitorInfoW")
+
+func (a *app) logicalFromPhysical(value int32) int {
+	dpi := a.dpi
+	if dpi == 0 {
+		dpi = 96
+	}
+	// Deliberately use truncation rather than a positive-only rounding offset:
+	// monitor origins may be negative in multi-monitor layouts.
+	return int(value) * 96 / int(dpi)
+}
+
+func (a *app) monitorWorkAreaLogical() (x, y, width, height int, ok bool) {
+	if a == nil || a.hwnd == 0 {
+		return 0, 0, 0, 0, false
+	}
+	monitor, _, _ := monitorFromWindowResponsive.Call(a.hwnd, monitorDefaultToNearest)
+	if monitor == 0 {
+		return 0, 0, 0, 0, false
+	}
+	info := responsiveMonitorInfo{Size: uint32(unsafe.Sizeof(responsiveMonitorInfo{}))}
+	result, _, _ := getMonitorInfoWResponsive.Call(monitor, uintptr(unsafe.Pointer(&info)))
+	if result == 0 || info.Work.Right <= info.Work.Left || info.Work.Bottom <= info.Work.Top {
+		return 0, 0, 0, 0, false
+	}
+	x = a.logicalFromPhysical(info.Work.Left)
+	y = a.logicalFromPhysical(info.Work.Top)
+	right := a.logicalFromPhysical(info.Work.Right)
+	bottom := a.logicalFromPhysical(info.Work.Bottom)
+	return x, y, right - x, bottom - y, true
+}
+
+func (a *app) responsiveWindowBounds() (x, y, width, height int) {
+	workX, workY, workWidth, workHeight, ok := a.monitorWorkAreaLogical()
+	if !ok {
+		screenWRaw, _, _ := getSystemMetrics.Call(smCxScreen)
+		screenHRaw, _, _ := getSystemMetrics.Call(smCyScreen)
+		if screenWRaw == 0 || screenHRaw == 0 {
+			return 40, 30, premiumStartWidth, premiumStartHeight
+		}
+		workWidth = a.unscale(int(screenWRaw))
+		workHeight = a.unscale(int(screenHRaw))
+	}
+	bounds := responsiveWindowBoundsForWorkArea(workX, workY, workWidth, workHeight)
+	return bounds.X, bounds.Y, bounds.Width, bounds.Height
+}
+
+func (a *app) responsiveMinTrackSize() (width, height int) {
+	_, _, workWidth, workHeight, ok := a.monitorWorkAreaLogical()
+	if !ok {
+		screenWRaw, _, _ := getSystemMetrics.Call(smCxScreen)
+		screenHRaw, _, _ := getSystemMetrics.Call(smCyScreen)
+		if screenWRaw != 0 {
+			workWidth = a.unscale(int(screenWRaw))
+		}
+		if screenHRaw != 0 {
+			workHeight = a.unscale(int(screenHRaw))
+		}
+	}
+	return responsiveMinimumTrackSize(workWidth, workHeight)
+}
+
+func (a *app) clampSuggestedWindowRectToWorkArea(value rect) rect {
+	if a == nil || a.hwnd == 0 {
+		return value
+	}
+	monitor, _, _ := monitorFromWindowResponsive.Call(a.hwnd, monitorDefaultToNearest)
+	if monitor == 0 {
+		return value
+	}
+	info := responsiveMonitorInfo{Size: uint32(unsafe.Sizeof(responsiveMonitorInfo{}))}
+	result, _, _ := getMonitorInfoWResponsive.Call(monitor, uintptr(unsafe.Pointer(&info)))
+	if result == 0 || info.Work.Right <= info.Work.Left || info.Work.Bottom <= info.Work.Top {
+		return value
+	}
+
+	width := value.Right - value.Left
+	height := value.Bottom - value.Top
+	workWidth := info.Work.Right - info.Work.Left
+	workHeight := info.Work.Bottom - info.Work.Top
+	if width > workWidth {
+		width = workWidth
+	}
+	if height > workHeight {
+		height = workHeight
+	}
+	if value.Left < info.Work.Left {
+		value.Left = info.Work.Left
+	}
+	if value.Top < info.Work.Top {
+		value.Top = info.Work.Top
+	}
+	if value.Left+width > info.Work.Right {
+		value.Left = info.Work.Right - width
+	}
+	if value.Top+height > info.Work.Bottom {
+		value.Top = info.Work.Bottom - height
+	}
+	value.Right = value.Left + width
+	value.Bottom = value.Top + height
+	return value
+}

--- a/internal/desktop/windows.go
+++ b/internal/desktop/windows.go
@@ -139,7 +139,7 @@ func Run(engine *api.Engine, version string) error {
 	a.hwnd = hwnd
 	a.dpi = windowDPI(hwnd)
 	apps.Store(hwnd, a)
-	x, y, w, h := a.preferredWindowBounds()
+	x, y, w, h := a.responsiveWindowBounds()
 	moveWindow.Call(hwnd, uintptr(a.scale(x)), uintptr(a.scale(y)), uintptr(a.scale(w)), uintptr(a.scale(h)), 0)
 	applyDarkTitleBar(hwnd)
 	if err := a.createControls(hinst); err != nil {
@@ -233,8 +233,9 @@ func wndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
 	case wmGetMinMaxInfo:
 		if lParam != 0 {
 			info := minMaxInfoFromLParam(lParam)
-			info.MinTrackSize.X = int32(a.scale(premiumMinWidth))
-			info.MinTrackSize.Y = int32(a.scale(premiumMinHeight))
+			minWidth, minHeight := a.responsiveMinTrackSize()
+			info.MinTrackSize.X = int32(a.scale(minWidth))
+			info.MinTrackSize.Y = int32(a.scale(minHeight))
 			minMaxInfoToLParam(lParam, info)
 		}
 		return 0
@@ -250,7 +251,7 @@ func wndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
 		}
 		a.applyDPI(newDPI)
 		if lParam != 0 {
-			r := rectFromLParam(lParam)
+			r := a.clampSuggestedWindowRectToWorkArea(rectFromLParam(lParam))
 			moveWindow.Call(hwnd, uintptr(r.Left), uintptr(r.Top), uintptr(r.Right-r.Left), uintptr(r.Bottom-r.Top), 1)
 		}
 		return 0

--- a/scripts/test_ui_stability_hardening.py
+++ b/scripts/test_ui_stability_hardening.py
@@ -215,7 +215,7 @@ class UIStabilityHardeningTests(unittest.TestCase):
         for marker in (
             "responsiveWindowBoundsForWorkArea",
             "responsiveMinimumTrackSize",
-            "monitorWorkAreaForWindow",
+            "monitorWorkAreaLogical",
         ):
             self.assertIn(marker, geometry)
         for marker in (

--- a/scripts/test_ui_stability_hardening.py
+++ b/scripts/test_ui_stability_hardening.py
@@ -198,17 +198,26 @@ class UIStabilityHardeningTests(unittest.TestCase):
         ui = self.read("internal/desktop/ui_windows.go")
         theme = self.read("internal/desktop/theme.go")
         windows = self.read("internal/desktop/windows.go")
+        geometry = self.read("internal/desktop/window_geometry_windows.go")
         layout = self.read("internal/desktop/workspace_layout_windows.go")
         for marker in (
             "premiumStartWidth", "premiumStartHeight", "premiumMinWidth", "premiumMinHeight",
         ):
             self.assertIn(marker, theme)
         for marker in (
-            "info.MinTrackSize.X = int32(a.scale(premiumMinWidth))",
-            "info.MinTrackSize.Y = int32(a.scale(premiumMinHeight))",
+            "minWidth, minHeight := a.responsiveMinTrackSize()",
+            "info.MinTrackSize.X = int32(a.scale(minWidth))",
+            "info.MinTrackSize.Y = int32(a.scale(minHeight))",
+            "r := a.clampSuggestedWindowRectToWorkArea(rectFromLParam(lParam))",
             "case wmSize:", "case wmDpiChanged:",
         ):
             self.assertIn(marker, windows)
+        for marker in (
+            "responsiveWindowBoundsForWorkArea",
+            "responsiveMinimumTrackSize",
+            "monitorWorkAreaForWindow",
+        ):
+            self.assertIn(marker, geometry)
         for marker in (
             "compact := width < 1180", "profileW := clampInt", "localPathW", "remotePathW",
             "queueH := clampInt", "a.move(a.transferList",

--- a/scripts/test_windows_responsive_geometry_contract.py
+++ b/scripts/test_windows_responsive_geometry_contract.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WindowsResponsiveGeometryContractTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_dpi_clamp_resolves_the_destination_monitor(self) -> None:
+        geometry = self.read("internal/desktop/window_geometry_windows.go")
+        clamp = geometry.split("func (a *app) clampSuggestedWindowRectToWorkArea", 1)[1]
+        self.assertIn('NewProc("MonitorFromRect")', geometry)
+        self.assertIn("monitorFromRectResponsive.Call", clamp)
+        self.assertNotIn("monitorFromWindowResponsive.Call(a.hwnd", clamp)
+
+    def test_minimum_and_startup_geometry_are_work_area_aware(self) -> None:
+        windows = self.read("internal/desktop/windows.go")
+        geometry = self.read("internal/desktop/window_geometry_windows.go")
+        pure = self.read("internal/desktop/window_geometry.go")
+        self.assertIn("a.responsiveWindowBounds()", windows)
+        self.assertIn("a.responsiveMinTrackSize()", windows)
+        self.assertIn("monitorWorkAreaLogical()", geometry)
+        self.assertIn("responsiveWindowBoundsForWorkArea", pure)
+        self.assertIn("responsiveMinimumTrackSize", pure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Summary

- use the canonical desktop startup geometry instead of a separate oversized Windows hardcode
- clamp startup and DPI-suggested bounds to the active monitor work area
- adapt minimum track size when the available monitor is smaller than the canonical premium minimum
- preserve multi-monitor offsets, including negative coordinates
- add regression tests for small displays and offset monitors

## Why

The previous geometry contract could shrink requested bounds to the screen and then immediately expand them back to the fixed 940x680 minimum. `WM_GETMINMAXINFO` reinforced the same fixed minimum. On small/effective work areas this could force Ghost FTP partly off-screen even though the workspace already has a compact layout path.

## Branding and compatibility

- [x] Public UI remains Ghost FTP branded.
- [x] No installed-application identity or compatibility identifiers changed.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] Credential handling is unchanged.
- [x] SFTP host-key verification and pinning remain active.
- [x] Local path confinement protections remain active.
- [x] No external Go module was added.

## Validation

Exact-head GitHub Actions must pass before merge, including Go format/tests/vet/race, security/privacy/documentation audits, Windows x64/x86 setup and portable builds, Authenticode smoke, Linux production packages, and distro install lifecycle.

## Regression coverage

`window_geometry_test.go` covers 800x600, 1024x600, canonical desktop sizing and negative-origin multi-monitor geometry. Windows-specific code maps those pure geometry rules to monitor work areas and DPI-change suggested rectangles.