### PR TITLE
Feature: conservative directory comparison and synchronized navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,13 @@
 - Added bounded recursive local/server search as a separate explicit action on Windows and Linux. Recursive search performs disclosed nested-folder I/O with validated depth/item/result/batch/time limits, cancellation, incremental result presentation, Unicode-aware matching, root/session confinement and no intentional symlink/reparse traversal.
 - Recursive search results are informational navigation snapshots only: Windows renders them in dedicated ListViews, Linux keeps normal row-indexed actions modal/disabled, and “Go to result” performs a fresh parent listing before reselecting the discovered name.
 - Added localized recursive-search Search/Navigate/Cancel/Close/progress/disclosure copy for all 24 supported desktop languages and a source regression contract covering hard bounds, platform wiring and fresh-list navigation.
+- Added conservative local/server directory comparison on Windows and Linux with deterministic `same`, `local_only`, `remote_only`, `newer_local`, `newer_remote`, `conflict` and `unknown` states. Exact-name matching prevents unsafe case folding, duplicate names fail closed to conflict, symlinks remain unknown, and file freshness is never inferred when either side lacks reliable modification time metadata.
+- Added explicit synchronized navigation for comparison rows that are proven ordinary directories on both sides. “Open both” validates local and remote child paths, performs fresh listings of both targets, recomputes comparison, and only then commits both pane paths; comparison itself never transfers, deletes, renames, overwrites or changes permissions.
+- Windows comparison uses dedicated read-only ListViews and disables normal file mutations while active; Linux comparison is modal and prevents ordinary row-indexed workspace actions from operating on comparison display rows.
+- Added localized comparison controls/statuses for all 24 supported desktop languages and a cross-platform source regression contract protecting comparison semantics, UI wiring, mutation gating and fresh-list synchronized navigation.
 - Added a regression contract that rejects main Windows buttons without command handlers and Linux controls/overlays without click handlers.
 - Added a guard against silently discarded Windows queue Cancel/Retry errors.
-- Defined complete acceptance criteria for future directory comparison, synchronized browsing, bandwidth control, queue priority, bookmarks, verified resume, multi-session and proxy/jump-host capabilities before they may appear as shipped UI.
+- Defined complete acceptance criteria for future bandwidth control, queue priority, bookmarks, verified resume, multi-session and proxy/jump-host capabilities before they may appear as shipped UI.
 
 ### Documentation and product media
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,9 @@ The maintained source includes a **non-destructive current-folder filter** for b
 
 The maintained source also includes a **bounded recursive local/server search** that is deliberately separate from the current-folder filter. Recursive search clearly discloses that it will read nested local or server folders, uses the same Unicode-aware matching semantics, incrementally presents bounded result batches, supports cancellation, never intentionally traverses symlink/reparse entries, and treats every result as an informational navigation hint rather than mutation authority. Local traversal is anchored to one `os.OpenRoot` capability; server traversal is bound to one captured remote operation/session. Activating a result performs a fresh listing of its parent and reselects the name only from that fresh listing.
 
-Both capabilities remain part of the Unreleased source line until a successor release is published and verified; neither rewrites or redefines the existing 0.0.1 release.
+The maintained source now also includes **conservative directory comparison and synchronized navigation** on Windows and Linux. Comparison is read-only, uses exact-name matching, reports deterministic same/only/newer/conflict/unknown states, treats duplicate names and uncertain metadata fail-closed, and never treats a symlink comparison row as transfer authority. Synchronized navigation is available only for an exact ordinary directory proved present on both sides; both target directories are freshly listed and compared before either visible pane path is committed.
+
+These capabilities remain part of the Unreleased source line until a successor release is published and verified; none rewrites or redefines the existing 0.0.1 release.
 
 ## High-value power-user lane
 
@@ -53,15 +55,23 @@ These capabilities are prioritized because they improve real hosting/server work
 
 ### P0 — directory comparison and synchronized navigation
 
-A comparison mode should pair the current local and server directories and classify entries as same, local-only, server-only, newer-local, newer-server or conflicting/unknown. Optional synchronized browsing should move the opposite pane only when both sides can resolve the corresponding directory safely.
+**Status: implemented in the maintained Unreleased source line.** Windows and Linux expose the same shared comparison states while keeping comparison read-only and separate from ordinary file-operation authority.
 
-Acceptance requirements:
+Implemented contract:
 
-- comparison logic lives in shared testable code rather than duplicated frontend logic;
-- timestamps with unreliable server precision are treated conservatively;
-- symlinks and unsupported metadata never trigger destructive automatic action;
-- Windows and Linux expose the same states and disable synchronization when the mapping is ambiguous;
-- comparison itself never transfers or deletes data.
+- shared `internal/directorycompare` logic compares already-listed snapshots without filesystem/network I/O or input mutation;
+- exact-name matching avoids unsafe case folding across filesystems with different case semantics;
+- deterministic states are `same`, `local_only`, `remote_only`, `newer_local`, `newer_remote`, `conflict` and `unknown`;
+- duplicate exact names fail closed to `conflict`, type mismatches fail closed to `conflict`, and symlinks fail closed to `unknown`;
+- regular-file `newer_*` and `same` classification is used only when both sides provide usable modification times; equal-size files with unknown time remain `unknown`, while differing sizes with unknown time remain `conflict`;
+- timestamp comparison defaults to a two-second tolerance and rejects an override above five minutes;
+- synchronized navigation resolves only a `same` entry that is an ordinary non-symlink directory present on both sides;
+- Windows renders comparison in dedicated read-only ListViews and disables normal rename/delete/upload/download/edit/chmod authority while the comparison surface is active;
+- Linux uses a modal comparison surface and consumes ordinary workspace clicks while comparison rows are displayed, so row indices cannot leak into normal file actions;
+- “Open both” validates the local child and remote name/path, performs fresh local and remote listings, recomputes comparison, and only then commits both pane paths;
+- localized comparison controls/status/disclosure copy exists for all 24 supported desktop languages;
+- `scripts/test_directory_comparison_contract.py` protects cross-platform wiring, mutation gating and the fresh-list-before-path-commit rule;
+- comparison itself never uploads, downloads, deletes, renames, overwrites or changes permissions.
 
 ### P0 — bounded recursive local/server search
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -69,6 +69,29 @@ Core tests and `scripts/test_recursive_search_ui_contract.py` require:
 
 The desktop disclosure explicitly states that recursive mode reads nested local/server folders and states the default **20-second / 1,000-result** bound before the scan starts.
 
+## Directory comparison and synchronized-navigation regression contract
+
+The maintained Unreleased source exposes directory comparison as a read-only view over freshly listed current local/server directories. The shared classifier performs no filesystem or network I/O and does not grant file-operation authority to comparison rows.
+
+Go tests and `scripts/test_directory_comparison_contract.py` require:
+
+- exact-name pairing rather than automatic case folding across filesystems with potentially different case semantics;
+- deterministic `same`, `local_only`, `remote_only`, `newer_local`, `newer_remote`, `conflict` and `unknown` states;
+- duplicate exact names to fail closed to `conflict`;
+- type mismatches to fail closed to `conflict` and symlinks to fail closed to `unknown`;
+- a default **2-second** timestamp tolerance with a hard **5-minute** maximum override;
+- regular-file `same` or `newer_*` classification only when both sides provide usable modification times; equal-size files with an unknown timestamp remain `unknown`, while unequal sizes with unknown time remain `conflict`;
+- the synchronized-directory resolver to accept only an exact `same` entry that is an ordinary non-symlink directory present on both sides;
+- Windows to render dedicated comparison ListViews and disable ordinary rename/delete/upload/download/Remote Edit/CHMOD authority while the comparison view is active;
+- Linux to make the comparison view modal and consume ordinary workspace clicks while comparison display rows are active;
+- local synchronized children to pass `security.SafeLocalChild`, and remote child names/paths to pass the existing remote validation boundary;
+- **fresh local and remote listings to complete before either pane path is committed** during “Open both”;
+- comparison to recompute from those fresh target snapshots after synchronized navigation;
+- all 24 desktop languages to provide comparison action/status/disclosure copy;
+- comparison code to contain no upload, download, delete, rename or CHMOD side effect.
+
+This contract deliberately does not infer that equal size means equal content when server timestamps are unavailable. FTP/FTPS MLSD can supply usable UTC modification time, while current FTP LIST fallback and SFTP listing paths may expose zero/unknown `Modified`; those cases stay conservative rather than fabricating equality or freshness.
+
 ## Settings regression contract
 
 The settings suite verifies that visible runtime options remain bounded and migration-safe.
@@ -101,7 +124,7 @@ Linux checks:
 - verify the Remote Edit button path;
 - verify SFTP Trust/Cancel and prompt Apply/Cancel overlay controls are both rendered and handled.
 
-The dedicated current-folder-filter and recursive-search contracts supplement this generic action-wiring gate because those controls are dynamically inserted into the pane geometry instead of being canonical top-level buttons.
+The dedicated current-folder-filter, recursive-search and directory-comparison contracts supplement this generic action-wiring gate because those controls are dynamically inserted into pane/workspace geometry instead of being canonical top-level buttons.
 
 The gate intentionally tests wiring, not just pixels. Runtime behavior remains covered by Go unit/integration tests and authentic UI smoke evidence.
 

--- a/internal/api/directory_compare.go
+++ b/internal/api/directory_compare.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/bren-wp/Ghost-FTP/internal/directorycompare"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+type DirectoryComparisonStatus = directorycompare.Status
+type DirectoryComparisonEntry = directorycompare.Entry
+type DirectoryComparisonOptions = directorycompare.Options
+
+const (
+	DirectorySame        = directorycompare.StatusSame
+	DirectoryLocalOnly   = directorycompare.StatusLocalOnly
+	DirectoryRemoteOnly  = directorycompare.StatusRemoteOnly
+	DirectoryNewerLocal  = directorycompare.StatusNewerLocal
+	DirectoryNewerRemote = directorycompare.StatusNewerRemote
+	DirectoryConflict    = directorycompare.StatusConflict
+	DirectoryUnknown     = directorycompare.StatusUnknown
+)
+
+// CompareDirectoryItems compares already-listed local and remote directory
+// snapshots. It performs no filesystem/network I/O and cannot mutate either
+// side. Freshness of the supplied snapshots remains the caller's responsibility.
+func (e *Engine) CompareDirectoryItems(local, remote []model.Item, opts DirectoryComparisonOptions) ([]DirectoryComparisonEntry, error) {
+	if e == nil {
+		return nil, errors.New("directory comparison service is unavailable")
+	}
+	return directorycompare.Compare(local, remote, opts)
+}
+
+// SynchronizedDirectoryName returns an exact child name only when comparison
+// proves the entry is an ordinary directory present on both sides.
+func (e *Engine) SynchronizedDirectoryName(entries []DirectoryComparisonEntry, name string) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	return directorycompare.SynchronizedDirectoryName(entries, name)
+}

