### PR TITLE
Hardening: post-0.0.1 reliability, UI contracts and documentation

### DIFF
--- a/.github/workflows/release-branch-trigger.yml
+++ b/.github/workflows/release-branch-trigger.yml
@@ -15,7 +15,7 @@ jobs:
   dispatch:
     if: ${{ github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/ghostftp-v') }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 60
     steps:
       - name: Checkout current main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -55,9 +55,92 @@ jobs:
             exit 1
           }
 
+          list_run_ids() {
+            local workflow="$1"
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow "$workflow" \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 50 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          }
+
+          wait_for_new_run() {
+            local workflow="$1"
+            local before_file="$2"
+            local deadline=$((SECONDS + 180))
+            local candidate=''
+            while (( SECONDS < deadline )); do
+              while IFS=$'\t' read -r id sha; do
+                [[ -n "$id" && "$sha" = "$main_sha" ]] || continue
+                if ! grep -Fxq "$id" "$before_file"; then
+                  candidate="$id"
+                  break
+                fi
+              done < <(
+                gh run list \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --workflow "$workflow" \
+                  --branch main \
+                  --event workflow_dispatch \
+                  --limit 50 \
+                  --json databaseId,headSha \
+                  --jq '.[] | [.databaseId, .headSha] | @tsv'
+              )
+              if [[ -n "$candidate" ]]; then
+                printf '%s\n' "$candidate"
+                return 0
+              fi
+              sleep 3
+            done
+            echo "Timed out waiting for dispatched $workflow run on $main_sha" >&2
+            return 1
+          }
+
+          release_before="$(mktemp)"
+          retention_before="$(mktemp)"
+          trap 'rm -f "$release_before" "$retention_before"' EXIT
+          list_run_ids release.yml > "$release_before"
+
           gh workflow run release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f version="$version"
 
-          echo "RELEASE_DISPATCH=PASS (Ghost FTP $version; commit=$main_sha)"
+          release_run_id="$(wait_for_new_run release.yml "$release_before")"
+          echo "RELEASE_RUN_ID=$release_run_id"
+          gh run watch "$release_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --exit-status \
+            --interval 10
+          release_conclusion="$(gh run view "$release_run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)"
+          test "$release_conclusion" = 'success' || {
+            echo "Canonical release run $release_run_id concluded $release_conclusion; retention will not start" >&2
+            exit 1
+          }
+
+          # workflow_run chaining is intentionally not trusted as the only path.
+          # A GITHUB_TOKEN-dispatched release can complete successfully without
+          # creating the expected downstream retention run. Dispatch the canonical
+          # retention workflow explicitly only after the exact release run succeeds.
+          list_run_ids release-retention.yml > "$retention_before"
+          gh workflow run release-retention.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
+
+          retention_run_id="$(wait_for_new_run release-retention.yml "$retention_before")"
+          echo "RETENTION_RUN_ID=$retention_run_id"
+          gh run watch "$retention_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --exit-status \
+            --interval 5
+          retention_conclusion="$(gh run view "$retention_run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)"
+          test "$retention_conclusion" = 'success' || {
+            echo "Canonical retention run $retention_run_id concluded $retention_conclusion" >&2
+            exit 1
+          }
+
+          echo "RELEASE_DISPATCH=PASS (Ghost FTP $version; commit=$main_sha; run=$release_run_id)"
+          echo "RELEASE_RETENTION_CHAIN=PASS (run=$retention_run_id)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Reliability and release engineering
+
+- Made the canonical release-branch lifecycle wait for the exact newly dispatched `Publish Ghost FTP` workflow run and require terminal success before retention can begin.
+- Added explicit canonical retention dispatch/read-back after a successful publish run so latest-only cleanup does not depend on `workflow_run` event chaining alone.
+- Added exact-main workflow-run identification and fail-closed release/retention completion checks.
+- Fixed release-note generation so semantic major version zero no longer implies Beta/prerelease and current 0.0.x releases retain their verified GitHub Packages section.
+
+### Settings and compatibility
+
+- Safely migrate omitted legacy `parallelism=0` saves to the canonical default of 2 while continuing to reject explicit negative or above-range values.
+- Expanded settings regression coverage so compatibility migration cannot silently weaken current validation rules.
+
+### Desktop quality
+
+- Added a regression contract that rejects main Windows buttons without command handlers and Linux controls/overlays without click handlers.
+- Added a guard against silently discarded Windows queue Cancel/Retry errors.
+- Defined complete acceptance criteria for future directory comparison, synchronized browsing, search/filter, bandwidth control, queue priority, bookmarks, verified resume, multi-session and proxy/jump-host capabilities before they may appear as shipped UI.
+
+### Documentation and product media
+
+- Redesigned the root README around the repository-local Ghost FTP icon and authentic Main Workspace, Site Manager, Settings and About screenshots.
+- Reorganized the documentation index around installation, settings, security/privacy, architecture, UI evidence, testing and release verification.
+- Added a README/media regression contract that rejects remote image sources, missing local media and loss of authentic screenshot provenance.
+- Expanded Settings, Testing, GitHub Releases and Roadmap documentation to match the hardened runtime/release contracts.
+
 ## 0.0.1 - 2026-09-09
 
 ### Desktop client

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Ghost FTP
 
 <p align="center">
-  <img src="build/icon.png" alt="Ghost FTP application icon" width="112">
+  <img src="build/icon.png" alt="Ghost FTP application icon" width="128">
 </p>
 
-**Ghost FTP** is a privacy-first native desktop file-transfer client for **Windows and Linux**. It provides a focused dual-pane workstation for **FTP, FTPS and SFTP**, saved profiles, protected credential handling, bounded transfer management and a built-in remote text editor without application telemetry.
+<p align="center"><strong>Fast, private and security-focused FTP/FTPS/SFTP for Windows and Linux.</strong></p>
+
+<p align="center">
+  Native desktop UI · Site Manager · Remote Edit · Safe transfer queue · 24 local languages · No application telemetry
+</p>
+
+**Ghost FTP** is a privacy-first native desktop file-transfer client for **Windows and Linux**. It combines a focused dual-pane workspace with **FTP, FTPS and SFTP**, saved profiles, protected credential handling, bounded transfer management and a built-in remote text editor. The design target is a modern professional transfer workstation: fewer ambiguous controls, safer defaults, clear state and strong failure handling without a mandatory product account or hidden cloud backend.
 
 - Current Ghost FTP version: **0.0.1**
 - Development status: **Active**
@@ -12,21 +18,52 @@
 - Default language: **English**
 - Selectable local languages: **24 languages**
 - Official product website: **https://ghostftp.com**
-
 - Releases: https://github.com/bren-wp/Ghost-FTP/releases
 - Repository: https://github.com/bren-wp/Ghost-FTP
 
 ![Ghost FTP main workspace](docs/images/ghost-ftp-main-workspace.png)
 
-The icon and UI images rendered by this README are repository-local assets. The README does not load remote badges, tracking pixels, icon CDNs or webfont resources.
+The icon and UI images rendered by this README are **repository-local assets**. The screenshots are captured from the production Windows x64 Portable build by the maintained authentic-UI workflow; mockups and generated approximations are not accepted as production UI evidence. No remote badge, tracking pixel, icon CDN or webfont is required to render this README.
 
-## 0.0.1
+## Product surfaces
 
-Ghost FTP 0.0.1 starts the current public release line. It combines the maintained Windows/Linux desktop client, FTP/FTPS/SFTP engine, secure installer/uninstaller behavior, responsive desktop geometry and built-in Remote Edit workflow into one release identity. Semantic major version `0` does not by itself mark this project release as a GitHub prerelease.
+<table>
+<tr>
+<td width="50%" valign="top"><strong>Site Manager</strong><br><br><img src="docs/images/ghost-ftp-site-manager.png" alt="Ghost FTP Site Manager"></td>
+<td width="50%" valign="top"><strong>Settings</strong><br><br><img src="docs/images/ghost-ftp-settings.png" alt="Ghost FTP Settings"></td>
+</tr>
+<tr>
+<td colspan="2" align="center"><strong>About / product identity</strong><br><br><img src="docs/images/ghost-ftp-about.png" alt="Ghost FTP About" width="620"></td>
+</tr>
+</table>
+
+See [Reference UI](docs/REFERENCE-UI.md) for screenshot provenance and the production visual contract.
+
+## What Ghost FTP already does
+
+### Transfer workstation
+
+- Local and Remote panes with independent navigation and sorting.
+- Upload/download queue with bounded concurrency.
+- Pause, resume, cancel, retry and clear-finished lifecycle.
+- Progress, transferred bytes, speed and ETA based on real transfer events.
+- Recursive directory transfer through the shared engine.
+- Explicit conflict policy: **Skip**, **Replace**, or **Replace + recovery backup**.
+- Safe staged activation/rollback rather than direct destructive overwrite.
+- Automatic retry only for errors classified as retryable; trust, permission, validation and unsafe-path failures do not become blind retry loops.
+
+### Server and profile workflow
+
+- FTP, explicit FTPS and SFTP.
+- Site Manager with saved profiles.
+- Password, SFTP private-key and passphrase workflows.
+- Per-save credential persistence decision instead of hidden automatic secret storage.
+- Connection diagnostics with bounded user-safe error reporting.
+- Strict connection-generation/identity binding so queued work cannot silently migrate to a different server session.
 
 ### Remote Edit
 
