### PR TITLE
Feature: safe transfer queue priority reordering

### DIFF
--- a/internal/api/queue_order.go
+++ b/internal/api/queue_order.go
@@ -1,0 +1,13 @@
+package api
+
+// MoveTransferUp raises one queued transfer by one queued position. The
+// transfer manager rejects running, completed and unknown jobs.
+func (e *Engine) MoveTransferUp(id string) error {
+	return e.transfers.MoveQueuedUp(id)
+}
+
+// MoveTransferDown lowers one queued transfer by one queued position. Running
+// and terminal jobs keep their scheduler/history position.
+func (e *Engine) MoveTransferDown(id string) error {
+	return e.transfers.MoveQueuedDown(id)
+}

--- a/internal/desktop/action_state_windows.go
+++ b/internal/desktop/action_state_windows.go
@@ -57,18 +57,23 @@ func (a *app) updateActionControls() {
 	}
 	setControlEnabled(a.remoteChmod, remoteReady && chmodSelected > 0)
 
-	transferState := deriveTransferActionState(a.transferJobs, selectedIndices(a.transferList), remoteReady, a.queuePaused)
+	selectedTransfers := selectedIndices(a.transferList)
+	transferState := deriveTransferActionState(a.transferJobs, selectedTransfers, remoteReady, a.queuePaused)
+	priorityState := deriveQueuePriorityState(a.transferJobs, selectedTransfers)
 	if a.connectionBusy {
 		transferState.Pause = false
 		transferState.Resume = false
 		transferState.Cancel = false
 		transferState.Retry = false
+		priorityState.MoveUp = false
+		priorityState.MoveDown = false
 	}
 	setControlEnabled(a.pauseQueue, transferState.Pause)
 	setControlEnabled(a.resumeQueue, transferState.Resume)
 	setControlEnabled(a.cancelJob, transferState.Cancel)
 	setControlEnabled(a.retryJob, transferState.Retry)
 	setControlEnabled(a.clearQueue, transferState.Clear && !a.connectionBusy)
+	a.updateQueuePriorityControls(priorityState)
 
 	a.refineWorkspaceLayout()
 }