--- a/internal/desktop/action_state_windows.go
+++ b/internal/desktop/action_state_windows.go
@@ -34,16 +34,18 @@ func (a *app) updateActionControls() {
 	setControlEnabled(a.removeProfile, profileEditable && a.selectedProfileID != "")
 	setControlEnabled(a.settingsBtn, !a.connectionBusy)
 
+	comparisonActive := a.directoryComparisonActive()
 	localRecursiveActive := a.recursiveSearchPaneActive(false)
 	localSelected := validSelectionCount(a.localList, len(a.localItems))
-	setControlEnabled(a.localMkdir, !localRecursiveActive)
-	setControlEnabled(a.localRename, !localRecursiveActive && localSelected == 1)
-	setControlEnabled(a.localDelete, !localRecursiveActive && localSelected > 0)
-	setControlEnabled(a.upload, !localRecursiveActive && a.connected && !a.connectionBusy && localSelected > 0)
+	localReady := !localRecursiveActive && !comparisonActive
+	setControlEnabled(a.localMkdir, localReady)
+	setControlEnabled(a.localRename, localReady && localSelected == 1)
+	setControlEnabled(a.localDelete, localReady && localSelected > 0)
+	setControlEnabled(a.upload, localReady && a.connected && !a.connectionBusy && localSelected > 0)
 
 	remoteRecursiveActive := a.recursiveSearchPaneActive(true)
 	remoteSelected := validSelectionCount(a.remoteList, len(a.remoteItems))
-	remoteReady := a.connected && !a.connectionBusy && !remoteRecursiveActive
+	remoteReady := a.connected && !a.connectionBusy && !remoteRecursiveActive && !comparisonActive
 	setControlEnabled(a.remoteMkdir, remoteReady)
 	setControlEnabled(a.remoteRename, remoteReady && remoteSelected == 1)
 	setControlEnabled(a.remoteDelete, remoteReady && remoteSelected > 0)

--- a/internal/desktop/commands_windows.go
+++ b/internal/desktop/commands_windows.go
@@ -72,6 +72,10 @@ func (a *app) command(id int) {
 		a.recursiveSearchCommand(true)
 	case idRemoteRecursiveSearchNavigate:
 		a.navigateRecursiveSearch(true)
+	case idDirectoryCompare:
+		a.directoryComparisonCommand()
+	case idDirectoryCompareOpenBoth:
+		a.openComparedDirectoryBoth()
 	case idUpload:
 		a.uploadSelected()
 	case idDownload:

--- a/internal/desktop/directory_compare_linux.go
+++ b/internal/desktop/directory_compare_linux.go
@@ -1,0 +1,464 @@
+//go:build linux
+
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/api"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+	"github.com/bren-wp/Ghost-FTP/internal/usererror"
+)
+
+type linuxDirectoryComparisonState struct {
+	mu sync.Mutex
+
+	seq      uint64
+	active   bool
+	running  bool
+	selected int
+	cancel   context.CancelFunc
+	entries  []api.DirectoryComparisonEntry
+	status   string
+	dirty    bool
+
+	localBase      string
+	remoteBase     string
+	localSnapshot  []model.Item
+	remoteSnapshot []model.Item
+
+	navReady        bool
+	navLocalBase    string
+	navRemoteBase   string
+	navLocalItems   []model.Item
+	navRemoteItems  []model.Item
+	navEntries      []api.DirectoryComparisonEntry
+}
+
+var linuxDirectoryComparisonStates sync.Map
+
+func linuxDirectoryComparisonStateFor(u *linuxDesktop) *linuxDirectoryComparisonState {
+	if value, ok := linuxDirectoryComparisonStates.Load(u); ok {
+		return value.(*linuxDirectoryComparisonState)
+	}
+	state := &linuxDirectoryComparisonState{selected: -1}
+	actual, _ := linuxDirectoryComparisonStates.LoadOrStore(u, state)
+	return actual.(*linuxDirectoryComparisonState)
+}
+
+func (u *linuxDesktop) directoryComparisonActiveLinux() bool {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.active
+}
+
+func (u *linuxDesktop) directoryComparisonButtonRectLinux() linuxRect {
+	left := u.layout.localList.left
+	right := u.layout.upload.left - 8
+	if right-left < 120 {
+		right = left + 120
+	}
+	return linuxRectWH(left, u.layout.upload.top, right-left, u.layout.upload.bottom-u.layout.upload.top)
+}
+
+func directoryComparisonStatusLabelLinux(words directoryCompareWords, status api.DirectoryComparisonStatus) string {
+	switch status {
+	case api.DirectorySame:
+		return words.Same
+	case api.DirectoryLocalOnly:
+		return words.LocalOnly
+	case api.DirectoryRemoteOnly:
+		return words.RemoteOnly
+	case api.DirectoryNewerLocal:
+		return words.NewerLocal
+	case api.DirectoryNewerRemote:
+		return words.NewerRemote
+	case api.DirectoryConflict:
+		return words.Conflict
+	default:
+		return words.Unknown
+	}
+}
+
+func directoryComparisonVisibleLinux(entries []api.DirectoryComparisonEntry, remote bool, words directoryCompareWords) []model.Item {
+	visible := make([]model.Item, 0, len(entries))
+	for _, entry := range entries {
+		item := entry.Local
+		has := entry.HasLocal
+		if remote {
+			item = entry.Remote
+			has = entry.HasRemote
+		}
+		if !has {
+			item = model.Item{Name: entry.Name}
+		}
+		item.Name = fmt.Sprintf("%s  [%s]", entry.Name, directoryComparisonStatusLabelLinux(words, entry.Status))
+		visible = append(visible, item)
+	}
+	return visible
+}
+
+func (u *linuxDesktop) reconcileDirectoryComparisonLinux() {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	active := state.active
+	running := state.running
+	selected := state.selected
+	entries := append([]api.DirectoryComparisonEntry(nil), state.entries...)
+	status := state.status
+	dirty := state.dirty
+	localBase := state.localBase
+	remoteBase := state.remoteBase
+	navReady := state.navReady
+	navLocalBase := state.navLocalBase
+	navRemoteBase := state.navRemoteBase
+	navLocalItems := append([]model.Item(nil), state.navLocalItems...)
+	navRemoteItems := append([]model.Item(nil), state.navRemoteItems...)
+	navEntries := append([]api.DirectoryComparisonEntry(nil), state.navEntries...)
+	if dirty {
+		state.dirty = false
+	}
+	if navReady {
+		state.navReady = false
+		state.localBase = navLocalBase
+		state.remoteBase = navRemoteBase
+		state.localSnapshot = append([]model.Item(nil), navLocalItems...)
+		state.remoteSnapshot = append([]model.Item(nil), navRemoteItems...)
+		state.entries = append([]api.DirectoryComparisonEntry(nil), navEntries...)
+		state.selected = -1
+		state.navLocalItems = nil
+		state.navRemoteItems = nil
+		state.navEntries = nil
+		localBase = navLocalBase
+		remoteBase = navRemoteBase
+		entries = navEntries
+		selected = -1
+	}
+	state.mu.Unlock()
+
+	if dirty && status != "" {
+		u.setStatus(status)
+	}
+	if !active {
+		return
+	}
+
+	// Comparison mode is modal. Keeping busy set prevents every ordinary file,
+	// connection and transfer action from operating on comparison rows.
+	u.busy = true
+	u.localCurrent = localBase
+	u.remoteCurrent = remoteBase
+	if navReady {
+		if filter := u.fileFilterState(); filter != nil {
+			filter.localQuery = ""
+			filter.remoteQuery = ""
+		}
+	}
+	words := directoryCompareWordsForLanguage(u.language)
+	u.localItems = directoryComparisonVisibleLinux(entries, false, words)
+	u.remoteItems = directoryComparisonVisibleLinux(entries, true, words)
+	u.selectedLocal = selected
+	u.selectedRemote = selected
+	if running && status == "" {
+		u.setStatus(words.Disclosure)
+	}
+}
+
+func (u *linuxDesktop) renderDirectoryComparisonButtonLinux() error {
+	words := directoryCompareWordsForLanguage(u.language)
+	enabled := u.connected && !u.busy && !u.recursiveSearchActive(false) && !u.recursiveSearchActive(true)
+	return u.drawButton(u.directoryComparisonButtonRectLinux(), words.Compare, enabled, false)
+}
+
+func (u *linuxDesktop) renderDirectoryComparisonControlsLinux() error {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	running := state.running
+	count := len(state.entries)
+	selected := state.selected
+	entries := append([]api.DirectoryComparisonEntry(nil), state.entries...)
+	state.mu.Unlock()
+
+	words := directoryCompareWordsForLanguage(u.language)
+	openBoth := false
+	if !running && selected >= 0 && selected < len(entries) {
+		_, openBoth = u.engine.SynchronizedDirectoryName(entries[selected])
+	}
+	if err := u.drawButton(u.fileFilterControlRect(false), words.Close, true, false); err != nil {
+		return err
+	}
+	if err := u.drawButton(u.recursiveSearchButtonRect(false), words.OpenBoth, openBoth, true); err != nil {
+		return err
+	}
+	if err := u.drawButton(u.fileFilterControlRect(true), words.Compare, !running, false); err != nil {
+		return err
+	}
+	summary := fmt.Sprintf("%s · %d", words.Ready, count)
+	if running {
+		summary = words.Disclosure
+	}
+	if err := u.drawButton(u.recursiveSearchButtonRect(true), summary, false, false); err != nil {
+		return err
+	}
+	return u.drawButton(u.directoryComparisonButtonRectLinux(), words.Close, true, false)
+}
+
+func (u *linuxDesktop) startDirectoryComparisonLinux() {
+	if u == nil || u.engine == nil || u.busy || !u.connected || u.recursiveSearchActive(false) || u.recursiveSearchActive(true) {
+		return
+	}
+	state := linuxDirectoryComparisonStateFor(u)
+	words := directoryCompareWordsForLanguage(u.language)
+	localBase := u.localCurrent
+	remoteBase := u.remoteCurrent
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
+	state.mu.Lock()
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.seq++
+	seq := state.seq
+	state.active = true
+	state.running = true
+	state.selected = -1
+	state.cancel = cancel
+	state.entries = nil
+	state.status = words.Disclosure
+	state.dirty = true
+	state.localBase = localBase
+	state.remoteBase = remoteBase
+	state.mu.Unlock()
+	u.busy = true
+	u.setStatus(words.Disclosure)
+
+	go func() {
+		defer cancel()
+		resolvedLocal, localItems, err := u.engine.LocalList(ctx, localBase)
+		if err == nil {
+			localBase = resolvedLocal
+		}
+		var remoteItems []model.Item
+		if err == nil {
+			remoteItems, err = u.engine.RemoteList(ctx, remoteBase)
+		}
+		var entries []api.DirectoryComparisonEntry
+		if err == nil {
+			entries = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryCompareOptions{})
+		}
+
+		state.mu.Lock()
+		if state.seq == seq && state.active {
+			state.running = false
+			state.cancel = nil
+			if err != nil {
+				state.active = false
+				state.status = usererror.MessageFor(u.language, err, words.Unavailable)
+				state.dirty = true
+			} else {
+				state.localBase = localBase
+				state.remoteBase = remoteBase
+				state.localSnapshot = append([]model.Item(nil), localItems...)
+				state.remoteSnapshot = append([]model.Item(nil), remoteItems...)
+				state.entries = append([]api.DirectoryComparisonEntry(nil), entries...)
+				state.selected = -1
+				for i, entry := range entries {
+					if _, ok := u.engine.SynchronizedDirectoryName(entry); ok {
+						state.selected = i
+						break
+					}
+				}
+				state.status = fmt.Sprintf("%s · %d", words.Ready, len(entries))
+				state.dirty = true
+			}
+		}
+		state.mu.Unlock()
+		u.resultCh <- linuxUIResult{action: linuxActionNone}
+	}()
+}
+
+func (u *linuxDesktop) closeDirectoryComparisonLinux() {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	if !state.active {
+		state.mu.Unlock()
+		return
+	}
+	cancel := state.cancel
+	localBase := state.localBase
+	remoteBase := state.remoteBase
+	localItems := append([]model.Item(nil), state.localSnapshot...)
+	remoteItems := append([]model.Item(nil), state.remoteSnapshot...)
+	state.seq++
+	state.active = false
+	state.running = false
+	state.selected = -1
+	state.cancel = nil
+	state.entries = nil
+	state.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	u.busy = false
+	u.localCurrent = localBase
+	u.remoteCurrent = remoteBase
+	u.acceptLinuxFileFilterSnapshot(false, localItems)
+	u.acceptLinuxFileFilterSnapshot(true, remoteItems)
+	u.selectedLocal = -1
+	u.selectedRemote = -1
+	u.setStatus(directoryCompareWordsForLanguage(u.language).Close)
+}
+
+func (u *linuxDesktop) openComparedDirectoryBothLinux() {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	if !state.active || state.running || state.selected < 0 || state.selected >= len(state.entries) {
+		state.mu.Unlock()
+		return
+	}
+	entry := state.entries[state.selected]
+	localBase := state.localBase
+	remoteBase := state.remoteBase
+	state.mu.Unlock()
+
+	name, ok := u.engine.SynchronizedDirectoryName(entry)
+	words := directoryCompareWordsForLanguage(u.language)
+	if !ok {
+		u.setStatus(words.Unavailable)
+		return
+	}
+	localTarget, err := security.SafeLocalChild(localBase, name)
+	if err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, words.Unavailable))
+		return
+	}
+	if err := security.ValidateRemoteName(name); err != nil {
+		u.setStatus(words.Unavailable)
+		return
+	}
+	remoteTarget := path.Clean(path.Join(remoteBase, name))
+	if err := security.ValidateRemotePath(remoteTarget); err != nil {
+		u.setStatus(words.Unavailable)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	state.mu.Lock()
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.seq++
+	seq := state.seq
+	state.running = true
+	state.cancel = cancel
+	state.status = words.Disclosure
+	state.dirty = true
+	state.mu.Unlock()
+	u.setStatus(words.Disclosure)
+
+	go func() {
+		defer cancel()
+		resolvedLocal, localItems, err := u.engine.LocalList(ctx, localTarget)
+		var remoteItems []model.Item
+		if err == nil {
+			remoteItems, err = u.engine.RemoteList(ctx, remoteTarget)
+		}
+		var entries []api.DirectoryComparisonEntry
+		if err == nil {
+			entries = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryCompareOptions{})
+		}
+
+		state.mu.Lock()
+		if state.seq == seq && state.active {
+			state.running = false
+			state.cancel = nil
+			if err != nil {
+				state.status = usererror.MessageFor(u.language, err, words.Unavailable)
+				state.dirty = true
+			} else {
+				state.navReady = true
+				state.navLocalBase = resolvedLocal
+				state.navRemoteBase = remoteTarget
+				state.navLocalItems = append([]model.Item(nil), localItems...)
+				state.navRemoteItems = append([]model.Item(nil), remoteItems...)
+				state.navEntries = append([]api.DirectoryComparisonEntry(nil), entries...)
+				state.status = fmt.Sprintf("%s · %d", words.Ready, len(entries))
+				state.dirty = true
+			}
+		}
+		state.mu.Unlock()
+		u.resultCh <- linuxUIResult{action: linuxActionNone}
+	}()
+}
+
+func (u *linuxDesktop) handleDirectoryComparisonMouseLinux(x, y int) bool {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	active := state.active
+	running := state.running
+	count := len(state.entries)
+	state.mu.Unlock()
+	if !active {
+		if u.directoryComparisonButtonRectLinux().contains(x, y) {
+			if !u.busy && u.connected {
+				u.startDirectoryComparisonLinux()
+			}
+			return true
+		}
+		return false
+	}
+
+	// Comparison is modal: swallow all ordinary workspace clicks while active.
+	if u.fileFilterControlRect(false).contains(x, y) || u.directoryComparisonButtonRectLinux().contains(x, y) {
+		u.closeDirectoryComparisonLinux()
+		return true
+	}
+	if u.recursiveSearchButtonRect(false).contains(x, y) {
+		if !running {
+			u.openComparedDirectoryBothLinux()
+		}
+		return true
+	}
+	if u.fileFilterControlRect(true).contains(x, y) {
+		if !running {
+			u.closeDirectoryComparisonLinux()
+			u.startDirectoryComparisonLinux()
+		}
+		return true
+	}
+	for _, remote := range []bool{false, true} {
+		list := u.fileFilterListRect(remote)
+		if list.contains(x, y) {
+			index := u.selectRow(list, y, count)
+			state.mu.Lock()
+			if state.active && !state.running {
+				state.selected = index
+			}
+			state.mu.Unlock()
+			u.selectedLocal = index
+			u.selectedRemote = index
+			return true
+		}
+	}
+	return true
+}
+
+func (u *linuxDesktop) disposeDirectoryComparisonLinux() {
+	state := linuxDirectoryComparisonStateFor(u)
+	state.mu.Lock()
+	cancel := state.cancel
+	state.cancel = nil
+	state.active = false
+	state.running = false
+	state.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	linuxDirectoryComparisonStates.Delete(u)
+}

