### PR TITLE
Feature: add secure remote text edit engine

### DIFF
--- a/internal/api/remote_edit.go
+++ b/internal/api/remote_edit.go
@@ -1,0 +1,378 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/remote"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+const MaxRemoteEditBytes int64 = 4 << 20
+
+var (
+	ErrRemoteEditConflict = errors.New("remote file changed since it was opened")
+	ErrRemoteEditBinary   = errors.New("remote file is not UTF-8 text and cannot be edited safely")
+	ErrRemoteEditTooLarge = errors.New("remote file is too large for the built-in editor")
+)
+
+type RemoteEditDocument struct {
+	Path        string
+	Text        string
+	Revision    string
+	Size        int64
+	Permissions string
+}
+
+type remoteEditWorkspace struct {
+	path string
+	root *os.Root
+	info os.FileInfo
+}
+
+func newRemoteEditWorkspace(base string) (*remoteEditWorkspace, error) {
+	dir, err := os.MkdirTemp(base, ".GhostFTP-edit-*")
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func() { _ = os.Remove(dir) }
+	if err := os.Chmod(dir, 0700); err != nil {
+		cleanup()
+		return nil, err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(dir) {
+		cleanup()
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("remote edit workspace is not a private directory")
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	return &remoteEditWorkspace{path: dir, root: root, info: info}, nil
+}
+
+func (w *remoteEditWorkspace) cleanup() {
+	if w == nil {
+		return
+	}
+	if w.root != nil {
+		for _, name := range []string{"content", "source"} {
+			_ = w.root.Remove(name)
+		}
+		_ = w.root.Close()
+		w.root = nil
+	}
+	if st, err := os.Lstat(w.path); err == nil && st.IsDir() && os.SameFile(w.info, st) && !security.IsReparsePoint(w.path) {
+		_ = os.Remove(w.path)
+	}
+}
+
+func (w *remoteEditWorkspace) pathFor(name string) string {
+	return filepath.Join(w.path, name)
+}
+
+func (w *remoteEditWorkspace) writeSource(data []byte) (string, error) {
+	f, err := w.root.OpenFile("source", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return "", err
+	}
+	closed := false
+	ok := false
+	defer func() {
+		if !closed {
+			_ = f.Close()
+		}
+		if !ok {
+			_ = w.root.Remove("source")
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return "", err
+	}
+	if err := f.Sync(); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	closed = true
+	st, err := w.root.Lstat("source")
+	if err != nil || !st.Mode().IsRegular() || st.Mode()&os.ModeSymlink != 0 || st.Size() != int64(len(data)) || security.IsReparsePoint(w.pathFor("source")) {
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New("remote edit staging file changed before upload")
+	}
+	ok = true
+	return w.pathFor("source"), nil
+}
+
+func remoteEditRevision(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func validRemoteEditRevision(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}
+
+func validateRemoteEditText(data []byte) error {
+	if int64(len(data)) > MaxRemoteEditBytes {
+		return ErrRemoteEditTooLarge
+	}
+	if !utf8.Valid(data) {
+		return ErrRemoteEditBinary
+	}
+	for _, b := range data {
+		if b == 0 {
+			return ErrRemoteEditBinary
+		}
+	}
+	return nil
+}
+
+func remoteEditPermissionMode(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if len(raw) == 3 || len(raw) == 4 {
+		for _, ch := range raw {
+			if ch < '0' || ch > '7' {
+				return ""
+			}
+		return raw
+	}
+	if len(raw) < 10 || len(raw) > 11 {
+		return ""
+	}
+	raw = raw[:10]
+	if !strings.ContainsRune("-bcdlps", rune(raw[0])) {
+		return ""
+	}
+	digits := []byte{'0', '0', '0'}
+	for group := 0; group < 3; group++ {
+		base := 1 + group*3
+		if !strings.ContainsRune("r-", rune(raw[base])) || !strings.ContainsRune("w-", rune(raw[base+1])) || !strings.ContainsRune("xstST-", rune(raw[base+2])) {
+			return ""
+		}
+		value := 0
+		if raw[base] == 'r' {
+			value += 4
+		}
+		if raw[base+1] == 'w' {
+			value += 2
+		}
+		if strings.ContainsRune("xst", rune(raw[base+2])) {
+			value++
+		}
+		digits[group] = byte('0' + value)
+	}
+	special := 0
+	if raw[3] == 's' || raw[3] == 'S' {
+		special += 4
+	}
+	if raw[6] == 's' || raw[6] == 'S' {
+		special += 2
+	}
+	if raw[9] == 't' || raw[9] == 'T' {
+		special++
+	}
+	if special != 0 {
+		return string([]byte{byte('0' + special), digits[0], digits[1], digits[2]})
+	}
+	return string(digits)
+}
+
+func editableRemoteItem(ctx context.Context, s remote.Session, remotePath string) (model.Item, error) {
+	if err := security.ValidateRemoteFilePath(remotePath); err != nil {
+		return model.Item{}, err
+	}
+	clean := path.Clean(remotePath)
+	dir, name := path.Dir(clean), path.Base(clean)
+	items, err := s.List(ctx, dir)
+	if err != nil {
+		return model.Item{}, err
+	}
+	for _, item := range items {
+		if item.Name != name {
+			continue
+		}
+		if item.IsDirectory || item.IsSymlink {
+			return model.Item{}, errors.New("only regular remote files can be edited")
+		}
+		if item.Size > MaxRemoteEditBytes {
+			return model.Item{}, ErrRemoteEditTooLarge
+		}
+		return item, nil
+	}
+	return model.Item{}, errors.New("remote file was not found in its parent directory")
+}
+
+func readRemoteEditFile(w *remoteEditWorkspace, name string) ([]byte, error) {
+	before, err := w.root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 || before.Size() > MaxRemoteEditBytes || security.IsReparsePoint(w.pathFor(name)) {
+		if before.Size() > MaxRemoteEditBytes {
+			return nil, ErrRemoteEditTooLarge
+		}
+		return nil, errors.New("downloaded edit source is not a regular file")
+	}
+	f, err := w.root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	opened, err := f.Stat()
+	if err != nil || !os.SameFile(before, opened) {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("downloaded edit source changed while opening")
+	}
+	data, err := io.ReadAll(io.LimitReader(f, MaxRemoteEditBytes+1))
+	if err != nil {
+		security.WipeBytes(data)
+		return nil, err
+	}
+	if int64(len(data)) > MaxRemoteEditBytes {
+		security.WipeBytes(data)
+		return nil, ErrRemoteEditTooLarge
+	}
+	after, err := f.Stat()
+	if err != nil || !os.SameFile(opened, after) || opened.Size() != after.Size() || int64(len(data)) != after.Size() || !opened.ModTime().Equal(after.ModTime()) {
+		security.WipeBytes(data)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("downloaded edit source changed while reading")
+	}
+	if err := validateRemoteEditText(data); err != nil {
+		security.WipeBytes(data)
+		return nil, err
+	}
+	return data, nil
+}
+
+func openRemoteEditWithSession(ctx context.Context, dataDir string, s remote.Session, remotePath string) (RemoteEditDocument, error) {
+	item, err := editableRemoteItem(ctx, s, remotePath)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	workspace, err := newRemoteEditWorkspace(dataDir)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	defer workspace.cleanup()
+	local := workspace.pathFor("content")
+	if err := s.Download(ctx, remotePath, local, remote.TransferOptions{LocalRoot: workspace.path}); err != nil {
+		return RemoteEditDocument{}, err
+	}
+	data, err := readRemoteEditFile(workspace, "content")
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	defer security.WipeBytes(data)
+	return RemoteEditDocument{
+		Path:        remotePath,
+		Text:        string(data),
+		Revision:    remoteEditRevision(data),
+		Size:        int64(len(data)),
+		Permissions: item.Permissions,
+	}, nil
+}
+
+func saveRemoteEditWithSession(ctx context.Context, dataDir string, s remote.Session, remotePath, expectedRevision, text string) (RemoteEditDocument, error) {
+	if !validRemoteEditRevision(expectedRevision) {
+		return RemoteEditDocument{}, errors.New("remote edit revision is invalid")
+	}
+	content := []byte(text)
+	defer security.WipeBytes(content)
+	if err := validateRemoteEditText(content); err != nil {
+		return RemoteEditDocument{}, err
+	}
+
+	current, err := openRemoteEditWithSession(ctx, dataDir, s, remotePath)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	if current.Revision != expectedRevision {
+		return RemoteEditDocument{}, ErrRemoteEditConflict
+	}
+
+	clean := path.Clean(remotePath)
+	dir, name := path.Dir(clean), path.Base(clean)
+	mode := remoteEditPermissionMode(current.Permissions)
+	if mode != "" {
+		// Prove the server accepts the exact existing mode before changing content.
+		// This makes permission preservation fail closed for servers that expose a
+		// POSIX mode but cannot safely apply it through the active protocol.
+		if err := s.Chmod(ctx, dir, name, mode); err != nil {
+			return RemoteEditDocument{}, fmt.Errorf("remote file permissions cannot be preserved safely: %w", err)
+		}
+	}
+
+	workspace, err := newRemoteEditWorkspace(dataDir)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	defer workspace.cleanup()
+	source, err := workspace.writeSource(content)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	if err := s.Upload(ctx, source, remotePath, remote.TransferOptions{}); err != nil {
+		return RemoteEditDocument{}, err
+	}
+	if mode != "" {
+		if err := s.Chmod(ctx, dir, name, mode); err != nil {
+			return RemoteEditDocument{}, fmt.Errorf("remote edit content was saved but original permissions could not be restored: %w", err)
+		}
+	}
+
+	writtenRevision := remoteEditRevision(content)
+	verified, err := openRemoteEditWithSession(ctx, dataDir, s, remotePath)
+	if err != nil {
+		return RemoteEditDocument{}, fmt.Errorf("remote edit was uploaded but read-back verification failed: %w", err)
+	}
+	if verified.Revision != writtenRevision {
+		return RemoteEditDocument{}, errors.New("remote edit was uploaded but read-back content did not match")
+	}
+	return verified, nil
+}
+
+func (e *Engine) RemoteEditOpen(ctx context.Context, remotePath string) (RemoteEditDocument, error) {
+	s, opCtx, release, err := e.remote.Operation(ctx)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	defer release()
+	return openRemoteEditWithSession(opCtx, e.dataDir, s, remotePath)
+}
+
+func (e *Engine) RemoteEditSave(ctx context.Context, remotePath, expectedRevision, text string) (RemoteEditDocument, error) {
+	s, opCtx, release, err := e.remote.Operation(ctx)
+	if err != nil {
+		return RemoteEditDocument{}, err
+	}
+	defer release()
+	return saveRemoteEditWithSession(opCtx, e.dataDir, s, remotePath, expectedRevision, text)
+}

--- a/internal/api/remote_edit.go
+++ b/internal/api/remote_edit.go
@@ -157,6 +157,7 @@ func remoteEditPermissionMode(raw string) string {
 			if ch < '0' || ch > '7' {
 				return ""
 			}
+		}
 		return raw
 	}
 	if len(raw) < 10 || len(raw) > 11 {

--- a/internal/api/remote_edit_test.go
+++ b/internal/api/remote_edit_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/remote"
+)
+
+type remoteEditTestSession struct {
+	remotePath   string
+	content      []byte
+	permissions  string
+	sizeOverride int64
+	isDirectory  bool
+	isSymlink    bool
+	downloads    int
+	uploads      int
+	chmodModes   []string
+	chmodErr     error
+}
+
+func (*remoteEditTestSession) Protocol() string { return "sftp" }
+func (*remoteEditTestSession) Host() string     { return "example.test" }
+func (*remoteEditTestSession) Port() int        { return 22 }
+func (s *remoteEditTestSession) List(context.Context, string) ([]model.Item, error) {
+	size := int64(len(s.content))
+	if s.sizeOverride != 0 {
+		size = s.sizeOverride
+	}
+	return []model.Item{{
+		Name: path.Base(s.remotePath), Size: size,
+		IsDirectory: s.isDirectory, IsSymlink: s.isSymlink, Permissions: s.permissions,
+	}}, nil
+}
+func (*remoteEditTestSession) Mkdir(context.Context, string, string) error          { return nil }
+func (*remoteEditTestSession) Rename(context.Context, string, string, string) error { return nil }
+func (*remoteEditTestSession) Delete(context.Context, string, string, bool) error   { return nil }
+func (s *remoteEditTestSession) Chmod(_ context.Context, _, _ string, mode string) error {
+	s.chmodModes = append(s.chmodModes, mode)
+	return s.chmodErr
+}
+func (s *remoteEditTestSession) Upload(_ context.Context, local, _ string, _ remote.TransferOptions) error {
+	data, err := os.ReadFile(local)
+	if err != nil {
+		return err
+	}
+	s.uploads++
+	s.content = append(s.content[:0], data...)
+	return nil
+}
+func (s *remoteEditTestSession) Download(_ context.Context, _ string, local string, _ remote.TransferOptions) error {
+	s.downloads++
+	return os.WriteFile(local, s.content, 0600)
+}
+func (*remoteEditTestSession) Close() error { return nil }
+
+func newRemoteEditTestSession(content string) *remoteEditTestSession {
+	return &remoteEditTestSession{
+		remotePath:  "/site/config.txt",
+		content:     []byte(content),
+		permissions: "-rw-r-----",
+	}
+}
+
+func assertNoRemoteEditWorkspace(t *testing.T, base string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(base, ".GhostFTP-edit-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("remote edit workspace leaked: %v", matches)
+	}
+}
+
+func TestRemoteEditOpenReturnsBoundedUTF8RevisionAndCleansWorkspace(t *testing.T) {
+	base := t.TempDir()
+	s := newRemoteEditTestSession("hello\nworld\n")
+	doc, err := openRemoteEditWithSession(context.Background(), base, s, s.remotePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Text != "hello\nworld\n" || doc.Size != int64(len(doc.Text)) {
+		t.Fatalf("unexpected document: %+v", doc)
+	}
+	if !validRemoteEditRevision(doc.Revision) {
+		t.Fatalf("invalid revision %q", doc.Revision)
+	}
+	if doc.Permissions != "-rw-r-----" {
+		t.Fatalf("permissions=%q", doc.Permissions)
+	}
+	if s.downloads != 1 {
+		t.Fatalf("downloads=%d, want 1", s.downloads)
+	}
+	assertNoRemoteEditWorkspace(t, base)
+}
+
+func TestRemoteEditRejectsBinaryAndOversizedFiles(t *testing.T) {
+	base := t.TempDir()
+	binary := newRemoteEditTestSession("")
+	binary.content = []byte{0xff, 0xfe, 0x00}
+	if _, err := openRemoteEditWithSession(context.Background(), base, binary, binary.remotePath); !errors.Is(err, ErrRemoteEditBinary) {
+		t.Fatalf("binary error=%v, want ErrRemoteEditBinary", err)
+	}
+	assertNoRemoteEditWorkspace(t, base)
+
+	large := newRemoteEditTestSession("small-placeholder")
+	large.sizeOverride = MaxRemoteEditBytes + 1
+	if _, err := openRemoteEditWithSession(context.Background(), base, large, large.remotePath); !errors.Is(err, ErrRemoteEditTooLarge) {
+		t.Fatalf("large error=%v, want ErrRemoteEditTooLarge", err)
+	}
+	if large.downloads != 0 {
+		t.Fatalf("oversized file was downloaded %d times", large.downloads)
+	}
+}
+
+func TestRemoteEditRejectsDirectoriesAndSymlinksBeforeDownload(t *testing.T) {
+	for _, mutate := range []func(*remoteEditTestSession){
+		func(s *remoteEditTestSession) { s.isDirectory = true },
+		func(s *remoteEditTestSession) { s.isSymlink = true },
+	} {
+		s := newRemoteEditTestSession("content")
+		mutate(s)
+		if _, err := openRemoteEditWithSession(context.Background(), t.TempDir(), s, s.remotePath); err == nil {
+			t.Fatal("expected non-regular remote entry rejection")
+		}
+		if s.downloads != 0 {
+			t.Fatal("non-regular remote entry reached download")
+		}
+	}
+}
+
+func TestRemoteEditSaveDetectsConcurrentChangeBeforeUpload(t *testing.T) {
+	base := t.TempDir()
+	s := newRemoteEditTestSession("version one\n")
+	doc, err := openRemoteEditWithSession(context.Background(), base, s, s.remotePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.content = []byte("changed elsewhere\n")
+	_, err = saveRemoteEditWithSession(context.Background(), base, s, s.remotePath, doc.Revision, "my edit\n")
+	if !errors.Is(err, ErrRemoteEditConflict) {
+		t.Fatalf("save error=%v, want ErrRemoteEditConflict", err)
+	}
+	if s.uploads != 0 {
+		t.Fatalf("conflicting edit uploaded %d times", s.uploads)
+	}
+	if string(s.content) != "changed elsewhere\n" {
+		t.Fatalf("conflicting content was modified: %q", s.content)
+	}
+	assertNoRemoteEditWorkspace(t, base)
+}
+
+func TestRemoteEditSavePreservesReportedModeAndVerifiesReadBack(t *testing.T) {
+	base := t.TempDir()
+	s := newRemoteEditTestSession("old\n")
+	s.permissions = "-rwxr-x---"
+	doc, err := openRemoteEditWithSession(context.Background(), base, s, s.remotePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := saveRemoteEditWithSession(context.Background(), base, s, s.remotePath, doc.Revision, "new value\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(s.content) != "new value\n" || updated.Text != "new value\n" {
+		t.Fatalf("content not updated: remote=%q doc=%q", s.content, updated.Text)
+	}
+	if s.uploads != 1 {
+		t.Fatalf("uploads=%d, want 1", s.uploads)
+	}
+	if len(s.chmodModes) != 2 || s.chmodModes[0] != "750" || s.chmodModes[1] != "750" {
+		t.Fatalf("chmod modes=%v, want [750 750]", s.chmodModes)
+	}
+	if updated.Revision == doc.Revision || !validRemoteEditRevision(updated.Revision) {
+		t.Fatalf("revision did not advance safely: before=%q after=%q", doc.Revision, updated.Revision)
+	}
+	assertNoRemoteEditWorkspace(t, base)
+}
+
+func TestRemoteEditSaveFailsBeforeUploadWhenReportedModeCannotBePreserved(t *testing.T) {
+	base := t.TempDir()
+	s := newRemoteEditTestSession("old\n")
+	doc, err := openRemoteEditWithSession(context.Background(), base, s, s.remotePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.chmodErr = errors.New("chmod unsupported")
+	_, err = saveRemoteEditWithSession(context.Background(), base, s, s.remotePath, doc.Revision, "new\n")
+	if err == nil {
+		t.Fatal("expected permission preservation failure")
+	}
+	if s.uploads != 0 || string(s.content) != "old\n" {
+		t.Fatalf("save changed content despite failed permission preflight: uploads=%d content=%q", s.uploads, s.content)
+	}
+	assertNoRemoteEditWorkspace(t, base)
+}
+
+func TestRemoteEditPermissionModeHandlesSpecialBits(t *testing.T) {
+	cases := map[string]string{
+		"0644":       "0644",
+		"755":        "755",
+		"-rw-r--r--": "644",
+		"-rwsr-xr-x": "4755",
+		"drwxrwsr-t": "3775",
+		"not-a-mode": "",
+	}
+	for input, want := range cases {
+		if got := remoteEditPermissionMode(input); got != want {
+			t.Fatalf("remoteEditPermissionMode(%q)=%q, want %q", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add the shared backend required for built-in remote text editing across FTP, FTPS and SFTP without adding a second protocol implementation or bypassing the existing transfer hardening.

## Remote Edit contract

- `Engine.RemoteEditOpen` downloads a selected regular remote file into a private transient workspace and returns bounded UTF-8 text plus a SHA-256 revision token.
- `Engine.RemoteEditSave` re-reads the current remote object through the same active session generation and refuses a stale save with `ErrRemoteEditConflict` when the revision changed.
- editor content is limited to 4 MiB and rejects NUL/non-UTF-8 binary input;
- directories and symlinks are rejected before download;
- staging uses private temporary directories/files and is removed after each operation;
- save reuses the existing transaction-safe remote Upload implementation rather than introducing a new unsafe write path;
- when the server reports a POSIX permission mode, save proves the existing mode can be re-applied before changing content and restores it after upload;
- the saved remote file is downloaded again and SHA-256 verified before the operation reports success.

## Platform parity

This PR deliberately contains no platform-specific editor UI. The typed Engine API is shared by Windows and Linux, so the subsequent native UI PR can expose exactly the same edit/save/conflict behavior on both frontends without duplicating FTP/SFTP logic.

## Security / privacy

- no telemetry, analytics, tracking or external service;
- no new network destination;
- no external Go dependency;
- FTPS/SFTP trust policy unchanged;
- no credentials in arguments/logs;
- no persistent plaintext copy of edited remote content;
- existing transactional upload, local-root and connection-generation protections remain authoritative.

## Regression coverage

Tests cover bounded UTF-8 open, binary/oversize rejection, directory/symlink rejection, staging cleanup, stale revision conflict, reported-mode preservation preflight, successful save/read-back verification and permission-mode conversion.