### PR TITLE
Queue priority: add Top and Bottom with queued-only stable ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-No unreleased changes are currently staged after 0.0.3 release preparation.
+### Queue priority and reordering
+
+- Completed four-way queued-transfer priority control with **Top**, **Up**, **Down** and **Bottom** actions through the shared transfer manager and Engine API.
+- Reordering rotates only queued scheduler slots, preserving running/terminal history positions, transfer IDs, connection bindings and the relative order of unaffected queued jobs.
+- Kept edge moves idempotent and event-free, while a real move emits one complete state snapshot without starting, retrying or cancelling transfer work as a side effect.
+- Added Windows and Linux controls with the same queued-only policy, ID-based selection restoration and local copy for all 24 supported desktop languages.
+- Added regression coverage for four-way ordering, non-queued slot stability, connection binding, tree-transfer directory-preparation ordering and cross-platform UI wiring.
+- This is post-0.0.3 source work for the next release; root `VERSION` and the already published `ghostftp-v0.0.3` release remain unchanged.
 
 ## 0.0.3 - 2026-09-10
 

--- a/docs/QUEUE-PRIORITY.md
+++ b/docs/QUEUE-PRIORITY.md
@@ -1,0 +1,93 @@
+# Ghost FTP queue priority and reordering
+
+Queue priority is implemented in the **post-0.0.3 source line** and is targeted for the next public release after the normal exact-head, post-merge and release-prep gates pass. It is not retroactively part of the already published Ghost FTP 0.0.3 release.
+
+## User contract
+
+A single selected transfer whose status is `queued` can be moved through four explicit actions:
+
+- **Top** — move to the first queued scheduler position;
+- **Move up** — move ahead of the nearest earlier queued transfer;
+- **Move down** — move behind the nearest later queued transfer;
+- **Bottom** — move to the final queued scheduler position.
+
+Running, completed, failed, cancelled and other non-queued jobs are not reorderable. At a queued boundary, Top/Up or Down/Bottom is an idempotent no-op rather than an error-producing state change.
+
+## Scheduler invariants
+
+`internal/transfer/queue_order.go` owns the scheduler mutation. The implementation builds the ordered list of slots currently occupied by `queued` jobs and rotates jobs only through those slots.
+
+For example:
+
+```text
+before: Q1, RUNNING, Q2, DONE, Q3
+action: Q3 -> Top
+after:  Q3, RUNNING, Q1, DONE, Q2
+```
+
+This gives the following fail-closed guarantees:
+
+- a running or terminal job keeps its exact list/history slot;
+- the selected queued job keeps the same transfer ID;
+- Top/Bottom preserves the relative order of every other queued job rather than swapping arbitrary endpoints;
+- `jobConnections` is not rewritten by reordering, so connection-generation/session ownership stays bound to transfer identity;
+- no new transfer is created, duplicated, retried, cancelled or started by a reorder action;
+- one successful reorder emits one complete `state` snapshot with the existing paused state;
+- an edge no-op emits no redundant queue event;
+- a closed manager, unknown transfer or non-queued transfer is rejected.
+
+Reordering is therefore a scheduler-order operation only. It does not mutate transfer payload paths, credentials, remote-session identity, conflict policy or transfer state.
+
+## Tree-transfer safety
+
+Directory-tree transfers prepare structural dependencies before their file jobs become runnable. Upload tree planning ensures required remote directories before `BatchReservation.Commit()`. Download tree planning prepares the safe local directory structure before the same queue commit boundary.
+
+Queue priority operates only on the resulting queued file-transfer jobs. It cannot move a file ahead of an unexecuted directory-creation queue job because those directory preparations are not represented as reorderable transfer jobs in this scheduler.
+
+## Engine API
+
+The desktop frontends use four bounded engine calls:
+
+```text
+MoveTransferTop(id)
+MoveTransferUp(id)
+MoveTransferDown(id)
+MoveTransferBottom(id)
+```
+
+Each delegates to the transfer manager's queued-only operation. No frontend edits the queue slice directly.
+
+## Windows behavior
+
+Windows renders four real owner-drawn controls beside the existing queue toolbar. Their enabled state is derived from the shared queued-only policy and connection-busy state. Commands route through the engine API, and refresh restores selection by transfer ID after the row changes position.
+
+The controls are localized through the same 24-language local catalog used by the existing Up/Down queue controls. They do not add a network service, telemetry path or hidden persistence layer.
+
+## Linux behavior
+
+Linux renders Top, Up, Down and Bottom controls using the same shared policy. Mouse actions call the same four engine operations, refresh from `Engine.Transfers()`, and restore the selected transfer by ID rather than stale row index.
+
+Running or otherwise non-queued selections expose no active priority action.
+
+## Interaction with pause, retry and connection lifecycle
+
+Queue priority does not call the transfer pump as a side effect. Existing pause/resume/cancel/retry behavior remains owned by the transfer manager and action-state layers.
+
+A reorder also does not rewrite `jobConnections`. If the active server connection changes, the existing generation/connection-identity protections remain authoritative; changing visual scheduler order cannot make stale queued work belong to a new session.
+
+## Regression coverage
+
+The maintained contract is protected by:
+
+- `internal/transfer/queue_order_test.go` — stable four-way queued ordering, running/terminal slot preservation, connection-binding preservation, edge idempotence, rejection behavior and state snapshots;
+- `internal/desktop/queue_priority_test.go` — shared single-selection/queued-only policy and all 24 translations;
+- `internal/desktop/queue_priority_linux_test.go` — Linux layout, queued-only state and ID-based selection restoration;
+- `scripts/test_queue_priority_contract.py` — engine/API/Windows/Linux wiring plus tree-transfer dependency ordering.
+
+Native Windows and Linux CI builds remain the compile/runtime gate for the platform-specific frontends. Because the maintained Windows UI changes, authentic Windows screenshot evidence is also required on the exact final PR head before merge.
+
+## Release boundary
+
+Root `VERSION` remains **0.0.3** during this feature work. The already published `ghostftp-v0.0.3` release must not be rewritten. Queue priority becomes a public release capability only after a later reviewed release-prep change advances the version and the complete publication/read-back/retention lifecycle succeeds.
+
+See [Roadmap](ROADMAP.md), [Testing](TESTING.md), [Architecture](ARCHITECTURE.md) and [Platform parity](PLATFORM-PARITY.md).

--- a/docs/QUEUE-PRIORITY.md
+++ b/docs/QUEUE-PRIORITY.md
@@ -40,7 +40,7 @@ Reordering is therefore a scheduler-order operation only. It does not mutate tra
 
 ## Tree-transfer safety
 
-Directory-tree transfers prepare structural dependencies before their file jobs become runnable. Upload tree planning ensures required remote directories before `BatchReservation.Commit()`. Download tree planning prepares the safe local directory structure before the same queue commit boundary.
+Directory-tree transfers prepare structural dependencies before their file jobs become runnable. Upload tree planning ensures required remote directories before the concrete `reservation.Commit()` call crosses the `BatchReservation.Commit()` boundary. Download tree planning prepares the safe local directory structure before the same queue commit boundary.
 
 Queue priority operates only on the resulting queued file-transfer jobs. It cannot move a file ahead of an unexecuted directory-creation queue job because those directory preparations are not represented as reorderable transfer jobs in this scheduler.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -109,15 +109,22 @@ Implemented contract:
 
 ### P0 — queue priority and reorder
 
-Add user-controlled queue priority/reordering while retaining connection-generation safety.
+**Status: implemented in the post-0.0.3 source line and targeted for the next public release.** This does not retroactively add the capability to the already published 0.0.3 binaries.
 
-Acceptance requirements:
+Implemented source contract:
 