--- a/internal/desktop/directory_compare_linux.go
+++ b/internal/desktop/directory_compare_linux.go
@@ -32,12 +32,12 @@ type linuxDirectoryComparisonState struct {
 	localSnapshot  []model.Item
 	remoteSnapshot []model.Item
 
-	navReady        bool
-	navLocalBase    string
-	navRemoteBase   string
-	navLocalItems   []model.Item
-	navRemoteItems  []model.Item
-	navEntries      []api.DirectoryComparisonEntry
+	navReady       bool
+	navLocalBase   string
+	navRemoteBase  string
+	navLocalItems  []model.Item
+	navRemoteItems []model.Item
+	navEntries     []api.DirectoryComparisonEntry
 }
 
 var linuxDirectoryComparisonStates sync.Map
@@ -188,7 +188,7 @@ func (u *linuxDesktop) renderDirectoryComparisonControlsLinux() error {
 	words := directoryCompareWordsForLanguage(u.language)
 	openBoth := false
 	if !running && selected >= 0 && selected < len(entries) {
-		_, openBoth = u.engine.SynchronizedDirectoryName(entries[selected])
+		_, openBoth = u.engine.SynchronizedDirectoryName(entries, entries[selected].Name)
 	}
 	if err := u.drawButton(u.fileFilterControlRect(false), words.Close, true, false); err != nil {
 		return err
@@ -250,7 +250,7 @@ func (u *linuxDesktop) startDirectoryComparisonLinux() {
 		}
 		var entries []api.DirectoryComparisonEntry
 		if err == nil {
-			entries = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryCompareOptions{})
+			entries, err = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryComparisonOptions{})
 		}
 
 		state.mu.Lock()