--- a/internal/desktop/commands_windows.go
+++ b/internal/desktop/commands_windows.go
@@ -74,6 +74,10 @@ func (a *app) command(id int) {
 		a.retrySelectedTransfer()
 	case idClearQueue:
 		a.clearFinishedTransfers()
+	case idMoveQueueUp:
+		a.moveSelectedTransfer(-1)
+	case idMoveQueueDown:
+		a.moveSelectedTransfer(1)
 	case idRefreshAll:
 		a.refreshLocal(getText(a.localPath))
 		if a.connected {

--- a/internal/desktop/queue_priority.go
+++ b/internal/desktop/queue_priority.go
@@ -1,0 +1,83 @@
+package desktop
+
+import (
+	"strings"
+
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+type queuePriorityState struct {
+	MoveUp   bool
+	MoveDown bool
+}
+
+// deriveQueuePriorityState is shared by Windows and Linux. Reordering is
+// intentionally single-selection and queued-only; running and terminal jobs
+// are immutable from the priority controls.
+func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePriorityState {
+	if len(selected) != 1 {
+		return queuePriorityState{}
+	}
+	index := selected[0]
+	if index < 0 || index >= len(jobs) || jobs[index].Status != "queued" {
+		return queuePriorityState{}
+	}
+
+	state := queuePriorityState{}
+	for i := index - 1; i >= 0; i-- {
+		if jobs[i].Status == "queued" {
+			state.MoveUp = true
+			break
+		}
+	}
+	for i := index + 1; i < len(jobs); i++ {
+		if jobs[i].Status == "queued" {
+			state.MoveDown = true
+			break
+		}
+	}
+	return state
+}
+
+type queuePriorityText struct {
+	MoveUp   string
+	MoveDown string
+	MovedUp  string
+	MovedDown string
+}
+
+var queuePriorityTranslations = map[string]queuePriorityText{
+	"en": {"Move up", "Move down", "Transfer moved up.", "Transfer moved down."},
+	"hr": {"Pomakni gore", "Pomakni dolje", "Prijenos je pomaknut gore.", "Prijenos je pomaknut dolje."},
+	"de": {"Nach oben", "Nach unten", "Übertragung nach oben verschoben.", "Übertragung nach unten verschoben."},
+	"fr": {"Monter", "Descendre", "Transfert déplacé vers le haut.", "Transfert déplacé vers le bas."},
+	"es": {"Subir", "Bajar", "Transferencia movida hacia arriba.", "Transferencia movida hacia abajo."},
+	"tr": {"Yukarı taşı", "Aşağı taşı", "Aktarım yukarı taşındı.", "Aktarım aşağı taşındı."},
+	"el": {"Μετακίνηση πάνω", "Μετακίνηση κάτω", "Η μεταφορά μετακινήθηκε πάνω.", "Η μεταφορά μετακινήθηκε κάτω."},
+	"pt": {"Mover para cima", "Mover para baixo", "Transferência movida para cima.", "Transferência movida para baixo."},
+	"zh": {"上移", "下移", "传输已上移。", "传输已下移。"},
+	"ru": {"Переместить вверх", "Переместить вниз", "Передача перемещена вверх.", "Передача перемещена вниз."},
+	"hi": {"ऊपर ले जाएँ", "नीचे ले जाएँ", "स्थानांतरण ऊपर ले जाया गया।", "स्थानांतरण नीचे ले जाया गया।"},
+	"ja": {"上へ移動", "下へ移動", "転送を上へ移動しました。", "転送を下へ移動しました。"},
+	"it": {"Sposta su", "Sposta giù", "Trasferimento spostato in alto.", "Trasferimento spostato in basso."},
+	"pl": {"Przenieś wyżej", "Przenieś niżej", "Transfer przeniesiono wyżej.", "Transfer przeniesiono niżej."},
+	"nl": {"Omhoog", "Omlaag", "Overdracht omhoog verplaatst.", "Overdracht omlaag verplaatst."},
+	"cs": {"Posunout nahoru", "Posunout dolů", "Přenos byl posunut nahoru.", "Přenos byl posunut dolů."},
+	"uk": {"Перемістити вгору", "Перемістити вниз", "Передачу переміщено вгору.", "Передачу переміщено вниз."},
+	"sv": {"Flytta upp", "Flytta ner", "Överföringen flyttades upp.", "Överföringen flyttades ner."},
+	"ro": {"Mută în sus", "Mută în jos", "Transferul a fost mutat în sus.", "Transferul a fost mutat în jos."},
+	"hu": {"Mozgatás fel", "Mozgatás le", "Az átvitel feljebb került.", "Az átvitel lejjebb került."},
+	"da": {"Flyt op", "Flyt ned", "Overførslen blev flyttet op.", "Overførslen blev flyttet ned."},
+	"fi": {"Siirrä ylös", "Siirrä alas", "Siirto siirrettiin ylöspäin.", "Siirto siirrettiin alaspäin."},
+	"no": {"Flytt opp", "Flytt ned", "Overføringen ble flyttet opp.", "Overføringen ble flyttet ned."},
+	"ko": {"위로 이동", "아래로 이동", "전송을 위로 이동했습니다.", "전송을 아래로 이동했습니다."},
+}
+
+func queuePriorityWords(language string) queuePriorityText {
+	code := i18n.Normalize(strings.TrimSpace(language))
+	if text, ok := queuePriorityTranslations[code]; ok {
+		return text
+	}
+	return queuePriorityTranslations[i18n.DefaultLanguage]
+}

--- a/internal/desktop/queue_priority.go
+++ b/internal/desktop/queue_priority.go
@@ -41,9 +41,9 @@ func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePri
 }
 
 type queuePriorityText struct {
-	MoveUp   string
-	MoveDown string
-	MovedUp  string
+	MoveUp    string
+	MoveDown  string
+	MovedUp   string
 	MovedDown string
 }
 

--- a/internal/desktop/queue_priority_test.go
+++ b/internal/desktop/queue_priority_test.go
@@ -1,0 +1,66 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestQueuePriorityStateRequiresOneQueuedSelection(t *testing.T) {
+	jobs := []model.TransferJob{
+		{ID: "running", Status: "running"},
+		{ID: "a", Status: "queued"},
+		{ID: "done", Status: "done"},
+		{ID: "b", Status: "queued"},
+		{ID: "c", Status: "queued"},
+	}
+
+	cases := []struct {
+		name     string
+		selected []int
+		up       bool
+		down     bool
+	}{
+		{name: "none", selected: nil},
+		{name: "multiple", selected: []int{1, 3}},
+		{name: "running", selected: []int{0}},
+		{name: "done", selected: []int{2}},
+		{name: "first queued", selected: []int{1}, down: true},
+		{name: "middle queued", selected: []int{3}, up: true, down: true},
+		{name: "last queued", selected: []int{4}, up: true},
+		{name: "out of range", selected: []int{99}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveQueuePriorityState(jobs, tc.selected)
+			if got.MoveUp != tc.up || got.MoveDown != tc.down {
+				t.Fatalf("deriveQueuePriorityState(%v) = %#v, want up=%v down=%v", tc.selected, got, tc.up, tc.down)
+			}
+		})
+	}
+}
+
+func TestQueuePriorityWordsCoverEverySupportedLanguage(t *testing.T) {
+	for _, language := range i18n.Languages() {
+		text, ok := queuePriorityTranslations[language.Code]
+		if !ok {
+			t.Fatalf("missing queue-priority translation for %s", language.Code)
+		}
+		if text.MoveUp == "" || text.MoveDown == "" || text.MovedUp == "" || text.MovedDown == "" {
+			t.Fatalf("incomplete queue-priority translation for %s: %#v", language.Code, text)
+		}
+		if got := queuePriorityWords(language.Code); got != text {
+			t.Fatalf("queuePriorityWords(%s) = %#v, want %#v", language.Code, got, text)
+		}
+	}
+}
+
+func TestQueuePriorityWordsNormalizeRegionalLanguage(t *testing.T) {
+	if got := queuePriorityWords("hr-HR"); got.MoveUp != "Pomakni gore" || got.MoveDown != "Pomakni dolje" {
+		t.Fatalf("Croatian regional normalization failed: %#v", got)
+	}
+	if got := queuePriorityWords("unknown"); got != queuePriorityTranslations["en"] {
+		t.Fatalf("unknown language did not fall back to English: %#v", got)
+	}
+}

--- a/internal/desktop/queue_priority_windows.go
+++ b/internal/desktop/queue_priority_windows.go
@@ -10,8 +10,8 @@ const (
 )
 
 var (
-	queueGetDlgItem    = user32.NewProc("GetDlgItem")
-	queueGetWindowRect = user32.NewProc("GetWindowRect")
+	queueGetDlgItem     = user32.NewProc("GetDlgItem")
+	queueGetWindowRect  = user32.NewProc("GetWindowRect")
 	queueScreenToClient = user32.NewProc("ScreenToClient")
 )
 

--- a/internal/desktop/queue_priority_windows.go
+++ b/internal/desktop/queue_priority_windows.go
@@ -1,0 +1,155 @@
+//go:build windows
+
+package desktop
+
+import "unsafe"
+
+const (
+	idMoveQueueUp   = 508
+	idMoveQueueDown = 509
+)
+
+var (
+	queueGetDlgItem    = user32.NewProc("GetDlgItem")
+	queueGetWindowRect = user32.NewProc("GetWindowRect")
+	queueScreenToClient = user32.NewProc("ScreenToClient")
+)
+
+func (a *app) queuePriorityButton(id int) uintptr {
+	if a == nil || a.hwnd == 0 {
+		return 0
+	}
+	hwnd, _, _ := queueGetDlgItem.Call(a.hwnd, uintptr(id))
+	return hwnd
+}
+
+func (a *app) ensureQueuePriorityControls() {
+	if a == nil || a.hwnd == 0 {
+		return
+	}
+	if a.queuePriorityButton(idMoveQueueUp) != 0 && a.queuePriorityButton(idMoveQueueDown) != 0 {
+		return
+	}
+
+	hinst, _, _ := getModuleHandleW.Call(0)
+	words := queuePriorityWords(a.languageCode())
+	create := func(id int, label, icon string) uintptr {
+		hwnd, _, _ := createWindowExW.Call(
+			0,
+			uintptr(unsafe.Pointer(wstr("BUTTON"))),
+			uintptr(unsafe.Pointer(wstr(label))),
+			wsChild|wsVisible|wsTabStop|bsOwnerDraw,
+			0, 0, 100, 30,
+			a.hwnd, uintptr(id), hinst, 0,
+		)
+		if hwnd == 0 {
+			return 0
+		}
+		sendMessageW.Call(hwnd, wmSetFont, a.font, 1)
+		a.registerButton(hwnd, icon, label, buttonDefault)
+		return hwnd
+	}
+
+	if a.queuePriorityButton(idMoveQueueUp) == 0 {
+		create(idMoveQueueUp, words.MoveUp, iconUp)
+	}
+	if a.queuePriorityButton(idMoveQueueDown) == 0 {
+		create(idMoveQueueDown, words.MoveDown, iconDownload)
+	}
+}
+
+func (a *app) updateQueuePriorityControls(state queuePriorityState) {
+	a.ensureQueuePriorityControls()
+	up := a.queuePriorityButton(idMoveQueueUp)
+	down := a.queuePriorityButton(idMoveQueueDown)
+	words := queuePriorityWords(a.languageCode())
+	a.setButtonLabel(up, words.MoveUp)
+	a.setButtonLabel(down, words.MoveDown)
+	setControlEnabled(up, state.MoveUp && !a.connectionBusy)
+	setControlEnabled(down, state.MoveDown && !a.connectionBusy)
+}
+
+func (a *app) layoutQueuePriorityControls() {
+	if a == nil || a.hwnd == 0 || a.clearQueue == 0 {
+		return
+	}
+	a.ensureQueuePriorityControls()
+	up := a.queuePriorityButton(idMoveQueueUp)
+	down := a.queuePriorityButton(idMoveQueueDown)
+	if up == 0 || down == 0 {
+		return
+	}
+
+	var clearRect rect
+	if ok, _, _ := queueGetWindowRect.Call(a.clearQueue, uintptr(unsafe.Pointer(&clearRect))); ok == 0 {
+		return
+	}
+	topLeft := point{X: clearRect.Left, Y: clearRect.Top}
+	bottomRight := point{X: clearRect.Right, Y: clearRect.Bottom}
+	if ok, _, _ := queueScreenToClient.Call(a.hwnd, uintptr(unsafe.Pointer(&topLeft))); ok == 0 {
+		return
+	}
+	if ok, _, _ := queueScreenToClient.Call(a.hwnd, uintptr(unsafe.Pointer(&bottomRight))); ok == 0 {
+		return
+	}
+
+	gap := a.scale(8)
+	x := int(bottomRight.X) + gap
+	y := int(topLeft.Y)
+	height := int(bottomRight.Y - topLeft.Y)
+	var client rect
+	if ok, _, _ := getClientRect.Call(a.hwnd, uintptr(unsafe.Pointer(&client))); ok == 0 {
+		return
+	}
+	available := int(client.Right) - a.scale(14) - x - gap
+	buttonWidth := available / 2
+	if buttonWidth > a.scale(132) {
+		buttonWidth = a.scale(132)
+	}
+	if buttonWidth < a.scale(88) {
+		buttonWidth = a.scale(88)
+	}
+	moveWindow.Call(up, uintptr(x), uintptr(y), uintptr(buttonWidth), uintptr(height), 1)
+	moveWindow.Call(down, uintptr(x+buttonWidth+gap), uintptr(y), uintptr(buttonWidth), uintptr(height), 1)
+}
+
+func (a *app) moveSelectedTransfer(direction int) {
+	selected := selectedIndices(a.transferList)
+	state := deriveQueuePriorityState(a.transferJobs, selected)
+	if len(selected) != 1 {
+		return
+	}
+	if direction < 0 && !state.MoveUp {
+		return
+	}
+	if direction > 0 && !state.MoveDown {
+		return
+	}
+	index := selected[0]
+	if index < 0 || index >= len(a.transferJobs) {
+		return
+	}
+
+	id := a.transferJobs[index].ID
+	var err error
+	words := queuePriorityWords(a.languageCode())
+	if direction < 0 {
+		err = a.engine.MoveTransferUp(id)
+	} else {
+		err = a.engine.MoveTransferDown(id)
+	}
+	if err != nil {
+		a.setStatus(a.userMessage(err, "error.generic"))
+		a.refreshTransfers()
+		return
+	}
+	if direction < 0 {
+		a.setStatus(words.MovedUp)
+	} else {
+		a.setStatus(words.MovedDown)
+	}
+	// The transfer manager emits a full state snapshot. refreshTransfers keeps
+	// selection bound to the transfer ID so the same job remains selected after
+	// its row position changes.
+	a.refreshTransfers()
+}

--- a/internal/desktop/workspace_layout_windows.go
+++ b/internal/desktop/workspace_layout_windows.go
@@ -75,6 +75,7 @@ func (a *app) refineWorkspaceLayout() {
 
 	a.stabilizeWorkspaceChrome()
 	a.applyApplicationSidebar()
+	a.layoutQueuePriorityControls()
 	applyFileColumnOrder(a.localList, false)
 	applyFileColumnOrder(a.remoteList, true)
 	// The sidebar changes the real file-pane widths after the top-level layout

--- a/internal/transfer/queue_order.go
+++ b/internal/transfer/queue_order.go
@@ -1,0 +1,79 @@
+package transfer
+
+import "errors"
+
+var (
+	errTransferOrderClosed    = errors.New("transfer manager is closed")
+	errTransferOrderMissing   = errors.New("transfer was not found")
+	errTransferOrderNotQueued = errors.New("only queued transfers can be reordered")
+)
+
+// MoveQueuedUp moves one waiting transfer ahead of the nearest earlier waiting
+// transfer. Running and terminal jobs keep their exact slots in the history
+// list; only the relative scheduler order of queued jobs changes.
+func (m *Manager) MoveQueuedUp(id string) error {
+	return m.moveQueued(id, -1)
+}
+
+// MoveQueuedDown moves one waiting transfer behind the nearest later waiting
+// transfer. Running and terminal jobs are never reordered or mutated.
+func (m *Manager) MoveQueuedDown(id string) error {
+	return m.moveQueued(id, 1)
+}
+
+func (m *Manager) moveQueued(id string, direction int) error {
+	if direction != -1 && direction != 1 {
+		return errors.New("invalid queue reorder direction")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return errTransferOrderClosed
+	}
+
+	index := -1
+	for i := range m.jobs {
+		if m.jobs[i].ID == id {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return errTransferOrderMissing
+	}
+	if m.jobs[index].Status != "queued" {
+		return errTransferOrderNotQueued
+	}
+
+	neighbor := -1
+	if direction < 0 {
+		for i := index - 1; i >= 0; i-- {
+			if m.jobs[i].Status == "queued" {
+				neighbor = i
+				break
+			}
+		}
+	} else {
+		for i := index + 1; i < len(m.jobs); i++ {
+			if m.jobs[i].Status == "queued" {
+				neighbor = i
+				break
+			}
+	}
+	if neighbor < 0 {
+		// The requested job is already at the corresponding queued edge. This is
+		// an idempotent no-op so a stale UI click cannot turn into an error after
+		// another queue event changes availability.
+		return nil
+	}
+
+	m.jobs[index], m.jobs[neighbor] = m.jobs[neighbor], m.jobs[index]
+	m.emitLocked(Event{
+		Type:   "state",
+		Jobs:   append([]model.TransferJob(nil), m.jobs...),
+		Paused: m.paused,
+	})
+	return nil
+}

--- a/internal/transfer/queue_order.go
+++ b/internal/transfer/queue_order.go
@@ -1,6 +1,10 @@
 package transfer
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
 
 var (
 	errTransferOrderClosed    = errors.New("transfer manager is closed")

--- a/internal/transfer/queue_order.go
+++ b/internal/transfer/queue_order.go
@@ -65,6 +65,7 @@ func (m *Manager) moveQueued(id string, direction int) error {
 				neighbor = i
 				break
 			}
+		}
 	}
 	if neighbor < 0 {
 		// The requested job is already at the corresponding queued edge. This is

--- a/internal/transfer/queue_order_test.go
+++ b/internal/transfer/queue_order_test.go
@@ -1,0 +1,175 @@
+package transfer
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/config"
+)
+
+func newPausedQueueManager(t *testing.T) (*Manager, string) {
+	t.Helper()
+	dir := t.TempDir()
+	m := New(disconnectedProvider{}, config.NewSettings(config.New(dir)))
+	m.Pause()
+	return m, dir
+}
+
+func addQueuedDownloads(t *testing.T, m *Manager, dir string, names ...string) []string {
+	t.Helper()
+	requests := make([]Request, 0, len(names))
+	for _, name := range names {
+		requests = append(requests, Request{
+			Direction:  "download",
+			LocalPath:  filepath.Join(dir, name),
+			RemotePath: "/" + name,
+		})
+	}
+	jobs, err := m.AddBatch(requests)
+	if err != nil {
+		t.Fatalf("AddBatch: %v", err)
+	}
+	ids := make([]string, len(jobs))
+	for i := range jobs {
+		ids[i] = jobs[i].ID
+	}
+	return ids
+}
+
+func queueIDs(m *Manager) []string {
+	jobs := m.List()
+	ids := make([]string, len(jobs))
+	for i := range jobs {
+		ids[i] = jobs[i].ID
+	}
+	return ids
+}
+
+func assertQueueIDs(t *testing.T, m *Manager, want ...string) {
+	t.Helper()
+	got := queueIDs(m)
+	if len(got) != len(want) {
+		t.Fatalf("queue length = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("queue[%d] = %q, want %q; full order=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestMoveQueuedUpAndDownChangesOnlySchedulerOrder(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt")
+
+	if err := m.MoveQueuedUp(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedUp: %v", err)
+	}
+	assertQueueIDs(t, m, ids[0], ids[2], ids[1])
+
+	if err := m.MoveQueuedUp(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedUp second time: %v", err)
+	}
+	assertQueueIDs(t, m, ids[2], ids[0], ids[1])
+
+	if err := m.MoveQueuedDown(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedDown: %v", err)
+	}
+	assertQueueIDs(t, m, ids[0], ids[2], ids[1])
+}
+
+func TestMoveQueuedSkipsRunningAndTerminalSlots(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt", "d.txt")
+
+	m.mu.Lock()
+	m.jobs[1].Status = "running"
+	m.jobs[2].Status = "done"
+	runningID := m.jobs[1].ID
+	terminalID := m.jobs[2].ID
+	m.mu.Unlock()
+
+	if err := m.MoveQueuedUp(ids[3]); err != nil {
+		t.Fatalf("MoveQueuedUp: %v", err)
+	}
+	assertQueueIDs(t, m, ids[3], runningID, terminalID, ids[0])
+
+	jobs := m.List()
+	if jobs[1].ID != runningID || jobs[1].Status != "running" {
+		t.Fatalf("running job was mutated: %#v", jobs[1])
+	}
+	if jobs[2].ID != terminalID || jobs[2].Status != "done" {
+		t.Fatalf("terminal job was mutated: %#v", jobs[2])
+	}
+}
+
+func TestMoveQueuedRejectsMissingAndNonQueuedJobs(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt")
+
+	if err := m.MoveQueuedUp("missing"); !errors.Is(err, errTransferOrderMissing) {
+		t.Fatalf("missing transfer error = %v, want %v", err, errTransferOrderMissing)
+	}
+
+	m.mu.Lock()
+	m.jobs[0].Status = "running"
+	m.mu.Unlock()
+	if err := m.MoveQueuedDown(ids[0]); !errors.Is(err, errTransferOrderNotQueued) {
+		t.Fatalf("non-queued transfer error = %v, want %v", err, errTransferOrderNotQueued)
+	}
+}
+
+func TestMoveQueuedAtEdgeIsIdempotentAndDoesNotEmitNoise(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt")
+	_, before := m.Events(0)
+
+	if err := m.MoveQueuedUp(ids[0]); err != nil {
+		t.Fatalf("MoveQueuedUp at edge: %v", err)
+	}
+	if err := m.MoveQueuedDown(ids[1]); err != nil {
+		t.Fatalf("MoveQueuedDown at edge: %v", err)
+	}
+	assertQueueIDs(t, m, ids[0], ids[1])
+
+	events, after := m.Events(before)
+	if after != before || len(events) != 0 {
+		t.Fatalf("edge no-op emitted queue events: before=%d after=%d events=%#v", before, after, events)
+	}
+}
+
+func TestMoveQueuedEmitsFullStateSnapshot(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt")
+	_, before := m.Events(0)
+
+	if err := m.MoveQueuedUp(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedUp: %v", err)
+	}
+	events, after := m.Events(before)
+	if after <= before {
+		t.Fatalf("event sequence did not advance: before=%d after=%d", before, after)
+	}
+	if len(events) != 1 || events[0].Type != "state" {
+		t.Fatalf("reorder events = %#v, want one state snapshot", events)
+	}
+	if !events[0].Paused {
+		t.Fatal("state snapshot lost paused queue state")
+	}
+	if len(events[0].Jobs) != 3 || events[0].Jobs[0].ID != ids[0] || events[0].Jobs[1].ID != ids[2] || events[0].Jobs[2].ID != ids[1] {
+		t.Fatalf("state snapshot order = %#v", events[0].Jobs)
+	}
+}
+
+func TestMoveQueuedRejectsClosedManager(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt")
+	m.mu.Lock()
+	m.closed = true
+	m.mu.Unlock()
+
+	if err := m.MoveQueuedDown(ids[0]); !errors.Is(err, errTransferOrderClosed) {
+		t.Fatalf("closed manager error = %v, want %v", err, errTransferOrderClosed)
+	}
+}

--- a/scripts/test_queue_priority_contract.py
+++ b/scripts/test_queue_priority_contract.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class QueuePriorityContractTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_core_reorders_only_queued_jobs(self) -> None:
+        core = self.read("internal/transfer/queue_order.go")
+        for marker in (
+            "func (m *Manager) MoveQueuedUp",
+            "func (m *Manager) MoveQueuedDown",
+            'm.jobs[index].Status != "queued"',
+            'm.jobs[i].Status == "queued"',
+            "m.jobs[index], m.jobs[neighbor] = m.jobs[neighbor], m.jobs[index]",
+            'Type:   "state"',
+            "Jobs:   append([]model.TransferJob(nil), m.jobs...)",
+            "Paused: m.paused",
+        ):
+            self.assertIn(marker, core)
+        self.assertNotIn("m.pump()", core, "reordering must not start transfers as a side effect")
+
+    def test_engine_exposes_bounded_queue_reordering_only(self) -> None:
+        api = self.read("internal/api/queue_order.go")
+        self.assertIn("MoveTransferUp", api)
+        self.assertIn("e.transfers.MoveQueuedUp(id)", api)
+        self.assertIn("MoveTransferDown", api)
+        self.assertIn("e.transfers.MoveQueuedDown(id)", api)
+
+    def test_shared_ui_policy_is_single_selection_and_queued_only(self) -> None:
+        policy = self.read("internal/desktop/queue_priority.go")
+        for marker in (
+            "len(selected) != 1",
+            'jobs[index].Status != "queued"',
+            'jobs[i].Status == "queued"',
+            "MoveUp = true",
+            "MoveDown = true",
+            "i18n.Normalize",
+        ):
+            self.assertIn(marker, policy)
+
+    def test_windows_priority_controls_are_real_wired_controls(self) -> None:
+        windows = self.read("internal/desktop/queue_priority_windows.go")
+        commands = self.read("internal/desktop/commands_windows.go")
+        actions = self.read("internal/desktop/action_state_windows.go")
+        layout = self.read("internal/desktop/workspace_layout_windows.go")
+        transfers = self.read("internal/desktop/transfers_windows.go")
+
+        for marker in (
+            "idMoveQueueUp",
+            "idMoveQueueDown",
+            'wstr("BUTTON")',
+            "wsChild|wsVisible|wsTabStop|bsOwnerDraw",
+            "a.engine.MoveTransferUp(id)",
+            "a.engine.MoveTransferDown(id)",
+            "queuePriorityWords(a.languageCode())",
+        ):
+            self.assertIn(marker, windows)
+        self.assertIn("case idMoveQueueUp:", commands)
+        self.assertIn("case idMoveQueueDown:", commands)
+        self.assertIn("deriveQueuePriorityState", actions)
+        self.assertIn("a.updateQueuePriorityControls(priorityState)", actions)
+        self.assertIn("a.layoutQueuePriorityControls()", layout)
+        self.assertIn("selected := a.selectedTransferIDSet()", transfers)
+        self.assertIn("a.restoreTransferSelection(selected)", transfers)
+
+    def test_tests_cover_scheduler_and_ui_invariants(self) -> None:
+        manager_tests = self.read("internal/transfer/queue_order_test.go")
+        ui_tests = self.read("internal/desktop/queue_priority_test.go")
+        for marker in (
+            "TestMoveQueuedUpAndDownChangesOnlySchedulerOrder",
+            "TestMoveQueuedSkipsRunningAndTerminalSlots",
+            "TestMoveQueuedRejectsMissingAndNonQueuedJobs",
+            "TestMoveQueuedAtEdgeIsIdempotentAndDoesNotEmitNoise",
+            "TestMoveQueuedEmitsFullStateSnapshot",
+            "TestMoveQueuedRejectsClosedManager",
+        ):
+            self.assertIn(marker, manager_tests)
+        self.assertIn("TestQueuePriorityStateRequiresOneQueuedSelection", ui_tests)
+        self.assertIn("TestQueuePriorityWordsCoverEverySupportedLanguage", ui_tests)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized for Ghost FTP.
- [x] Existing license/contribution constraints remain unchanged.

## Scope

Add one focused FileZilla-class power-user capability: deterministic queue priority/reordering for waiting transfers, with Core/API semantics and Windows desktop controls.

Linux desktop UI parity is intentionally completed in follow-up PR #212 so the large X11 surface can remain a separate, reviewable change rather than being rewritten unsafely inside this PR.

## Core contract
- Only `queued` transfers may move.
- Move Up/Down swaps with the nearest queued neighbor only.
- Running and terminal jobs are never reordered or mutated.
- Edge moves are idempotent no-ops.
- Reordering emits one full queue `state` snapshot and does not alter transfer identity, connection binding, retries, progress or content.

## UI contract delivered here
- Windows exposes localized native Move Up / Move Down controls with state derived from one selected queued job.
- Multi-selection, running/terminal selection and unavailable directions remain disabled.
- Selection follows transfer ID after a reorder.
- Shared queue-priority policy and 24-language text are platform-neutral and reused by Linux in #212.

## Security / privacy
- [x] No new protocol behavior or secure-transport downgrade.
- [x] No new dependency, telemetry, analytics, tracking or external service.
- [x] No new credential persistence or secret surface.
- [x] Existing FTPS/SFTP trust, local path confinement and transfer safety remain unchanged.

## Validation
- [x] Final exact-head PR CI completed/success on `b570c98ac71b0b72241770d0b6280a0defc015e1`.
- [x] Core quality, Windows production, Linux production, distro packages/install matrix and Authentic UI Screenshots passed on the final PR head.
- [x] Post-merge `main` SHA `4efd5080f305ff51bd8b89738aa665fa450e0d79` passed Core quality, Windows production, Linux production, distro packages and Debian 13 / Ubuntu 26.04 LTS / Fedora 44 install-remove-GUI smoke.

Follow-up: #212 adds the Linux X11 Move Up / Move Down controls and Linux-specific regression coverage without changing scheduler semantics.