### PR TITLE
Fix: refresh remote metadata after editor save

### DIFF
--- a/internal/desktop/remote_edit_linux.go
+++ b/internal/desktop/remote_edit_linux.go
@@ -23,6 +23,8 @@ const (
 	linuxRemoteEditPendingReload
 )
 
+const linuxActionRemoteEditMetadataRefresh = linuxActionTransfer + 1
+
 type linuxRemoteEditState struct {
 	mu sync.Mutex
 
@@ -135,6 +137,25 @@ func (u *linuxDesktop) openSelectedRemoteEditor() {
 }
 
 func (u *linuxDesktop) handleRemoteEditResult(result linuxUIResult) bool {
+	if result.action == linuxActionRemoteEditMetadataRefresh {
+		if result.err == nil {
+			selectedName := ""
+			if item, ok := u.selectedRemoteItem(); ok {
+				selectedName = item.Name
+			}
+			u.remoteCurrent = result.localBase
+			u.remoteItems = result.remoteItems
+			u.selectedRemote = -1
+			for index := range u.remoteItems {
+				if u.remoteItems[index].Name == selectedName {
+					u.selectedRemote = index
+					break
+				}
+			}
+		}
+		return true
+	}
+
 	state := linuxRemoteEditStateFor(u)
 	state.mu.Lock()
 	pending := state.pending
@@ -174,7 +195,23 @@ func (u *linuxDesktop) handleRemoteEditResult(result linuxUIResult) bool {
 	state.message = message
 	state.mu.Unlock()
 	u.setStatus(message)
+	if pending == linuxRemoteEditPendingSave {
+		u.refreshRemoteMetadataAfterEdit()
+	}
 	return true
+}
+
+func (u *linuxDesktop) refreshRemoteMetadataAfterEdit() {
+	if u.busy || !u.connected {
+		return
+	}
+	target := u.remoteCurrent
+	u.startAction(linuxActionRemoteEditMetadataRefresh, func() linuxUIResult {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		items, err := u.engine.RemoteList(ctx, target)
+		return linuxUIResult{remoteItems: items, localBase: target, err: err}
+	})
 }
 
 func (u *linuxDesktop) remoteEditSave() {

--- a/internal/desktop/remote_edit_metadata_refresh_linux_test.go
+++ b/internal/desktop/remote_edit_metadata_refresh_linux_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package desktop
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestRemoteEditMetadataRefreshPreservesSelectionAndStatus(t *testing.T) {
+	u := &linuxDesktop{
+		remoteCurrent:  "/site",
+		remoteItems:    []model.Item{{Name: "index.php", Size: 10}, {Name: "other.txt", Size: 5}},
+		selectedRemote: 0,
+		status:         "Saved and verified.",
+	}
+
+	result := linuxUIResult{
+		action:    linuxActionRemoteEditMetadataRefresh,
+		localBase: "/site",
+		remoteItems: []model.Item{
+			{Name: "other.txt", Size: 5},
+			{Name: "index.php", Size: 42},
+		},
+	}
+	if !u.handleRemoteEditResult(result) {
+		t.Fatal("metadata refresh result was not consumed")
+	}
+	if u.status != "Saved and verified." {
+		t.Fatalf("metadata refresh changed successful save status: %q", u.status)
+	}
+	if u.selectedRemote != 1 {
+		t.Fatalf("edited file selection was not restored: got %d", u.selectedRemote)
+	}
+	if got := u.remoteItems[u.selectedRemote].Size; got != 42 {
+		t.Fatalf("remote metadata was not refreshed: got size %d", got)
+	}
+}
+
+func TestRemoteEditMetadataRefreshFailureDoesNotRewriteSaveOutcome(t *testing.T) {
+	u := &linuxDesktop{
+		remoteCurrent:  "/site",
+		remoteItems:    []model.Item{{Name: "index.php", Size: 10}},
+		selectedRemote: 0,
+		status:         "Saved and verified.",
+	}
+
+	result := linuxUIResult{
+		action: linuxActionRemoteEditMetadataRefresh,
+		err:    errors.New("listing unavailable"),
+	}
+	if !u.handleRemoteEditResult(result) {
+		t.Fatal("failed metadata refresh result was not consumed")
+	}
+	if u.status != "Saved and verified." {
+		t.Fatalf("listing failure replaced successful save status: %q", u.status)
+	}
+	if len(u.remoteItems) != 1 || u.remoteItems[0].Size != 10 {
+		t.Fatalf("failed refresh replaced the existing remote list: %#v", u.remoteItems)
+	}
+}

--- a/internal/desktop/remote_edit_windows.go
+++ b/internal/desktop/remote_edit_windows.go
@@ -166,6 +166,7 @@ func (a *app) saveRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEdit
 				return
 			}
 			a.setStatus(words.Saved)
+			a.refreshRemote(a.remoteCurrent)
 			a.showRemoteTextEditor(saved, next, next.Text, generation)
 		})
 	})