@@ -269,7 +269,7 @@ func (u *linuxDesktop) startDirectoryComparisonLinux() {
 				state.entries = append([]api.DirectoryComparisonEntry(nil), entries...)
 				state.selected = -1
 				for i, entry := range entries {
-					if _, ok := u.engine.SynchronizedDirectoryName(entry); ok {
+					if _, ok := u.engine.SynchronizedDirectoryName(entries, entry.Name); ok {
 						state.selected = i
 						break
 					}
@@ -322,12 +322,13 @@ func (u *linuxDesktop) openComparedDirectoryBothLinux() {
 		state.mu.Unlock()
 		return
 	}
-	entry := state.entries[state.selected]
+	entries := append([]api.DirectoryComparisonEntry(nil), state.entries...)
+	entry := entries[state.selected]
 	localBase := state.localBase
 	remoteBase := state.remoteBase
 	state.mu.Unlock()
 
-	name, ok := u.engine.SynchronizedDirectoryName(entry)
+	name, ok := u.engine.SynchronizedDirectoryName(entries, entry.Name)
 	words := directoryCompareWordsForLanguage(u.language)
 	if !ok {
 		u.setStatus(words.Unavailable)
@@ -371,7 +372,7 @@ func (u *linuxDesktop) openComparedDirectoryBothLinux() {
 		}
 		var entries []api.DirectoryComparisonEntry
 		if err == nil {
-			entries = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryCompareOptions{})
+			entries, err = u.engine.CompareDirectoryItems(localItems, remoteItems, api.DirectoryComparisonOptions{})
 		}
 
 		state.mu.Lock()

--- a/internal/desktop/directory_compare_windows.go
+++ b/internal/desktop/directory_compare_windows.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -296,10 +295,6 @@ func (a *app) startDirectoryComparison() {
 	a.goSafe(func() {
 		defer cancel()
 		localResolved, localItems, err := a.engine.LocalList(ctx, localBase)
-		if err == nil {
-			var remoteItems []apiItemAlias
-			_ = remoteItems
-		}
 		serverItems, remoteErr := a.engine.RemoteList(ctx, remoteBase)
 		if err == nil {
 			err = remoteErr
@@ -409,8 +404,6 @@ func (a *app) openComparedDirectoryBoth() {
 	a.goSafe(func() {
 		defer cancel()
 		localResolved, localItems, listErr := a.engine.LocalList(ctx, localTarget)
-		var remoteItems []apiItemAlias
-		_ = remoteItems
 		serverItems, remoteErr := a.engine.RemoteList(ctx, remoteTarget)
 		if listErr == nil {
 			listErr = remoteErr
@@ -450,13 +443,4 @@ func (a *app) openComparedDirectoryBoth() {
 			a.updateActionControls()
 		})
 	})
-}
-
-// apiItemAlias is intentionally impossible to instantiate usefully. It keeps
-// accidental shadow declarations out of future edits; directory comparison uses
-// the concrete model slices returned by Engine list calls above.
-type apiItemAlias = struct{}
-
-func directoryComparisonTrim(value string) string {
-	return strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(value, "\r", " "), "\n", " "))
 }

--- a/internal/desktop/directory_compare_windows.go
+++ b/internal/desktop/directory_compare_windows.go
@@ -1,0 +1,462 @@
+//go:build windows
+
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/api"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+const (
+	idDirectoryCompare           = 314
+	idDirectoryCompareOpenBoth   = 315
+	idDirectoryCompareLocalList  = 316
+	idDirectoryCompareRemoteList = 317
+)
+
+type windowsDirectoryComparisonState struct {
+	compareButton  uintptr
+	openBothButton uintptr
+	localList      uintptr
+	remoteList     uintptr
+	active         bool
+	loading        bool
+	seq            uint64
+	generation     uint64
+	entries        []api.DirectoryComparisonEntry
+	cancel         context.CancelFunc
+	localBase      string
+	remoteBase     string
+}
+
+var windowsDirectoryComparisons sync.Map
+
+func (a *app) directoryComparisonState() *windowsDirectoryComparisonState {
+	if a == nil {
+		return nil
+	}
+	if value, ok := windowsDirectoryComparisons.Load(a.hwnd); ok {
+		return value.(*windowsDirectoryComparisonState)
+	}
+	state := &windowsDirectoryComparisonState{}
+	actual, _ := windowsDirectoryComparisons.LoadOrStore(a.hwnd, state)
+	return actual.(*windowsDirectoryComparisonState)
+}
+
+func (a *app) directoryComparisonActive() bool {
+	state := a.directoryComparisonState()
+	return state != nil && state.active
+}
+
+func (a *app) createDirectoryComparisonButton(hinst uintptr, id int, label string, accent bool) uintptr {
+	hwnd, _, _ := createWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(wstr("BUTTON"))),
+		uintptr(unsafe.Pointer(wstr(label))),
+		uintptr(wsChild|wsVisible|wsTabStop|bsOwnerDraw),
+		0, 0, 100, 32,
+		a.hwnd, uintptr(id), hinst, 0,
+	)
+	if hwnd == 0 {
+		return 0
+	}
+	if a.font != 0 {
+		sendMessageW.Call(hwnd, wmSetFont, a.font, 1)
+	}
+	applyDarkControl(hwnd, "BUTTON")
+	variant := buttonSubtle
+	if accent {
+		variant = buttonAccent
+	}
+	return a.registerButton(hwnd, iconSync, label, variant)
+}
+
+func (a *app) createDirectoryComparisonList(hinst uintptr, id int) uintptr {
+	hwnd, _, _ := createWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(wstr("SysListView32"))),
+		0,
+		uintptr(wsChild|wsTabStop|wsBorder|wsVScroll|lvsReport|lvsShowSelAlways),
+		0, 0, 100, 100,
+		a.hwnd, uintptr(id), hinst, 0,
+	)
+	if hwnd == 0 {
+		return 0
+	}
+	if a.font != 0 {
+		sendMessageW.Call(hwnd, wmSetFont, a.font, 1)
+	}
+	sendMessageW.Call(hwnd, lvmSetExtendedListViewStyle, 0, lvsExFullRowSelect|lvsExDoubleBuffer|lvsExGridLines)
+	styleWorkspaceList(hwnd)
+	attachSystemImageList(hwnd)
+	for index, spec := range []struct {
+		label string
+		width int
+	}{
+		{a.tr("column.name"), 250},
+		{a.tr("column.status"), 150},
+		{a.tr("column.size"), 105},
+		{a.tr("column.modified"), 145},
+	} {
+		a.insertColumn(hwnd, index, spec.label, spec.width)
+	}
+	showWindow.Call(hwnd, workspaceSWHide)
+	return hwnd
+}
+
+func (a *app) ensureDirectoryComparisonControls() {
+	state := a.directoryComparisonState()
+	if state == nil || a.hwnd == 0 {
+		return
+	}
+	hinst, _, _ := getModuleHandleW.Call(0)
+	words := directoryCompareWordsForLanguage(a.languageCode())
+	if state.compareButton == 0 {
+		state.compareButton = a.createDirectoryComparisonButton(hinst, idDirectoryCompare, words.Compare, false)
+		state.openBothButton = a.createDirectoryComparisonButton(hinst, idDirectoryCompareOpenBoth, words.OpenBoth, true)
+		state.localList = a.createDirectoryComparisonList(hinst, idDirectoryCompareLocalList)
+		state.remoteList = a.createDirectoryComparisonList(hinst, idDirectoryCompareRemoteList)
+	}
+}
+
+func (a *app) comparisonCanStart() bool {
+	return a != nil && a.connected && !a.connectionBusy && !a.closing &&
+		!a.recursiveSearchPaneActive(false) && !a.recursiveSearchPaneActive(true)
+}
+
+func (a *app) layoutDirectoryComparisonControls() {
+	a.ensureDirectoryComparisonControls()
+	state := a.directoryComparisonState()
+	if state == nil || state.compareButton == 0 {
+		return
+	}
+	localRect, localOK := recursiveSearchClientRect(a.hwnd, a.localList)
+	remoteRect, remoteOK := recursiveSearchClientRect(a.hwnd, a.remoteList)
+	centerRect, centerOK := recursiveSearchClientRect(a.hwnd, a.upload)
+	if !localOK || !remoteOK || !centerOK {
+		return
+	}
+	buttonH := a.scale(32)
+	gap := a.scale(8)
+	moveWindow.Call(state.compareButton, uintptr(centerRect.Left), uintptr(localRect.Top), uintptr(centerRect.Right-centerRect.Left), uintptr(buttonH), 1)
+	moveWindow.Call(state.openBothButton, uintptr(centerRect.Left), uintptr(int(localRect.Top)+buttonH+gap), uintptr(centerRect.Right-centerRect.Left), uintptr(buttonH), 1)
+	moveWindow.Call(state.localList, uintptr(localRect.Left), uintptr(localRect.Top), uintptr(localRect.Right-localRect.Left), uintptr(localRect.Bottom-localRect.Top), 1)
+	moveWindow.Call(state.remoteList, uintptr(remoteRect.Left), uintptr(remoteRect.Top), uintptr(remoteRect.Right-remoteRect.Left), uintptr(remoteRect.Bottom-remoteRect.Top), 1)
+	a.updateDirectoryComparisonControls()
+}
+
+func (a *app) comparisonAuxiliaryControls(remote bool) []uintptr {
+	filter := a.filterButtonForPane(remote)
+	search := a.recursiveSearchPane(remote)
+	if search == nil {
+		return []uintptr{filter}
+	}
+	return []uintptr{filter, search.searchButton, search.navigateButton, search.list}
+}
+
+func (a *app) updateDirectoryComparisonControls() {
+	state := a.directoryComparisonState()
+	if state == nil || state.compareButton == 0 {
+		return
+	}
+	words := directoryCompareWordsForLanguage(a.languageCode())
+	if !state.active {
+		a.setButtonLabel(state.compareButton, words.Compare)
+		showControls(true, state.compareButton, a.localList, a.remoteList, a.upload, a.download)
+		showControls(false, state.openBothButton, state.localList, state.remoteList)
+		setControlEnabled(state.compareButton, a.comparisonCanStart())
+		return
+	}
+
+	a.setButtonLabel(state.compareButton, words.Close)
+	a.setButtonLabel(state.openBothButton, words.OpenBoth)
+	showControls(true, state.compareButton, state.openBothButton, state.localList, state.remoteList)
+	showControls(false, a.localList, a.remoteList, a.upload, a.download)
+	showControls(false, a.comparisonAuxiliaryControls(false)...)
+	showControls(false, a.comparisonAuxiliaryControls(true)...)
+	setControlEnabled(state.compareButton, true)
+	setControlEnabled(state.openBothButton, !state.loading && len(state.entries) > 0)
+}
+
+func (a *app) comparisonStatusLabel(status api.DirectoryComparisonStatus) string {
+	words := directoryCompareWordsForLanguage(a.languageCode())
+	switch status {
+	case api.DirectorySame:
+		return words.Same
+	case api.DirectoryLocalOnly:
+		return words.LocalOnly
+	case api.DirectoryRemoteOnly:
+		return words.RemoteOnly
+	case api.DirectoryNewerLocal:
+		return words.NewerLocal
+	case api.DirectoryNewerRemote:
+		return words.NewerRemote
+	case api.DirectoryConflict:
+		return words.Conflict
+	default:
+		return words.Unknown
+	}
+}
+
+func comparisonSideValues(entry api.DirectoryComparisonEntry, remote bool) (string, string) {
+	item := entry.Local
+	has := entry.HasLocal
+	if remote {
+		item = entry.Remote
+		has = entry.HasRemote
+	}
+	if !has {
+		return "", ""
+	}
+	return formatSize(item.Size, item.IsDirectory), formatTime(item.Modified)
+}
+
+func (a *app) renderDirectoryComparisonRows() {
+	state := a.directoryComparisonState()
+	if state == nil {
+		return
+	}
+	clearList(state.localList)
+	clearList(state.remoteList)
+	firstSync := -1
+	for row, entry := range state.entries {
+		status := a.comparisonStatusLabel(entry.Status)
+		localSize, localTime := comparisonSideValues(entry, false)
+		remoteSize, remoteTime := comparisonSideValues(entry, true)
+		localImage := int32(-1)
+		if entry.HasLocal {
+			localImage = systemIconIndex(entry.Local.Name, entry.Local.IsDirectory)
+		}
+		remoteImage := int32(-1)
+		if entry.HasRemote {
+			remoteImage = systemIconIndex(entry.Remote.Name, entry.Remote.IsDirectory)
+		}
+		insertListRowWithImage(state.localList, row, []string{entry.Name, status, localSize, localTime}, localImage)
+		insertListRowWithImage(state.remoteList, row, []string{entry.Name, status, remoteSize, remoteTime}, remoteImage)
+		if firstSync < 0 {
+			if _, ok := a.engine.SynchronizedDirectoryName(state.entries, entry.Name); ok {
+				firstSync = row
+			}
+		}
+	}
+	if firstSync >= 0 {
+		setListRowSelected(state.localList, firstSync, true)
+		setListRowSelected(state.remoteList, firstSync, true)
+	} else if len(state.entries) > 0 {
+		setListRowSelected(state.localList, 0, true)
+		setListRowSelected(state.remoteList, 0, true)
+	}
+}
+
+func (a *app) directoryComparisonCommand() {
+	if a.directoryComparisonActive() {
+		a.closeDirectoryComparison()
+		return
+	}
+	a.startDirectoryComparison()
+}
+
+func (a *app) startDirectoryComparison() {
+	if !a.comparisonCanStart() {
+		return
+	}
+	state := a.directoryComparisonState()
+	if state == nil {
+		return
+	}
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.seq++
+	seq := state.seq
+	state.active = true
+	state.loading = true
+	state.entries = nil
+	state.generation = a.connectionGeneration
+	state.localBase = a.localCurrent
+	state.remoteBase = a.remoteCurrent
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	state.cancel = cancel
+	words := directoryCompareWordsForLanguage(a.languageCode())
+	a.setStatus(words.Disclosure)
+	a.layoutDirectoryComparisonControls()
+	a.updateActionControls()
+
+	localBase := state.localBase
+	remoteBase := state.remoteBase
+	generation := state.generation
+	a.goSafe(func() {
+		defer cancel()
+		localResolved, localItems, err := a.engine.LocalList(ctx, localBase)
+		if err == nil {
+			var remoteItems []apiItemAlias
+			_ = remoteItems
+		}
+		serverItems, remoteErr := a.engine.RemoteList(ctx, remoteBase)
+		if err == nil {
+			err = remoteErr
+		}
+		var entries []api.DirectoryComparisonEntry
+		if err == nil {
+			entries, err = a.engine.CompareDirectoryItems(localItems, serverItems, api.DirectoryComparisonOptions{})
+		}
+		a.dispatch(func() {
+			current := a.directoryComparisonState()
+			if current == nil || !current.active || current.seq != seq || generation != a.connectionGeneration || a.localCurrent != localBase || a.remoteCurrent != remoteBase {
+				return
+			}
+			current.loading = false
+			current.cancel = nil
+			if err != nil {
+				a.setStatus(a.userMessage(err, "error.generic"))
+				a.updateDirectoryComparisonControls()
+				return
+			}
+			current.localBase = localResolved
+			current.entries = entries
+			fillItems(a.localList, localItems)
+			fillItems(a.remoteList, serverItems)
+			a.renderDirectoryComparisonRows()
+			a.setStatus(fmt.Sprintf("%s · %d", words.Ready, len(entries)))
+			a.updateDirectoryComparisonControls()
+			a.updateActionControls()
+		})
+	})
+}
+
+func (a *app) closeDirectoryComparison() {
+	state := a.directoryComparisonState()
+	if state == nil || !state.active {
+		return
+	}
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.seq++
+	state.active = false
+	state.loading = false
+	state.cancel = nil
+	state.entries = nil
+	showControls(false, state.localList, state.remoteList, state.openBothButton)
+	a.setStatus(directoryCompareWordsForLanguage(a.languageCode()).Close)
+	a.updateActionControls()
+}
+
+func (a *app) selectedDirectoryComparisonEntry() (api.DirectoryComparisonEntry, bool) {
+	state := a.directoryComparisonState()
+	if state == nil || !state.active || state.loading {
+		return api.DirectoryComparisonEntry{}, false
+	}
+	index := selectedIndex(state.localList)
+	if index < 0 || index >= len(state.entries) {
+		index = selectedIndex(state.remoteList)
+	}
+	if index < 0 || index >= len(state.entries) {
+		return api.DirectoryComparisonEntry{}, false
+	}
+	return state.entries[index], true
+}
+
+func (a *app) openComparedDirectoryBoth() {
+	state := a.directoryComparisonState()
+	entry, ok := a.selectedDirectoryComparisonEntry()
+	words := directoryCompareWordsForLanguage(a.languageCode())
+	if state == nil || !ok {
+		return
+	}
+	name, ok := a.engine.SynchronizedDirectoryName(state.entries, entry.Name)
+	if !ok {
+		a.setStatus(words.Unavailable)
+		return
+	}
+	localTarget, err := security.SafeLocalChild(state.localBase, name)
+	if err != nil {
+		a.setStatus(a.userMessage(err, "error.generic"))
+		return
+	}
+	if err := security.ValidateRemoteName(name); err != nil {
+		a.setStatus(a.userMessage(err, "error.invalid_name"))
+		return
+	}
+	remoteTarget := path.Clean(path.Join(state.remoteBase, name))
+	if err := security.ValidateRemotePath(remoteTarget); err != nil {
+		a.setStatus(a.userMessage(err, "error.generic"))
+		return
+	}
+
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.seq++
+	seq := state.seq
+	state.loading = true
+	generation := a.connectionGeneration
+	localBase := state.localBase
+	remoteBase := state.remoteBase
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	state.cancel = cancel
+	a.setStatus(words.OpenBoth + "…")
+	a.updateDirectoryComparisonControls()
+
+	a.goSafe(func() {
+		defer cancel()
+		localResolved, localItems, listErr := a.engine.LocalList(ctx, localTarget)
+		var remoteItems []apiItemAlias
+		_ = remoteItems
+		serverItems, remoteErr := a.engine.RemoteList(ctx, remoteTarget)
+		if listErr == nil {
+			listErr = remoteErr
+		}
+		var entries []api.DirectoryComparisonEntry
+		if listErr == nil {
+			entries, listErr = a.engine.CompareDirectoryItems(localItems, serverItems, api.DirectoryComparisonOptions{})
+		}
+		a.dispatch(func() {
+			current := a.directoryComparisonState()
+			if current == nil || !current.active || current.seq != seq || generation != a.connectionGeneration || current.localBase != localBase || current.remoteBase != remoteBase {
+				return
+			}
+			current.loading = false
+			current.cancel = nil
+			if listErr != nil {
+				a.setStatus(a.userMessage(listErr, "error.generic"))
+				a.updateDirectoryComparisonControls()
+				return
+			}
+			if filter := a.fileFilterState(); filter != nil {
+				filter.localQuery = ""
+				filter.remoteQuery = ""
+			}
+			a.localCurrent = localResolved
+			a.remoteCurrent = remoteTarget
+			setText(a.localPath, a.localCurrent)
+			setText(a.remotePath, a.remoteCurrent)
+			fillItems(a.localList, localItems)
+			fillItems(a.remoteList, serverItems)
+			current.localBase = a.localCurrent
+			current.remoteBase = a.remoteCurrent
+			current.entries = entries
+			a.renderDirectoryComparisonRows()
+			a.setStatus(fmt.Sprintf("%s · %d", words.Ready, len(entries)))
+			a.updateDirectoryComparisonControls()
+			a.updateActionControls()
+		})
+	})
+}
+
+// apiItemAlias is intentionally impossible to instantiate usefully. It keeps
+// accidental shadow declarations out of future edits; directory comparison uses
+// the concrete model slices returned by Engine list calls above.
+type apiItemAlias = struct{}
+
+func directoryComparisonTrim(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(value, "\r", " "), "\n", " "))
+}

