### PR TITLE
Docs: bind roadmap to Ghost FTP 0.0.2

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # Ghost FTP roadmap
 
-Ghost FTP **0.0.1** starts the current public release line. The roadmap prioritizes correctness, security, privacy, reliability, Windows/Linux parity and measured performance before broad new surface area. The objective is not to reproduce legacy FTP clients screen-for-screen; Ghost FTP should deliver a smaller, clearer and safer professional workflow while adding power-user capabilities only when their complete runtime path is production-ready.
+Ghost FTP **0.0.2** is the current source/release candidate. The roadmap prioritizes correctness, security, privacy, reliability, Windows/Linux parity and measured performance before broad new surface area. The objective is not to reproduce legacy FTP clients screen-for-screen; Ghost FTP should deliver a smaller, clearer and safer professional workflow while adding power-user capabilities only when their complete runtime path is production-ready.
 
-## Current 0.0.1 foundation
+## Current 0.0.2 foundation
 
 The current release gate includes:
 
@@ -16,6 +16,9 @@ The current release gate includes:
 - truthful transfer progress, speed and ETA;
 - built-in Remote Edit with bounded text handling, revision/conflict protection and verified save/read-back;
 - queue pause/resume/cancel/retry/clear-finished controls;
+- non-destructive current-folder filtering on both local and server panes;
+- bounded recursive local/server search with cancellation and fresh-list navigation;
+- conservative directory comparison and synchronized navigation for proven paired directories;
 - native Windows Setup/Portable packaging and Linux DEB/portable packaging;
 - 24-language local catalog with English default/fallback;
 - production race/vet/security/privacy/dependency/documentation audits;
@@ -39,15 +42,15 @@ The immediate 0.0.x hardening lane includes:
 9. Windows/Linux functional parity for file operations, queue state, shortcuts, settings and error handling;
 10. documentation and authentic real-application screenshots synchronized with exact maintained source.
 
-## 0.0.x work implemented after 0.0.1
+## 0.0.2 navigation work
 
-The maintained source includes a **non-destructive current-folder filter** for both local and server panes on Windows and Linux. It filters only entries already loaded into the pane, performs no filesystem or network scan while filtering, preserves an authoritative unfiltered snapshot, and gives row-indexed actions only the visible filtered slice. Empty input restores the complete snapshot without another listing request. The filter is localized for all 24 supported desktop languages.
+Ghost FTP 0.0.2 includes a **non-destructive current-folder filter** for both local and server panes on Windows and Linux. It filters only entries already loaded into the pane, performs no filesystem or network scan while filtering, preserves an authoritative unfiltered snapshot, and gives row-indexed actions only the visible filtered slice. Empty input restores the complete snapshot without another listing request. The filter is localized for all 24 supported desktop languages.
 
-The maintained source also includes a **bounded recursive local/server search** that is deliberately separate from the current-folder filter. Recursive search clearly discloses that it will read nested local or server folders, uses the same Unicode-aware matching semantics, incrementally presents bounded result batches, supports cancellation, never intentionally traverses symlink/reparse entries, and treats every result as an informational navigation hint rather than mutation authority. Local traversal is anchored to one `os.OpenRoot` capability; server traversal is bound to one captured remote operation/session. Activating a result performs a fresh listing of its parent and reselects the name only from that fresh listing.
+Ghost FTP 0.0.2 also includes a **bounded recursive local/server search** that is deliberately separate from the current-folder filter. Recursive search clearly discloses that it will read nested local or server folders, uses the same Unicode-aware matching semantics, incrementally presents bounded result batches, supports cancellation, never intentionally traverses symlink/reparse entries, and treats every result as an informational navigation hint rather than mutation authority. Local traversal is anchored to one `os.OpenRoot` capability; server traversal is bound to one captured remote operation/session. Activating a result performs a fresh listing of its parent and reselects the name only from that fresh listing.
 
-The maintained source now also includes **conservative directory comparison and synchronized navigation** on Windows and Linux. Comparison is read-only, uses exact-name matching, reports deterministic same/only/newer/conflict/unknown states, treats duplicate names and uncertain metadata fail-closed, and never treats a symlink comparison row as transfer authority. Synchronized navigation is available only for an exact ordinary directory proved present on both sides; both target directories are freshly listed and compared before either visible pane path is committed.
+Ghost FTP 0.0.2 also includes **conservative directory comparison and synchronized navigation** on Windows and Linux. Comparison is read-only, uses exact-name matching, reports deterministic same/only/newer/conflict/unknown states, treats duplicate names and uncertain metadata fail-closed, and never treats a symlink comparison row as transfer authority. Synchronized navigation is available only for an exact ordinary directory proved present on both sides; both target directories are freshly listed and compared before either visible pane path is committed.
 