-A regular remote text file can be opened directly from the Remote pane and edited without launching an external editor. The shared engine used by Windows and Linux provides:
+A regular remote text file can be opened directly from the Remote pane and edited without launching an external editor. The shared Windows/Linux engine provides:
 
 - bounded editing up to the maintained Remote Edit size limit;
 - UTF-8/text validation and binary rejection;
@@ -36,46 +73,23 @@ A regular remote text file can be opened directly from the Remote pane and edite
 - remote permission preservation when the server exposes a trustworthy mode;
 - metadata refresh after a successful save while retaining the edited-file selection.
 
-The UI remains intentionally compact: high-value actions are available without permanently adding extra panes or toolbars.
-
 ### Security and privacy baseline
 
 Ghost FTP preserves FTPS certificate/hostname validation, explicit secure-protocol selection with no silent downgrade, strict SFTP host-key verification/pinning, protected-secret lifetime rules, local root/path protections, staged transfer activation/rollback, trusted Linux transport/AskPass provenance and exact-object Windows cleanup where ownership must be proven.
 
-Ghost FTP includes no application analytics, advertising, tracking pixels, fingerprinting, automatic crash upload, mandatory product account or hidden profile synchronization. Go telemetry is disabled in production CI and release workflows.
+Ghost FTP includes **no application analytics, advertising, tracking pixels, fingerprinting, automatic crash upload, mandatory Ghost FTP account or hidden profile synchronization**. Go telemetry is disabled in production CI and release workflows.
 
-See [Security](docs/SECURITY.md) and [Privacy](docs/PRIVACY.md).
+See [Security](docs/SECURITY.md), [Privacy](docs/PRIVACY.md) and [Architecture](docs/ARCHITECTURE.md).
 
-## Desktop workflow
+## Design goals beyond legacy FTP clients
 
-Ghost FTP provides:
+Ghost FTP is not developed by cloning another client screen-for-screen. New capabilities are accepted only when the engine, Windows UI, Linux UI, tests, privacy/security model and documentation agree on the behavior. Current improvement priorities include stronger queue control, large-directory responsiveness, directory comparison/search/filter workflows, navigation productivity and bandwidth-aware transfer controls. Features are not advertised as shipped until their complete runtime path is implemented and tested.
 
-- a **Local** file pane;
-- a **Remote** server pane;
-- **Site Manager** for saved profiles;
-- built-in Remote Edit for supported text files;
-- a transfer queue with pause/resume/cancel/retry lifecycle;
-- connection diagnostics and status surfaces;
-- keyboard-first navigation and file actions;
-- language, appearance, transfer and connection settings.
+See the [Roadmap](docs/ROADMAP.md) for the maintained power-user plan.
 
-The Windows frontend uses native Win32 drawing and controls. The Linux frontend uses the maintained X11/XWayland-compatible native path. Both consume the same typed Core behavior.
+## 0.0.1
 
-![Ghost FTP Site Manager](docs/images/ghost-ftp-site-manager.png)
-
-## Authentic UI evidence
-
-The maintained screenshots below are produced from the real production Windows x64 Portable executable. Mockups, generated approximations and manually composed replacements are not accepted as production UI evidence.
-
-### Settings
-
-![Ghost FTP Settings](docs/images/ghost-ftp-settings.png)
-
-### About
-
-![Ghost FTP About](docs/images/ghost-ftp-about.png)
-
-See [Reference UI](docs/REFERENCE-UI.md).
+Ghost FTP 0.0.1 starts the current public release line. It combines the maintained Windows/Linux desktop client, FTP/FTPS/SFTP engine, secure installer/uninstaller behavior, responsive desktop geometry and built-in Remote Edit workflow into one release identity. Semantic major version `0` does not by itself mark this project release as a GitHub prerelease.
 
 ## Protocols
 
@@ -90,6 +104,21 @@ SFTP uses SSH transport semantics with host-key verification. Password and key-b
 ### FTP — explicit compatibility
 
 Plain FTP remains available only as an explicit compatibility choice for legacy servers that intentionally require unencrypted FTP.
+
+## Settings that have runtime effect
+
+The Settings surfaces are backed by one validated configuration model rather than decorative UI state:
+
+- **Parallel transfers:** 1–8, default 2.
+- **Connection timeout:** 5–60 seconds, default 15.
+- **Automatic retries:** 0–3, default 0.
+- **Retry delay:** 1–30 seconds, default 3.
+- **Conflict policy:** skip / replace / replace with recovery backup.
+- **Delete confirmation:** enabled by default.
+- **Appearance:** maintained Windows Classic Light/Dark behavior.
+- **Language:** 24 local languages, English fallback.
+
+Missing legacy settings are migrated to safe canonical defaults; explicit invalid values remain validation failures. See [Settings](docs/SETTINGS.md).
 
 ## Languages
 
@@ -144,7 +173,7 @@ The same verified release directory is published as a distribution-only GHCR bun
 ghcr.io/bren-wp/ghost-ftp:0.0.1
 ```
 
-The GHCR object is not a supported runtime container. After a new Ghost FTP release is successfully published and remotely verified, the release-retention workflow removes older Ghost FTP GitHub releases, tags, superseded release branches and obsolete package versions while retaining the current release package. **Only the latest public Ghost FTP version is retained.**
+The GHCR object is not a supported runtime container. After a new Ghost FTP release is successfully published and remotely verified, the release-retention workflow removes older Ghost FTP GitHub releases, tags, superseded release branches and obsolete package versions while retaining the current release package. The release-branch trigger also waits for the canonical release result and explicitly verifies the canonical retention result, so the latest-only lifecycle is not dependent on a single downstream event notification. **Only the latest public Ghost FTP version is retained.**
 
 See [GitHub Releases](docs/GITHUB-RELEASES.md), [GitHub Packages](docs/PACKAGES.md), [Release verification](docs/RELEASE-VERIFICATION.md) and [Versioning](docs/VERSIONING.md).
 
@@ -173,6 +202,10 @@ Canonical Linux packages:
 ```bash
 bash linux/BUILD.sh
 ```
+
+## Quality gates
+
+The production CI/release path checks Go formatting, race tests, unit/integration tests, vet, dependency policy, privacy/security audits, platform parity, localization, release/version documentation contracts, Windows x64/x86 packaging, Linux amd64/arm64/i386 packaging, distro lifecycle smoke tests and authentic Windows UI screenshots. A green source test is not enough by itself for publication: release identity, remote asset read-back and retention are separately fail-closed.
 
 ## Documentation
 

--- a/docs/GITHUB-RELEASES.md
+++ b/docs/GITHUB-RELEASES.md
@@ -32,7 +32,22 @@ For the current candidate:
 release/ghostftp-v0.0.1
 ```
 
-`.github/workflows/release-branch-trigger.yml` accepts the branch only when its semantic version matches root `VERSION` and its SHA equals exact current `main`. It then dispatches the canonical release workflow on `main` with the version guard.
+`.github/workflows/release-branch-trigger.yml` accepts the branch only when its semantic version matches root `VERSION` and its SHA equals exact current `main`.
+
+The trigger then performs a deterministic lifecycle rather than treating dispatch as success:
+
+1. snapshot the existing `release.yml` workflow-dispatch run IDs;
+2. dispatch canonical `release.yml` on `main` with the exact version guard;
+3. discover the newly created `Publish Ghost FTP` run whose `headSha` equals the validated `main` SHA;
+4. wait for that exact run with `gh run watch --exit-status`;
+5. verify its terminal conclusion is `success`;
+6. only then snapshot existing retention runs and explicitly dispatch canonical `release-retention.yml` on `main`;
+7. discover the new exact-main retention run;
+8. wait for it and require terminal `success` before the release-branch trigger itself can succeed.
+
+This explicit completion chain exists because a workflow dispatched with the repository `GITHUB_TOKEN` must not rely on a downstream `workflow_run` notification as its only retention path. `release-retention.yml` keeps its `workflow_run` trigger as defense in depth, but the release branch lifecycle is successful only after canonical retention is observed successfully.
+
+The trigger never force-moves release identities and never dispatches retention before the canonical release run succeeds.
 
 ## 0.0.1 public files
 
@@ -74,6 +89,8 @@ That is **15 public files** total.
 
 Before publication the release workflow compares current `main` with the release workflow source SHA. It performs the comparison again after publication before the delayed remote asset read-back. If `main` moves, publication fails rather than claiming stale source.
 
+The release-branch trigger also filters the newly dispatched publish and retention workflow runs by the validated exact `main` SHA. An older successful workflow run cannot satisfy a new release lifecycle.
+
 ## Immutable-current publication transaction
 
 The requested `ghostftp-v0.0.1` tag/release must not already exist. The publish workflow never clobbers a release asset or rewrites an existing current release tag.