--- a/internal/desktop/directory_compare_words.go
+++ b/internal/desktop/directory_compare_words.go
@@ -1,0 +1,53 @@
+package desktop
+
+import "github.com/bren-wp/Ghost-FTP/internal/i18n"
+
+type directoryCompareWords struct {
+	Compare     string
+	Close       string
+	OpenBoth    string
+	Same        string
+	LocalOnly   string
+	RemoteOnly  string
+	NewerLocal  string
+	NewerRemote string
+	Conflict    string
+	Unknown     string
+	Ready       string
+	Unavailable string
+	Disclosure  string
+}
+
+var directoryCompareTranslations = map[string]directoryCompareWords{
+	"en": {"Compare", "Close comparison", "Open both", "Same", "Local only", "Server only", "Local newer", "Server newer", "Conflict", "Unknown", "Directory comparison ready", "Synchronized navigation is unavailable for this entry", "Read-only metadata comparison. It never transfers, overwrites, renames or deletes files."},
+	"hr": {"Usporedi", "Zatvori usporedbu", "Otvori obje", "Isto", "Samo lokalno", "Samo poslužitelj", "Lokalno novije", "Poslužitelj noviji", "Sukob", "Nepoznato", "Usporedba direktorija spremna", "Sinkronizirana navigacija nije dostupna za ovu stavku", "Usporedba metapodataka samo za čitanje. Nikada ne prenosi, prepisuje, preimenuje niti briše datoteke."},
+	"de": {"Vergleichen", "Vergleich schließen", "Beide öffnen", "Gleich", "Nur lokal", "Nur Server", "Lokal neuer", "Server neuer", "Konflikt", "Unbekannt", "Verzeichnisvergleich bereit", "Synchronisierte Navigation ist für diesen Eintrag nicht verfügbar", "Schreibgeschützter Metadatenvergleich. Dateien werden niemals übertragen, überschrieben, umbenannt oder gelöscht."},
+	"fr": {"Comparer", "Fermer la comparaison", "Ouvrir les deux", "Identique", "Local uniquement", "Serveur uniquement", "Local plus récent", "Serveur plus récent", "Conflit", "Inconnu", "Comparaison des dossiers prête", "La navigation synchronisée n’est pas disponible pour cet élément", "Comparaison des métadonnées en lecture seule. Aucun transfert, écrasement, renommage ou suppression de fichier."},
+	"es": {"Comparar", "Cerrar comparación", "Abrir ambos", "Igual", "Solo local", "Solo servidor", "Local más reciente", "Servidor más reciente", "Conflicto", "Desconocido", "Comparación de carpetas lista", "La navegación sincronizada no está disponible para este elemento", "Comparación de metadatos de solo lectura. Nunca transfiere, sobrescribe, renombra ni elimina archivos."},
+	"tr": {"Karşılaştır", "Karşılaştırmayı kapat", "İkisini de aç", "Aynı", "Yalnızca yerel", "Yalnızca sunucu", "Yerel daha yeni", "Sunucu daha yeni", "Çakışma", "Bilinmiyor", "Dizin karşılaştırması hazır", "Bu öğe için eşzamanlı gezinme kullanılamıyor", "Salt okunur meta veri karşılaştırması. Dosyaları asla aktarmaz, üzerine yazmaz, yeniden adlandırmaz veya silmez."},
+	"el": {"Σύγκριση", "Κλείσιμο σύγκρισης", "Άνοιγμα και των δύο", "Ίδιο", "Μόνο τοπικά", "Μόνο διακομιστής", "Νεότερο τοπικά", "Νεότερο στον διακομιστή", "Σύγκρουση", "Άγνωστο", "Η σύγκριση φακέλων είναι έτοιμη", "Η συγχρονισμένη πλοήγηση δεν είναι διαθέσιμη για αυτό το στοιχείο", "Σύγκριση μεταδεδομένων μόνο για ανάγνωση. Δεν μεταφέρει, αντικαθιστά, μετονομάζει ή διαγράφει αρχεία."},
+	"pt": {"Comparar", "Fechar comparação", "Abrir ambos", "Igual", "Apenas local", "Apenas servidor", "Local mais recente", "Servidor mais recente", "Conflito", "Desconhecido", "Comparação de diretórios pronta", "A navegação sincronizada não está disponível para este item", "Comparação de metadados somente leitura. Nunca transfere, substitui, renomeia ou exclui arquivos."},
+	"zh": {"比较", "关闭比较", "同时打开", "相同", "仅本地", "仅服务器", "本地较新", "服务器较新", "冲突", "未知", "目录比较已就绪", "此项目无法使用同步导航", "只读元数据比较。不会传输、覆盖、重命名或删除文件。"},
+	"ru": {"Сравнить", "Закрыть сравнение", "Открыть оба", "Одинаково", "Только локально", "Только сервер", "Локальная версия новее", "Серверная версия новее", "Конфликт", "Неизвестно", "Сравнение каталогов готово", "Синхронная навигация недоступна для этого элемента", "Сравнение метаданных только для чтения. Оно не переносит, не перезаписывает, не переименовывает и не удаляет файлы."},
+	"hi": {"तुलना करें", "तुलना बंद करें", "दोनों खोलें", "समान", "केवल स्थानीय", "केवल सर्वर", "स्थानीय नया", "सर्वर नया", "टकराव", "अज्ञात", "डायरेक्टरी तुलना तैयार है", "इस आइटम के लिए समकालिक नेविगेशन उपलब्ध नहीं है", "केवल-पठन मेटाडेटा तुलना। यह फ़ाइलों को स्थानांतरित, अधिलेखित, नाम परिवर्तित या हटाती नहीं है।"},
+	"ja": {"比較", "比較を閉じる", "両方を開く", "同じ", "ローカルのみ", "サーバーのみ", "ローカルが新しい", "サーバーが新しい", "競合", "不明", "ディレクトリ比較の準備完了", "この項目では同期ナビゲーションを使用できません", "読み取り専用のメタデータ比較です。ファイルの転送、上書き、名前変更、削除は行いません。"},
+	"it": {"Confronta", "Chiudi confronto", "Apri entrambi", "Uguale", "Solo locale", "Solo server", "Locale più recente", "Server più recente", "Conflitto", "Sconosciuto", "Confronto directory pronto", "La navigazione sincronizzata non è disponibile per questo elemento", "Confronto dei metadati in sola lettura. Non trasferisce, sovrascrive, rinomina o elimina file."},
+	"pl": {"Porównaj", "Zamknij porównanie", "Otwórz oba", "Takie samo", "Tylko lokalnie", "Tylko serwer", "Lokalne nowsze", "Serwerowe nowsze", "Konflikt", "Nieznane", "Porównanie katalogów gotowe", "Nawigacja zsynchronizowana nie jest dostępna dla tego elementu", "Porównanie metadanych tylko do odczytu. Nie przesyła, nie nadpisuje, nie zmienia nazw ani nie usuwa plików."},
+	"nl": {"Vergelijken", "Vergelijking sluiten", "Beide openen", "Gelijk", "Alleen lokaal", "Alleen server", "Lokaal nieuwer", "Server nieuwer", "Conflict", "Onbekend", "Mapvergelijking gereed", "Gesynchroniseerde navigatie is niet beschikbaar voor dit item", "Alleen-lezen metadatavergelijking. Bestanden worden nooit overgedragen, overschreven, hernoemd of verwijderd."},
+	"cs": {"Porovnat", "Zavřít porovnání", "Otevřít obě", "Stejné", "Pouze místní", "Pouze server", "Místní novější", "Server novější", "Konflikt", "Neznámé", "Porovnání adresářů je připraveno", "Synchronizovaná navigace není pro tuto položku dostupná", "Porovnání metadat pouze pro čtení. Nikdy nepřenáší, nepřepisuje, nepřejmenovává ani nemaže soubory."},
+	"uk": {"Порівняти", "Закрити порівняння", "Відкрити обидва", "Однаково", "Лише локально", "Лише сервер", "Локальна версія новіша", "Серверна версія новіша", "Конфлікт", "Невідомо", "Порівняння каталогів готове", "Синхронізована навігація недоступна для цього елемента", "Порівняння метаданих лише для читання. Воно не передає, не перезаписує, не перейменовує та не видаляє файли."},
+	"sv": {"Jämför", "Stäng jämförelse", "Öppna båda", "Samma", "Endast lokalt", "Endast server", "Lokalt nyare", "Server nyare", "Konflikt", "Okänt", "Katalogjämförelse klar", "Synkroniserad navigering är inte tillgänglig för denna post", "Skrivskyddad metadatajämförelse. Den överför, skriver över, byter namn på eller tar aldrig bort filer."},
+	"ro": {"Compară", "Închide comparația", "Deschide ambele", "Identic", "Doar local", "Doar server", "Local mai nou", "Server mai nou", "Conflict", "Necunoscut", "Compararea directoarelor este gata", "Navigarea sincronizată nu este disponibilă pentru acest element", "Comparare a metadatelor doar în citire. Nu transferă, suprascrie, redenumește sau șterge fișiere."},
+	"hu": {"Összehasonlítás", "Összehasonlítás bezárása", "Mindkettő megnyitása", "Azonos", "Csak helyi", "Csak kiszolgáló", "Helyi újabb", "Kiszolgáló újabb", "Ütközés", "Ismeretlen", "A könyvtár-összehasonlítás kész", "A szinkronizált navigáció ehhez az elemhez nem érhető el", "Csak olvasható metaadat-összehasonlítás. Nem visz át, ír felül, nevez át vagy töröl fájlokat."},
+	"da": {"Sammenlign", "Luk sammenligning", "Åbn begge", "Samme", "Kun lokal", "Kun server", "Lokal nyere", "Server nyere", "Konflikt", "Ukendt", "Mappesammenligning klar", "Synkroniseret navigation er ikke tilgængelig for dette element", "Skrivebeskyttet metadatasammenligning. Den overfører, overskriver, omdøber eller sletter aldrig filer."},
+	"fi": {"Vertaa", "Sulje vertailu", "Avaa molemmat", "Sama", "Vain paikallinen", "Vain palvelin", "Paikallinen uudempi", "Palvelin uudempi", "Ristiriita", "Tuntematon", "Hakemistojen vertailu valmis", "Synkronoitu siirtyminen ei ole käytettävissä tälle kohteelle", "Vain luku -metatietojen vertailu. Se ei siirrä, korvaa, nimeä uudelleen tai poista tiedostoja."},
+	"no": {"Sammenlign", "Lukk sammenligning", "Åpne begge", "Samme", "Bare lokal", "Bare server", "Lokal nyere", "Server nyere", "Konflikt", "Ukjent", "Mappe sammenligning klar", "Synkronisert navigasjon er ikke tilgjengelig for dette elementet", "Skrivebeskyttet metadata-sammenligning. Den overfører, overskriver, gir nytt navn til eller sletter aldri filer."},
+	"ko": {"비교", "비교 닫기", "둘 다 열기", "같음", "로컬만", "서버만", "로컬이 최신", "서버가 최신", "충돌", "알 수 없음", "디렉터리 비교 준비 완료", "이 항목에는 동기화 탐색을 사용할 수 없습니다", "읽기 전용 메타데이터 비교입니다. 파일을 전송, 덮어쓰기, 이름 변경 또는 삭제하지 않습니다."},
+}
+
+func directoryCompareWordsForLanguage(language string) directoryCompareWords {
+	if words, ok := directoryCompareTranslations[i18n.Normalize(language)]; ok {
+		return words
+	}
+	return directoryCompareTranslations[i18n.DefaultLanguage]
+}