--- a/scripts/test_remote_edit_metadata_refresh_contract.py
+++ b/scripts/test_remote_edit_metadata_refresh_contract.py
@@ -1,0 +1,55 @@
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class RemoteEditMetadataRefreshContract(unittest.TestCase):
+    def read(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def test_windows_refreshes_listing_only_after_verified_save(self):
+        source = self.read("internal/desktop/remote_edit_windows.go")
+        save_start = source.index("func (a *app) saveRemoteTextEditor")
+        reload_start = source.index("func (a *app) reloadRemoteTextEditor")
+        save_body = source[save_start:reload_start]
+
+        saved_status = save_body.index("a.setStatus(words.Saved)")
+        refresh = save_body.index("a.refreshRemote(a.remoteCurrent)")
+        reopen = save_body.index("a.showRemoteTextEditor(saved, next, next.Text, generation)")
+        conflict_return = save_body.index("return", save_body.index("if err != nil"))
+
+        self.assertLess(conflict_return, saved_status)
+        self.assertLess(saved_status, refresh)
+        self.assertLess(refresh, reopen)
+        self.assertEqual(save_body.count("a.refreshRemote(a.remoteCurrent)"), 1)
+
+    def test_linux_uses_quiet_serialized_metadata_refresh(self):
+        source = self.read("internal/desktop/remote_edit_linux.go")
+
+        self.assertIn("linuxActionRemoteEditMetadataRefresh", source)
+        self.assertIn("func (u *linuxDesktop) refreshRemoteMetadataAfterEdit()", source)
+        self.assertIn("u.engine.RemoteList(ctx, target)", source)
+        self.assertIn("if pending == linuxRemoteEditPendingSave", source)
+        self.assertIn("u.refreshRemoteMetadataAfterEdit()", source)
+        self.assertIn("if result.action == linuxActionRemoteEditMetadataRefresh", source)
+        self.assertIn("selectedName = item.Name", source)
+        self.assertIn("u.remoteItems[index].Name == selectedName", source)
+
+        refresh_start = source.index("func (u *linuxDesktop) refreshRemoteMetadataAfterEdit()")
+        save_start = source.index("func (u *linuxDesktop) remoteEditSave()")
+        refresh_body = source[refresh_start:save_start]
+        self.assertNotIn("setStatus", refresh_body)
+
+    def test_metadata_refresh_does_not_add_a_second_transfer_path(self):
+        windows = self.read("internal/desktop/remote_edit_windows.go")
+        linux = self.read("internal/desktop/remote_edit_linux.go")
+
+        self.assertNotIn("exec.Command", windows + linux)
+        self.assertNotIn("os.StartProcess", windows + linux)
+        self.assertEqual(windows.count("RemoteEditSave"), 1)
+        self.assertEqual(linux.count("RemoteEditSave"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix stale remote-list metadata after a successful built-in Remote Edit save on Windows and Linux.

## Behavior

- Windows starts the existing selection-preserving asynchronous remote refresh only after `RemoteEditSave` succeeds and read-back verification has completed.
- Linux starts a serialized quiet metadata refresh after the save result is confirmed successful.
- Linux keeps the successful **Saved** status visible while refreshing metadata.
- Linux restores the selected edited file by name after the fresh listing arrives.
- A follow-up Linux listing failure does not rewrite a verified save as a save failure or replace the existing remote list.

## Safety

- no change to `RemoteEditOpen` / `RemoteEditSave` revision, size, text/binary, confinement or read-back verification contracts;
- no second FTP/FTPS/SFTP implementation;
- no external process/editor, telemetry, tracking, dependency, service or new network destination;
- failed/conflicted saves do not trigger the success-only metadata refresh path.

## Regression coverage

- Linux tests cover metadata replacement, selection restoration and quiet failure behavior.
- Python structural contract requires the success-only Windows refresh and serialized Linux metadata-refresh path.

`REMOTE_EDIT_METADATA_REFRESH=SUCCESS_ONLY`