@@ -85,7 +102,22 @@ After the new release is successfully published and remotely verified, `.github/
 - superseded `release/ghostftp-v*` branches;
 - obsolete Ghost FTP container package versions.
 
-The current release branch and current package version are retained. The cleanup runs only after the canonical `Publish Ghost FTP` workflow succeeds, and manual cleanup additionally verifies the current release is non-draft, `prerelease=false`, has exactly 15 assets and points to current `main`. Repository commit history on `main` is not rewritten.
+The current release branch and current package version are retained. The cleanup independently verifies that the current release is non-draft, `prerelease=false`, has exactly 15 assets and points to current `main` before destructive cleanup. Repository commit history on `main` is not rewritten.
+
+## Failure behavior
+
+The release lifecycle fails closed:
+
+- if the release branch does not match root `VERSION`;
+- if the release branch SHA is not exact current `main`;
+- if a newly dispatched exact release run cannot be identified;
+- if the canonical release run fails or is cancelled;
+- if retention is requested before publish success;
+- if the current release/tag/asset set does not pass retention preflight;
+- if a newly dispatched retention run cannot be identified;
+- if canonical retention fails or is cancelled.
+
+A successful workflow dispatch request by itself is **not** treated as successful publication.
 
 ## Linux portable parity gate
 
@@ -131,4 +163,4 @@ ghcr.io/bren-wp/ghost-ftp:0.0.1
 
 It is a **distribution bundle**, not a runtime container. The release workflow publishes the exact-version tag together with current aliases and verifies the exact-version package after push. Retention preserves the package version carrying the current exact semantic-version tag and removes obsolete package versions only after release verification succeeds.
 
-See [Packages](PACKAGES.md), [Release verification](RELEASE-VERIFICATION.md), [Signing](SIGNING.md) and [Versioning](VERSIONING.md).
+See [Packages](PACKAGES.md), [Release verification](RELEASE-VERIFICATION.md), [Signing](SIGNING.md), [Testing](TESTING.md) and [Versioning](VERSIONING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,10 @@
 # Ghost FTP documentation
 
 <p align="center">
-  <img src="../build/icon.png" alt="Ghost FTP application icon" width="96">
+  <img src="../build/icon.png" alt="Ghost FTP application icon" width="108">
 </p>
+
+<p align="center"><strong>Production behavior, security boundaries, UI evidence and release engineering for Ghost FTP.</strong></p>
 
 - **Current Ghost FTP release: 0.0.1**
 - Development status: **Active**
@@ -14,45 +16,78 @@
 - Languages: **24 selectable local languages**
 - Product website: **https://ghostftp.com**
 
-The root [`VERSION`](../VERSION) file is the authoritative production version source. Active documentation describes the current 0.0.1 public line; superseded public release/tag identities are removed only after a newer release is successfully published and verified.
+The root [`VERSION`](../VERSION) file is the authoritative production version source. Active documentation describes the current 0.0.1 public line. Superseded release identities are removed only after the successor has passed source gates, publication, remote read-back and the canonical retention workflow.
+
+## Start here
+
+| Goal | Document |
+| --- | --- |
+| Install or run Ghost FTP | [`INSTALLATION.md`](INSTALLATION.md) |
+| Understand all current settings | [`SETTINGS.md`](SETTINGS.md) |
+| Verify UI behavior and screenshots | [`REFERENCE-UI.md`](REFERENCE-UI.md) |
+| Understand security boundaries | [`SECURITY.md`](SECURITY.md) |
+| Understand privacy/no-telemetry behavior | [`PRIVACY.md`](PRIVACY.md) |
+| Understand architecture/Core ownership | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| Verify Windows/Linux parity | [`PLATFORM-PARITY.md`](PLATFORM-PARITY.md) |
+| Validate a downloaded release | [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) |
+| Understand release/version lifecycle | [`VERSIONING.md`](VERSIONING.md) and [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) |
+| See next power-user work | [`ROADMAP.md`](ROADMAP.md) |
+| Build/test/contribute | [`TESTING.md`](TESTING.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 
 ## Authentic visual reference
 
-Documentation media is repository-local. No remote badge image, tracking pixel, remote icon resource, remote webfont or analytics resource is required when these documents render.
+Documentation media is **repository-local**. No remote badge image, tracking pixel, remote icon resource, remote webfont or analytics resource is required when these documents render. Production screenshots come from the real Windows x64 Portable build and are checked by the authentic-UI workflow.
 
-### Main Workspace
+<table>
+<tr>
+<td width="50%" valign="top"><strong>Main Workspace</strong><br><br><img src="images/ghost-ftp-main-workspace.png" alt="Ghost FTP Main Workspace"></td>
+<td width="50%" valign="top"><strong>Site Manager</strong><br><br><img src="images/ghost-ftp-site-manager.png" alt="Ghost FTP Site Manager"></td>
+</tr>
+<tr>
+<td width="50%" valign="top"><strong>Settings</strong><br><br><img src="images/ghost-ftp-settings.png" alt="Ghost FTP Settings"></td>
+<td width="50%" valign="top"><strong>About</strong><br><br><img src="images/ghost-ftp-about.png" alt="Ghost FTP About"></td>
+</tr>
+</table>
 
-![Ghost FTP Main Workspace](images/ghost-ftp-main-workspace.png)
+See [`REFERENCE-UI.md`](REFERENCE-UI.md) for provenance and the rule that mockups/generated approximations are not production UI evidence.
 
-### Site Manager
+## Current 0.0.1 capability contract
 
-![Ghost FTP Site Manager](images/ghost-ftp-site-manager.png)
-
-### Settings
-
-![Ghost FTP Settings](images/ghost-ftp-settings.png)
-
-### About
-
-![Ghost FTP About](images/ghost-ftp-about.png)
-
-See [`REFERENCE-UI.md`](REFERENCE-UI.md) for authentic screenshot provenance and the rule that mockups/generated approximations are not production UI evidence.
+- FTP, explicit FTPS and SFTP through one typed Core engine.
+- Native Windows and Linux frontends consuming the same typed engine behavior.
+- Built-in Remote Edit with bounded text validation, revision/conflict protection and verified read-back.
+- Transfer queue pause/resume/cancel/retry and truthful progress/speed/ETA.
+- Explicit conflict policy with safe staged activation and rollback behavior.
+- Site Manager profiles with protected saved-secret handling and connection identity binding.
+- Strict SFTP host-key verification/pinning and no silent FTPS downgrade.
+- Rooted local path/transfer protections and remote cleanup uncertainty reporting.
+- Trusted Linux transport/AskPass provenance.
+- Ownership-bound Windows installer/uninstaller/shortcut cleanup.
+- Validated local settings for concurrency, timeout, retry, overwrite policy, delete confirmation, appearance and language.
+- No telemetry, analytics, advertising, tracking or hidden product backend.
 
 ## Product and architecture
 
-- [`ARCHITECTURE.md`](ARCHITECTURE.md) — architecture and trust boundaries.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — components, ownership and trust boundaries.
 - [`PLATFORM-PARITY.md`](PLATFORM-PARITY.md) — Windows/Linux parity contract.
 - [`REFERENCE-UI.md`](REFERENCE-UI.md) — native desktop UI and authentic evidence.
-- [`SETTINGS.md`](SETTINGS.md) — settings and persistence behavior.
+- [`SETTINGS.md`](SETTINGS.md) — validated settings and persistence behavior.
 - [`LOCALIZATION.md`](LOCALIZATION.md) — 24-language local localization model.
+- [`DEPENDENCIES.md`](DEPENDENCIES.md) — dependency and external-tool policy.
+
+## Security and privacy
+
+- [`SECURITY.md`](SECURITY.md) — protocol, filesystem, installer and release trust boundaries.
+- [`PRIVACY.md`](PRIVACY.md) — local-first data handling and no-telemetry contract.
+- [`SIGNING.md`](SIGNING.md) — optional production Authenticode and truthful unsigned state.
+- [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) — third-party notices.
 
 ## Installation and releases
 
 - [`INSTALLATION.md`](INSTALLATION.md) — Windows Setup/Portable and Linux installation.
-- [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) — canonical release shape and latest-only retention.
+- [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) — canonical release shape and deterministic latest-only retention lifecycle.
 - [`PACKAGES.md`](PACKAGES.md) — verified GitHub Packages distribution bundle policy.
 - [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) — checksums, source identity and signing verification.
-- [`SIGNING.md`](SIGNING.md) — optional production Authenticode signing.
 - [`VERSIONING.md`](VERSIONING.md) — controlled 0.0.x public version policy.
 
 Ghost FTP 0.0.1 uses the canonical **12 platform artifacts / 15 public files** release shape and is published as the current GitHub Release with `prerelease=false`. The same verified release directory is mirrored as a distribution-only bundle at:
@@ -62,19 +97,6 @@ ghcr.io/bren-wp/ghost-ftp:0.0.1
 ```
 
 Supplemental distro-specific CI packages built by `linux/BUILD-DISTROS.sh` cover Debian, Ubuntu, Fedora and a distro-neutral Portable family. Native lifecycle/GUI smoke verification is maintained for **Debian 13 amd64**, **Ubuntu 26.04 LTS amd64** and **Fedora 44 x86_64**. These packages are **not yet part of the canonical release allow-list**.