-- reordering queued jobs never changes the identity of already-running work;
-- parent/child tree-transfer ordering remains valid;
-- selected jobs can move up/down/top/bottom without duplicate execution;
-- pause/resume/cancel/retry semantics remain deterministic;
-- queue ordering survives only where doing so cannot resurrect stale server work.
+- a single selected `queued` job can move **Top**, **Up**, **Down** or **Bottom** on Windows and Linux;
+- scheduler mutation rotates only slots occupied by queued jobs, so running and terminal jobs keep their exact history positions;
+- Top/Bottom preserves the relative order of all other queued jobs instead of swapping unrelated endpoints;
+- transfer IDs and `jobConnections` bindings are unchanged by reordering;
+- edge actions are idempotent no-ops and emit no redundant queue state event;
+- a real reorder emits one complete queue `state` snapshot and never starts/retries/cancels a transfer as a side effect;
+- directory-tree structural dependencies remain safe because remote/local directories are prepared before the batch of file jobs is committed to the runnable queue;
+- both desktop frontends restore selection by transfer ID after reordering rather than reusing a stale row index;
+- all four actions and success states have local copy for all 24 supported desktop languages;
+- `scripts/test_queue_priority_contract.py` and Go unit tests protect scheduler, connection-binding, tree-transfer, UI-wiring and localization invariants.
+
+See [Queue priority and reordering](QUEUE-PRIORITY.md) for the detailed source and release-boundary contract.
 
 ### P1 — navigation bookmarks and profile start directories
 
@@ -197,7 +204,7 @@ Security hardening should favor deterministic rejection and actionable errors ov
 
 Release security should improve publisher trust when a real certificate is available without weakening integrity verification or inventing trust when it is not.
 
-New productivity features must preserve the same trust model: search, compare, bandwidth, bookmarks, resume, multi-session and proxy functionality may not introduce hidden cloud state, telemetry or credential replication.
+New productivity features must preserve the same trust model: search, compare, bandwidth, queue priority, bookmarks, resume, multi-session and proxy functionality may not introduce hidden cloud state, telemetry or credential replication.
 
 ## macOS direction
 

--- a/internal/api/queue_order.go
+++ b/internal/api/queue_order.go
@@ -1,5 +1,11 @@
 package api
 
