### PR TITLE
Windows: enforce installer artifact and integrated-uninstall contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added explicit canonical retention dispatch/read-back after a successful publish run so latest-only cleanup does not depend on `workflow_run` event chaining alone.
 - Added exact-main workflow-run identification and fail-closed release/retention completion checks.
 - Fixed release-note generation so semantic major version zero no longer implies Beta/prerelease and current 0.0.x releases retain their verified GitHub Packages section.
+- Hardened Windows release verification so the public artifact directory rejects any unexpected executable outside the canonical Setup/Portable x64/x86 naming contract; the no-permanent-uninstaller claim is now backed by an observed artifact check.
 
 ### Settings and compatibility
 

--- a/scripts/test_windows_installer_artifact_contract.py
+++ b/scripts/test_windows_installer_artifact_contract.py
@@ -32,22 +32,36 @@ class WindowsInstallerArtifactContractTests(unittest.TestCase):
 
             verify_release.assert_windows_artifact_directory_clean(root)
 
+    def assert_extra_executable_rejected(self, name: str) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "Ghost-FTP-0.0.2-Setup-x64.exe").write_bytes(b"setup")
+            (root / "Ghost-FTP-0.0.2-Portable-x64.exe").write_bytes(b"portable")
+            (root / name).write_bytes(b"unexpected")
+            with self.assertRaisesRegex(ValueError, "unexpected Windows executable artifact"):
+                verify_release.assert_windows_artifact_directory_clean(root)
+
     def test_any_extra_public_executable_is_rejected(self) -> None:
-        forbidden = (
+        for name in (
             "Uninstall.exe",
             "Uninstaller.exe",
             "unins000.exe",
             "Ghost-FTP-0.0.2-Uninstaller-x64.exe",
             "helper.exe",
-        )
-        for name in forbidden:
-            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
-                root = Path(temp)
-                (root / "Ghost-FTP-0.0.2-Setup-x64.exe").write_bytes(b"setup")
-                (root / "Ghost-FTP-0.0.2-Portable-x64.exe").write_bytes(b"portable")
-                (root / name).write_bytes(b"unexpected")
-                with self.assertRaisesRegex(ValueError, "unexpected Windows executable artifact"):
-                    verify_release.assert_windows_artifact_directory_clean(root)
+        ):
+            with self.subTest(name=name):
+                self.assert_extra_executable_rejected(name)
+
+    def test_noncanonical_ghostftp_executable_names_are_rejected(self) -> None:
+        for name in (
+            "Ghost-FTP-0.0.2-Setup-arm64.exe",
+            "Ghost-FTP-0.0.2-Setup-x32.exe",
+            "Ghost-FTP-0.0.2-Setup-x64-debug.exe",
+            "Ghost-FTP-0.0.2-beta-Setup-x64.exe",
+            "GhostFTP-0.0.2-Setup-x64.exe",
+        ):
+            with self.subTest(name=name):
+                self.assert_extra_executable_rejected(name)
 
     def test_build_pipeline_remains_self_hosted_go_installer(self) -> None:
         build = (ROOT / "BUILD-WINDOWS.ps1").read_text(encoding="utf-8")

--- a/scripts/test_windows_installer_artifact_contract.py
+++ b/scripts/test_windows_installer_artifact_contract.py
@@ -66,12 +66,15 @@ class WindowsInstallerArtifactContractTests(unittest.TestCase):
             self.assertNotIn(marker, lower)
 
     def test_integrated_uninstall_is_owned_by_installed_application(self) -> None:
+        constants = (ROOT / "cmd/installer/uninstall_constants.go").read_text(encoding="utf-8")
         registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
         runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
 
+        self.assertIn('const installedExecutableDigestValue = "InstalledExecutableSHA256"', constants)
         self.assertIn('fmt.Sprintf("\\\"%s\\\" --uninstall", appPath)', registration)
+        self.assertIn("{installedExecutableDigestValue, digest}", registration)
         self.assertIn('strings.TrimSpace(args[1]), "--uninstall"', runtime)
-        self.assertIn("InstalledExecutableSHA256", registration)
+        self.assertIn("ghostFTPInstalledDigestValue", runtime)
         self.assertIn("RemoveVerifiedRegularFileMatchingSHA256", runtime)
 
 