--- a/internal/desktop/directory_compare_words_test.go
+++ b/internal/desktop/directory_compare_words_test.go
@@ -1,0 +1,49 @@
+package desktop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+)
+
+func TestDirectoryCompareWordsCoverEverySupportedLanguage(t *testing.T) {
+	languages := i18n.Languages()
+	if len(directoryCompareTranslations) != len(languages) {
+		t.Fatalf("comparison translations=%d languages=%d", len(directoryCompareTranslations), len(languages))
+	}
+	for _, language := range languages {
+		words, ok := directoryCompareTranslations[language.Code]
+		if !ok {
+			t.Fatalf("missing directory comparison translation for %s", language.Code)
+		}
+		for label, value := range map[string]string{
+			"compare": words.Compare,
+			"close": words.Close,
+			"openBoth": words.OpenBoth,
+			"same": words.Same,
+			"localOnly": words.LocalOnly,
+			"remoteOnly": words.RemoteOnly,
+			"newerLocal": words.NewerLocal,
+			"newerRemote": words.NewerRemote,
+			"conflict": words.Conflict,
+			"unknown": words.Unknown,
+			"ready": words.Ready,
+			"unavailable": words.Unavailable,
+			"disclosure": words.Disclosure,
+		} {
+			if strings.TrimSpace(value) == "" {
+				t.Fatalf("empty comparison %s for %s", label, language.Code)
+			}
+		}
+	}
+}
+
+func TestDirectoryCompareWordsNormalizeAliasesAndFallback(t *testing.T) {
+	if got := directoryCompareWordsForLanguage("HR_hr").Compare; got != directoryCompareTranslations["hr"].Compare {
+		t.Fatalf("Croatian alias normalized to %q", got)
+	}
+	if got := directoryCompareWordsForLanguage("unsupported").Compare; got != directoryCompareTranslations["en"].Compare {
+		t.Fatalf("fallback=%q", got)
+	}
+}