-
-## Current 0.0.1 capability contract
-
-- FTP, explicit FTPS and SFTP through one typed Core engine.
-- Built-in Remote Edit on Windows and Linux using the same bounded/revision-checked engine path.
-- Save conflict detection, line-ending preservation, read-back verification and remote metadata refresh.
-- Transfer queue pause/resume/cancel/retry behavior.
-- Site Manager profiles and protected saved-secret handling.
-- Strict SFTP host-key verification/pinning and no silent FTPS downgrade.
-- Rooted local path/transfer protections.
-- Trusted Linux transport/AskPass provenance.
-- Ownership-bound Windows installer/uninstaller/shortcut cleanup.
-- No telemetry, analytics, advertising, tracking or hidden product backend.
 
 ## Current publication identity
 
@@ -107,27 +129,20 @@ Ghost-FTP-0.0.1-Linux-arm64.tar.gz
 Ghost-FTP-0.0.1-Linux-i386.tar.gz
 ```
 
-After the current release passes remote read-back verification, `.github/workflows/release-retention.yml` removes older Ghost FTP releases, tags, superseded release branches and obsolete package versions while retaining the current release package. `main` commit history is not rewritten.
-
-## Security and privacy
-
-- [`SECURITY.md`](SECURITY.md)
-- [`PRIVACY.md`](PRIVACY.md)
-- [`DEPENDENCIES.md`](DEPENDENCIES.md)
-- [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md)
+After publication and remote read-back succeed, `.github/workflows/release-retention.yml` verifies the current tag/release/15-file set and removes superseded Ghost FTP releases, tags, canonical release branches and package versions. The release-branch trigger additionally waits for both the canonical publish run and canonical retention run to succeed. `main` commit history is not rewritten.
 
 ## Quality and engineering
 
-- [`TESTING.md`](TESTING.md)
-- [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- [`ROADMAP.md`](ROADMAP.md)
-- [`SUPPORT.md`](SUPPORT.md)
-- [`prompts/GHOST-FTP-ENGINEERING-AUDIT-PROMPT.md`](prompts/GHOST-FTP-ENGINEERING-AUDIT-PROMPT.md)
-- [`prompts/GHOSTFTP-COM-DARK-THEME-REDESIGN-PROMPT.md`](prompts/GHOSTFTP-COM-DARK-THEME-REDESIGN-PROMPT.md)
+- [`TESTING.md`](TESTING.md) — exact-head CI, package lifecycle and regression suites.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — engineering rules and PR expectations.
+- [`ROADMAP.md`](ROADMAP.md) — prioritized next capabilities and acceptance criteria.
+- [`SUPPORT.md`](SUPPORT.md) — support information and diagnostic expectations.
+- [`prompts/GHOST-FTP-ENGINEERING-AUDIT-PROMPT.md`](prompts/GHOST-FTP-ENGINEERING-AUDIT-PROMPT.md) — engineering audit prompt.
+- [`prompts/GHOSTFTP-COM-DARK-THEME-REDESIGN-PROMPT.md`](prompts/GHOSTFTP-COM-DARK-THEME-REDESIGN-PROMPT.md) — website theme prompt.
 
 ## Release history
 
 - [`RELEASE-HISTORY.md`](RELEASE-HISTORY.md) — current public-line history.
 - [`../CHANGELOG.md`](../CHANGELOG.md) — source for generated release notes.
 
-Only the current public version is retained in active release history after retention cleanup succeeds.
+Only the current public version is retained in active release history after retention cleanup succeeds. Git history remains the engineering provenance of earlier work.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,42 +1,176 @@
 # Ghost FTP roadmap
 
-Ghost FTP **0.0.1** starts the current public release line. The roadmap prioritizes correctness, security, privacy, reliability, Windows/Linux parity and measured performance before broad new surface area.
+Ghost FTP **0.0.1** starts the current public release line. The roadmap prioritizes correctness, security, privacy, reliability, Windows/Linux parity and measured performance before broad new surface area. The objective is not to reproduce legacy FTP clients screen-for-screen; Ghost FTP should deliver a smaller, clearer and safer professional workflow while adding power-user capabilities only when their complete runtime path is production-ready.
 
 ## Current 0.0.1 foundation
 
 The current release gate includes:
 
 - native Windows and Linux desktop clients backed by one typed Engine;
-- FTP, FTPS and SFTP workflows;
+- FTP, explicit FTPS and SFTP workflows;
 - SFTP password/key/passphrase authentication and host-key trust;
-- local-only profiles with platform-local protected secret storage;
+- local-only profiles with platform-local protected secret handling;
 - validated connection timeout, retry, conflict and parallel-transfer settings;
 - transfer generation binding, source snapshots and staged/rollback-oriented operations;
 - privacy-safe connection diagnostics;
 - truthful transfer progress, speed and ETA;
 - built-in Remote Edit with bounded text handling, revision/conflict protection and verified save/read-back;
+- queue pause/resume/cancel/retry/clear-finished controls;
 - native Windows Setup/Portable packaging and Linux DEB/portable packaging;
 - 24-language local catalog with English default/fallback;
 - production race/vet/security/privacy/dependency/documentation audits;
 - current GitHub Release publication with `prerelease=false`;
 - truthful Windows signing-state metadata with fail-closed verification when trusted production signing is configured;
 - current GitHub Packages/GHCR distribution-bundle publication and read-back;
-- latest-only release/tag/package retention only after a successor is successfully published and verified.
+- latest-only release/tag/package retention after a successor is successfully published and verified.
 
-## Next 0.0.x priorities
+## Quality work before new surface area
 
-After 0.0.1 is fully published and verified, the next public release is **0.0.2**. Work should be driven by demonstrated defects or high-value functionality, including:
+The immediate 0.0.x hardening lane includes:
 
-1. connection lifecycle, stale-session state and reconnect correctness;
-2. cancel/retry/partial-transfer/interrupted-transfer behavior;
-3. large-directory/list memory and UI responsiveness;
-4. further Remote Edit shutdown/disconnect/conflict edge cases;
-5. transfer atomicity, overwrite decisions, temp-file cleanup and application-shutdown behavior;
-6. Windows/Linux functional parity for file operations, queue state, shortcuts, settings and error handling;
-7. measured performance improvements such as avoiding duplicate stat/list work, stale callbacks and unnecessary redraws;
-8. accessibility and keyboard refinements;
-9. documentation and authentic real-application screenshots synchronized with exact release source;
-10. carefully selected FileZilla/WinSCP/Cyberduck-class capabilities only where they add real user value without clutter.
+1. deterministic release → remote read-back → retention orchestration, including explicit verification of the exact release and retention workflow runs;
+2. regression coverage that rejects visible desktop controls with no action handler;
+3. compatibility-safe settings migration without weakening validation of explicit invalid values;
+4. connection lifecycle, stale-session state and reconnect correctness;
+5. cancel/retry/partial-transfer/interrupted-transfer behavior and actionable queue errors;
+6. transfer atomicity, overwrite decisions, temp-file cleanup and application-shutdown behavior;
+7. large-directory/list memory and UI responsiveness;
+8. further Remote Edit shutdown/disconnect/conflict edge cases;
+9. Windows/Linux functional parity for file operations, queue state, shortcuts, settings and error handling;
+10. documentation and authentic real-application screenshots synchronized with exact maintained source.
+
+## High-value power-user lane
+
+These capabilities are prioritized because they improve real hosting/server workflows. They are **planned, not advertised as shipped**, until all acceptance gates below are satisfied.
+
+### P0 — directory comparison and synchronized navigation
+
+A comparison mode should pair the current local and server directories and classify entries as same, local-only, server-only, newer-local, newer-server or conflicting/unknown. Optional synchronized browsing should move the opposite pane only when both sides can resolve the corresponding directory safely.
+
+Acceptance requirements:
+
+- comparison logic lives in shared testable code rather than duplicated frontend logic;
+- timestamps with unreliable server precision are treated conservatively;
+- symlinks and unsupported metadata never trigger destructive automatic action;
+- Windows and Linux expose the same states and disable synchronization when the mapping is ambiguous;
+- comparison itself never transfers or deletes data.
+
+### P0 — local/server search and non-destructive filters
+
+Add fast filtering of the currently loaded directory plus an explicitly bounded recursive search mode. Filtering must not alter the underlying item model or silently hide selected destructive targets.
+
+Acceptance requirements:
+
+- case behavior is explicit and platform-independent where practical;
+- recursive server search has a strict item/depth/time bound;
+- cancellation is immediate and leaves the connection usable;
+- hidden/filtered selections cannot be deleted or transferred accidentally;
+- large result sets are incrementally presented rather than blocking the UI thread.
+
+### P0 — bandwidth-aware transfer controls
+
+Add optional upload/download rate limits with **unlimited** as the default. Limits belong in the shared transfer/transport layer, not as decorative frontend timers.
+
+Acceptance requirements:
+
+- separate upload and download limits;
+- units are explicit and validated;
+- aggregate behavior is defined when parallel transfers are enabled;
+- changing a limit cannot corrupt an active transfer;
+- no busy-wait throttling and no misleading UI-only speed cap;
+- Windows/Linux settings use the same persisted model.
+
+### P0 — queue priority and reorder
+
+Add user-controlled queue priority/reordering while retaining connection-generation safety.
+
+Acceptance requirements:
+
+- reordering queued jobs never changes the identity of already-running work;
+- parent/child tree-transfer ordering remains valid;
+- selected jobs can move up/down/top/bottom without duplicate execution;
+- pause/resume/cancel/retry semantics remain deterministic;
+- queue ordering survives only where doing so cannot resurrect stale server work.
+
+### P1 — navigation bookmarks and profile start directories
+
+Allow reusable local/server bookmarks plus explicit default local/server directories per site profile.
+
+Acceptance requirements:
+
+- bookmarks store paths, never credentials;
+- stale local paths and unavailable server paths produce actionable errors;
+- profile identity changes cannot inherit unrelated server paths silently;
+- quick-connect bookmarks do not create hidden persistent profiles.
+
+### P1 — stronger interrupted-transfer resume
+
+Introduce verified resume where the underlying protocol/server semantics can prove the partial object is the intended object. Unsupported cases must fall back to a safe restart, not append blindly.
+
+Acceptance requirements:
+
+- remote/local object identity and existing length are checked before resume;
+- overwrite/backup policy still applies;
+- checksum/read-back verification is used where available and appropriate;
+- a failed resume never leaves the destination reported as successfully complete.
+
+### P1 — multiple live sessions / tabs
+
+Multiple server sessions can provide a significant productivity gain, but this must not weaken the current single-session generation/identity invariants.
+
+Acceptance requirements:
+
+- every queue item is bound to one explicit session identity;
+- tab close cancels/drains only that session's work;
+- saved secrets are never copied between tabs implicitly;
+- UI status and transfer ownership remain unambiguous;
+- resource limits prevent unbounded session creation.
+
+### P1 — proxy / jump-host boundary
+
+Proxy or SSH jump-host support is useful only if transport trust remains explicit. Any implementation must make the destination identity and intermediary identity clear and must not silently weaken TLS or SSH host verification.
+
+### P2 — profile import/export
+
+Portable profile exchange may be added for non-secret site metadata. Secret export must remain opt-in, strongly protected and clearly separated from ordinary profile export; plaintext credential export is not an acceptable default.
+
+## UI/product rules for new features
+
+A visible control is not a feature definition. Every new button, menu item, shortcut or option must have:
+
+1. a clear shared-engine or platform-runtime owner;
+2. disabled/enabled-state rules;
+3. success, failure and cancellation behavior;
+4. user-safe error handling;
+5. Windows/Linux exposure or a documented platform reason;
+6. localization coverage for user-visible text;
+7. unit/integration/regression coverage;
+8. updated active documentation;
+9. authentic UI evidence when the maintained desktop surface changes.
+
+The maintained UI wiring regression must continue to reject a main desktop button that has no handler.
+
+## Performance direction
+
+Optimization work should target measured hotspots:
+
+- avoid full-workspace redraw when state is unchanged;
+- keep UI work out of transfer/network critical paths;
+- avoid repeated filesystem scans when a validated snapshot is sufficient;
+- keep transfer progress publication bounded and truthful;
+- reduce unnecessary allocations/copies in listing and transfer planning;
+- incrementally render or virtualize very large directory/search result sets where needed;
+- batch UI invalidation rather than repainting for every transfer event;
+- prevent goroutine leaks, stale callbacks and incomplete timeout cleanup;
+- keep CI deterministic and offline for the Go dependency graph.
+
+## Security/privacy direction
+
+Security hardening should favor deterministic rejection and actionable errors over permissive fallback. Privacy improvements should reduce secret lifetime and diagnostic exposure rather than adding remote reporting.
+
+Release security should improve publisher trust when a real certificate is available without weakening integrity verification or inventing trust when it is not.
+
+New productivity features must preserve the same trust model: search, compare, bookmarks, resume, multi-session and proxy functionality may not introduce hidden cloud state, telemetry or credential replication.
 
 ## macOS direction
 
@@ -62,27 +196,9 @@ Future work must preserve:
 - verified GitHub Release and GitHub Package publication;
 - no unreviewed external Go dependencies.
 
-## Performance direction
-
-Optimization work should target measured hotspots:
-
-- avoid full-workspace redraw when state is unchanged;
-- keep UI work out of transfer/network critical paths;
-- avoid repeated filesystem scans when a validated snapshot is sufficient;
-- keep transfer progress publication bounded and truthful;
-- reduce unnecessary allocations/copies in listing and transfer planning;
-- prevent goroutine leaks, stale callbacks and incomplete timeout cleanup;
-- keep CI deterministic and offline for the Go dependency graph.
-
-## Security/privacy direction
-
-Security hardening should favor deterministic rejection and actionable errors over permissive fallback. Privacy improvements should reduce secret lifetime and diagnostic exposure rather than adding remote reporting.
-
-Release security should improve publisher trust when a real certificate is available without weakening integrity verification or inventing trust when it is not.
-
 ## Release direction
 
-The public sequence is `0.0.1`, `0.0.2`, `0.0.3`, and so on. `0.0.0` is reserved. A current release identity is never rewritten in place. A newer version must pass exact-head and post-merge verification, publication and remote read-back before superseded public release/tag/package identities can be removed by retention.
+The public sequence is `0.0.1`, `0.0.2`, `0.0.3`, and so on. `0.0.0` is reserved. A current release identity is never rewritten in place. A newer version must pass exact-head and post-merge verification, publication, remote read-back and canonical retention verification before the release lifecycle is considered complete.
 
 ## Definition of roadmap completion
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,6 +1,6 @@
 # Ghost FTP settings
 
-Ghost FTP **0.0.1** treats settings as validated runtime policy rather than decorative UI state. Persisted values are accepted only within bounds enforced by the shared configuration layer.
+Ghost FTP **0.0.1** treats settings as validated runtime policy rather than decorative UI state. Persisted values are accepted only within bounds enforced by the shared configuration layer, and visible controls must map to behavior in the shared engine rather than maintaining frontend-only shadow state.
 
 ## Current persisted settings
 
@@ -14,6 +14,35 @@ Ghost FTP **0.0.1** treats settings as validated runtime policy rather than deco
 - `confirmDelete` — confirmation for user-initiated destructive operations.
 
 Compatibility state such as older overwrite booleans may be normalized internally but must not become duplicate user-facing controls.
+
+## Runtime ownership
+
+Every exposed option has one explicit runtime owner:
+
+| Option | Runtime effect |
+| --- | --- |
+| Parallel transfers | Bounds how many transfer workers may run concurrently. |
+| Connection timeout | Bounds connection establishment and related connection work. |
+| Automatic retries | Limits retries for failures classified as retryable. |
+| Retry delay | Defines the bounded delay between eligible automatic retries. |
+| Conflict policy | Selects skip, safe replace, or safe replace with retained recovery backup. |
+| Delete confirmation | Controls user confirmation before destructive local/server deletion. |
+| Appearance | Selects the maintained Windows Classic Light/Dark workspace. |
+| Language | Selects one of the local 24-language catalogs with English fallback. |
+
+The Windows and Linux settings surfaces consume the same shared model for options they expose. A frontend must not silently accept a value that the shared configuration layer rejects.
+
+## Compatibility and migration
+
+Older or partial settings payloads are migrated only when a missing value can be distinguished safely from an explicit user value.
+
+- Missing legacy `parallelism=0` migrates to the canonical default **2**, because valid user values begin at 1.
+- Missing connection timeout and retry delay continue to migrate to their canonical safe defaults.
+- Explicit invalid parallelism such as a negative value or a value above 8 is still rejected rather than silently rewritten.
+- Unknown persisted conflict-policy state fails closed to the conservative replace-with-recovery-backup behavior.
+- Legacy overwrite booleans are synchronized from the one canonical `conflictPolicy` field when settings are saved.
+
+Regression tests cover both migration and continued rejection of explicit invalid values.
 
 ## Windows settings surface
 
@@ -75,6 +104,12 @@ Credential persistence is a per-save privacy decision rather than a hidden globa
 
 Delete confirmation defaults to enabled. Destructive actions must respect the validated shared setting.
 
+## Button and option quality rule
+
+A control is not considered implemented merely because it is visible. Main desktop controls are covered by a regression contract that compares the Windows button IDs with their command handlers and the Linux rendered control rectangles with their click handlers. Settings changes additionally require a backend validation path and tests proving the setting changes runtime behavior or policy.
+
+New power-user options such as bandwidth limits, directory comparison/synchronized browsing, search/filter and queue priority are roadmap items until the complete engine + Windows + Linux + localization + test path exists. They must not appear as decorative or non-functional switches.
+
 ## Persistence and recovery
 
 Settings are stored in bounded local state with safe replacement/recovery behavior. Loaded data is normalized before it becomes effective runtime policy, and the state-directory identity is pinned so later pathname replacement cannot silently redirect settings/profile I/O.
@@ -83,4 +118,4 @@ Settings are stored in bounded local state with safe replacement/recovery behavi
 
 One behavior has one canonical setting. A new option is release-ready only when it has a clear runtime owner, safe bounded default, migration behavior, honest platform exposure and localized user-facing copy where required.
 
-See [Architecture](ARCHITECTURE.md), [Privacy](PRIVACY.md), [Security](SECURITY.md) and [Localization](LOCALIZATION.md).
+See [Architecture](ARCHITECTURE.md), [Privacy](PRIVACY.md), [Security](SECURITY.md), [Testing](TESTING.md) and [Localization](LOCALIZATION.md).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Ghost FTP testing and quality gates
 
-Ghost FTP **0.0.1** is validated through layered source, security, native build, packaging and lifecycle gates.
+Ghost FTP **0.0.1** is validated through layered source, security, native build, packaging, UI-action and release-lifecycle gates.
 
 ## Core quality gate
 
@@ -24,7 +24,47 @@ Tests cover the maintained FTP/FTPS/SFTP engine contract, including:
 - transfer staging/activation/rollback behavior;
 - connection-generation guards;
 - privacy-safe diagnostics;
+- bounded automatic retry policy;
+- queue pause/resume/cancel/retry lifecycle;
 - Remote Edit text/binary, size, revision/conflict, permission, read-back and metadata-refresh behavior.
+
+## Settings regression contract
+
+The settings suite verifies that visible runtime options remain bounded and migration-safe.
+
+Examples include:
+
+- parallelism accepts only **1–8** for explicit current values;
+- an omitted legacy `parallelism=0` migrates to the canonical default **2**;
+- negative or above-range explicit parallelism remains a validation error;
+- connection timeout, retry count and retry delay stay inside documented bounds;
+- unknown persisted conflict-policy state fails closed to conservative recovery behavior;
+- one canonical conflict-policy field synchronizes legacy compatibility fields.
+
+This prevents compatibility migration from becoming an excuse to silently accept arbitrary invalid settings.
+
+## Desktop action wiring gate
+
+`scripts/test_ui_action_wiring.py` prevents visible main controls from becoming decorative/dead UI.
+
+Windows checks:
+
+- enumerate main-window `mkButton(...)` command IDs from `createControls`;
+- require every such ID to have a `case id...:` handler in `command()`;
+- keep queue Cancel/Retry engine failures from being silently discarded.
+
+Linux checks:
+
+- require every maintained main control rectangle (connect/disconnect/profile/settings/navigation/file operations/upload/download/queue actions) to exist in layout construction;
+- require the same control to have a mouse click handler;
+- verify the Remote Edit button path;
+- verify SFTP Trust/Cancel and prompt Apply/Cancel overlay controls are both rendered and handled.
+
+The gate intentionally tests wiring, not just pixels. Runtime behavior remains covered by Go unit/integration tests and authentic UI smoke evidence.
+
+## README/media integrity
+
+README and active documentation use repository-local Ghost FTP icon/screenshot assets. Authentic screenshots are generated from the production Windows x64 Portable application. Remote tracking pixels, icon CDNs and mockup images are not accepted as release UI evidence.
 
 ## Windows production gate
 
@@ -81,6 +121,8 @@ For a release-prep change that affects the canonical production build, the expec
 3. Ghost FTP Linux Distro Install Matrix;
 4. Authentic UI Screenshots when its path/trigger contract applies.
 
+A green run for an older commit does not satisfy a newer PR head.
+
 ## Release publication gate
 
 0.0.1 publication additionally requires:
@@ -93,8 +135,39 @@ For a release-prep change that affects the canonical production build, the expec
 - verified `ghcr.io/bren-wp/ghost-ftp:0.0.1` distribution-bundle publication/read-back;
 - successful latest-only retention cleanup after publication.
 
+## Deterministic release-to-retention gate
+
+The release branch trigger does not consider `gh workflow run release.yml` itself a successful release. Its regression/audit contract requires the trigger to:
+
+1. record pre-existing release run IDs;
+2. dispatch the canonical release workflow;
+3. identify the newly created workflow-dispatch run whose `headSha` equals validated current `main`;
+4. wait for that exact run with `gh run watch --exit-status`;
+5. require terminal `success`;
+6. only then dispatch canonical retention;
+7. identify the new exact-main retention run;
+8. wait for and require terminal retention `success`.
+
+This closes the class of failure where publication succeeds but downstream `workflow_run` chaining is not emitted for a token-dispatched workflow. The retained `workflow_run` retention trigger remains defense in depth; successful release-branch orchestration requires explicit observed retention completion.
+
 ## Retention validation
 
 The retention workflow must leave only the current `ghostftp-v0.0.1` release/tag, retain the current canonical release branch and exact-version GHCR package, remove superseded release branches/package versions, and leave `main` commit history untouched.
 
-See [GitHub Releases](GITHUB-RELEASES.md), [Release verification](RELEASE-VERIFICATION.md) and [Versioning](VERSIONING.md).
+Before destructive cleanup it independently verifies current release identity, `draft=false`, `prerelease=false`, exactly **15 assets**, and current tag SHA equality with current `main`.
+
+## Quality rule for new power-user features
+
+A new feature such as search/filter, directory comparison, synchronized browsing, bandwidth limits, queue priority or bookmarks is not release-ready until all applicable layers exist:
+
+- shared engine/runtime behavior;
+- validation and safe defaults;
+- Windows and Linux controls or an explicit documented platform limitation;
+- localized user-facing copy;
+- success/failure/cancel semantics;
+- unit/integration/regression tests;
+- action-wiring coverage for new controls;
+- active documentation;
+- authentic screenshot evidence when the maintained UI changes.
+
+See [GitHub Releases](GITHUB-RELEASES.md), [Release verification](RELEASE-VERIFICATION.md), [Settings](SETTINGS.md), [Roadmap](ROADMAP.md) and [Versioning](VERSIONING.md).

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -185,12 +185,17 @@ func (s *SettingsStore) Set(v model.Settings) (model.Settings, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Missing values from older clients migrate to current safe defaults and
-	// legacy overwrite booleans are converted into the canonical policy.
+	// legacy overwrite booleans are converted into the canonical policy. Zero is
+	// not a valid parallelism value, so it is unambiguous as an omitted legacy
+	// field. Explicit negative/out-of-range values remain validation failures.
 	if v.Language == "" {
 		v.Language = i18n.DefaultLanguage
 	}
 	if v.Appearance == "" {
 		v.Appearance = model.AppearanceLight
+	}
+	if v.Parallelism == 0 {
+		v.Parallelism = DefaultParallelism
 	}
 	if v.ConnectionTimeoutSeconds == 0 {
 		v.ConnectionTimeoutSeconds = DefaultConnectionTimeoutSeconds

--- a/internal/config/settings_policy_test.go
+++ b/internal/config/settings_policy_test.go
@@ -72,6 +72,36 @@ func TestGetNormalizesLegacyOutOfRangeSettings(t *testing.T) {
 	}
 }
 
+func TestSetMigratesMissingLegacyParallelism(t *testing.T) {
+	settings := NewSettings(New(t.TempDir()))
+	legacy := DefaultSettings()
+	legacy.Parallelism = 0
+	got, err := settings.Set(legacy)
+	if err != nil {
+		t.Fatalf("missing legacy parallelism should migrate, got error: %v", err)
+	}
+	if got.Parallelism != DefaultParallelism {
+		t.Fatalf("parallelism=%d want canonical default %d", got.Parallelism, DefaultParallelism)
+	}
+	persisted, err := settings.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Parallelism != DefaultParallelism {
+		t.Fatalf("persisted parallelism=%d want %d", persisted.Parallelism, DefaultParallelism)
+	}
+}
+
+func TestSetStillRejectsExplicitInvalidParallelism(t *testing.T) {
+	for _, value := range []int{-1, MaxParallelism + 1} {
+		settings := DefaultSettings()
+		settings.Parallelism = value
+		if _, err := NewSettings(New(t.TempDir())).Set(settings); err == nil {
+			t.Fatalf("parallelism=%d should remain an explicit validation failure", value)
+		}
+	}
+}
+
 func TestLegacyConflictPolicyMigrationPreservesBehavior(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -145,9 +145,19 @@ def main() -> int:
         "source_version=\"$(tr -d '\\r\\n' < VERSION)\"",
         "gh workflow run release.yml",
         "test \"$GITHUB_SHA\" = \"$main_sha\"",
+        "wait_for_new_run()",
+        "--json databaseId,headSha",
+        "gh run watch \"$release_run_id\"",
+        "test \"$release_conclusion\" = 'success'",
+        "gh workflow run release-retention.yml",
+        "gh run watch \"$retention_run_id\"",
+        "test \"$retention_conclusion\" = 'success'",
+        "RELEASE_RETENTION_CHAIN=PASS",
     )
     if "--force" in trigger:
         fail("release branch trigger must not force-move release identities")
+    if trigger.index("test \"$release_conclusion\" = 'success'") > trigger.index("gh workflow run release-retention.yml"):
+        fail("release retention may be dispatched before the canonical release succeeds")
 
     require(
         ".github/workflows/ci.yml",
@@ -220,6 +230,7 @@ def main() -> int:
     print("CURRENT_RELEASE_PRERELEASE_FLAG=FALSE")
     print("MINIMUM_PUBLIC_VERSION=0.0.1")
     print("LATEST_ONLY_RELEASE_RETENTION=YES")
+    print("RELEASE_RETENTION_CHAIN=REQUIRED")
     print("AUTHENTICODE_PRIVATE_KEY_IN_REPOSITORY=BLOCKED")
     print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -24,22 +24,15 @@ def extract_section(changelog: str, version: str) -> str:
 
 
 def build_notes(version: str, section: str) -> str:
-    major = int(version.split(".", 1)[0])
-    channel = "Beta prerelease" if major == 0 else "Stable"
-    package_section = "" if major == 0 else f"""
-GitHub Packages
----------------
-- Package: ghcr.io/bren-wp/ghost-ftp:{version}
-- Type: verified OCI distribution bundle, not a runtime container.
-- Contents: the same verified release directory under /ghostftp-release/.
-- Stable aliases: {major}, {'.'.join(version.split('.')[:2])}, latest.
-- The workflow verifies registry readback before completing publication.
-"""
+    parts = version.split(".")
+    major = int(parts[0])
+    minor_alias = ".".join(parts[:2])
 
     return f"""Ghost FTP {version}
 
 Privacy-first FTP, FTPS and SFTP desktop client for Windows and Linux.
-Release channel: {channel}.
+Release channel: Current.
+GitHub prerelease flag: false.
 
 Highlights
 ----------
@@ -66,7 +59,15 @@ Linux:
 - Ghost-FTP-{version}-Linux-arm64.tar.gz — package-manager-neutral portable archive for arm64.
 - Ghost-FTP-{version}-Linux-i386.tar.gz — package-manager-neutral portable archive for i386.
 - Ghost-FTP-{version}-Linux-multiarch.zip — bundle containing the three verified Debian packages.
-{package_section}
+
+GitHub Packages
+---------------
+- Package: ghcr.io/bren-wp/ghost-ftp:{version}
+- Type: verified OCI distribution bundle, not a runtime container.
+- Contents: the same verified release directory under /ghostftp-release/.
+- Current aliases: {major}, {minor_alias}, latest.
+- The workflow verifies the exact-version registry readback before completing publication.
+
 Verification files
 ------------------
 - SHA256.txt — SHA-256 checksums for every public release file except SHA256.txt itself.
@@ -75,12 +76,14 @@ Verification files
 
 Release contract
 ----------------
+- Current Ghost FTP releases are not inferred to be prereleases from semantic-version major zero.
 - 12 platform artifacts.
 - 15 public release files total, including the three verification/metadata files.
 - Active application platforms: Windows and Linux.
 - Local language catalog: 24 selectable languages with English default/fallback.
 - Application telemetry: disabled.
 - Linux portable archives are structurally verified and their ghostftp executable must be byte-identical to the matching DEB payload before publication.
+- Publication is bound to the exact verified main commit and followed by canonical latest-only retention verification.
 
 Signing and trust
 -----------------

--- a/scripts/test_readme_media_contract.py
+++ b/scripts/test_readme_media_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReadmeMediaContractTests(unittest.TestCase):
+    required_root_media = {
+        "build/icon.png",
+        "docs/images/ghost-ftp-main-workspace.png",
+        "docs/images/ghost-ftp-site-manager.png",
+        "docs/images/ghost-ftp-settings.png",
+        "docs/images/ghost-ftp-about.png",
+    }
+
+    def _image_sources(self, text: str) -> set[str]:
+        html = set(re.findall(r'<img\s+[^>]*src=["\']([^"\']+)["\']', text, flags=re.I))
+        markdown = set(re.findall(r'!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)', text))
+        return {value.strip() for value in html | markdown if value.strip()}
+
+    def _assert_local_existing_images(self, rel: str) -> set[str]:
+        doc = ROOT / rel
+        text = doc.read_text(encoding="utf-8")
+        sources = self._image_sources(text)
+        self.assertTrue(sources, f"{rel} must render at least one local Ghost FTP image")
+        for source in sorted(sources):
+            lowered = source.lower()
+            self.assertFalse(
+                lowered.startswith(("http://", "https://", "//", "data:")),
+                f"{rel} contains non-local image source {source!r}",
+            )
+            self.assertNotIn("?", source, f"{rel} image source must be a stable repository path: {source!r}")
+            resolved = (doc.parent / source).resolve()
+            try:
+                resolved.relative_to(ROOT.resolve())
+            except ValueError as exc:
+                self.fail(f"{rel} image source escapes repository root: {source!r}: {exc}")
+            self.assertTrue(resolved.is_file(), f"{rel} references missing image {source!r}")
+        return sources
+
+    def test_root_readme_uses_product_icon_and_authentic_screenshot_set(self) -> None:
+        sources = self._assert_local_existing_images("README.md")
+        missing = sorted(self.required_root_media - sources)
+        self.assertEqual(missing, [], "README is missing required maintained product media: " + ", ".join(missing))
+
+    def test_docs_index_uses_only_local_media(self) -> None:
+        sources = self._assert_local_existing_images("docs/README.md")
+        expected = {
+            "../build/icon.png",
+            "images/ghost-ftp-main-workspace.png",
+            "images/ghost-ftp-site-manager.png",
+            "images/ghost-ftp-settings.png",
+            "images/ghost-ftp-about.png",
+        }
+        self.assertEqual(sorted(expected - sources), [], "docs index is missing maintained product media")
+
+    def test_readme_copy_keeps_authentic_media_provenance_explicit(self) -> None:
+        root = (ROOT / "README.md").read_text(encoding="utf-8")
+        docs = (ROOT / "docs/README.md").read_text(encoding="utf-8")
+        for marker in (
+            "repository-local assets",
+            "production Windows x64 Portable build",
+            "mockups",
+        ):
+            self.assertIn(marker, root)
+        for marker in (
+            "repository-local",
+            "production Windows x64 Portable build",
+            "Mockups",
+        ):
+            self.assertIn(marker, docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_readme_media_contract.py
+++ b/scripts/test_readme_media_contract.py
@@ -61,18 +61,15 @@ class ReadmeMediaContractTests(unittest.TestCase):
     def test_readme_copy_keeps_authentic_media_provenance_explicit(self) -> None:
         root = (ROOT / "README.md").read_text(encoding="utf-8")
         docs = (ROOT / "docs/README.md").read_text(encoding="utf-8")
-        for marker in (
-            "repository-local assets",
-            "production Windows x64 Portable build",
-            "mockups",
-        ):
-            self.assertIn(marker, root)
-        for marker in (
-            "repository-local",
-            "production Windows x64 Portable build",
-            "Mockups",
-        ):
-            self.assertIn(marker, docs)
+        for text, label in ((root, "README.md"), (docs, "docs/README.md")):
+            lowered = text.lower()
+            self.assertIn("repository-local", lowered, f"{label} must state local media provenance")
+            self.assertIn(
+                "windows x64 portable build",
+                lowered,
+                f"{label} must bind screenshots to the maintained Windows x64 Portable build",
+            )
+            self.assertIn("mockup", lowered, f"{label} must reject mockups as production evidence")
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -10,36 +10,38 @@ class ReleaseNotesTests(unittest.TestCase):
     def test_extracts_exact_version_section(self) -> None:
         changelog = """# Changelog
 
-## 1.4.0 — Current
+## 0.0.2 — Current
 
 - current change
 
-## 1.3.0 — Previous
+## 0.0.1 — Previous
 
 - previous change
 """
-        section = extract_section(changelog, "1.4.0")
+        section = extract_section(changelog, "0.0.2")
         self.assertIn("current change", section)
         self.assertNotIn("previous change", section)
 
-    def test_stable_notes_match_windows_linux_release_contract(self) -> None:
-        notes = build_notes("1.4.0", "- Production stability improvement.")
+    def test_current_notes_match_windows_linux_release_contract(self) -> None:
+        notes = build_notes("0.0.2", "- Production stability improvement.")
         for marker in (
-            "Ghost FTP 1.4.0",
+            "Ghost FTP 0.0.2",
             "Privacy-first FTP, FTPS and SFTP desktop client for Windows and Linux",
-            "Release channel: Stable",
-            "ghostftp-v1.4.0",
-            "Ghost-FTP-1.4.0-Setup-x64.exe",
-            "Ghost-FTP-1.4.0-Setup-x32.exe",
-            "Ghost-FTP-1.4.0-Linux-amd64.deb",
-            "Ghost-FTP-1.4.0-Linux-arm64.deb",
-            "Ghost-FTP-1.4.0-Linux-i386.deb",
-            "Ghost-FTP-1.4.0-Linux-amd64.tar.gz",
-            "Ghost-FTP-1.4.0-Linux-arm64.tar.gz",
-            "Ghost-FTP-1.4.0-Linux-i386.tar.gz",
-            "Ghost-FTP-1.4.0-Linux-multiarch.zip",
-            "ghcr.io/bren-wp/ghost-ftp:1.4.0",
-            "distribution bundle, not a runtime container",
+            "Release channel: Current",
+            "GitHub prerelease flag: false",
+            "ghostftp-v0.0.2",
+            "Ghost-FTP-0.0.2-Setup-x64.exe",
+            "Ghost-FTP-0.0.2-Setup-x32.exe",
+            "Ghost-FTP-0.0.2-Linux-amd64.deb",
+            "Ghost-FTP-0.0.2-Linux-arm64.deb",
+            "Ghost-FTP-0.0.2-Linux-i386.deb",
+            "Ghost-FTP-0.0.2-Linux-amd64.tar.gz",
+            "Ghost-FTP-0.0.2-Linux-arm64.tar.gz",
+            "Ghost-FTP-0.0.2-Linux-i386.tar.gz",
+            "Ghost-FTP-0.0.2-Linux-multiarch.zip",
+            "ghcr.io/bren-wp/ghost-ftp:0.0.2",
+            "verified OCI distribution bundle, not a runtime container",
+            "Current aliases: 0, 0.0, latest",
             "12 platform artifacts",
             "15 public release files",
             "SHA256.txt",
@@ -48,9 +50,13 @@ class ReleaseNotesTests(unittest.TestCase):
             "WINDOWS_AUTHENTICODE=unsigned",
             "Never treat a locally generated or self-signed certificate as a trusted public publisher identity",
             "Application telemetry: disabled",
+            "latest-only retention verification",
         ):
             self.assertIn(marker, notes)
         for retired in (
+            "Release channel: Beta prerelease",
+            "Release channel: Stable",
+            "Stable aliases",
             "macOS",
             "Android",
             "iOS",
@@ -60,11 +66,13 @@ class ReleaseNotesTests(unittest.TestCase):
         ):
             self.assertNotIn(retired, notes)
 
-    def test_beta_notes_do_not_claim_stable_package_aliases(self) -> None:
-        notes = build_notes("0.9.9", "- Beta verification.")
-        self.assertIn("Release channel: Beta prerelease", notes)
-        self.assertNotIn("ghcr.io/bren-wp/ghost-ftp:0.9.9", notes)
-        self.assertNotIn("Stable aliases", notes)
+    def test_zero_major_does_not_imply_prerelease_or_hide_package(self) -> None:
+        notes = build_notes("0.9.9", "- Current-line verification.")
+        self.assertIn("Release channel: Current", notes)
+        self.assertIn("GitHub prerelease flag: false", notes)
+        self.assertIn("ghcr.io/bren-wp/ghost-ftp:0.9.9", notes)
+        self.assertIn("Current aliases: 0, 0.9, latest", notes)
+        self.assertNotIn("Beta prerelease", notes)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_trigger_contract.py
+++ b/scripts/test_release_trigger_contract.py
@@ -41,6 +41,35 @@ class ReleaseTriggerContractTests(unittest.TestCase):
         for marker in required:
             self.assertIn(marker, trigger)
 
+    def test_release_branch_trigger_waits_for_exact_release_before_retention(self):
+        trigger = (ROOT / ".github/workflows/release-branch-trigger.yml").read_text(encoding="utf-8")
+        required = [
+            "wait_for_new_run()",
+            "--json databaseId,headSha",
+            '[[ -n "$id" && "$sha" = "$main_sha" ]]',
+            'release_run_id="$(wait_for_new_run release.yml "$release_before")"',
+            'gh run watch "$release_run_id"',
+            '--exit-status',
+            'release_conclusion="$(gh run view "$release_run_id"',
+            'test "$release_conclusion" = \'success\'',
+            "gh workflow run release-retention.yml",
+            'retention_run_id="$(wait_for_new_run release-retention.yml "$retention_before")"',
+            'gh run watch "$retention_run_id"',
+            'test "$retention_conclusion" = \'success\'',
+            "RELEASE_RETENTION_CHAIN=PASS",
+        ]
+        for marker in required:
+            self.assertIn(marker, trigger)
+
+        release_watch = trigger.index('gh run watch "$release_run_id"')
+        release_success = trigger.index('test "$release_conclusion" = \'success\'')
+        retention_dispatch = trigger.index("gh workflow run release-retention.yml")
+        retention_watch = trigger.index('gh run watch "$retention_run_id"')
+        self.assertLess(release_watch, release_success)
+        self.assertLess(release_success, retention_dispatch)
+        self.assertLess(retention_dispatch, retention_watch)
+        self.assertNotIn("--force", trigger)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_ui_action_wiring.py
+++ b/scripts/test_ui_action_wiring.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class UIActionWiringTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_every_main_windows_button_has_a_command_handler(self) -> None:
+        ui = self.read("internal/desktop/ui_windows.go")
+        commands = self.read("internal/desktop/commands_windows.go")
+
+        # createControls is the authoritative main-window surface. Modal-local
+        # controls have their own window procedures and are deliberately outside
+        # this check.
+        create_controls = ui.split("func (a *app) createControls", 1)[1].split(
+            "func windowDPI", 1
+        )[0]
+        button_ids = set(
+            re.findall(r"mkButton\([^\n]*?,\s*(id[A-Za-z0-9_]+)\)", create_controls)
+        )
+        self.assertGreaterEqual(len(button_ids), 20, "unexpectedly small Windows button surface")
+
+        missing = sorted(
+            button_id
+            for button_id in button_ids
+            if f"case {button_id}:" not in commands
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "main-window buttons without command handlers: " + ", ".join(missing),
+        )
+
+    def test_linux_main_controls_are_both_rendered_and_click_wired(self) -> None:
+        ui = self.read("internal/desktop/gui_linux.go")
+
+        controls = (
+            "connect",
+            "disconnect",
+            "settings",
+            "profile",
+            "saveProfile",
+            "removeProfile",
+            "localUp",
+            "localRefresh",
+            "remoteUp",
+            "remoteRefresh",
+            "localNew",
+            "localRename",
+            "localDelete",
+            "remoteNew",
+            "remoteRename",
+            "remoteDelete",
+            "remoteChmod",
+            "upload",
+            "download",
+            "pause",
+            "resume",
+            "cancelJob",
+            "retryJob",
+            "clearQueue",
+        )
+        for control in controls:
+            self.assertRegex(
+                ui,
+                rf"layout\.{re.escape(control)}\s*=\s*linuxRectWH\(",
+                f"Linux control {control} is not assigned a clickable rectangle",
+            )
+            self.assertIn(
+                f"case l.{control}.contains(x, y):",
+                ui,
+                f"Linux control {control} is rendered but has no click handler",
+            )
+
+        self.assertIn("case u.remoteEditButtonRect().contains(x, y):", ui)
+        self.assertIn("u.openSelectedRemoteEditor()", ui)
+
+    def test_linux_overlay_buttons_are_wired(self) -> None:
+        ui = self.read("internal/desktop/gui_linux.go")
+        prompts = self.read("internal/desktop/gui_linux_actions.go")
+
+        for control in ("trust", "cancelTrust"):
+            self.assertRegex(ui, rf"u\.layout\.{control}\s*=\s*linuxRectWH\(")
+            self.assertIn(f"if u.layout.{control}.contains(x, y)", ui)
+
+        for control in ("promptOK", "promptCancel"):
+            self.assertRegex(prompts, rf"u\.layout\.{control}\s*=\s*linuxRectWH\(")
+            self.assertIn(f"if u.layout.{control}.contains(x, y)", prompts)
+
+    def test_queue_action_errors_are_not_silently_discarded_on_windows(self) -> None:
+        transfers = self.read("internal/desktop/transfers_windows.go")
+        self.assertNotIn("_ = a.engine.CancelTransfer", transfers)
+        self.assertNotIn("_ = a.engine.RetryTransfer", transfers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized for Ghost FTP.
- [x] Existing proprietary/source-available license and contribution constraints remain unchanged.

## Summary

Post-0.0.1 hardening focused on release reliability, settings compatibility, UI action correctness, product documentation and authentic repository-local README media.

### Reliability / release engineering
- Make the canonical release-branch trigger wait for the exact newly dispatched `Publish Ghost FTP` run.
- Require terminal publish success before canonical retention can be dispatched.
- Explicitly dispatch, discover and wait for the exact-main retention run so latest-only cleanup does not rely on `workflow_run` chaining alone.
- Extend release audits/regressions to enforce this ordering and exact-run contract.
- Fix release-note generation so 0.0.x remains Current / `prerelease=false` instead of being inferred as Beta and keeps the GHCR distribution-bundle section.

### Settings / runtime policy
- Migrate omitted legacy `parallelism=0` to canonical default 2.
- Continue rejecting explicit negative or >8 parallelism.
- Add migration and fail-closed regression coverage.

### Desktop/UI quality
- Add a regression that rejects main Windows buttons without command handlers.
- Add equivalent Linux main-control and overlay click-wiring coverage.
- Guard Windows queue Cancel/Retry against silent error-discard regressions.

### README / docs / media
- Redesign README around the repository-local Ghost FTP icon and authentic Main Workspace, Site Manager, Settings and About screenshots.
- Reorganize the documentation index and strengthen Settings, Testing, GitHub Releases and Roadmap documentation.
- Add a media contract rejecting remote/tracking image sources and missing maintained screenshots.
- Define high-value power-user capabilities with full acceptance criteria rather than exposing decorative/non-functional controls.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or crash-reporting service added.
- [x] No new runtime hidden network destination added.
- [x] Existing FTPS/SFTP trust and local path protections remain intact.
- [x] No external Go dependency added.
- [x] No real credentials or customer data added.

## Release safety

This PR does **not** change `VERSION` and does **not** republish 0.0.1. Current public release/tag/package identity remains unchanged. The release-trigger hardening applies to the next canonical release-branch creation.

## Validation required before merge

The PR is mergeable only when all workflows triggered for the exact final head are terminal `completed/success`, including Ghost FTP CI and applicable Linux/UI gates. Older or partial green runs do not satisfy this requirement.

Regression coverage added/updated for release trigger ordering, release notes, settings migration, desktop action wiring and local README media integrity.