--- a/scripts/test_windows_installer_artifact_contract.py
+++ b/scripts/test_windows_installer_artifact_contract.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_PATH = ROOT / "scripts" / "verify_release.py"
+
+spec = importlib.util.spec_from_file_location("ghostftp_verify_release", VERIFY_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("unable to load verify_release.py")
+verify_release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(verify_release)
+
+
+class WindowsInstallerArtifactContractTests(unittest.TestCase):
+    def test_canonical_setup_and_portable_names_are_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for name in (
+                "Ghost-FTP-0.0.2-Setup-x64.exe",
+                "Ghost-FTP-0.0.2-Portable-x64.exe",
+                "Ghost-FTP-0.0.2-Setup-x86.exe",
+                "Ghost-FTP-0.0.2-Portable-x86.exe",
+            ):
+                (root / name).write_bytes(b"fixture")
+            (root / "SHA256.txt").write_text("fixture\n", encoding="ascii")
+            (root / "internal").mkdir()
+
+            verify_release.assert_windows_artifact_directory_clean(root)
+
+    def test_any_extra_public_executable_is_rejected(self) -> None:
+        forbidden = (
+            "Uninstall.exe",
+            "Uninstaller.exe",
+            "unins000.exe",
+            "Ghost-FTP-0.0.2-Uninstaller-x64.exe",
+            "helper.exe",
+        )
+        for name in forbidden:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                (root / "Ghost-FTP-0.0.2-Setup-x64.exe").write_bytes(b"setup")
+                (root / "Ghost-FTP-0.0.2-Portable-x64.exe").write_bytes(b"portable")
+                (root / name).write_bytes(b"unexpected")
+                with self.assertRaisesRegex(ValueError, "unexpected Windows executable artifact"):
+                    verify_release.assert_windows_artifact_directory_clean(root)
+
+    def test_build_pipeline_remains_self_hosted_go_installer(self) -> None:
+        build = (ROOT / "BUILD-WINDOWS.ps1").read_text(encoding="utf-8")
+        lower = build.lower()
+
+        self.assertIn("'./cmd/installer'", build)
+        self.assertIn("'scripts/make_payload.py'", build)
+        self.assertIn("'scripts/verify_release.py'", build)
+        self.assertIn("$publicFiles.Count -ne 4", build)
+
+        # The production Windows build is intentionally self-contained. A future
+        # installer replacement is allowed only after explicitly revisiting the
+        # integrated-uninstall and artifact contracts rather than slipping in as
+        # an undeclared build dependency.
+        for marker in ("iscc.exe", "makensis", "candle.exe", "light.exe", "wix build"):
+            self.assertNotIn(marker, lower)
+
+    def test_integrated_uninstall_is_owned_by_installed_application(self) -> None:
+        registration = (ROOT / "cmd/installer/uninstall_registration_windows.go").read_text(encoding="utf-8")
+        runtime = (ROOT / "internal/platform/integrated_uninstall_windows.go").read_text(encoding="utf-8")
+
+        self.assertIn('fmt.Sprintf("\\\"%s\\\" --uninstall", appPath)', registration)
+        self.assertIn('strings.TrimSpace(args[1]), "--uninstall"', runtime)
+        self.assertIn("InstalledExecutableSHA256", registration)
+        self.assertIn("RemoveVerifiedRegularFileMatchingSHA256", runtime)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False)
+    if not result.result.wasSuccessful():
+        raise SystemExit(1)
+    print("WINDOWS_INSTALLER_ARTIFACT_CONTRACT=PASS")

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import re
 import struct
 from pathlib import Path
 
@@ -21,12 +22,40 @@ TELEMETRY_MARKERS = [
     b"bugsnag", b"crashlytics", b"appcenter", b"telemetrydeck",
 ]
 
+PUBLIC_WINDOWS_EXECUTABLE_RE = re.compile(
+    r"^Ghost-FTP-\d+\.\d+\.\d+-(?:Setup|Portable)-(?:x64|x86)\.exe$",
+    re.IGNORECASE,
+)
+
 
 def assert_no_telemetry_markers(path: Path, data: bytes) -> None:
     lower = data.lower()
     for marker in TELEMETRY_MARKERS:
         if marker in lower or marker.decode("ascii").encode("utf-16le") in lower:
             raise ValueError(f"{path.name}: telemetry/vendor marker found: {marker.decode('ascii')}")
+
+
+def assert_windows_artifact_directory_clean(artifact_dir: Path) -> None:
+    """Reject unexpected permanent Windows executables in the public artifact directory.
+
+    Setup and Portable are the only supported Windows executable artifact roles. This
+    turns the no-permanent-uninstaller policy into an observed artifact invariant
+    instead of relying on a status string printed by the verifier.
+    """
+    if not artifact_dir.is_dir():
+        raise ValueError(f"Windows artifact directory is unavailable: {artifact_dir}")
+
+    unexpected = sorted(
+        path.name
+        for path in artifact_dir.iterdir()
+        if path.is_file()
+        and path.suffix.lower() == ".exe"
+        and not PUBLIC_WINDOWS_EXECUTABLE_RE.fullmatch(path.name)
+    )
+    if unexpected:
+        raise ValueError(
+            "unexpected Windows executable artifact(s): " + ", ".join(unexpected)
+        )
 
 
 def detect_arch(machine: int, magic: int) -> str:
@@ -121,6 +150,12 @@ def main() -> None:
     ap.add_argument("--arch", choices=("x64", "x86"), default=None)
     args = ap.parse_args()
 
+    setup_parent = args.setup.resolve().parent
+    portable_parent = args.portable.resolve().parent
+    if setup_parent != portable_parent:
+        raise SystemExit("Setup and Portable must come from the same Windows artifact directory")
+    assert_windows_artifact_directory_clean(setup_parent)
+
     results = [read_pe(p, args.arch) for p in (args.setup, args.portable)]
     arches = {result[2] for result in results}
     if len(arches) != 1:
@@ -136,6 +171,7 @@ def main() -> None:
 
     print("SETUP_PE_OK=YES")
     print("PORTABLE_PE_OK=YES")
+    print("WINDOWS_EXECUTABLE_ARTIFACT_SET=CANONICAL")
     print("UNINSTALLER_BINARY=ABSENT")
     print(f"WINDOWS_ARCH={arch}")
     print("PUBLIC_BRAND=Ghost FTP")


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized as continued Ghost FTP quality improvement.
- [x] Inno Setup was explicitly allowed only if it would simplify/improve production packaging; it was evaluated and deliberately not introduced because the current self-hosted Go installer preserves a stronger integrated-uninstall ownership contract without adding another installer toolchain.

## Problem

`scripts/verify_release.py` printed `UNINSTALLER_BINARY=ABSENT`, but that line alone did not inspect the public Windows artifact directory for an accidental additional executable such as `Uninstall.exe`, `unins000.exe`, or another helper/uninstaller binary.

Ghost FTP intentionally uses the installed `GhostFTP.exe --uninstall` command as the Add/Remove Programs owner, with executable identity and SHA-256 ownership checks. A permanent second uninstaller executable is therefore a contract regression.

## Scope

- Make Windows release verification scan the actual Setup/Portable artifact directory.
- Accept only canonical `Ghost-FTP-<semver>-Setup-x64.exe`, `...Setup-x86.exe`, `...Portable-x64.exe`, and `...Portable-x86.exe` executable roles.
- Reject every unexpected public `.exe`, including conventional standalone uninstallers, generic helper executables, legacy branding and noncanonical architecture/debug/prerelease names.
- Require Setup and Portable inputs to originate from the same artifact directory.
- Emit `WINDOWS_EXECUTABLE_ARTIFACT_SET=CANONICAL` only after the observed artifact check succeeds.
- Preserve existing PE architecture, VERSIONINFO, manifest, mitigation, Authenticode, telemetry and SHA-256 verification.
- Keep the production Windows pipeline self-hosted with Go + `make_payload.py`; no Inno/NSIS/WiX dependency is introduced.
- Document the strengthened contract in `CHANGELOG.md`.

## Base hardening discovered during validation

The first Windows CI attempt exposed an existing state-directory identity race unrelated to this PR. That issue was isolated into #216, fixed with eager Windows filesystem identity binding, fully validated, merged, and post-merge verified on `main` as `527e68ef5ad71f66397b8dce4cc2c141bd7125ea`. This branch was then updated by a normal merge from that verified `main`; no history was rewritten.

## Change isolation

Against current base `527e68ef5ad71f66397b8dce4cc2c141bd7125ea`, the PR changes exactly three files: `scripts/verify_release.py`, `scripts/test_windows_installer_artifact_contract.py`, and `CHANGELOG.md`.

- No installer runtime/UI code changed.
- No setup/portable public naming changed.
- No protocol, transfer, settings, filesystem, TLS/FTPS or SFTP behavior changed in this PR.
- No `VERSION`, release, tag or GHCR change.
- No new dependency, telemetry, analytics, advertising or external service.

## Validation

Exact final head: `7d92ed38b548f237bc04c95e9433ebfaaa174c43`.

- [x] Exact-head Ghost FTP CI completed/success.
- [x] Core formatting, Go race/vet, repository/platform/security/privacy/docs/release audits and Python regression suite completed/success.
- [x] Linux amd64/arm64/i386 production build completed/success.
- [x] Windows x64/x86 Setup and Portable production build completed/success.
- [x] New canonical executable artifact-directory verification completed/success on the produced Windows packages.
- [x] Existing Windows release artifact verification completed/success.
- [x] Authenticode private-key pipeline smoke completed/success.
- [x] Final diff remains exactly the intended three installer-contract files.

`main` remained exact verified `527e68ef5ad71f66397b8dce4cc2c141bd7125ea` immediately before merge and the PR remained mergeable. Merge is guarded by exact head `7d92ed38b548f237bc04c95e9433ebfaaa174c43`; exact post-merge `main` push workflows must complete/succeed afterward.