### PR TITLE
Linux: add transfer queue priority parity

### DIFF
--- a/internal/desktop/gui_linux.go
+++ b/internal/desktop/gui_linux.go
@@ -625,6 +625,9 @@ func (u *linuxDesktop) renderQueue() error {
 	if err := u.drawButton(u.layout.clearQueue, u.tr("transfer.clear"), len(u.transferJobs) > 0, false); err != nil {
 		return err
 	}
+	if err := u.renderQueuePriorityControls(); err != nil {
+		return err
+	}
 	if err := u.x.fillRect(u.layout.queue.left, u.layout.queue.top, u.layout.queue.right-u.layout.queue.left, u.layout.queue.bottom-u.layout.queue.top, premiumTheme.List); err != nil {
 		return err
 	}
@@ -1013,6 +1016,9 @@ func (u *linuxDesktop) handleMouse(x, y int) {
 		}
 	}
 	l := u.layout
+	if u.handleQueuePriorityMouse(x, y) {
+		return
+	}
 	switch {
 	case l.connect.contains(x, y):
 		u.connectToServer("")

--- a/internal/desktop/queue_priority_linux.go
+++ b/internal/desktop/queue_priority_linux.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package desktop
+
+import (
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+	"github.com/bren-wp/Ghost-FTP/internal/usererror"
+)
+
+const (
+	linuxQueuePriorityGap       = 8
+	linuxQueuePriorityUpWidth   = 96
+	linuxQueuePriorityDownWidth = 112
+)
+
+func (u *linuxDesktop) queuePriorityRects() (linuxRect, linuxRect) {
+	y := u.layout.clearQueue.top
+	up := linuxRectWH(u.layout.clearQueue.right+linuxQueuePriorityGap, y, linuxQueuePriorityUpWidth, 28)
+	down := linuxRectWH(up.right+linuxQueuePriorityGap, y, linuxQueuePriorityDownWidth, 28)
+	return up, down
+}
+
+func (u *linuxDesktop) selectedQueuePriorityState() queuePriorityState {
+	if u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {
+		return queuePriorityState{}
+	}
+	return deriveQueuePriorityState(u.transferJobs, []int{u.selectedTransfer})
+}
+
+func (u *linuxDesktop) renderQueuePriorityControls() error {
+	up, down := u.queuePriorityRects()
+	state := u.selectedQueuePriorityState()
+	words := queuePriorityWords(u.language)
+	if err := u.drawButton(up, words.MoveUp, state.MoveUp && !u.busy, false); err != nil {
+		return err
+	}
+	return u.drawButton(down, words.MoveDown, state.MoveDown && !u.busy, false)
+}
+
+func (u *linuxDesktop) restoreQueuePrioritySelection(id string) {
+	u.selectedTransfer = -1
+	for index := range u.transferJobs {
+		if u.transferJobs[index].ID == id {
+			u.selectedTransfer = index
+			return
+		}
+	}
+}
+
+func (u *linuxDesktop) moveSelectedQueueTransfer(moveUp bool) {
+	if u.busy || u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {
+		return
+	}
+	state := u.selectedQueuePriorityState()
+	if (moveUp && !state.MoveUp) || (!moveUp && !state.MoveDown) {
+		return
+	}
+
+	id := u.transferJobs[u.selectedTransfer].ID
+	var err error
+	if moveUp {
+		err = u.engine.MoveTransferUp(id)
+	} else {
+		err = u.engine.MoveTransferDown(id)
+	}
+	if err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+
+	u.transferJobs = u.engine.Transfers()
+	u.restoreQueuePrioritySelection(id)
+	words := queuePriorityWords(u.language)
+	if moveUp {
+		u.setStatus(words.MovedUp)
+	} else {
+		u.setStatus(words.MovedDown)
+	}
+}
+
+func (u *linuxDesktop) handleQueuePriorityMouse(x, y int) bool {
+	up, down := u.queuePriorityRects()
+	if up.contains(x, y) {
+		u.moveSelectedQueueTransfer(true)
+		return true
+	}
+	if down.contains(x, y) {
+		u.moveSelectedQueueTransfer(false)
+		return true
+	}
+	return false
+}

--- a/internal/desktop/queue_priority_linux_test.go
+++ b/internal/desktop/queue_priority_linux_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestLinuxQueuePriorityRectsFollowClearQueueWithoutOverlap(t *testing.T) {
+	u := &linuxDesktop{layout: linuxDesktopLayout{clearQueue: linuxRectWH(440, 700, 110, 28)}}
+	up, down := u.queuePriorityRects()
+
+	if up.top != u.layout.clearQueue.top || down.top != u.layout.clearQueue.top {
+		t.Fatalf("priority controls must stay aligned with the queue toolbar: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
+	}
+	if up.left <= u.layout.clearQueue.right || down.left <= up.right {
+		t.Fatalf("priority controls overlap existing queue controls: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
+	}
+	if up.bottom != u.layout.clearQueue.bottom || down.bottom != u.layout.clearQueue.bottom {
+		t.Fatalf("priority controls must preserve the queue toolbar height: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
+	}
+}
+
+func TestLinuxQueuePriorityStateUsesSharedQueuedOnlyPolicy(t *testing.T) {
+	u := &linuxDesktop{
+		selectedTransfer: 2,
+		transferJobs: []model.TransferJob{
+			{ID: "running", Status: "running"},
+			{ID: "first", Status: "queued"},
+			{ID: "selected", Status: "queued"},
+			{ID: "done", Status: "done"},
+			{ID: "last", Status: "queued"},
+		},
+	}
+
+	state := u.selectedQueuePriorityState()
+	if !state.MoveUp || !state.MoveDown {
+		t.Fatalf("selected queued job should move across nearest queued neighbors: %+v", state)
+	}
+
+	u.transferJobs[u.selectedTransfer].Status = "running"
+	state = u.selectedQueuePriorityState()
+	if state.MoveUp || state.MoveDown {
+		t.Fatalf("running transfer must not expose priority controls: %+v", state)
+	}
+}
+
+func TestLinuxQueuePrioritySelectionRestoresByTransferID(t *testing.T) {
+	u := &linuxDesktop{
+		selectedTransfer: 0,
+		transferJobs: []model.TransferJob{
+			{ID: "a", Status: "queued"},
+			{ID: "c", Status: "queued"},
+			{ID: "b", Status: "queued"},
+		},
+	}
+
+	u.restoreQueuePrioritySelection("b")
+	if u.selectedTransfer != 2 {
+		t.Fatalf("selection must follow transfer identity after reorder, got index %d", u.selectedTransfer)
+	}
+
+	u.restoreQueuePrioritySelection("missing")
+	if u.selectedTransfer != -1 {
+		t.Fatalf("missing transfer identity must clear stale selection, got index %d", u.selectedTransfer)
+	}
+}

--- a/scripts/test_queue_priority_contract.py
+++ b/scripts/test_queue_priority_contract.py
@@ -70,9 +70,28 @@ class QueuePriorityContractTests(unittest.TestCase):
         self.assertIn("selected := a.selectedTransferIDSet()", transfers)
         self.assertIn("a.restoreTransferSelection(selected)", transfers)
 
+    def test_linux_priority_controls_are_rendered_click_wired_and_identity_safe(self) -> None:
+        linux = self.read("internal/desktop/queue_priority_linux.go")
+        gui = self.read("internal/desktop/gui_linux.go")
+
+        for marker in (
+            "deriveQueuePriorityState",
+            "queuePriorityWords(u.language)",
+            "u.engine.MoveTransferUp(id)",
+            "u.engine.MoveTransferDown(id)",
+            "u.transferJobs = u.engine.Transfers()",
+            "u.restoreQueuePrioritySelection(id)",
+            "func (u *linuxDesktop) renderQueuePriorityControls() error",
+            "func (u *linuxDesktop) handleQueuePriorityMouse(x, y int) bool",
+        ):
+            self.assertIn(marker, linux)
+        self.assertIn("u.renderQueuePriorityControls()", gui)
+        self.assertIn("u.handleQueuePriorityMouse(x, y)", gui)
+
     def test_tests_cover_scheduler_and_ui_invariants(self) -> None:
         manager_tests = self.read("internal/transfer/queue_order_test.go")
         ui_tests = self.read("internal/desktop/queue_priority_test.go")
+        linux_tests = self.read("internal/desktop/queue_priority_linux_test.go")
         for marker in (
             "TestMoveQueuedUpAndDownChangesOnlySchedulerOrder",
             "TestMoveQueuedSkipsRunningAndTerminalSlots",
@@ -84,6 +103,9 @@ class QueuePriorityContractTests(unittest.TestCase):
             self.assertIn(marker, manager_tests)
         self.assertIn("TestQueuePriorityStateRequiresOneQueuedSelection", ui_tests)
         self.assertIn("TestQueuePriorityWordsCoverEverySupportedLanguage", ui_tests)
+        self.assertIn("TestLinuxQueuePriorityRectsFollowClearQueueWithoutOverlap", linux_tests)
+        self.assertIn("TestLinuxQueuePriorityStateUsesSharedQueuedOnlyPolicy", linux_tests)
+        self.assertIn("TestLinuxQueuePrioritySelectionRestoresByTransferID", linux_tests)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized as continued Ghost FTP improvement.
- [x] Existing license/contribution constraints remain unchanged.

## Scope

Complete the Linux desktop parity follow-up to #211 by exposing the already-merged bounded queue-priority engine through real X11 Move Up / Move Down controls.

## Linux UI contract

- Render localized Move Up / Move Down controls beside the existing queue toolbar.
- Reuse the shared `deriveQueuePriorityState` policy from #211: exactly one selected transfer, `queued` only, and a queued neighbor must exist in the requested direction.
- Dispatch only through the existing `Engine.MoveTransferUp` / `MoveTransferDown` API.
- Refresh the queue immediately after a successful reorder and restore selection by transfer ID, not by stale row index.
- Disabled or stale clicks are safe no-ops.
- Existing overlay routing remains authoritative; priority mouse handling is reached only from the normal base `handleMouse` path.

## Change isolation

- No scheduler, protocol or security semantics are changed here; scheduler behavior remains the tested implementation from #211.
- `gui_linux.go` receives only two small integration hooks: one render hook and one mouse-dispatch hook.
- Linux-specific behavior lives in `queue_priority_linux.go` with Linux-only tests.
- `scripts/test_queue_priority_contract.py` now fails if Linux render/click/ID-restoration wiring disappears.
- Toolbar geometry remains inside the canonical Linux minimum width: the final priority control ends at x=774 while `premiumMinWidth` is 940.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash reporting added.
- [x] No automatic external API or hidden network destination added.
- [x] No password/private-key/passphrase persistence or logging change.
- [x] SFTP host-key verification and pinning remain active.
- [x] Local path-confinement and symlink/reparse-point protections remain unchanged.
- [x] No external Go module added.

## Validation

- [x] Fail-closed exact-base patch preconditions passed before the two X11 hooks were committed.
- [x] `git diff --check` passed.
- [x] Focused `python3 scripts/test_queue_priority_contract.py` passed.
- [x] Focused `go test ./internal/desktop ./internal/api ./internal/transfer` passed.
- [x] Full exact-head Ghost FTP CI completed/success on `8d0dbc73d120da59a4ea7c64e5a7cdf6372d18d8`.
- [x] Exact-head Linux distro package workflow completed/success.
- [x] Exact-head Linux distro install matrix completed/success, including Debian 13, Ubuntu 26.04 LTS and Fedora 44 native lifecycle/GUI smoke.
- [x] Exact-head Authentic UI Screenshots completed/success; repository persistence was skipped, so the validated head did not move.

Merge only with the exact validated head SHA, then verify every workflow GitHub launches for the exact new `main` SHA after merge.