+// MoveTransferTop raises one queued transfer to the first queued scheduler
+// position. Running and terminal jobs keep their history slots.
+func (e *Engine) MoveTransferTop(id string) error {
+	return e.transfers.MoveQueuedTop(id)
+}
+
 // MoveTransferUp raises one queued transfer by one queued position. The
 // transfer manager rejects running, completed and unknown jobs.
 func (e *Engine) MoveTransferUp(id string) error {
@@ -10,4 +16,10 @@ func (e *Engine) MoveTransferUp(id string) error {
 // and terminal jobs keep their scheduler/history position.
 func (e *Engine) MoveTransferDown(id string) error {
 	return e.transfers.MoveQueuedDown(id)
+}
+
+// MoveTransferBottom lowers one queued transfer to the final queued scheduler
+// position without changing running or terminal history slots.
+func (e *Engine) MoveTransferBottom(id string) error {
+	return e.transfers.MoveQueuedBottom(id)
 }

--- a/internal/desktop/commands_windows.go
+++ b/internal/desktop/commands_windows.go
@@ -90,10 +90,14 @@ func (a *app) command(id int) {
 		a.retrySelectedTransfer()
 	case idClearQueue:
 		a.clearFinishedTransfers()
+	case idMoveQueueTop:
+		a.moveSelectedTransfer(queuePriorityTop)
 	case idMoveQueueUp:
-		a.moveSelectedTransfer(-1)
+		a.moveSelectedTransfer(queuePriorityUp)
 	case idMoveQueueDown:
-		a.moveSelectedTransfer(1)
+		a.moveSelectedTransfer(queuePriorityDown)
+	case idMoveQueueBottom:
+		a.moveSelectedTransfer(queuePriorityBottom)
 	case idRefreshAll:
 		a.refreshLocal(getText(a.localPath))
 		if a.connected {

--- a/internal/desktop/queue_priority.go
+++ b/internal/desktop/queue_priority.go
@@ -7,14 +7,25 @@ import (
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 )
 
+type queuePriorityAction int
+
+const (
+	queuePriorityTop queuePriorityAction = iota
+	queuePriorityUp
+	queuePriorityDown
+	queuePriorityBottom
+)
+
 type queuePriorityState struct {
-	MoveUp   bool
-	MoveDown bool
+	MoveTop    bool
+	MoveUp     bool
+	MoveDown   bool
+	MoveBottom bool
 }
 
 // deriveQueuePriorityState is shared by Windows and Linux. Reordering is
 // intentionally single-selection and queued-only; running and terminal jobs
-// are immutable from the priority controls.
+// are immutable from all priority controls.
 func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePriorityState {
 	if len(selected) != 1 {
 		return queuePriorityState{}
@@ -27,6 +38,7 @@ func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePri
 	state := queuePriorityState{}
 	for i := index - 1; i >= 0; i-- {
 		if jobs[i].Status == "queued" {
+			state.MoveTop = true
 			state.MoveUp = true
 			break
 		}
@@ -34,6 +46,7 @@ func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePri
 	for i := index + 1; i < len(jobs); i++ {
 		if jobs[i].Status == "queued" {
 			state.MoveDown = true
+			state.MoveBottom = true
 			break
 		}
 	}
@@ -41,37 +54,41 @@ func deriveQueuePriorityState(jobs []model.TransferJob, selected []int) queuePri
 }
 
 type queuePriorityText struct {
-	MoveUp    string
-	MoveDown  string
-	MovedUp   string
-	MovedDown string
+	MoveTop     string
+	MoveUp      string
+	MoveDown    string
+	MoveBottom  string
+	MovedTop    string
+	MovedUp     string
+	MovedDown   string
+	MovedBottom string
 }
 
 var queuePriorityTranslations = map[string]queuePriorityText{
-	"en": {"Move up", "Move down", "Transfer moved up.", "Transfer moved down."},
-	"hr": {"Pomakni gore", "Pomakni dolje", "Prijenos je pomaknut gore.", "Prijenos je pomaknut dolje."},
-	"de": {"Nach oben", "Nach unten", "Übertragung nach oben verschoben.", "Übertragung nach unten verschoben."},
-	"fr": {"Monter", "Descendre", "Transfert déplacé vers le haut.", "Transfert déplacé vers le bas."},
-	"es": {"Subir", "Bajar", "Transferencia movida hacia arriba.", "Transferencia movida hacia abajo."},
-	"tr": {"Yukarı taşı", "Aşağı taşı", "Aktarım yukarı taşındı.", "Aktarım aşağı taşındı."},
-	"el": {"Μετακίνηση πάνω", "Μετακίνηση κάτω", "Η μεταφορά μετακινήθηκε πάνω.", "Η μεταφορά μετακινήθηκε κάτω."},
-	"pt": {"Mover para cima", "Mover para baixo", "Transferência movida para cima.", "Transferência movida para baixo."},
-	"zh": {"上移", "下移", "传输已上移。", "传输已下移。"},
-	"ru": {"Переместить вверх", "Переместить вниз", "Передача перемещена вверх.", "Передача перемещена вниз."},
-	"hi": {"ऊपर ले जाएँ", "नीचे ले जाएँ", "स्थानांतरण ऊपर ले जाया गया।", "स्थानांतरण नीचे ले जाया गया।"},
-	"ja": {"上へ移動", "下へ移動", "転送を上へ移動しました。", "転送を下へ移動しました。"},
-	"it": {"Sposta su", "Sposta giù", "Trasferimento spostato in alto.", "Trasferimento spostato in basso."},
-	"pl": {"Przenieś wyżej", "Przenieś niżej", "Transfer przeniesiono wyżej.", "Transfer przeniesiono niżej."},
-	"nl": {"Omhoog", "Omlaag", "Overdracht omhoog verplaatst.", "Overdracht omlaag verplaatst."},
-	"cs": {"Posunout nahoru", "Posunout dolů", "Přenos byl posunut nahoru.", "Přenos byl posunut dolů."},
-	"uk": {"Перемістити вгору", "Перемістити вниз", "Передачу переміщено вгору.", "Передачу переміщено вниз."},
-	"sv": {"Flytta upp", "Flytta ner", "Överföringen flyttades upp.", "Överföringen flyttades ner."},
-	"ro": {"Mută în sus", "Mută în jos", "Transferul a fost mutat în sus.", "Transferul a fost mutat în jos."},
-	"hu": {"Mozgatás fel", "Mozgatás le", "Az átvitel feljebb került.", "Az átvitel lejjebb került."},
-	"da": {"Flyt op", "Flyt ned", "Overførslen blev flyttet op.", "Overførslen blev flyttet ned."},
-	"fi": {"Siirrä ylös", "Siirrä alas", "Siirto siirrettiin ylöspäin.", "Siirto siirrettiin alaspäin."},
-	"no": {"Flytt opp", "Flytt ned", "Overføringen ble flyttet opp.", "Overføringen ble flyttet ned."},
-	"ko": {"위로 이동", "아래로 이동", "전송을 위로 이동했습니다.", "전송을 아래로 이동했습니다."},
+	"en": {"Top", "Move up", "Move down", "Bottom", "Transfer moved to top.", "Transfer moved up.", "Transfer moved down.", "Transfer moved to bottom."},
+	"hr": {"Na vrh", "Pomakni gore", "Pomakni dolje", "Na dno", "Prijenos je pomaknut na vrh.", "Prijenos je pomaknut gore.", "Prijenos je pomaknut dolje.", "Prijenos je pomaknut na dno."},
+	"de": {"Ganz nach oben", "Nach oben", "Nach unten", "Ganz nach unten", "Übertragung ganz nach oben verschoben.", "Übertragung nach oben verschoben.", "Übertragung nach unten verschoben.", "Übertragung ganz nach unten verschoben."},
+	"fr": {"Tout en haut", "Monter", "Descendre", "Tout en bas", "Transfert déplacé tout en haut.", "Transfert déplacé vers le haut.", "Transfert déplacé vers le bas.", "Transfert déplacé tout en bas."},
+	"es": {"Al inicio", "Subir", "Bajar", "Al final", "Transferencia movida al inicio.", "Transferencia movida hacia arriba.", "Transferencia movida hacia abajo.", "Transferencia movida al final."},
+	"tr": {"En üste", "Yukarı taşı", "Aşağı taşı", "En alta", "Aktarım en üste taşındı.", "Aktarım yukarı taşındı.", "Aktarım aşağı taşındı.", "Aktarım en alta taşındı."},
+	"el": {"Στην κορυφή", "Μετακίνηση πάνω", "Μετακίνηση κάτω", "Στο τέλος", "Η μεταφορά μετακινήθηκε στην κορυφή.", "Η μεταφορά μετακινήθηκε πάνω.", "Η μεταφορά μετακινήθηκε κάτω.", "Η μεταφορά μετακινήθηκε στο τέλος."},
+	"pt": {"Para o topo", "Mover para cima", "Mover para baixo", "Para o fim", "Transferência movida para o topo.", "Transferência movida para cima.", "Transferência movida para baixo.", "Transferência movida para o fim."},
+	"zh": {"移到顶部", "上移", "下移", "移到底部", "传输已移到顶部。", "传输已上移。", "传输已下移。", "传输已移到底部。"},
+	"ru": {"В начало", "Переместить вверх", "Переместить вниз", "В конец", "Передача перемещена в начало.", "Передача перемещена вверх.", "Передача перемещена вниз.", "Передача перемещена в конец."},
+	"hi": {"सबसे ऊपर", "ऊपर ले जाएँ", "नीचे ले जाएँ", "सबसे नीचे", "स्थानांतरण सबसे ऊपर ले जाया गया।", "स्थानांतरण ऊपर ले जाया गया।", "स्थानांतरण नीचे ले जाया गया।", "स्थानांतरण सबसे नीचे ले जाया गया।"},
+	"ja": {"先頭へ", "上へ移動", "下へ移動", "末尾へ", "転送を先頭へ移動しました。", "転送を上へ移動しました。", "転送を下へ移動しました。", "転送を末尾へ移動しました。"},
+	"it": {"In cima", "Sposta su", "Sposta giù", "In fondo", "Trasferimento spostato in cima.", "Trasferimento spostato in alto.", "Trasferimento spostato in basso.", "Trasferimento spostato in fondo."},
+	"pl": {"Na początek", "Przenieś wyżej", "Przenieś niżej", "Na koniec", "Transfer przeniesiono na początek.", "Transfer przeniesiono wyżej.", "Transfer przeniesiono niżej.", "Transfer przeniesiono na koniec."},
+	"nl": {"Naar bovenaan", "Omhoog", "Omlaag", "Naar onderaan", "Overdracht naar bovenaan verplaatst.", "Overdracht omhoog verplaatst.", "Overdracht omlaag verplaatst.", "Overdracht naar onderaan verplaatst."},
+	"cs": {"Na začátek", "Posunout nahoru", "Posunout dolů", "Na konec", "Přenos byl přesunut na začátek.", "Přenos byl posunut nahoru.", "Přenos byl posunut dolů.", "Přenos byl přesunut na konec."},
+	"uk": {"На початок", "Перемістити вгору", "Перемістити вниз", "У кінець", "Передачу переміщено на початок.", "Передачу переміщено вгору.", "Передачу переміщено вниз.", "Передачу переміщено в кінець."},
+	"sv": {"Överst", "Flytta upp", "Flytta ner", "Nederst", "Överföringen flyttades överst.", "Överföringen flyttades upp.", "Överföringen flyttades ner.", "Överföringen flyttades nederst."},
+	"ro": {"La început", "Mută în sus", "Mută în jos", "La sfârșit", "Transferul a fost mutat la început.", "Transferul a fost mutat în sus.", "Transferul a fost mutat în jos.", "Transferul a fost mutat la sfârșit."},
+	"hu": {"Legfelülre", "Mozgatás fel", "Mozgatás le", "Legalulra", "Az átvitel a sor elejére került.", "Az átvitel feljebb került.", "Az átvitel lejjebb került.", "Az átvitel a sor végére került."},
+	"da": {"Øverst", "Flyt op", "Flyt ned", "Nederst", "Overførslen blev flyttet øverst.", "Overførslen blev flyttet op.", "Overførslen blev flyttet ned.", "Overførslen blev flyttet nederst."},
+	"fi": {"Ylimmäksi", "Siirrä ylös", "Siirrä alas", "Alimmaksi", "Siirto siirrettiin ylimmäksi.", "Siirto siirrettiin ylöspäin.", "Siirto siirrettiin alaspäin.", "Siirto siirrettiin alimmaksi."},
+	"no": {"Øverst", "Flytt opp", "Flytt ned", "Nederst", "Overføringen ble flyttet øverst.", "Overføringen ble flyttet opp.", "Overføringen ble flyttet ned.", "Overføringen ble flyttet nederst."},
+	"ko": {"맨 위로", "위로 이동", "아래로 이동", "맨 아래로", "전송을 맨 위로 이동했습니다.", "전송을 위로 이동했습니다.", "전송을 아래로 이동했습니다.", "전송을 맨 아래로 이동했습니다."},
 }
 
 func queuePriorityWords(language string) queuePriorityText {

--- a/internal/desktop/queue_priority_linux.go
+++ b/internal/desktop/queue_priority_linux.go
@@ -8,16 +8,20 @@ import (
 )
 
 const (
-	linuxQueuePriorityGap       = 8
-	linuxQueuePriorityUpWidth   = 96
-	linuxQueuePriorityDownWidth = 112
+	linuxQueuePriorityGap         = 6
+	linuxQueuePriorityTopWidth    = 82
+	linuxQueuePriorityUpWidth     = 92
+	linuxQueuePriorityDownWidth   = 104
+	linuxQueuePriorityBottomWidth = 88
 )
 
-func (u *linuxDesktop) queuePriorityRects() (linuxRect, linuxRect) {
+func (u *linuxDesktop) queuePriorityRects() (linuxRect, linuxRect, linuxRect, linuxRect) {
 	y := u.layout.clearQueue.top
-	up := linuxRectWH(u.layout.clearQueue.right+linuxQueuePriorityGap, y, linuxQueuePriorityUpWidth, 28)
+	top := linuxRectWH(u.layout.clearQueue.right+linuxQueuePriorityGap, y, linuxQueuePriorityTopWidth, 28)
+	up := linuxRectWH(top.right+linuxQueuePriorityGap, y, linuxQueuePriorityUpWidth, 28)
 	down := linuxRectWH(up.right+linuxQueuePriorityGap, y, linuxQueuePriorityDownWidth, 28)
-	return up, down
+	bottom := linuxRectWH(down.right+linuxQueuePriorityGap, y, linuxQueuePriorityBottomWidth, 28)
+	return top, up, down, bottom
 }
 
 func (u *linuxDesktop) selectedQueuePriorityState() queuePriorityState {
@@ -28,13 +32,19 @@ func (u *linuxDesktop) selectedQueuePriorityState() queuePriorityState {
 }
 
 func (u *linuxDesktop) renderQueuePriorityControls() error {
-	up, down := u.queuePriorityRects()
+	top, up, down, bottom := u.queuePriorityRects()
 	state := u.selectedQueuePriorityState()
 	words := queuePriorityWords(u.language)
+	if err := u.drawButton(top, words.MoveTop, state.MoveTop && !u.busy, false); err != nil {
+		return err
+	}
 	if err := u.drawButton(up, words.MoveUp, state.MoveUp && !u.busy, false); err != nil {
 		return err
 	}
-	return u.drawButton(down, words.MoveDown, state.MoveDown && !u.busy, false)
+	if err := u.drawButton(down, words.MoveDown, state.MoveDown && !u.busy, false); err != nil {
+		return err
+	}
+	return u.drawButton(bottom, words.MoveBottom, state.MoveBottom && !u.busy, false)
 }
 
 func (u *linuxDesktop) restoreQueuePrioritySelection(id string) {
@@ -47,21 +57,39 @@ func (u *linuxDesktop) restoreQueuePrioritySelection(id string) {
 	}
 }
 
-func (u *linuxDesktop) moveSelectedQueueTransfer(moveUp bool) {
+func (u *linuxDesktop) moveSelectedQueueTransfer(action queuePriorityAction) {
 	if u.busy || u.selectedTransfer < 0 || u.selectedTransfer >= len(u.transferJobs) {
 		return
 	}
 	state := u.selectedQueuePriorityState()
-	if (moveUp && !state.MoveUp) || (!moveUp && !state.MoveDown) {
+	allowed := false
+	switch action {
+	case queuePriorityTop:
+		allowed = state.MoveTop
+	case queuePriorityUp:
+		allowed = state.MoveUp
+	case queuePriorityDown:
+		allowed = state.MoveDown
+	case queuePriorityBottom:
+		allowed = state.MoveBottom
+	default:
+		return
+	}
+	if !allowed {
 		return
 	}
 
 	id := u.transferJobs[u.selectedTransfer].ID
 	var err error
-	if moveUp {
+	switch action {
+	case queuePriorityTop:
+		err = u.engine.MoveTransferTop(id)
+	case queuePriorityUp:
 		err = u.engine.MoveTransferUp(id)
-	} else {
+	case queuePriorityDown:
 		err = u.engine.MoveTransferDown(id)
+	case queuePriorityBottom:
+		err = u.engine.MoveTransferBottom(id)
 	}
 	if err != nil {
 		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
@@ -71,22 +99,34 @@ func (u *linuxDesktop) moveSelectedQueueTransfer(moveUp bool) {
 	u.transferJobs = u.engine.Transfers()
 	u.restoreQueuePrioritySelection(id)
 	words := queuePriorityWords(u.language)
-	if moveUp {
+	switch action {
+	case queuePriorityTop:
+		u.setStatus(words.MovedTop)
+	case queuePriorityUp:
 		u.setStatus(words.MovedUp)
-	} else {
+	case queuePriorityDown:
 		u.setStatus(words.MovedDown)
+	case queuePriorityBottom:
+		u.setStatus(words.MovedBottom)
 	}
 }
 
 func (u *linuxDesktop) handleQueuePriorityMouse(x, y int) bool {
-	up, down := u.queuePriorityRects()
-	if up.contains(x, y) {
-		u.moveSelectedQueueTransfer(true)
+	top, up, down, bottom := u.queuePriorityRects()
+	switch {
+	case top.contains(x, y):
+		u.moveSelectedQueueTransfer(queuePriorityTop)
 		return true
-	}
-	if down.contains(x, y) {
-		u.moveSelectedQueueTransfer(false)
+	case up.contains(x, y):
+		u.moveSelectedQueueTransfer(queuePriorityUp)
 		return true
+	case down.contains(x, y):
+		u.moveSelectedQueueTransfer(queuePriorityDown)
+		return true
+	case bottom.contains(x, y):
+		u.moveSelectedQueueTransfer(queuePriorityBottom)
+		return true
+	default:
+		return false
 	}
-	return false
 }

--- a/internal/desktop/queue_priority_linux_test.go
+++ b/internal/desktop/queue_priority_linux_test.go
@@ -10,16 +10,15 @@ import (
 
 func TestLinuxQueuePriorityRectsFollowClearQueueWithoutOverlap(t *testing.T) {
 	u := &linuxDesktop{layout: linuxDesktopLayout{clearQueue: linuxRectWH(440, 700, 110, 28)}}
-	up, down := u.queuePriorityRects()
+	top, up, down, bottom := u.queuePriorityRects()
 
-	if up.top != u.layout.clearQueue.top || down.top != u.layout.clearQueue.top {
-		t.Fatalf("priority controls must stay aligned with the queue toolbar: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
+	for name, rect := range map[string]linuxRect{"top": top, "up": up, "down": down, "bottom": bottom} {
+		if rect.top != u.layout.clearQueue.top || rect.bottom != u.layout.clearQueue.bottom {
+			t.Fatalf("%s priority control must stay aligned with queue toolbar: clear=%+v rect=%+v", name, u.layout.clearQueue, rect)
+		}
 	}
-	if up.left <= u.layout.clearQueue.right || down.left <= up.right {
-		t.Fatalf("priority controls overlap existing queue controls: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
-	}
-	if up.bottom != u.layout.clearQueue.bottom || down.bottom != u.layout.clearQueue.bottom {
-		t.Fatalf("priority controls must preserve the queue toolbar height: clear=%+v up=%+v down=%+v", u.layout.clearQueue, up, down)
+	if top.left <= u.layout.clearQueue.right || up.left <= top.right || down.left <= up.right || bottom.left <= down.right {
+		t.Fatalf("priority controls overlap existing controls: clear=%+v top=%+v up=%+v down=%+v bottom=%+v", u.layout.clearQueue, top, up, down, bottom)
 	}
 }
 
@@ -36,13 +35,13 @@ func TestLinuxQueuePriorityStateUsesSharedQueuedOnlyPolicy(t *testing.T) {
 	}
 
 	state := u.selectedQueuePriorityState()
-	if !state.MoveUp || !state.MoveDown {
-		t.Fatalf("selected queued job should move across nearest queued neighbors: %+v", state)
+	if !state.MoveTop || !state.MoveUp || !state.MoveDown || !state.MoveBottom {
+		t.Fatalf("selected queued job should expose all priority directions: %+v", state)
 	}
 
 	u.transferJobs[u.selectedTransfer].Status = "running"
 	state = u.selectedQueuePriorityState()
-	if state.MoveUp || state.MoveDown {
+	if state.MoveTop || state.MoveUp || state.MoveDown || state.MoveBottom {
 		t.Fatalf("running transfer must not expose priority controls: %+v", state)
 	}
 }

--- a/internal/desktop/queue_priority_test.go
+++ b/internal/desktop/queue_priority_test.go
@@ -17,8 +17,8 @@ func TestQueuePriorityStateRequiresOneQueuedSelection(t *testing.T) {
 	}
 
 	cases := []struct {
-		name                 string
-		selected             []int
+		name                  string
+		selected              []int
 		top, up, down, bottom bool
 	}{
 		{name: "none", selected: nil},

--- a/internal/desktop/queue_priority_test.go
+++ b/internal/desktop/queue_priority_test.go
@@ -17,25 +17,24 @@ func TestQueuePriorityStateRequiresOneQueuedSelection(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		selected []int
-		up       bool
-		down     bool
+		name                 string
+		selected             []int
+		top, up, down, bottom bool
 	}{
 		{name: "none", selected: nil},
 		{name: "multiple", selected: []int{1, 3}},
 		{name: "running", selected: []int{0}},
 		{name: "done", selected: []int{2}},
-		{name: "first queued", selected: []int{1}, down: true},
-		{name: "middle queued", selected: []int{3}, up: true, down: true},
-		{name: "last queued", selected: []int{4}, up: true},
+		{name: "first queued", selected: []int{1}, down: true, bottom: true},
+		{name: "middle queued", selected: []int{3}, top: true, up: true, down: true, bottom: true},
+		{name: "last queued", selected: []int{4}, top: true, up: true},
 		{name: "out of range", selected: []int{99}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := deriveQueuePriorityState(jobs, tc.selected)
-			if got.MoveUp != tc.up || got.MoveDown != tc.down {
-				t.Fatalf("deriveQueuePriorityState(%v) = %#v, want up=%v down=%v", tc.selected, got, tc.up, tc.down)
+			if got.MoveTop != tc.top || got.MoveUp != tc.up || got.MoveDown != tc.down || got.MoveBottom != tc.bottom {
+				t.Fatalf("deriveQueuePriorityState(%v) = %#v, want top=%v up=%v down=%v bottom=%v", tc.selected, got, tc.top, tc.up, tc.down, tc.bottom)
 			}
 		})
 	}
@@ -47,7 +46,7 @@ func TestQueuePriorityWordsCoverEverySupportedLanguage(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing queue-priority translation for %s", language.Code)
 		}
-		if text.MoveUp == "" || text.MoveDown == "" || text.MovedUp == "" || text.MovedDown == "" {
+		if text.MoveTop == "" || text.MoveUp == "" || text.MoveDown == "" || text.MoveBottom == "" || text.MovedTop == "" || text.MovedUp == "" || text.MovedDown == "" || text.MovedBottom == "" {
 			t.Fatalf("incomplete queue-priority translation for %s: %#v", language.Code, text)
 		}
 		if got := queuePriorityWords(language.Code); got != text {
@@ -57,7 +56,7 @@ func TestQueuePriorityWordsCoverEverySupportedLanguage(t *testing.T) {
 }
 
 func TestQueuePriorityWordsNormalizeRegionalLanguage(t *testing.T) {
-	if got := queuePriorityWords("hr-HR"); got.MoveUp != "Pomakni gore" || got.MoveDown != "Pomakni dolje" {
+	if got := queuePriorityWords("hr-HR"); got.MoveTop != "Na vrh" || got.MoveUp != "Pomakni gore" || got.MoveDown != "Pomakni dolje" || got.MoveBottom != "Na dno" {
 		t.Fatalf("Croatian regional normalization failed: %#v", got)
 	}
 	if got := queuePriorityWords("unknown"); got != queuePriorityTranslations["en"] {

--- a/internal/desktop/queue_priority_windows.go
+++ b/internal/desktop/queue_priority_windows.go
@@ -5,8 +5,10 @@ package desktop
 import "unsafe"
 
 const (
-	idMoveQueueUp   = 508
-	idMoveQueueDown = 509
+	idMoveQueueUp     = 508
+	idMoveQueueDown   = 509
+	idMoveQueueTop    = 510
+	idMoveQueueBottom = 511
 )
 
 var (
@@ -27,7 +29,15 @@ func (a *app) ensureQueuePriorityControls() {
 	if a == nil || a.hwnd == 0 {
 		return
 	}
-	if a.queuePriorityButton(idMoveQueueUp) != 0 && a.queuePriorityButton(idMoveQueueDown) != 0 {
+	ids := []int{idMoveQueueTop, idMoveQueueUp, idMoveQueueDown, idMoveQueueBottom}
+	allPresent := true
+	for _, id := range ids {
+		if a.queuePriorityButton(id) == 0 {
+			allPresent = false
+			break
+		}
+	}
+	if allPresent {
 		return
 	}
 
@@ -50,23 +60,35 @@ func (a *app) ensureQueuePriorityControls() {
 		return hwnd
 	}
 
+	if a.queuePriorityButton(idMoveQueueTop) == 0 {
+		create(idMoveQueueTop, words.MoveTop, iconUp)
+	}
 	if a.queuePriorityButton(idMoveQueueUp) == 0 {
 		create(idMoveQueueUp, words.MoveUp, iconUp)
 	}
 	if a.queuePriorityButton(idMoveQueueDown) == 0 {
 		create(idMoveQueueDown, words.MoveDown, iconDownload)
 	}
+	if a.queuePriorityButton(idMoveQueueBottom) == 0 {
+		create(idMoveQueueBottom, words.MoveBottom, iconDownload)
+	}
 }
 
 func (a *app) updateQueuePriorityControls(state queuePriorityState) {
 	a.ensureQueuePriorityControls()
+	top := a.queuePriorityButton(idMoveQueueTop)
 	up := a.queuePriorityButton(idMoveQueueUp)
 	down := a.queuePriorityButton(idMoveQueueDown)
+	bottom := a.queuePriorityButton(idMoveQueueBottom)
 	words := queuePriorityWords(a.languageCode())
+	a.setButtonLabel(top, words.MoveTop)
 	a.setButtonLabel(up, words.MoveUp)
 	a.setButtonLabel(down, words.MoveDown)
+	a.setButtonLabel(bottom, words.MoveBottom)
+	setControlEnabled(top, state.MoveTop && !a.connectionBusy)
 	setControlEnabled(up, state.MoveUp && !a.connectionBusy)
 	setControlEnabled(down, state.MoveDown && !a.connectionBusy)
+	setControlEnabled(bottom, state.MoveBottom && !a.connectionBusy)
 }
 
 func (a *app) layoutQueuePriorityControls() {
@@ -74,10 +96,16 @@ func (a *app) layoutQueuePriorityControls() {
 		return
 	}
 	a.ensureQueuePriorityControls()
-	up := a.queuePriorityButton(idMoveQueueUp)
-	down := a.queuePriorityButton(idMoveQueueDown)
-	if up == 0 || down == 0 {
-		return
+	controls := []uintptr{
+		a.queuePriorityButton(idMoveQueueTop),
+		a.queuePriorityButton(idMoveQueueUp),
+		a.queuePriorityButton(idMoveQueueDown),
+		a.queuePriorityButton(idMoveQueueBottom),
+	}
+	for _, control := range controls {
+		if control == 0 {
+			return
+		}
 	}
 
 	var clearRect rect
@@ -93,7 +121,7 @@ func (a *app) layoutQueuePriorityControls() {
 		return
 	}
 
-	gap := a.scale(8)
+	gap := a.scale(6)
 	x := int(bottomRight.X) + gap
 	y := int(topLeft.Y)
 	height := int(bottomRight.Y - topLeft.Y)
@@ -101,28 +129,39 @@ func (a *app) layoutQueuePriorityControls() {
 	if ok, _, _ := getClientRect.Call(a.hwnd, uintptr(unsafe.Pointer(&client))); ok == 0 {
 		return
 	}
-	available := int(client.Right) - a.scale(14) - x - gap
-	buttonWidth := available / 2
-	if buttonWidth > a.scale(132) {
-		buttonWidth = a.scale(132)
+	available := int(client.Right) - a.scale(14) - x
+	buttonWidth := (available - 3*gap) / 4
+	if buttonWidth > a.scale(112) {
+		buttonWidth = a.scale(112)
 	}
-	if buttonWidth < a.scale(88) {
-		buttonWidth = a.scale(88)
+	if buttonWidth < a.scale(60) {
+		buttonWidth = a.scale(60)
 	}
-	moveWindow.Call(up, uintptr(x), uintptr(y), uintptr(buttonWidth), uintptr(height), 1)
-	moveWindow.Call(down, uintptr(x+buttonWidth+gap), uintptr(y), uintptr(buttonWidth), uintptr(height), 1)
+	for i, control := range controls {
+		moveWindow.Call(control, uintptr(x+i*(buttonWidth+gap)), uintptr(y), uintptr(buttonWidth), uintptr(height), 1)
+	}
 }
 
-func (a *app) moveSelectedTransfer(direction int) {
+func (a *app) moveSelectedTransfer(action queuePriorityAction) {
 	selected := selectedIndices(a.transferList)
 	state := deriveQueuePriorityState(a.transferJobs, selected)
 	if len(selected) != 1 {
 		return
 	}
-	if direction < 0 && !state.MoveUp {
+	allowed := false
+	switch action {
+	case queuePriorityTop:
+		allowed = state.MoveTop
+	case queuePriorityUp:
+		allowed = state.MoveUp
+	case queuePriorityDown:
+		allowed = state.MoveDown
+	case queuePriorityBottom:
+		allowed = state.MoveBottom
+	default:
 		return
 	}
-	if direction > 0 && !state.MoveDown {
+	if !allowed {
 		return
 	}
 	index := selected[0]
@@ -133,23 +172,32 @@ func (a *app) moveSelectedTransfer(direction int) {
 	id := a.transferJobs[index].ID
 	var err error
 	words := queuePriorityWords(a.languageCode())
-	if direction < 0 {
+	switch action {
+	case queuePriorityTop:
+		err = a.engine.MoveTransferTop(id)
+	case queuePriorityUp:
 		err = a.engine.MoveTransferUp(id)
-	} else {
+	case queuePriorityDown:
 		err = a.engine.MoveTransferDown(id)
+	case queuePriorityBottom:
+		err = a.engine.MoveTransferBottom(id)
 	}
 	if err != nil {
 		a.setStatus(a.userMessage(err, "error.generic"))
 		a.refreshTransfers()
 		return
 	}
-	if direction < 0 {
+	switch action {
+	case queuePriorityTop:
+		a.setStatus(words.MovedTop)
+	case queuePriorityUp:
 		a.setStatus(words.MovedUp)
-	} else {
+	case queuePriorityDown:
 		a.setStatus(words.MovedDown)
+	case queuePriorityBottom:
+		a.setStatus(words.MovedBottom)
 	}
-	// The transfer manager emits a full state snapshot. refreshTransfers keeps
-	// selection bound to the transfer ID so the same job remains selected after
-	// its row position changes.
+	// refreshTransfers restores selection by transfer ID, not by the previous
+	// row index, so the same job remains selected after any reorder operation.
 	a.refreshTransfers()
 }

--- a/internal/transfer/queue_order.go
+++ b/internal/transfer/queue_order.go
@@ -12,22 +12,42 @@ var (
 	errTransferOrderNotQueued = errors.New("only queued transfers can be reordered")
 )
 
+type queuedMove int
+
+const (
+	queuedMoveTop queuedMove = iota
+	queuedMoveUp
+	queuedMoveDown
+	queuedMoveBottom
+)
+
+// MoveQueuedTop moves one waiting transfer to the first queued scheduler slot.
+// Running and terminal jobs keep their exact list/history slots.
+func (m *Manager) MoveQueuedTop(id string) error {
+	return m.moveQueued(id, queuedMoveTop)
+}
+
 // MoveQueuedUp moves one waiting transfer ahead of the nearest earlier waiting
-// transfer. Running and terminal jobs keep their exact slots in the history
-// list; only the relative scheduler order of queued jobs changes.
+// transfer. Running and terminal jobs keep their exact list/history slots.
 func (m *Manager) MoveQueuedUp(id string) error {
-	return m.moveQueued(id, -1)
+	return m.moveQueued(id, queuedMoveUp)
 }
 
 // MoveQueuedDown moves one waiting transfer behind the nearest later waiting
 // transfer. Running and terminal jobs are never reordered or mutated.
 func (m *Manager) MoveQueuedDown(id string) error {
-	return m.moveQueued(id, 1)
+	return m.moveQueued(id, queuedMoveDown)
 }
 
-func (m *Manager) moveQueued(id string, direction int) error {
-	if direction != -1 && direction != 1 {
-		return errors.New("invalid queue reorder direction")
+// MoveQueuedBottom moves one waiting transfer to the final queued scheduler
+// slot without moving running or terminal history entries.
+func (m *Manager) MoveQueuedBottom(id string) error {
+	return m.moveQueued(id, queuedMoveBottom)
+}
+
+func (m *Manager) moveQueued(id string, move queuedMove) error {
+	if move < queuedMoveTop || move > queuedMoveBottom {
+		return errors.New("invalid queue reorder operation")
 	}
 
 	m.mu.Lock()
@@ -51,30 +71,54 @@ func (m *Manager) moveQueued(id string, direction int) error {
 		return errTransferOrderNotQueued
 	}
 
-	neighbor := -1
-	if direction < 0 {
-		for i := index - 1; i >= 0; i-- {
-			if m.jobs[i].Status == "queued" {
-				neighbor = i
-				break
-			}
+	queuedSlots := make([]int, 0, len(m.jobs))
+	queuedPosition := -1
+	for i := range m.jobs {
+		if m.jobs[i].Status != "queued" {
+			continue
 		}
-	} else {
-		for i := index + 1; i < len(m.jobs); i++ {
-			if m.jobs[i].Status == "queued" {
-				neighbor = i
-				break
-			}
+		if i == index {
+			queuedPosition = len(queuedSlots)
 		}
+		queuedSlots = append(queuedSlots, i)
 	}
-	if neighbor < 0 {
-		// The requested job is already at the corresponding queued edge. This is
-		// an idempotent no-op so a stale UI click cannot turn into an error after
-		// another queue event changes availability.
+	if queuedPosition < 0 {
+		return errTransferOrderNotQueued
+	}
+
+	destination := queuedPosition
+	switch move {
+	case queuedMoveTop:
+		destination = 0
+	case queuedMoveUp:
+		if queuedPosition > 0 {
+			destination--
+		}
+	case queuedMoveDown:
+		if queuedPosition+1 < len(queuedSlots) {
+			destination++
+		}
+	case queuedMoveBottom:
+		destination = len(queuedSlots) - 1
+	}
+	if destination == queuedPosition {
+		// Edge moves are idempotent. A stale UI click after another queue state
+		// update must not emit noise or become an operational error.
 		return nil
 	}
 
-	m.jobs[index], m.jobs[neighbor] = m.jobs[neighbor], m.jobs[index]
+	selected := m.jobs[index]
+	if destination < queuedPosition {
+		for pos := queuedPosition; pos > destination; pos-- {
+			m.jobs[queuedSlots[pos]] = m.jobs[queuedSlots[pos-1]]
+		}
+	} else {
+		for pos := queuedPosition; pos < destination; pos++ {
+			m.jobs[queuedSlots[pos]] = m.jobs[queuedSlots[pos+1]]
+		}
+	}
+	m.jobs[queuedSlots[destination]] = selected
+
 	m.emitLocked(Event{
 		Type:   "state",
 		Jobs:   append([]model.TransferJob(nil), m.jobs...),

--- a/internal/transfer/queue_order_test.go
+++ b/internal/transfer/queue_order_test.go
@@ -79,28 +79,58 @@ func TestMoveQueuedUpAndDownChangesOnlySchedulerOrder(t *testing.T) {
 	assertQueueIDs(t, m, ids[0], ids[2], ids[1])
 }
 
-func TestMoveQueuedSkipsRunningAndTerminalSlots(t *testing.T) {
+func TestMoveQueuedTopAndBottomPreserveQueuedRelativeOrder(t *testing.T) {
 	m, dir := newPausedQueueManager(t)
 	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt", "d.txt")
 
+	if err := m.MoveQueuedTop(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedTop: %v", err)
+	}
+	assertQueueIDs(t, m, ids[2], ids[0], ids[1], ids[3])
+
+	if err := m.MoveQueuedBottom(ids[0]); err != nil {
+		t.Fatalf("MoveQueuedBottom: %v", err)
+	}
+	assertQueueIDs(t, m, ids[2], ids[1], ids[3], ids[0])
+}
+
+func TestMoveQueuedSkipsRunningAndTerminalSlots(t *testing.T) {
+	m, dir := newPausedQueueManager(t)
+	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt", "d.txt", "e.txt")
+
 	m.mu.Lock()
 	m.jobs[1].Status = "running"
-	m.jobs[2].Status = "done"
+	m.jobs[3].Status = "done"
 	runningID := m.jobs[1].ID
-	terminalID := m.jobs[2].ID
+	terminalID := m.jobs[3].ID
+	m.jobConnections[ids[0]] = "connection-a"
+	m.jobConnections[ids[2]] = "connection-a"
+	m.jobConnections[ids[4]] = "connection-a"
 	m.mu.Unlock()
 
-	if err := m.MoveQueuedUp(ids[3]); err != nil {
-		t.Fatalf("MoveQueuedUp: %v", err)
+	if err := m.MoveQueuedTop(ids[4]); err != nil {
+		t.Fatalf("MoveQueuedTop: %v", err)
 	}
-	assertQueueIDs(t, m, ids[3], runningID, terminalID, ids[0])
+	assertQueueIDs(t, m, ids[4], runningID, ids[0], terminalID, ids[2])
+
+	if err := m.MoveQueuedBottom(ids[4]); err != nil {
+		t.Fatalf("MoveQueuedBottom: %v", err)
+	}
+	assertQueueIDs(t, m, ids[0], runningID, ids[2], terminalID, ids[4])
 
 	jobs := m.List()
 	if jobs[1].ID != runningID || jobs[1].Status != "running" {
 		t.Fatalf("running job was mutated: %#v", jobs[1])
 	}
-	if jobs[2].ID != terminalID || jobs[2].Status != "done" {
-		t.Fatalf("terminal job was mutated: %#v", jobs[2])
+	if jobs[3].ID != terminalID || jobs[3].Status != "done" {
+		t.Fatalf("terminal job was mutated: %#v", jobs[3])
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, id := range []string{ids[0], ids[2], ids[4]} {
+		if got := m.jobConnections[id]; got != "connection-a" {
+			t.Fatalf("reorder changed connection binding for %s: %q", id, got)
+		}
 	}
 }
 
@@ -108,15 +138,19 @@ func TestMoveQueuedRejectsMissingAndNonQueuedJobs(t *testing.T) {
 	m, dir := newPausedQueueManager(t)
 	ids := addQueuedDownloads(t, m, dir, "a.txt")
 
-	if err := m.MoveQueuedUp("missing"); !errors.Is(err, errTransferOrderMissing) {
-		t.Fatalf("missing transfer error = %v, want %v", err, errTransferOrderMissing)
+	for _, move := range []func(string) error{m.MoveQueuedTop, m.MoveQueuedUp, m.MoveQueuedDown, m.MoveQueuedBottom} {
+		if err := move("missing"); !errors.Is(err, errTransferOrderMissing) {
+			t.Fatalf("missing transfer error = %v, want %v", err, errTransferOrderMissing)
+		}
 	}
 
 	m.mu.Lock()
 	m.jobs[0].Status = "running"
 	m.mu.Unlock()
-	if err := m.MoveQueuedDown(ids[0]); !errors.Is(err, errTransferOrderNotQueued) {
-		t.Fatalf("non-queued transfer error = %v, want %v", err, errTransferOrderNotQueued)
+	for _, move := range []func(string) error{m.MoveQueuedTop, m.MoveQueuedUp, m.MoveQueuedDown, m.MoveQueuedBottom} {
+		if err := move(ids[0]); !errors.Is(err, errTransferOrderNotQueued) {
+			t.Fatalf("non-queued transfer error = %v, want %v", err, errTransferOrderNotQueued)
+		}
 	}
 }
 
@@ -125,11 +159,17 @@ func TestMoveQueuedAtEdgeIsIdempotentAndDoesNotEmitNoise(t *testing.T) {
 	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt")
 	_, before := m.Events(0)
 
+	if err := m.MoveQueuedTop(ids[0]); err != nil {
+		t.Fatalf("MoveQueuedTop at edge: %v", err)
+	}
 	if err := m.MoveQueuedUp(ids[0]); err != nil {
 		t.Fatalf("MoveQueuedUp at edge: %v", err)
 	}
 	if err := m.MoveQueuedDown(ids[1]); err != nil {
 		t.Fatalf("MoveQueuedDown at edge: %v", err)
+	}
+	if err := m.MoveQueuedBottom(ids[1]); err != nil {
+		t.Fatalf("MoveQueuedBottom at edge: %v", err)
 	}
 	assertQueueIDs(t, m, ids[0], ids[1])
 
@@ -144,8 +184,8 @@ func TestMoveQueuedEmitsFullStateSnapshot(t *testing.T) {
 	ids := addQueuedDownloads(t, m, dir, "a.txt", "b.txt", "c.txt")
 	_, before := m.Events(0)
 
-	if err := m.MoveQueuedUp(ids[2]); err != nil {
-		t.Fatalf("MoveQueuedUp: %v", err)
+	if err := m.MoveQueuedTop(ids[2]); err != nil {
+		t.Fatalf("MoveQueuedTop: %v", err)
 	}
 	events, after := m.Events(before)
 	if after <= before {
@@ -157,7 +197,7 @@ func TestMoveQueuedEmitsFullStateSnapshot(t *testing.T) {
 	if !events[0].Paused {
 		t.Fatal("state snapshot lost paused queue state")
 	}
-	if len(events[0].Jobs) != 3 || events[0].Jobs[0].ID != ids[0] || events[0].Jobs[1].ID != ids[2] || events[0].Jobs[2].ID != ids[1] {
+	if len(events[0].Jobs) != 3 || events[0].Jobs[0].ID != ids[2] || events[0].Jobs[1].ID != ids[0] || events[0].Jobs[2].ID != ids[1] {
 		t.Fatalf("state snapshot order = %#v", events[0].Jobs)
 	}
 }
@@ -169,7 +209,9 @@ func TestMoveQueuedRejectsClosedManager(t *testing.T) {
 	m.closed = true
 	m.mu.Unlock()
 
-	if err := m.MoveQueuedDown(ids[0]); !errors.Is(err, errTransferOrderClosed) {
-		t.Fatalf("closed manager error = %v, want %v", err, errTransferOrderClosed)
+	for _, move := range []func(string) error{m.MoveQueuedTop, m.MoveQueuedUp, m.MoveQueuedDown, m.MoveQueuedBottom} {
+		if err := move(ids[0]); !errors.Is(err, errTransferOrderClosed) {
+			t.Fatalf("closed manager error = %v, want %v", err, errTransferOrderClosed)
+		}
 	}
 }

--- a/scripts/test_queue_priority_contract.py
+++ b/scripts/test_queue_priority_contract.py
@@ -119,6 +119,19 @@ class QueuePriorityContractTests(unittest.TestCase):
         self.assertLess(upload.index("ensureRemoteDirectoryCached"), upload.index("reservation.Commit()"))
         self.assertLess(download.index("prepareLocalDirectories"), download.index("reservation.Commit()"))
 
+    def test_docs_keep_source_feature_separate_from_published_003(self) -> None:
+        roadmap = self.read("docs/ROADMAP.md")
+        detail = self.read("docs/QUEUE-PRIORITY.md")
+        self.assertIn("implemented in the post-0.0.3 source line", roadmap)
+        self.assertIn("targeted for the next public release", roadmap)
+        self.assertIn("post-0.0.3 source line", detail)
+        self.assertIn("not retroactively part of the already published Ghost FTP 0.0.3 release", detail)
+        self.assertIn("MoveTransferTop(id)", detail)
+        self.assertIn("MoveTransferBottom(id)", detail)
+        self.assertIn("jobConnections", detail)
+        self.assertIn("reservation.Commit()", detail)
+        self.assertIn("Root `VERSION` remains **0.0.3**", detail)
+
     def test_tests_cover_scheduler_and_ui_invariants(self) -> None:
         manager_tests = self.read("internal/transfer/queue_order_test.go")
         ui_tests = self.read("internal/desktop/queue_priority_test.go")

--- a/scripts/test_queue_priority_contract.py
+++ b/scripts/test_queue_priority_contract.py
@@ -11,36 +11,49 @@ class QueuePriorityContractTests(unittest.TestCase):
     def read(self, rel: str) -> str:
         return (ROOT / rel).read_text(encoding="utf-8")
 
-    def test_core_reorders_only_queued_jobs(self) -> None:
+    def test_core_reorders_only_queued_jobs_and_preserves_nonqueued_slots(self) -> None:
         core = self.read("internal/transfer/queue_order.go")
         for marker in (
+            "func (m *Manager) MoveQueuedTop",
             "func (m *Manager) MoveQueuedUp",
             "func (m *Manager) MoveQueuedDown",
+            "func (m *Manager) MoveQueuedBottom",
             'm.jobs[index].Status != "queued"',
-            'm.jobs[i].Status == "queued"',
-            "m.jobs[index], m.jobs[neighbor] = m.jobs[neighbor], m.jobs[index]",
+            'm.jobs[i].Status != "queued"',
+            "queuedSlots = append(queuedSlots, i)",
+            "m.jobs[queuedSlots[pos]] = m.jobs[queuedSlots[pos-1]]",
+            "m.jobs[queuedSlots[pos]] = m.jobs[queuedSlots[pos+1]]",
             'Type:   "state"',
             "Jobs:   append([]model.TransferJob(nil), m.jobs...)",
             "Paused: m.paused",
         ):
             self.assertIn(marker, core)
         self.assertNotIn("m.pump()", core, "reordering must not start transfers as a side effect")
+        self.assertNotIn("jobConnections[", core, "reordering must not rewrite connection identity bindings")
 
-    def test_engine_exposes_bounded_queue_reordering_only(self) -> None:
+    def test_engine_exposes_four_bounded_queue_reorder_actions(self) -> None:
         api = self.read("internal/api/queue_order.go")
-        self.assertIn("MoveTransferUp", api)
-        self.assertIn("e.transfers.MoveQueuedUp(id)", api)
-        self.assertIn("MoveTransferDown", api)
-        self.assertIn("e.transfers.MoveQueuedDown(id)", api)
+        for method, manager in (
+            ("MoveTransferTop", "MoveQueuedTop"),
+            ("MoveTransferUp", "MoveQueuedUp"),
+            ("MoveTransferDown", "MoveQueuedDown"),
+            ("MoveTransferBottom", "MoveQueuedBottom"),
+        ):
+            self.assertIn(method, api)
+            self.assertIn(f"e.transfers.{manager}(id)", api)
 
-    def test_shared_ui_policy_is_single_selection_and_queued_only(self) -> None:
+    def test_shared_ui_policy_is_single_selection_queued_only_and_four_way(self) -> None:
         policy = self.read("internal/desktop/queue_priority.go")
         for marker in (
             "len(selected) != 1",
             'jobs[index].Status != "queued"',
             'jobs[i].Status == "queued"',
+            "MoveTop = true",
             "MoveUp = true",
             "MoveDown = true",
+            "MoveBottom = true",
+            "queuePriorityTop",
+            "queuePriorityBottom",
             "i18n.Normalize",
         ):
             self.assertIn(marker, policy)
@@ -53,17 +66,26 @@ class QueuePriorityContractTests(unittest.TestCase):
         transfers = self.read("internal/desktop/transfers_windows.go")
 
         for marker in (
+            "idMoveQueueTop",
             "idMoveQueueUp",
             "idMoveQueueDown",
+            "idMoveQueueBottom",
             'wstr("BUTTON")',
             "wsChild|wsVisible|wsTabStop|bsOwnerDraw",
+            "a.engine.MoveTransferTop(id)",
             "a.engine.MoveTransferUp(id)",
             "a.engine.MoveTransferDown(id)",
+            "a.engine.MoveTransferBottom(id)",
             "queuePriorityWords(a.languageCode())",
         ):
             self.assertIn(marker, windows)
-        self.assertIn("case idMoveQueueUp:", commands)
-        self.assertIn("case idMoveQueueDown:", commands)
+        for marker in (
+            "case idMoveQueueTop:",
+            "case idMoveQueueUp:",
+            "case idMoveQueueDown:",
+            "case idMoveQueueBottom:",
+        ):
+            self.assertIn(marker, commands)
         self.assertIn("deriveQueuePriorityState", actions)
         self.assertIn("a.updateQueuePriorityControls(priorityState)", actions)
         self.assertIn("a.layoutQueuePriorityControls()", layout)
@@ -77,8 +99,10 @@ class QueuePriorityContractTests(unittest.TestCase):
         for marker in (
             "deriveQueuePriorityState",
             "queuePriorityWords(u.language)",
+            "u.engine.MoveTransferTop(id)",
             "u.engine.MoveTransferUp(id)",
             "u.engine.MoveTransferDown(id)",
+            "u.engine.MoveTransferBottom(id)",
             "u.transferJobs = u.engine.Transfers()",
             "u.restoreQueuePrioritySelection(id)",
             "func (u *linuxDesktop) renderQueuePriorityControls() error",
@@ -88,17 +112,26 @@ class QueuePriorityContractTests(unittest.TestCase):
         self.assertIn("u.renderQueuePriorityControls()", gui)
         self.assertIn("u.handleQueuePriorityMouse(x, y)", gui)
 
+    def test_tree_transfer_dependencies_are_prepared_before_queue_commit(self) -> None:
+        tree = self.read("internal/api/tree_transfer.go")
+        upload = tree[tree.index("func (s *Engine) addUploadTree"):tree.index("func buildDownloadPlan")]
+        download = tree[tree.index("func (s *Engine) addDownloadTree"):tree.index("type localDirectoryPreparationHooks")]
+        self.assertLess(upload.index("ensureRemoteDirectoryCached"), upload.index("reservation.Commit()"))
+        self.assertLess(download.index("prepareLocalDirectories"), download.index("reservation.Commit()"))
+
     def test_tests_cover_scheduler_and_ui_invariants(self) -> None:
         manager_tests = self.read("internal/transfer/queue_order_test.go")
         ui_tests = self.read("internal/desktop/queue_priority_test.go")
         linux_tests = self.read("internal/desktop/queue_priority_linux_test.go")
         for marker in (
             "TestMoveQueuedUpAndDownChangesOnlySchedulerOrder",
+            "TestMoveQueuedTopAndBottomPreserveQueuedRelativeOrder",
             "TestMoveQueuedSkipsRunningAndTerminalSlots",
             "TestMoveQueuedRejectsMissingAndNonQueuedJobs",
             "TestMoveQueuedAtEdgeIsIdempotentAndDoesNotEmitNoise",
             "TestMoveQueuedEmitsFullStateSnapshot",
             "TestMoveQueuedRejectsClosedManager",
+            "reorder changed connection binding",
         ):
             self.assertIn(marker, manager_tests)
         self.assertIn("TestQueuePriorityStateRequiresOneQueuedSelection", ui_tests)


### PR DESCRIPTION
## Summary

Complete the next P0 queue-priority source capability after the verified Ghost FTP 0.0.3 release, without changing `VERSION` or rewriting the published 0.0.3 identity.

### Scheduler and API
- add queued-only `MoveQueuedTop` / `MoveQueuedBottom` beside existing Up/Down;
- rotate only queued scheduler slots so running/terminal history slots remain fixed;
- preserve transfer IDs, `jobConnections` bindings and the relative order of unaffected queued jobs;
- keep boundary actions idempotent and event-free;
- emit one full state snapshot for a real reorder and never start/retry/cancel work as a reorder side effect;
- expose four bounded Engine operations: Top / Up / Down / Bottom.

### Desktop parity
- add real Top and Bottom controls on Windows and Linux;
- retain the shared single-selection, queued-only enablement policy;
- restore selection by transfer ID after reordering;
- localize all four actions/statuses for all 24 maintained desktop languages.

### Dependency/session safety
- preserve connection-generation ownership by leaving `jobConnections` untouched;
- protect the tree-transfer invariant that remote/local directory structure is prepared before file jobs cross `BatchReservation.Commit()` into the runnable queue.

### Documentation and regression gates
- add `docs/QUEUE-PRIORITY.md` with scheduler/UI/session/release-boundary invariants;
- mark queue priority as post-0.0.3 source work targeted for the next release, not as a retroactive 0.0.3 capability;
- update Unreleased changelog and source regression contract.

## Merge gate

Do not merge until every workflow triggered for the exact final PR head is `completed/success`, including Core race/vet/audits/regressions, Windows production build, Linux production/distro package gates, distro lifecycle checks and Authentic UI Screenshots because the maintained Windows UI changes.

This PR does **not** bump `VERSION`, create a release branch, tag, GitHub Release or modify the published `ghostftp-v0.0.3` release.