### PR TITLE
Linux: harden transfer queue action state and errors

### DIFF
--- a/internal/desktop/gui_linux.go
+++ b/internal/desktop/gui_linux.go
@@ -607,22 +607,23 @@ func (u *linuxDesktop) renderWorkspace() error {
 }
 
 func (u *linuxDesktop) renderQueue() error {
+	actions := u.linuxTransferActionState()
 	if err := u.x.text(premiumOuterGap, u.layout.pause.top+19, strings.ToUpper(u.tr("section.transfers")), premiumTheme.Muted, premiumTheme.Window); err != nil {
 		return err
 	}
-	if err := u.drawButton(u.layout.pause, u.tr("transfer.pause"), !u.queuePaused, false); err != nil {
+	if err := u.drawButton(u.layout.pause, u.tr("transfer.pause"), actions.Pause && !u.busy, false); err != nil {
 		return err
 	}
-	if err := u.drawButton(u.layout.resume, u.tr("transfer.resume"), u.queuePaused, false); err != nil {
+	if err := u.drawButton(u.layout.resume, u.tr("transfer.resume"), actions.Resume && !u.busy, false); err != nil {
 		return err
 	}
-	if err := u.drawButton(u.layout.cancelJob, u.tr("common.cancel"), u.selectedTransfer >= 0, false); err != nil {
+	if err := u.drawButton(u.layout.cancelJob, u.tr("common.cancel"), actions.Cancel && !u.busy, false); err != nil {
 		return err
 	}
-	if err := u.drawButton(u.layout.retryJob, u.tr("transfer.retry"), u.selectedTransfer >= 0, false); err != nil {
+	if err := u.drawButton(u.layout.retryJob, u.tr("transfer.retry"), actions.Retry && !u.busy, false); err != nil {
 		return err
 	}
-	if err := u.drawButton(u.layout.clearQueue, u.tr("transfer.clear"), len(u.transferJobs) > 0, false); err != nil {
+	if err := u.drawButton(u.layout.clearQueue, u.tr("transfer.clear"), actions.Clear && !u.busy, false); err != nil {
 		return err
 	}
 	if err := u.renderQueuePriorityControls(); err != nil {
@@ -1073,16 +1074,11 @@ func (u *linuxDesktop) handleMouse(x, y int) {
 		u.queuePaused = false
 		u.setStatus("Transfer queue resumed.")
 	case l.cancelJob.contains(x, y):
-		if u.selectedTransfer >= 0 && u.selectedTransfer < len(u.transferJobs) {
-			_ = u.engine.CancelTransfer(u.transferJobs[u.selectedTransfer].ID)
-		}
+		u.cancelSelectedTransferLinux()
 	case l.retryJob.contains(x, y):
-		if u.selectedTransfer >= 0 && u.selectedTransfer < len(u.transferJobs) {
-			_ = u.engine.RetryTransfer(u.transferJobs[u.selectedTransfer].ID)
-		}
+		u.retrySelectedTransferLinux()
 	case l.clearQueue.contains(x, y):
-		u.engine.ClearFinishedTransfers()
-		u.selectedTransfer = -1
+		u.clearFinishedTransfersLinux()
 	case l.queue.contains(x, y):
 		index := (y - l.queue.top - 11) / 22
 		if index >= 0 && index < len(u.transferJobs) {

--- a/internal/desktop/gui_linux.go
+++ b/internal/desktop/gui_linux.go
@@ -1066,13 +1066,9 @@ func (u *linuxDesktop) handleMouse(x, y int) {
 	case l.download.contains(x, y):
 		u.queueTransfer("download")
 	case l.pause.contains(x, y):
-		u.engine.PauseTransfers()
-		u.queuePaused = true
-		u.setStatus("Transfer queue paused.")
+		u.pauseTransfersLinux()
 	case l.resume.contains(x, y):
-		u.engine.ResumeTransfers()
-		u.queuePaused = false
-		u.setStatus("Transfer queue resumed.")
+		u.resumeTransfersLinux()
 	case l.cancelJob.contains(x, y):
 		u.cancelSelectedTransferLinux()
 	case l.retryJob.contains(x, y):

--- a/internal/desktop/queue_actions_linux.go
+++ b/internal/desktop/queue_actions_linux.go
@@ -29,6 +29,26 @@ func (u *linuxDesktop) refreshLinuxTransfersPreservingSelection(id string) {
 	}
 }
 
+func (u *linuxDesktop) pauseTransfersLinux() {
+	state := u.linuxTransferActionState()
+	if u.busy || !state.Pause {
+		return
+	}
+	u.engine.PauseTransfers()
+	u.queuePaused = true
+	u.setStatus("Transfer queue paused.")
+}
+
+func (u *linuxDesktop) resumeTransfersLinux() {
+	state := u.linuxTransferActionState()
+	if u.busy || !state.Resume {
+		return
+	}
+	u.engine.ResumeTransfers()
+	u.queuePaused = false
+	u.setStatus("Transfer queue resumed.")
+}
+
 func (u *linuxDesktop) cancelSelectedTransferLinux() {
 	state := u.linuxTransferActionState()
 	if u.busy || !state.Cancel || u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {

--- a/internal/desktop/queue_actions_linux.go
+++ b/internal/desktop/queue_actions_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package desktop
+
+import (
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+	"github.com/bren-wp/Ghost-FTP/internal/usererror"
+)
+
+func (u *linuxDesktop) linuxTransferActionState() transferActionState {
+	selected := []int(nil)
+	if u.selectedTransfer >= 0 && u.selectedTransfer < len(u.transferJobs) {
+		selected = []int{u.selectedTransfer}
+	}
+	return deriveTransferActionState(u.transferJobs, selected, u.connected, u.queuePaused)
+}
+
+func (u *linuxDesktop) refreshLinuxTransfersPreservingSelection(id string) {
+	u.transferJobs = u.engine.Transfers()
+	u.selectedTransfer = -1
+	if id == "" {
+		return
+	}
+	for index := range u.transferJobs {
+		if u.transferJobs[index].ID == id {
+			u.selectedTransfer = index
+			return
+		}
+	}
+}
+
+func (u *linuxDesktop) cancelSelectedTransferLinux() {
+	state := u.linuxTransferActionState()
+	if u.busy || !state.Cancel || u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {
+		return
+	}
+
+	id := u.transferJobs[u.selectedTransfer].ID
+	if err := u.engine.CancelTransfer(id); err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+	u.refreshLinuxTransfersPreservingSelection(id)
+	u.setStatus(u.tr("common.cancel"))
+}
+
+func (u *linuxDesktop) retrySelectedTransferLinux() {
+	state := u.linuxTransferActionState()
+	if u.busy || !state.Retry || u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {
+		return
+	}
+
+	id := u.transferJobs[u.selectedTransfer].ID
+	if err := u.engine.RetryTransfer(id); err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+	u.refreshLinuxTransfersPreservingSelection(id)
+	u.setStatus(u.tr("transfer.retry"))
+}
+
+func (u *linuxDesktop) clearFinishedTransfersLinux() {
+	state := u.linuxTransferActionState()
+	if u.busy || !state.Clear {
+		return
+	}
+
+	selectedID := ""
+	if u.selectedTransfer >= 0 && u.selectedTransfer < len(u.transferJobs) {
+		selectedID = u.transferJobs[u.selectedTransfer].ID
+	}
+	u.engine.ClearFinishedTransfers()
+	u.refreshLinuxTransfersPreservingSelection(selectedID)
+	u.setStatus(u.tr("transfer.clear"))
+}

--- a/internal/desktop/queue_actions_linux_test.go
+++ b/internal/desktop/queue_actions_linux_test.go
@@ -50,3 +50,60 @@ func TestLinuxTransferActionStateRejectsStaleSelection(t *testing.T) {
 		t.Fatalf("queue-wide pause must remain available for active work: %+v", state)
 	}
 }
+
+func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
+	pause := &linuxDesktop{
+		busy:              true,
+		connected:         true,
+		selectedTransfer:  0,
+		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+	}
+	pause.pauseTransfersLinux()
+	if pause.queuePaused {
+		t.Fatal("busy pause click must be inert")
+	}
+
+	resume := &linuxDesktop{
+		busy:              true,
+		connected:         true,
+		queuePaused:       true,
+		selectedTransfer:  0,
+		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+	}
+	resume.resumeTransfersLinux()
+	if !resume.queuePaused {
+		t.Fatal("busy resume click must be inert")
+	}
+
+	cancel := &linuxDesktop{
+		busy:              true,
+		connected:         true,
+		selectedTransfer:  0,
+		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+	}
+	cancel.cancelSelectedTransferLinux()
+	if cancel.transferJobs[0].Status != "queued" {
+		t.Fatalf("busy cancel click mutated transfer: %+v", cancel.transferJobs[0])
+	}
+
+	retry := &linuxDesktop{
+		busy:              true,
+		connected:         true,
+		selectedTransfer:  0,
+		transferJobs:      []model.TransferJob{{ID: "failed", Status: "failed"}},
+	}
+	retry.retrySelectedTransferLinux()
+	if retry.transferJobs[0].Status != "failed" {
+		t.Fatalf("busy retry click mutated transfer: %+v", retry.transferJobs[0])
+	}
+
+	clear := &linuxDesktop{
+		busy:              true,
+		selectedTransfer:  0,
+		transferJobs:      []model.TransferJob{{ID: "done", Status: "done"}},
+	}
+	clear.clearFinishedTransfersLinux()
+	if len(clear.transferJobs) != 1 || clear.transferJobs[0].Status != "done" {
+		t.Fatalf("busy clear click mutated queue: %+v", clear.transferJobs)
+	}
+}

--- a/internal/desktop/queue_actions_linux_test.go
+++ b/internal/desktop/queue_actions_linux_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestLinuxTransferActionStateUsesSharedStatusPolicy(t *testing.T) {
+	u := &linuxDesktop{
+		connected:        true,
+		selectedTransfer: 0,
+		transferJobs: []model.TransferJob{
+			{ID: "active", Status: "running"},
+			{ID: "failed", Status: "failed"},
+		},
+	}
+
+	state := u.linuxTransferActionState()
+	if !state.Pause || state.Resume || !state.Cancel || state.Retry || !state.Clear {
+		t.Fatalf("unexpected action state for running selection: %+v", state)
+	}
+
+	u.selectedTransfer = 1
+	state = u.linuxTransferActionState()
+	if state.Cancel || !state.Retry || !state.Clear {
+		t.Fatalf("failed selection should expose retry but not cancel: %+v", state)
+	}
+
+	u.connected = false
+	state = u.linuxTransferActionState()
+	if state.Retry || state.Pause || state.Resume {
+		t.Fatalf("disconnected Linux UI must not expose connection-bound queue actions: %+v", state)
+	}
+}
+
+func TestLinuxTransferActionStateRejectsStaleSelection(t *testing.T) {
+	u := &linuxDesktop{
+		connected:        true,
+		selectedTransfer: 9,
+		transferJobs:     []model.TransferJob{{ID: "queued", Status: "queued"}},
+	}
+	state := u.linuxTransferActionState()
+	if state.Cancel || state.Retry {
+		t.Fatalf("stale selection must not expose item mutation actions: %+v", state)
+	}
+	if !state.Pause {
+		t.Fatalf("queue-wide pause must remain available for active work: %+v", state)
+	}
+}

--- a/internal/desktop/queue_actions_linux_test.go
+++ b/internal/desktop/queue_actions_linux_test.go
@@ -53,10 +53,10 @@ func TestLinuxTransferActionStateRejectsStaleSelection(t *testing.T) {
 
 func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
 	pause := &linuxDesktop{
-		busy:              true,
-		connected:         true,
-		selectedTransfer:  0,
-		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+		busy:             true,
+		connected:        true,
+		selectedTransfer: 0,
+		transferJobs:     []model.TransferJob{{ID: "queued", Status: "queued"}},
 	}
 	pause.pauseTransfersLinux()
 	if pause.queuePaused {
@@ -64,11 +64,11 @@ func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
 	}
 
 	resume := &linuxDesktop{
-		busy:              true,
-		connected:         true,
-		queuePaused:       true,
-		selectedTransfer:  0,
-		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+		busy:             true,
+		connected:        true,
+		queuePaused:      true,
+		selectedTransfer: 0,
+		transferJobs:     []model.TransferJob{{ID: "queued", Status: "queued"}},
 	}
 	resume.resumeTransfersLinux()
 	if !resume.queuePaused {
@@ -76,10 +76,10 @@ func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
 	}
 
 	cancel := &linuxDesktop{
-		busy:              true,
-		connected:         true,
-		selectedTransfer:  0,
-		transferJobs:      []model.TransferJob{{ID: "queued", Status: "queued"}},
+		busy:             true,
+		connected:        true,
+		selectedTransfer: 0,
+		transferJobs:     []model.TransferJob{{ID: "queued", Status: "queued"}},
 	}
 	cancel.cancelSelectedTransferLinux()
 	if cancel.transferJobs[0].Status != "queued" {
@@ -87,10 +87,10 @@ func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
 	}
 
 	retry := &linuxDesktop{
-		busy:              true,
-		connected:         true,
-		selectedTransfer:  0,
-		transferJobs:      []model.TransferJob{{ID: "failed", Status: "failed"}},
+		busy:             true,
+		connected:        true,
+		selectedTransfer: 0,
+		transferJobs:     []model.TransferJob{{ID: "failed", Status: "failed"}},
 	}
 	retry.retrySelectedTransferLinux()
 	if retry.transferJobs[0].Status != "failed" {
@@ -98,9 +98,9 @@ func TestLinuxBusyQueueMutationsAreInert(t *testing.T) {
 	}
 
 	clear := &linuxDesktop{
-		busy:              true,
-		selectedTransfer:  0,
-		transferJobs:      []model.TransferJob{{ID: "done", Status: "done"}},
+		busy:             true,
+		selectedTransfer: 0,
+		transferJobs:     []model.TransferJob{{ID: "done", Status: "done"}},
 	}
 	clear.clearFinishedTransfersLinux()
 	if len(clear.transferJobs) != 1 || clear.transferJobs[0].Status != "done" {

--- a/scripts/test_ui_action_wiring.py
+++ b/scripts/test_ui_action_wiring.py
@@ -106,6 +106,8 @@ class UIActionWiringTests(unittest.TestCase):
         for marker in (
             "deriveTransferActionState",
             "usererror.MessageFor",
+            "u.engine.PauseTransfers()",
+            "u.engine.ResumeTransfers()",
             "u.engine.CancelTransfer(id)",
             "u.engine.RetryTransfer(id)",
             "u.refreshLinuxTransfersPreservingSelection(id)",
@@ -121,9 +123,21 @@ class UIActionWiringTests(unittest.TestCase):
         self.assertIn('u.drawButton(u.layout.cancelJob, u.tr("common.cancel"), actions.Cancel && !u.busy, false)', ui)
         self.assertIn('u.drawButton(u.layout.retryJob, u.tr("transfer.retry"), actions.Retry && !u.busy, false)', ui)
         self.assertIn('u.drawButton(u.layout.clearQueue, u.tr("transfer.clear"), actions.Clear && !u.busy, false)', ui)
+        self.assertIn("u.pauseTransfersLinux()", ui)
+        self.assertIn("u.resumeTransfersLinux()", ui)
         self.assertIn("u.cancelSelectedTransferLinux()", ui)
         self.assertIn("u.retrySelectedTransferLinux()", ui)
         self.assertIn("u.clearFinishedTransfersLinux()", ui)
+
+    def test_linux_disabled_queue_controls_are_functionally_inert(self) -> None:
+        actions = self.read("internal/desktop/queue_actions_linux.go")
+        for state in ("Pause", "Resume", "Cancel", "Retry", "Clear"):
+            self.assertIn(f"!state.{state}", actions)
+        self.assertGreaterEqual(
+            actions.count("u.busy || !state."),
+            5,
+            "every Linux queue mutation helper must reject busy or disabled state",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_ui_action_wiring.py
+++ b/scripts/test_ui_action_wiring.py
@@ -131,12 +131,18 @@ class UIActionWiringTests(unittest.TestCase):
 
     def test_linux_disabled_queue_controls_are_functionally_inert(self) -> None:
         actions = self.read("internal/desktop/queue_actions_linux.go")
+        tests = self.read("internal/desktop/queue_actions_linux_test.go")
         for state in ("Pause", "Resume", "Cancel", "Retry", "Clear"):
             self.assertIn(f"!state.{state}", actions)
         self.assertGreaterEqual(
             actions.count("u.busy || !state."),
             5,
             "every Linux queue mutation helper must reject busy or disabled state",
+        )
+        self.assertIn(
+            "TestLinuxBusyQueueMutationsAreInert",
+            tests,
+            "behavioral busy-state regression coverage must remain present",
         )
 
 

--- a/scripts/test_ui_action_wiring.py
+++ b/scripts/test_ui_action_wiring.py
@@ -99,6 +99,32 @@ class UIActionWiringTests(unittest.TestCase):
         self.assertNotIn("_ = a.engine.CancelTransfer", transfers)
         self.assertNotIn("_ = a.engine.RetryTransfer", transfers)
 
+    def test_linux_queue_actions_share_policy_and_surface_engine_errors(self) -> None:
+        ui = self.read("internal/desktop/gui_linux.go")
+        actions = self.read("internal/desktop/queue_actions_linux.go")
+
+        for marker in (
+            "deriveTransferActionState",
+            "usererror.MessageFor",
+            "u.engine.CancelTransfer(id)",
+            "u.engine.RetryTransfer(id)",
+            "u.refreshLinuxTransfersPreservingSelection(id)",
+            "u.engine.ClearFinishedTransfers()",
+        ):
+            self.assertIn(marker, actions)
+
+        self.assertNotIn("_ = u.engine.CancelTransfer", ui)
+        self.assertNotIn("_ = u.engine.RetryTransfer", ui)
+        self.assertIn("actions := u.linuxTransferActionState()", ui)
+        self.assertIn('u.drawButton(u.layout.pause, u.tr("transfer.pause"), actions.Pause && !u.busy, false)', ui)
+        self.assertIn('u.drawButton(u.layout.resume, u.tr("transfer.resume"), actions.Resume && !u.busy, false)', ui)
+        self.assertIn('u.drawButton(u.layout.cancelJob, u.tr("common.cancel"), actions.Cancel && !u.busy, false)', ui)
+        self.assertIn('u.drawButton(u.layout.retryJob, u.tr("transfer.retry"), actions.Retry && !u.busy, false)', ui)
+        self.assertIn('u.drawButton(u.layout.clearQueue, u.tr("transfer.clear"), actions.Clear && !u.busy, false)', ui)
+        self.assertIn("u.cancelSelectedTransferLinux()", ui)
+        self.assertIn("u.retrySelectedTransferLinux()", ui)
+        self.assertIn("u.clearFinishedTransfersLinux()", ui)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized as continued Ghost FTP improvement.
- [x] Existing license/contribution constraints remain unchanged.

## Problem

The Linux queue toolbar could visually expose actions outside the transfer manager's valid states, and disabled Pause/Resume controls were still functionally clickable. Linux also discarded `CancelTransfer` / `RetryTransfer` errors with `_ =`, so stale selections or connection-binding failures could fail silently.

## Scope

Align Linux queue actions with the existing shared Windows/Linux policy without changing transfer-manager semantics.

- Reuse `deriveTransferActionState` as the single source of truth.
- Cancel is enabled and executable only for selected `queued` / `running` work.
- Retry is enabled and executable only for selected `failed` / `cancelled` work while connected.
- Pause/Resume require connected active work, the correct paused state, and a non-busy UI both visually and in the click path.
- Clear is enabled/executable only when terminal work exists and the UI is not busy.
- All five queue mutations reject busy or policy-disabled state inside their helper, so stale/programmatic clicks are inert.
- Cancel/Retry Engine errors are surfaced through `usererror.MessageFor`, not discarded or shown raw.
- Successful Cancel/Retry refresh the Engine snapshot while preserving selection by transfer ID.
- Clear removes terminal jobs while preserving a selected active transfer when it remains in the queue.

## Change isolation

- No scheduler, retry-policy, protocol, TLS/SFTP trust, path-confinement or connection-binding semantics changed.
- New Linux-specific behavior is isolated in `queue_actions_linux.go` and Linux-only tests.
- `gui_linux.go` only switches existing button enable expressions and five click dispatches to the hardened helper path.
- `scripts/test_ui_action_wiring.py` fails if Linux queue errors are silently discarded, shared action-state wiring disappears, or disabled controls regain an active mutation path.
- `TestLinuxBusyQueueMutationsAreInert` executes Pause, Resume, Cancel, Retry and Clear with `busy=true` and no Engine instance, proving each helper exits before any mutation/Engine call.

## Security / privacy

- [x] No new dependency, telemetry, analytics or external service.
- [x] No credential persistence or logging change.
- [x] Existing SFTP host-key verification and FTPS behavior remain unchanged.
- [x] Existing local path traversal/symlink/reparse-point protections remain unchanged.

## Validation

- [x] Both large-file integrations used fail-closed exact-base/exact-target preconditions against `main` `e675e02a3af9cb19cf3f9a788200147b0e7907ad`.
- [x] Temporary patch workflows completed/success and self-deleted their automation branches.
- [x] `git diff --check` passed for the GUI patches.
- [x] Focused `python3 scripts/test_ui_action_wiring.py` passed after GUI integration.
- [x] Focused `go test ./internal/desktop ./internal/api ./internal/transfer` passed after GUI integration.
- [x] The gofmt regression detected by full CI was corrected and revalidated.
- [x] Full exact-head Ghost FTP CI completed/success on `04ca5b9bfd85739034a422bd1253428a85a1307e`.
- [x] Exact-head Linux distro package workflow completed/success.
- [x] Exact-head Linux distro install matrix completed/success.
- [x] Exact-head Authentic UI Screenshots completed/success.

All four required workflows are `completed/success` for exact final head `04ca5b9bfd85739034a422bd1253428a85a1307e`. Merge is guarded by this exact head SHA, followed by post-merge `main` verification.