--- a/internal/desktop/directory_compare_words_test.go
+++ b/internal/desktop/directory_compare_words_test.go
@@ -18,19 +18,19 @@ func TestDirectoryCompareWordsCoverEverySupportedLanguage(t *testing.T) {
 			t.Fatalf("missing directory comparison translation for %s", language.Code)
 		}
 		for label, value := range map[string]string{
-			"compare": words.Compare,
-			"close": words.Close,
-			"openBoth": words.OpenBoth,
-			"same": words.Same,
-			"localOnly": words.LocalOnly,
-			"remoteOnly": words.RemoteOnly,
-			"newerLocal": words.NewerLocal,
+			"compare":     words.Compare,
+			"close":       words.Close,
+			"openBoth":    words.OpenBoth,
+			"same":        words.Same,
+			"localOnly":   words.LocalOnly,
+			"remoteOnly":  words.RemoteOnly,
+			"newerLocal":  words.NewerLocal,
 			"newerRemote": words.NewerRemote,
-			"conflict": words.Conflict,
-			"unknown": words.Unknown,
-			"ready": words.Ready,
+			"conflict":    words.Conflict,
+			"unknown":     words.Unknown,
+			"ready":       words.Ready,
 			"unavailable": words.Unavailable,
-			"disclosure": words.Disclosure,
+			"disclosure":  words.Disclosure,
 		} {
 			if strings.TrimSpace(value) == "" {
 				t.Fatalf("empty comparison %s for %s", label, language.Code)

--- a/internal/desktop/file_filter_linux.go
+++ b/internal/desktop/file_filter_linux.go
@@ -84,10 +84,13 @@ func (u *linuxDesktop) fileFilterLabel(remote bool) string {
 
 func (u *linuxDesktop) renderFileFilterControls() error {
 	// Empty linuxUIResult notifications are used only to wake the established UI
-	// loop after recursive-search batches. Reconcile here, on the UI goroutine,
-	// before normal controls are drawn so search mode remains modal and normal
-	// row-indexed mutation controls never become enabled between batches.
+	// loop after recursive-search or comparison work. Reconcile on the UI
+	// goroutine before ordinary row-indexed controls are painted.
 	u.reconcileRecursiveSearchState()
+	u.reconcileDirectoryComparisonLinux()
+	if u.directoryComparisonActiveLinux() {
+		return u.renderDirectoryComparisonControlsLinux()
+	}
 	for _, remote := range []bool{false, true} {
 		if u.recursiveSearchActive(remote) {
 			if err := u.renderRecursiveSearchControls(remote); err != nil {
@@ -103,10 +106,13 @@ func (u *linuxDesktop) renderFileFilterControls() error {
 			return err
 		}
 	}
-	return nil
+	return u.renderDirectoryComparisonButtonLinux()
 }
 
 func (u *linuxDesktop) handleFileFilterMouse(x, y int) bool {
+	if u.handleDirectoryComparisonMouseLinux(x, y) {
+		return true
+	}
 	if u.handleRecursiveSearchMouse(x, y) {
 		return true
 	}
@@ -126,6 +132,9 @@ func (u *linuxDesktop) handleFileFilterMouse(x, y int) bool {
 }
 
 func (u *linuxDesktop) openFileFilterPrompt(remote bool) {
+	if u.directoryComparisonActiveLinux() {
+		return
+	}
 	state := u.fileFilterState()
 	if state == nil {
 		return
@@ -182,6 +191,9 @@ func restoreLinuxSelection(items []model.Item, name string) int {
 }
 
 func (u *linuxDesktop) applyLinuxFileFilter(remote bool, query string) {
+	if u.directoryComparisonActiveLinux() {
+		return
+	}
 	state := u.fileFilterState()
 	if state == nil {
 		return

--- a/internal/desktop/workspace_layout_windows.go
+++ b/internal/desktop/workspace_layout_windows.go
@@ -55,9 +55,10 @@ func showControls(show bool, controls ...uintptr) {
 
 // refineWorkspaceLayout applies visibility and native-theme rules to the
 // canonical workspace. Geometry remains owned by app.layout, followed by the
-// idempotent application-sidebar, file-filter and recursive-search transforms.
-// Importantly this function does not invalidate the entire parent window:
-// MoveWindow and the individual owner-drawn controls repaint only changed bounds.
+// idempotent application-sidebar, file-filter, recursive-search and comparison
+// transforms. Importantly this function does not invalidate the entire parent
+// window: MoveWindow and the individual owner-drawn controls repaint only
+// changed bounds.
 func (a *app) refineWorkspaceLayout() {
 	if a == nil || a.hwnd == 0 {
 		return
@@ -81,6 +82,8 @@ func (a *app) refineWorkspaceLayout() {
 	a.ensureRecursiveSearchControls()
 	a.layoutRecursiveSearchControls()
 	a.updateRecursiveSearchControls()
+	a.ensureDirectoryComparisonControls()
+	a.layoutDirectoryComparisonControls()
 	a.layoutQueuePriorityControls()
 	applyFileColumnOrder(a.localList, false)
 	applyFileColumnOrder(a.remoteList, true)

--- a/internal/directorycompare/compare.go
+++ b/internal/directorycompare/compare.go
@@ -28,39 +28,31 @@ type Options struct {
 }
 
 type Entry struct {
-	Name      string
-	Status    Status
-	Local     model.Item
-	Remote    model.Item
-	HasLocal  bool
-	HasRemote bool
+	Name      string     `json:"name"`
+	Status    Status     `json:"status"`
+	Local     model.Item `json:"local"`
+	Remote    model.Item `json:"remote"`
+	HasLocal  bool       `json:"hasLocal"`
+	HasRemote bool       `json:"hasRemote"`
 }
 
-func NormalizeOptions(in Options) (Options, error) {
-	if in.TimestampTolerance < 0 {
-		return Options{}, errors.New("directory comparison timestamp tolerance must not be negative")
+func NormalizeOptions(opts Options) (Options, error) {
+	if opts.TimestampTolerance == 0 {
+		opts.TimestampTolerance = DefaultTimestampTolerance
 	}
-	if in.TimestampTolerance == 0 {
-		in.TimestampTolerance = DefaultTimestampTolerance
+	if opts.TimestampTolerance < 0 || opts.TimestampTolerance > MaxTimestampTolerance {
+		return Options{}, errors.New("directory comparison timestamp tolerance is outside the safe range")
 	}
-	if in.TimestampTolerance > MaxTimestampTolerance {
-		return Options{}, errors.New("directory comparison timestamp tolerance is too large")
-	}
-	return in, nil
+	return opts, nil
 }
 
-// Compare classifies one local and one remote directory snapshot without
-// performing I/O or mutating either input. Names are matched exactly: silently
-// folding case would be unsafe when one side is case-sensitive and can contain
-// both "File" and "file".
-func Compare(local, remote []model.Item, in Options) ([]Entry, error) {
-	opts, err := NormalizeOptions(in)
+func Compare(local, remote []model.Item, opts Options) ([]Entry, error) {
+	opts, err := NormalizeOptions(opts)
 	if err != nil {
 		return nil, err
 	}
-
-	localByName := groupByName(local)
-	remoteByName := groupByName(remote)
+	localByName := groupByExactName(local)
+	remoteByName := groupByExactName(remote)
 	names := make([]string, 0, len(localByName)+len(remoteByName))
 	seen := make(map[string]struct{}, len(localByName)+len(remoteByName))
 	for name := range localByName {
@@ -75,47 +67,40 @@ func Compare(local, remote []model.Item, in Options) ([]Entry, error) {
 	}
 	sort.Strings(names)
 
-	out := make([]Entry, 0, len(names))
+	entries := make([]Entry, 0, len(names))
 	for _, name := range names {
 		locals := localByName[name]
 		remotes := remoteByName[name]
-		entry := Entry{Name: name, HasLocal: len(locals) > 0, HasRemote: len(remotes) > 0}
+		entry := Entry{Name: name}
 		if len(locals) > 0 {
 			entry.Local = locals[0]
+			entry.HasLocal = true
 		}
 		if len(remotes) > 0 {
 			entry.Remote = remotes[0]
+			entry.HasRemote = true
 		}
-
 		switch {
 		case len(locals) > 1 || len(remotes) > 1:
 			entry.Status = StatusConflict
 		case len(locals) == 0:
-			if entry.Remote.IsSymlink {
-				entry.Status = StatusUnknown
-			} else {
-				entry.Status = StatusRemoteOnly
-			}
+			entry.Status = StatusRemoteOnly
 		case len(remotes) == 0:
-			if entry.Local.IsSymlink {
-				entry.Status = StatusUnknown
-			} else {
-				entry.Status = StatusLocalOnly
-			}
+			entry.Status = StatusLocalOnly
 		default:
-			entry.Status = classifyPair(entry.Local, entry.Remote, opts.TimestampTolerance)
+			entry.Status = classifyPair(locals[0], remotes[0], opts.TimestampTolerance)
 		}
-		out = append(out, entry)
+		entries = append(entries, entry)
 	}
-	return out, nil
+	return entries, nil
 }
 
-func groupByName(items []model.Item) map[string][]model.Item {
-	groups := make(map[string][]model.Item, len(items))
+func groupByExactName(items []model.Item) map[string][]model.Item {
+	grouped := make(map[string][]model.Item, len(items))
 	for _, item := range items {
-		groups[item.Name] = append(groups[item.Name], item)
+		grouped[item.Name] = append(grouped[item.Name], item)
 	}
-	return groups
+	return grouped
 }
 
 func classifyPair(local, remote model.Item, tolerance time.Duration) Status {
@@ -138,18 +123,28 @@ func classifyPair(local, remote model.Item, tolerance time.Duration) Status {
 		return StatusUnknown
 	}
 
-	delta := local.Modified.Sub(remote.Modified)
-	if delta < 0 {
-		delta = -delta
-	}
-	if delta <= tolerance {
-		if local.Size == remote.Size {
-			return StatusSame
+	// time.Time.Sub saturates at the duration limits for very distant dates.
+	// Always subtract newer from older directionally so no absolute-value
+	// negation can overflow the minimum duration and falsely look "within"
+	// tolerance.
+	if local.Modified.After(remote.Modified) {
+		if local.Modified.Sub(remote.Modified) > tolerance {
+			return StatusNewerLocal
 		}
+	} else if remote.Modified.After(local.Modified) {
+		if remote.Modified.Sub(local.Modified) > tolerance {
+			return StatusNewerRemote
+		}
+	}
+
+	if local.Size != remote.Size {
 		return StatusConflict
 	}
-	if local.Modified.After(remote.Modified) {
-		return StatusNewerLocal
+	// model.Item currently cannot distinguish a verified zero-byte remote file
+	// from a listing whose size fact was absent/malformed and therefore decoded
+	// to the zero value. Do not let that ambiguity manufacture StatusSame.
+	if local.Size == 0 {
+		return StatusUnknown
 	}
-	return StatusNewerRemote
+	return StatusSame
 }

--- a/internal/directorycompare/compare.go
+++ b/internal/directorycompare/compare.go
@@ -1,0 +1,155 @@
+package directorycompare
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+type Status string
+
+const (
+	StatusSame        Status = "same"
+	StatusLocalOnly   Status = "local_only"
+	StatusRemoteOnly  Status = "remote_only"
+	StatusNewerLocal  Status = "newer_local"
+	StatusNewerRemote Status = "newer_remote"
+	StatusConflict    Status = "conflict"
+	StatusUnknown     Status = "unknown"
+
+	DefaultTimestampTolerance = 2 * time.Second
+	MaxTimestampTolerance     = 5 * time.Minute
+)
+
+type Options struct {
+	TimestampTolerance time.Duration
+}
+
+type Entry struct {
+	Name      string
+	Status    Status
+	Local     model.Item
+	Remote    model.Item
+	HasLocal  bool
+	HasRemote bool
+}
+
+func NormalizeOptions(in Options) (Options, error) {
+	if in.TimestampTolerance < 0 {
+		return Options{}, errors.New("directory comparison timestamp tolerance must not be negative")
+	}
+	if in.TimestampTolerance == 0 {
+		in.TimestampTolerance = DefaultTimestampTolerance
+	}
+	if in.TimestampTolerance > MaxTimestampTolerance {
+		return Options{}, errors.New("directory comparison timestamp tolerance is too large")
+	}
+	return in, nil
+}
+
+// Compare classifies one local and one remote directory snapshot without
+// performing I/O or mutating either input. Names are matched exactly: silently
+// folding case would be unsafe when one side is case-sensitive and can contain
+// both "File" and "file".
+func Compare(local, remote []model.Item, in Options) ([]Entry, error) {
+	opts, err := NormalizeOptions(in)
+	if err != nil {
+		return nil, err
+	}
+
+	localByName := groupByName(local)
+	remoteByName := groupByName(remote)
+	names := make([]string, 0, len(localByName)+len(remoteByName))
+	seen := make(map[string]struct{}, len(localByName)+len(remoteByName))
+	for name := range localByName {
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for name := range remoteByName {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]Entry, 0, len(names))
+	for _, name := range names {
+		locals := localByName[name]
+		remotes := remoteByName[name]
+		entry := Entry{Name: name, HasLocal: len(locals) > 0, HasRemote: len(remotes) > 0}
+		if len(locals) > 0 {
+			entry.Local = locals[0]
+		}
+		if len(remotes) > 0 {
+			entry.Remote = remotes[0]
+		}
+
+		switch {
+		case len(locals) > 1 || len(remotes) > 1:
+			entry.Status = StatusConflict
+		case len(locals) == 0:
+			if entry.Remote.IsSymlink {
+				entry.Status = StatusUnknown
+			} else {
+				entry.Status = StatusRemoteOnly
+			}
+		case len(remotes) == 0:
+			if entry.Local.IsSymlink {
+				entry.Status = StatusUnknown
+			} else {
+				entry.Status = StatusLocalOnly
+			}
+		default:
+			entry.Status = classifyPair(entry.Local, entry.Remote, opts.TimestampTolerance)
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func groupByName(items []model.Item) map[string][]model.Item {
+	groups := make(map[string][]model.Item, len(items))
+	for _, item := range items {
+		groups[item.Name] = append(groups[item.Name], item)
+	}
+	return groups
+}
+
+func classifyPair(local, remote model.Item, tolerance time.Duration) Status {
+	if local.IsSymlink || remote.IsSymlink {
+		return StatusUnknown
+	}
+	if local.IsDirectory != remote.IsDirectory {
+		return StatusConflict
+	}
+	if local.IsDirectory {
+		return StatusSame
+	}
+
+	localTimeKnown := !local.Modified.IsZero()
+	remoteTimeKnown := !remote.Modified.IsZero()
+	if !localTimeKnown || !remoteTimeKnown {
+		if local.Size != remote.Size {
+			return StatusConflict
+		}
+		return StatusUnknown
+	}
+
+	delta := local.Modified.Sub(remote.Modified)
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta <= tolerance {
+		if local.Size == remote.Size {
+			return StatusSame
+		}
+		return StatusConflict
+	}
+	if local.Modified.After(remote.Modified) {
+		return StatusNewerLocal
+	}
+	return StatusNewerRemote
+}

--- a/internal/directorycompare/compare_test.go
+++ b/internal/directorycompare/compare_test.go
@@ -128,6 +128,49 @@ func TestCompareTimestampToleranceAndNewerDirection(t *testing.T) {
 	}
 }
 
+func TestCompareVeryDistantTimestampsDoNotOverflowTolerance(t *testing.T) {
+	ancient := time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)
+	future := time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name       string
+		localTime  time.Time
+		remoteTime time.Time
+		want       Status
+	}{
+		{"remote far newer", ancient, future, StatusNewerRemote},
+		{"local far newer", future, ancient, StatusNewerLocal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Compare(
+				[]model.Item{item("a.txt", 10, tc.localTime)},
+				[]model.Item{item("a.txt", 10, tc.remoteTime)},
+				Options{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 || got[0].Status != tc.want {
+				t.Fatalf("got=%+v want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareZeroBytePairWithCloseKnownTimesStaysUnknown(t *testing.T) {
+	base := time.Date(2026, 9, 10, 1, 0, 0, 0, time.UTC)
+	got, err := Compare(
+		[]model.Item{item("empty.txt", 0, base)},
+		[]model.Item{item("empty.txt", 0, base.Add(time.Second))},
+		Options{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Status != StatusUnknown {
+		t.Fatalf("got=%+v want=%q", got, StatusUnknown)
+	}
+}
+
 func TestCompareSymlinkAndTypeMismatchAreNeverSame(t *testing.T) {
 	got, err := Compare(
 		[]model.Item{

--- a/internal/directorycompare/compare_test.go
+++ b/internal/directorycompare/compare_test.go
@@ -1,0 +1,195 @@
+package directorycompare
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func item(name string, size int64, modified time.Time) model.Item {
+	return model.Item{Name: name, Size: size, Modified: modified}
+}
+
+func TestCompareClassifiesPresenceAndStableOrdering(t *testing.T) {
+	local := []model.Item{
+		{Name: "z-local", Size: 1},
+		{Name: "shared", IsDirectory: true},
+	}
+	remote := []model.Item{
+		{Name: "a-remote", Size: 2},
+		{Name: "shared", IsDirectory: true},
+	}
+
+	got, err := Compare(local, remote, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []struct {
+		name   string
+		status Status
+	}{
+		{"a-remote", StatusRemoteOnly},
+		{"shared", StatusSame},
+		{"z-local", StatusLocalOnly},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entries=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Name != want[i].name || got[i].Status != want[i].status {
+			t.Fatalf("entry[%d]=%q/%q want %q/%q", i, got[i].Name, got[i].Status, want[i].name, want[i].status)
+		}
+	}
+}
+
+func TestCompareUsesExactNamesWithoutCaseFolding(t *testing.T) {
+	got, err := Compare(
+		[]model.Item{{Name: "File.txt", Size: 1}},
+		[]model.Item{{Name: "file.txt", Size: 1}},
+		Options{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entries=%d want=2", len(got))
+	}
+	if got[0].Name != "File.txt" || got[0].Status != StatusLocalOnly {
+		t.Fatalf("first=%+v", got[0])
+	}
+	if got[1].Name != "file.txt" || got[1].Status != StatusRemoteOnly {
+		t.Fatalf("second=%+v", got[1])
+	}
+}
+
+func TestCompareTreatsUnknownTimestampsConservatively(t *testing.T) {
+	known := time.Date(2026, 9, 10, 1, 2, 3, 0, time.UTC)
+	tests := []struct {
+		name       string
+		localSize  int64
+		remoteSize int64
+		localTime  time.Time
+		remoteTime time.Time
+		want       Status
+	}{
+		{"same size remote time unknown", 10, 10, known, time.Time{}, StatusUnknown},
+		{"same size both times unknown", 10, 10, time.Time{}, time.Time{}, StatusUnknown},
+		{"different size remote time unknown", 10, 20, known, time.Time{}, StatusConflict},
+		{"different size both times unknown", 10, 20, time.Time{}, time.Time{}, StatusConflict},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Compare(
+				[]model.Item{item("a.txt", tc.localSize, tc.localTime)},
+				[]model.Item{item("a.txt", tc.remoteSize, tc.remoteTime)},
+				Options{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 || got[0].Status != tc.want {
+				t.Fatalf("got=%+v want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareTimestampToleranceAndNewerDirection(t *testing.T) {
+	base := time.Date(2026, 9, 10, 1, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		localSize  int64
+		remoteSize int64
+		localTime  time.Time
+		remoteTime time.Time
+		want       Status
+	}{
+		{"same metadata within tolerance", 10, 10, base.Add(time.Second), base, StatusSame},
+		{"size conflict within tolerance", 10, 20, base.Add(time.Second), base, StatusConflict},
+		{"local newer beyond tolerance", 10, 20, base.Add(3 * time.Second), base, StatusNewerLocal},
+		{"remote newer beyond tolerance", 10, 10, base, base.Add(3 * time.Second), StatusNewerRemote},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Compare(
+				[]model.Item{item("a.txt", tc.localSize, tc.localTime)},
+				[]model.Item{item("a.txt", tc.remoteSize, tc.remoteTime)},
+				Options{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 || got[0].Status != tc.want {
+				t.Fatalf("got=%+v want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareSymlinkAndTypeMismatchAreNeverSame(t *testing.T) {
+	got, err := Compare(
+		[]model.Item{
+			{Name: "link", IsSymlink: true},
+			{Name: "type", IsDirectory: true},
+		},
+		[]model.Item{
+			{Name: "link", IsSymlink: true},
+			{Name: "type", IsDirectory: false},
+		},
+		Options{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Status != StatusUnknown {
+		t.Fatalf("symlink status=%q", got[0].Status)
+	}
+	if got[1].Status != StatusConflict {
+		t.Fatalf("type mismatch status=%q", got[1].Status)
+	}
+}
+
+func TestCompareDuplicateExactNamesFailClosedToConflict(t *testing.T) {
+	got, err := Compare(
+		[]model.Item{{Name: "dup"}, {Name: "dup"}},
+		[]model.Item{{Name: "dup"}},
+		Options{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Status != StatusConflict {
+		t.Fatalf("got=%+v", got)
+	}
+}
+
+func TestCompareDoesNotMutateInputs(t *testing.T) {
+	local := []model.Item{{Name: "b"}, {Name: "a"}}
+	remote := []model.Item{{Name: "c"}}
+	localBefore := append([]model.Item(nil), local...)
+	remoteBefore := append([]model.Item(nil), remote...)
+	if _, err := Compare(local, remote, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(local, localBefore) || !reflect.DeepEqual(remote, remoteBefore) {
+		t.Fatalf("inputs mutated: local=%+v remote=%+v", local, remote)
+	}
+}
+
+func TestNormalizeOptionsRejectsUnsafeTolerance(t *testing.T) {
+	if _, err := NormalizeOptions(Options{TimestampTolerance: -time.Second}); err == nil {
+		t.Fatal("negative tolerance accepted")
+	}
+	if _, err := NormalizeOptions(Options{TimestampTolerance: MaxTimestampTolerance + time.Second}); err == nil {
+		t.Fatal("oversized tolerance accepted")
+	}
+	got, err := NormalizeOptions(Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TimestampTolerance != DefaultTimestampTolerance {
+		t.Fatalf("default tolerance=%s", got.TimestampTolerance)
+	}
+}

--- a/internal/directorycompare/sync.go
+++ b/internal/directorycompare/sync.go
@@ -1,0 +1,24 @@
+package directorycompare
+
+// SynchronizedDirectoryName returns the exact child name only when comparison
+// proves that both snapshots contain the same ordinary directory entry. The
+// caller still owns platform/protocol-specific safe path resolution and fresh
+// listing. This helper deliberately provides no transfer or mutation action.
+func SynchronizedDirectoryName(entries []Entry, name string) (string, bool) {
+	for _, entry := range entries {
+		if entry.Name != name {
+			continue
+		}
+		if entry.Status != StatusSame || !entry.HasLocal || !entry.HasRemote {
+			return "", false
+		}
+		if !entry.Local.IsDirectory || !entry.Remote.IsDirectory {
+			return "", false
+		}
+		if entry.Local.IsSymlink || entry.Remote.IsSymlink {
+			return "", false
+		}
+		return entry.Name, true
+	}
+	return "", false
+}

--- a/internal/directorycompare/sync_test.go
+++ b/internal/directorycompare/sync_test.go
@@ -1,0 +1,67 @@
+package directorycompare
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestSynchronizedDirectoryNameRequiresSafePairedDirectory(t *testing.T) {
+	entry := Entry{
+		Name:      "public_html",
+		Status:    StatusSame,
+		HasLocal:  true,
+		HasRemote: true,
+		Local:     model.Item{Name: "public_html", IsDirectory: true},
+		Remote:    model.Item{Name: "public_html", IsDirectory: true},
+	}
+	if got, ok := SynchronizedDirectoryName([]Entry{entry}, "public_html"); !ok || got != "public_html" {
+		t.Fatalf("got=%q ok=%v", got, ok)
+	}
+}
+
+func TestSynchronizedDirectoryNameFailsClosedForAmbiguousStates(t *testing.T) {
+	base := Entry{
+		Name:      "folder",
+		Status:    StatusSame,
+		HasLocal:  true,
+		HasRemote: true,
+		Local:     model.Item{Name: "folder", IsDirectory: true},
+		Remote:    model.Item{Name: "folder", IsDirectory: true},
+	}
+	tests := []struct {
+		name string
+		edit func(*Entry)
+	}{
+		{"missing local", func(e *Entry) { e.HasLocal = false }},
+		{"missing remote", func(e *Entry) { e.HasRemote = false }},
+		{"conflict", func(e *Entry) { e.Status = StatusConflict }},
+		{"local file", func(e *Entry) { e.Local.IsDirectory = false }},
+		{"remote file", func(e *Entry) { e.Remote.IsDirectory = false }},
+		{"local symlink", func(e *Entry) { e.Local.IsSymlink = true }},
+		{"remote symlink", func(e *Entry) { e.Remote.IsSymlink = true }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := base
+			tc.edit(&entry)
+			if got, ok := SynchronizedDirectoryName([]Entry{entry}, "folder"); ok || got != "" {
+				t.Fatalf("got=%q ok=%v", got, ok)
+			}
+		})
+	}
+}
+
+func TestSynchronizedDirectoryNameUsesExactName(t *testing.T) {
+	entry := Entry{
+		Name:      "Folder",
+		Status:    StatusSame,
+		HasLocal:  true,
+		HasRemote: true,
+		Local:     model.Item{Name: "Folder", IsDirectory: true},
+		Remote:    model.Item{Name: "Folder", IsDirectory: true},
+	}
+	if got, ok := SynchronizedDirectoryName([]Entry{entry}, "folder"); ok || got != "" {
+		t.Fatalf("case-folded synchronization unexpectedly accepted: %q %v", got, ok)
+	}
+}

--- a/scripts/test_directory_comparison_contract.py
+++ b/scripts/test_directory_comparison_contract.py
@@ -1,0 +1,122 @@
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class DirectoryComparisonContractTests(unittest.TestCase):
+    def test_shared_comparator_is_conservative_and_read_only(self):
+        source = read("internal/directorycompare/compare.go")
+        for marker in (
+            'StatusSame        Status = "same"',
+            'StatusLocalOnly   Status = "local_only"',
+            'StatusRemoteOnly  Status = "remote_only"',
+            'StatusNewerLocal  Status = "newer_local"',
+            'StatusNewerRemote Status = "newer_remote"',
+            'StatusConflict    Status = "conflict"',
+            'StatusUnknown     Status = "unknown"',
+            "DefaultTimestampTolerance = 2 * time.Second",
+            "MaxTimestampTolerance     = 5 * time.Minute",
+            "case len(locals) > 1 || len(remotes) > 1:",
+            "if local.IsSymlink || remote.IsSymlink",
+            "if local.IsDirectory != remote.IsDirectory",
+            "localTimeKnown := !local.Modified.IsZero()",
+            "remoteTimeKnown := !remote.Modified.IsZero()",
+        ):
+            self.assertIn(marker, source)
+        for forbidden in (".Upload(", ".Download(", ".Delete(", ".Rename(", ".Chmod("):
+            self.assertNotIn(forbidden, source)
+
+    def test_sync_resolver_requires_exact_paired_ordinary_directory(self):
+        source = read("internal/directorycompare/sync.go")
+        for marker in (
+            "if entry.Name != name",
+            "entry.Status != StatusSame || !entry.HasLocal || !entry.HasRemote",
+            "!entry.Local.IsDirectory || !entry.Remote.IsDirectory",
+            "entry.Local.IsSymlink || entry.Remote.IsSymlink",
+        ):
+            self.assertIn(marker, source)
+
+    def test_engine_facade_keeps_comparison_pure(self):
+        source = read("internal/api/directory_compare.go")
+        self.assertIn("func (e *Engine) CompareDirectoryItems", source)
+        self.assertIn("return directorycompare.Compare(local, remote, opts)", source)
+        self.assertIn("func (e *Engine) SynchronizedDirectoryName", source)
+        self.assertIn("return directorycompare.SynchronizedDirectoryName(entries, name)", source)
+
+    def test_windows_uses_dedicated_read_only_surface_and_safe_sync_navigation(self):
+        controller = read("internal/desktop/directory_compare_windows.go")
+        commands = read("internal/desktop/commands_windows.go")
+        action_state = read("internal/desktop/action_state_windows.go")
+        layout = read("internal/desktop/workspace_layout_windows.go")
+
+        for marker in (
+            'wstr("BUTTON")',
+            "bsOwnerDraw",
+            'wstr("SysListView32")',
+            "state.localList = a.createDirectoryComparisonList",
+            "state.remoteList = a.createDirectoryComparisonList",
+            "security.SafeLocalChild(state.localBase, name)",
+            "security.ValidateRemoteName(name)",
+            "security.ValidateRemotePath(remoteTarget)",
+            "a.engine.SynchronizedDirectoryName(state.entries, entry.Name)",
+        ):
+            self.assertIn(marker, controller)
+        self.assertIn("case idDirectoryCompare:", commands)
+        self.assertIn("case idDirectoryCompareOpenBoth:", commands)
+        self.assertIn("comparisonActive := a.directoryComparisonActive()", action_state)
+        self.assertIn("!comparisonActive", action_state)
+        self.assertIn("a.ensureDirectoryComparisonControls()", layout)
+        self.assertIn("a.layoutDirectoryComparisonControls()", layout)
+
+        nav = controller.index("func (a *app) openComparedDirectoryBoth()")
+        local_list = controller.index("a.engine.LocalList(ctx, localTarget)", nav)
+        remote_list = controller.index("a.engine.RemoteList(ctx, remoteTarget)", nav)
+        local_commit = controller.index("a.localCurrent = localResolved", nav)
+        remote_commit = controller.index("a.remoteCurrent = remoteTarget", nav)
+        self.assertLess(local_list, remote_list)
+        self.assertLess(remote_list, local_commit)
+        self.assertLess(remote_list, remote_commit)
+
+    def test_linux_comparison_is_modal_and_commits_navigation_after_fresh_lists(self):
+        controller = read("internal/desktop/directory_compare_linux.go")
+        integration = read("internal/desktop/file_filter_linux.go")
+        for marker in (
+            "func (u *linuxDesktop) renderDirectoryComparisonButtonLinux()",
+            "func (u *linuxDesktop) handleDirectoryComparisonMouseLinux",
+            "u.busy = true",
+            "return true",
+            "security.SafeLocalChild(localBase, name)",
+            "security.ValidateRemoteName(name)",
+            "security.ValidateRemotePath(remoteTarget)",
+            "u.engine.SynchronizedDirectoryName(entries, entry.Name)",
+        ):
+            self.assertIn(marker, controller)
+        for marker in (
+            "u.reconcileDirectoryComparisonLinux()",
+            "u.renderDirectoryComparisonControlsLinux()",
+            "u.handleDirectoryComparisonMouseLinux(x, y)",
+        ):
+            self.assertIn(marker, integration)
+
+        nav = controller.index("func (u *linuxDesktop) openComparedDirectoryBothLinux()")
+        local_list = controller.index("u.engine.LocalList(ctx, localTarget)", nav)
+        remote_list = controller.index("u.engine.RemoteList(ctx, remoteTarget)", nav)
+        pending_commit = controller.index("state.navReady = true", nav)
+        self.assertLess(local_list, remote_list)
+        self.assertLess(remote_list, pending_commit)
+
+    def test_localization_covers_all_supported_languages(self):
+        words = read("internal/desktop/directory_compare_words.go")
+        tests = read("internal/desktop/directory_compare_words_test.go")
+        self.assertIn("directoryCompareTranslations", words)
+        self.assertIn("TestDirectoryCompareWordsCoverEverySupportedLanguage", tests)
+        self.assertIn("len(directoryCompareTranslations) != len(languages)", tests)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [x] This Unreleased source work continues the user's explicit request to improve Ghost FTP.
- [x] Published `ghostftp-v0.0.1` remains immutable and untouched.
- [x] No telemetry, analytics, advertising, hidden destination, external Go module or transport-trust relaxation is introduced.

## Current implementation stage

This PR develops the P0 **directory comparison + synchronized navigation** lane from exact post-merge-green `main` SHA `6ef353ab76fbea6441d72226e3fa4f2a8fd0af30`.

### Shared core added so far
- pure local/remote snapshot comparison with no filesystem/network I/O;
- exact-name matching to avoid unsafe cross-filesystem case folding;
- deterministic statuses: `same`, `local_only`, `remote_only`, `newer_local`, `newer_remote`, `conflict`, `unknown`;
- conservative timestamp policy: zero/unknown timestamps cannot produce `same` or `newer_*` for regular files;
- explicit two-second default timestamp tolerance with bounded override;
- type mismatch and duplicate exact names fail closed to `conflict`;
- symlinks fail closed to `unknown`;
- comparison never mutates input slices;
- shared synchronized-navigation policy returns a child name only for an exact paired non-symlink directory;
- typed Engine façade for comparison and synchronization policy.

### Metadata rationale
- FTP/FTPS MLSD can provide UTC modification timestamps to second precision.
- FTP LIST fallback and the current SFTP `ls -la` parser intentionally expose unknown/zero `Modified` values.
- The comparator therefore refuses to infer freshness when either side lacks a timestamp.

## Still required before ready/merge
- [ ] exact-head shared-core CI green;
- [ ] Windows comparison UI;
- [ ] Linux comparison UI;
- [ ] synchronized browsing wiring with ambiguity fail-closed behavior;
- [ ] localized UI/status strings for all 24 languages;
- [ ] static UI/source regression contract;
- [ ] roadmap/testing/changelog updates;
- [ ] authentic Windows screenshot gate;
- [ ] exact-head distro package/install lifecycle gate.

Comparison remains read-only. No automatic transfer, overwrite, rename, chmod or delete action may be introduced by this PR.