### PR TITLE
Windows: eagerly bind state directory filesystem identity

### DIFF
--- a/internal/config/state_directory_identity_other.go
+++ b/internal/config/state_directory_identity_other.go
@@ -4,6 +4,10 @@ package config
 
 import "os"
 
+func primeStateDirectoryIdentity(info os.FileInfo) bool {
+	return info != nil
+}
+
 func sameStateDirectoryIdentity(before, after os.FileInfo) bool {
 	return before != nil && after != nil && os.SameFile(before, after)
 }

--- a/internal/config/state_directory_identity_windows.go
+++ b/internal/config/state_directory_identity_windows.go
@@ -7,6 +7,18 @@ import (
 	"syscall"
 )
 
+// primeStateDirectoryIdentity forces os.FileInfo's lazy Windows file identity
+// to resolve while the validated path still names the object being bound.
+//
+// On Windows, os.SameFile loads VolumeSerialNumber/FileIndex lazily from the
+// path saved inside FileInfo. If the path is renamed and replaced before the
+// first SameFile call, an unprimed historical FileInfo can otherwise resolve
+// to the replacement object. Comparing the FileInfo with itself here makes Go
+// cache that immutable file ID at bind/revalidation time.
+func primeStateDirectoryIdentity(info os.FileInfo) bool {
+	return info != nil && os.SameFile(info, info)
+}
+
 func sameStateDirectoryIdentity(before, after os.FileInfo) bool {
 	if before == nil || after == nil || !os.SameFile(before, after) {
 		return false

--- a/internal/config/state_directory_identity_windows_test.go
+++ b/internal/config/state_directory_identity_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func setWindowsDirectoryCreationTime(t *testing.T, path string, creation syscall.Filetime) {
+	t.Helper()
+
+	pathUTF16, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := syscall.CreateFile(
+		pathUTF16,
+		syscall.FILE_WRITE_ATTRIBUTES,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.CloseHandle(handle)
+
+	if err := syscall.SetFileTime(handle, &creation, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWindowsStateDirectoryIdentitySurvivesCreationTimeCollision(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "state")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := stateDirectoryInfo(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeData, ok := before.Sys().(*syscall.Win32FileAttributeData)
+	if !ok || beforeData == nil {
+		t.Fatal("missing Win32 directory metadata")
+	}
+
+	original := filepath.Join(base, "state-original")
+	if err := os.Rename(dir, original); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the replacement deliberately share the original creation timestamp.
+	// The old implementation could then accept it because os.SameFile had not
+	// resolved the original FileInfo's lazy Windows file ID before the rename.
+	setWindowsDirectoryCreationTime(t, dir, beforeData.CreationTime)
+
+	after, err := stateDirectoryInfo(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sameStateDirectoryIdentity(before, after) {
+		t.Fatal("replacement directory with matching creation time reused the bound identity")
+	}
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -48,6 +48,9 @@ func stateDirectoryInfo(dir string) (os.FileInfo, error) {
 	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || security.IsReparsePoint(dir) {
 		return nil, errors.New("state mapa mora biti obična lokalna mapa bez preusmjeravanja")
 	}
+	if !primeStateDirectoryIdentity(info) {
+		return nil, errors.New("identitet state mape nije moguće pouzdano vezati")
+	}
 	return info, nil
 }
 


### PR DESCRIPTION
## Authorization

- [x] This security/reliability hardening is part of the user's explicit request to continue improving Ghost FTP.
- [x] Scope is intentionally separate from installer artifact PR #215.

## Problem

A Windows production CI run for #215 exposed an existing failure in `TestStoreRejectsReplacementDirectoryAfterBinding`: a renamed/recreated state directory was accepted once by the Store.

This is not caused by #215. The root cause is Windows `os.SameFile` laziness: Go's Windows `FileInfo` retains the path and resolves `VolumeSerialNumber` / `FileIndexHigh` / `FileIndexLow` on the first `SameFile` call. If the directory path is replaced before that first call, the historical `FileInfo` can resolve the replacement object. The existing CreationTime secondary comparison can also collide for rapidly created directories.

## Fix

- Add a platform identity-priming contract.
- On Windows, call `os.SameFile(info, info)` immediately while validating/binding the state directory so Go caches its Win32 volume/file-index identity before later path replacement.
- Fail closed if the identity cannot be resolved reliably.
- Preserve non-Windows semantics; the non-Windows priming hook is a nil guard only.
- Keep the existing `os.SameFile` + CreationTime comparison as defense in depth after both snapshots have been primed.

## Deterministic regression

A Windows-only regression test creates and binds the original state directory, renames it, creates a replacement at the original path, deliberately gives the replacement the same CreationTime, and requires the bound identity comparison to reject it.

## Change isolation

- Exactly four files under `internal/config`.
- No installer, release, transfer, protocol, UI, telemetry, dependency or VERSION changes.
- No weakening of recovery behavior: an initially absent/invalid state path may still bind after the caller repairs it, as existing tests require.

## Validation gate

Exact final head: `1f4d61f73ac360a1a8068a1d163efc1bd3d25de7`.

- [x] Exact-head Ghost FTP CI completed/success.
- [x] Core formatting, race/vet, audits and regression suite completed/success.
- [x] Windows x64/x86 production build completed/success, including the previously failing state-directory tests, release artifact verification and Authenticode smoke.
- [x] Linux amd64/arm64/i386 production build completed/success.
- [x] Linux distro package parity completed/success.
- [x] Debian 13, Ubuntu 26.04 LTS and Fedora 44 install/remove/GUI lifecycle completed/success.

`main` remained exact `83b5344bebc6b690add09cfe1099aa0acee322d4` before merge and the PR remained mergeable. Merge is guarded by the exact final head SHA. After merge, exact post-merge `main` push workflows must be verified before #215 is revalidated.