-These capabilities remain part of the Unreleased source line until a successor release is published and verified; none rewrites or redefines the existing 0.0.1 release.
+These capabilities are part of the 0.0.2 source/release candidate and must remain bound to the exact 0.0.2 source revision that passes publication and retention verification.
 
 ## High-value power-user lane
 
@@ -55,7 +58,7 @@ These capabilities are prioritized because they improve real hosting/server work
 
 ### P0 — directory comparison and synchronized navigation
 
-**Status: implemented in the maintained Unreleased source line.** Windows and Linux expose the same shared comparison states while keeping comparison read-only and separate from ordinary file-operation authority.
+**Status: implemented in Ghost FTP 0.0.2.** Windows and Linux expose the same shared comparison states while keeping comparison read-only and separate from ordinary file-operation authority.
 
 Implemented contract:
 
@@ -75,7 +78,7 @@ Implemented contract:
 
 ### P0 — bounded recursive local/server search
 
-**Status: implemented in the maintained Unreleased source line.** The instant current-folder filter remains I/O-free; recursive search is a separate explicit action because it performs additional local/server listing work.
+**Status: implemented in Ghost FTP 0.0.2.** The instant current-folder filter remains I/O-free; recursive search is a separate explicit action because it performs additional local/server listing work.
 
 Implemented contract:
 

--- a/scripts/test_file_filter_ui_contract.py
+++ b/scripts/test_file_filter_ui_contract.py
@@ -136,13 +136,14 @@ class FileFilterUIContractTests(unittest.TestCase):
         self.assertNotIn("net.", shared)
 
     def test_active_docs_distinguish_filter_from_bounded_recursive_search(self) -> None:
+        version = source("VERSION").strip().lower()
         roadmap = source("docs/ROADMAP.md").lower()
         testing = source("docs/TESTING.md").lower()
         changelog_lines = [line.strip().lower() for line in source("CHANGELOG.md").splitlines()]
 
         self.assertIn("non-destructive current-folder filter", roadmap)
         self.assertIn("p0 — bounded recursive local/server search", roadmap)
-        self.assertIn("status: implemented in the maintained unreleased source line", roadmap)
+        self.assertIn(f"status: implemented in ghost ftp {version}", roadmap)
         self.assertIn("current-folder filter regression contract", testing)
         self.assertIn("deliberately separate from bounded recursive search", testing)
         self.assertIn("bounded recursive search regression contract", testing)

--- a/scripts/test_roadmap_version_contract.py
+++ b/scripts/test_roadmap_version_contract.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RoadmapVersionContractTests(unittest.TestCase):
+    def test_roadmap_tracks_current_version_and_shipped_navigation_status(self) -> None:
+        version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+        roadmap = (ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+
+        self.assertRegex(version, r"^0\.0\.[1-9]\d*$")
+        self.assertIn(f"Ghost FTP **{version}** is the current source/release candidate.", roadmap)
+        self.assertIn(f"## Current {version} foundation", roadmap)
+        self.assertIn(f"## {version} navigation work", roadmap)
+        self.assertIn(f"**Status: implemented in Ghost FTP {version}.**", roadmap)
+        self.assertNotIn("implemented in the maintained Unreleased source line", roadmap)
+        self.assertNotIn("These capabilities remain part of the Unreleased source line", roadmap)
+
+        current_markers = re.findall(r"Ghost FTP \*\*(\d+\.\d+\.\d+)\*\* is the current source/release candidate", roadmap)
+        self.assertEqual(current_markers, [version])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Close the final stale-version documentation gap discovered after the 0.0.2 release-prep merge.

- Bind `docs/ROADMAP.md` to current source/release candidate 0.0.2.
- Mark the current-folder filter, bounded recursive search, and conservative directory comparison/synchronized navigation as 0.0.2 capabilities instead of `Unreleased` work.
- Preserve planned status for capabilities that are not explicitly marked implemented.
- Add `scripts/test_roadmap_version_contract.py` so future `VERSION` bumps cannot leave the roadmap on an older current-version narrative.

No runtime, transport, filesystem, secret-handling, telemetry/privacy, packaging, signing, tag, or release-history behavior changes.

Merge only after all required exact-head workflows complete successfully. After merge, verify exact-main push workflows again before creating `release/ghostftp-v0.0.2`.