### PR TITLE
feat: add account-bound navigation bookmarks and profile start directories

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -78,7 +78,7 @@ jobs:
         shell: pwsh
         run: .\BUILD-WINDOWS.ps1
 
-      - name: Capture authentic main, Site Manager, Settings and About windows
+      - name: Capture authentic main, Site Manager, Bookmarks, Settings and About windows
         shell: pwsh
         run: |
           $version = (Get-Content VERSION -Raw).Trim()
@@ -99,6 +99,7 @@ jobs:
           $expected = @(
             'ui-screenshots\Ghost-FTP-main-workspace.png',
             'ui-screenshots\Ghost-FTP-site-manager.png',
+            'ui-screenshots\Ghost-FTP-bookmarks.png',
             'ui-screenshots\Ghost-FTP-settings.png',
             'ui-screenshots\Ghost-FTP-about.png'
           )
@@ -171,13 +172,15 @@ jobs:
           $visuals = @(
             'docs/images/ghost-ftp-main-workspace.png',
             'docs/images/ghost-ftp-site-manager.png',
+            'docs/images/ghost-ftp-bookmarks.png',
             'docs/images/ghost-ftp-settings.png',
             'docs/images/ghost-ftp-about.png'
           )
           Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-main-workspace.png' -Destination $visuals[0] -Force
           Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-site-manager.png' -Destination $visuals[1] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-settings.png' -Destination $visuals[2] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-about.png' -Destination $visuals[3] -Force
+          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-bookmarks.png' -Destination $visuals[2] -Force
+          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-settings.png' -Destination $visuals[3] -Force
+          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-about.png' -Destination $visuals[4] -Force
 
           git add -- $visuals
           if ($LASTEXITCODE -ne 0) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
 - Added regression coverage for four-way ordering, non-queued slot stability, connection binding, tree-transfer directory-preparation ordering and cross-platform UI wiring.
 - This is post-0.0.3 source work for the next release; root `VERSION` and the already published `ghostftp-v0.0.3` release remain unchanged.
 
+### Navigation bookmarks and profile start directories
+
+- Added reusable local and remote bookmarks through a shared non-secret persistence model; remote bookmark identity contains only protocol, host, port and username and is captured from the real active Engine connection.
+- Made bookmark activation authoritative only after fresh navigation: local targets must list successfully, while remote targets must match the active account and retain the same connection identity across the server listing.
+- Added a native Windows bookmark manager and Linux X11 bookmark overlay with Open, Add local, Add remote, Delete and Close behavior wired through the shared Engine contract.
+- Added an additional Windows `connectionGeneration` guard around remote bookmark UI commits and Linux modal/action routing that keeps stored paths from bypassing the existing navigation lifecycle.
+- Hardened profile start-directory behavior so an inherited server path cannot silently cross a protocol/host/port/username account boundary; Linux also restores the previous verified local base and requires a successful local listing before a selected profile start becomes pane state.
+- Added Go coverage plus `scripts/test_navigation_bookmarks_contract.py` for non-secret persistence, corrupt-state fail-closed behavior, account/session revalidation, profile-start isolation, cross-platform UI wiring and documentation/release boundaries.
+- Added `docs/NAVIGATION-BOOKMARKS.md`; this remains post-0.0.3 source work targeted for the next public release, while root `VERSION` and the already published `ghostftp-v0.0.3` release remain unchanged.
+
 ## 0.0.3 - 2026-09-10
 
 ### Bandwidth-aware transfers

--- a/docs/NAVIGATION-BOOKMARKS.md
+++ b/docs/NAVIGATION-BOOKMARKS.md
@@ -124,7 +124,9 @@ The overlay supports the same functional actions as Windows:
 - delete selected bookmark;
 - close.
 
-Keyboard and mouse handling are routed through the established Linux prompt/modal dispatcher. Bookmark naming prompts feed the same Engine save methods used by Windows, and bookmark activation goes through `Engine.NavigateBookmark` rather than directly trusting the stored path.
+The bookmark list uses a bounded visible viewport. Keyboard selection automatically keeps the selected item in view, while mouse-accessible up/down controls move through collections larger than the overlay. Hit testing includes the viewport offset and rejects the list padding, so Open/Delete always refer to a visibly selectable bookmark even when the persisted collection is larger than one page.
+
+Keyboard and mouse handling are routed through the established Linux prompt/modal dispatcher. Bookmark naming prompts feed the same Engine save methods used by Windows, and bookmark activation goes through `Engine.NavigateBookmark` rather than directly trusting the stored path. Cancelling a bookmark-name child prompt returns to the manager instead of abandoning the entire bookmark flow.
 
 The Bookmarks control is rendered through the existing workspace/file-filter extension path and has a matching click handler; it is not a decorative or dead control.
 
@@ -157,10 +159,12 @@ The guard runs on the UI goroutine before the Bookmarks header is painted and tr
 - the previous verified local base is restored immediately;
 - the requested profile local start is passed to `refreshLocal`;
 - only successful local listing may commit the resulting canonical base;
-- a remote start is retained only while protocol/host/port/username still match the selected profile;
-- editing the selected profile's account fields resets the remote start to the protocol default (`/` for FTP/FTPS, `.` for SFTP).
+- selecting a profile installs its saved/default remote start once;
+- any subsequent change to protocol, canonical host, port or exact username resets the current server start once to the new protocol default (`/` for FTP/FTPS, `.` for SFTP), even if the current value came from navigation on the old account;
+- after that account-bound reset has occurred, a newly entered explicit Remote Path survives ordinary repaints;
+- profile switching itself is disabled while a Linux connection is active or another Linux UI action is busy, preventing profile selection from mutating path/account drafts in the middle of an active session.
 
-This keeps a stale local or server path from becoming visible authority merely because a profile row was selected.
+This keeps stale local, inherited, or previously navigated server paths from becoming visible authority merely because a profile row was selected or its account identity was edited.
 
 ## Error and stale-state behavior
 
@@ -173,7 +177,7 @@ The feature is fail-closed around navigation authority:
 - remote bookmark account mismatch is rejected;
 - disconnect/reconnect during remote navigation invalidates the operation;
 - Windows stale async callbacks are rejected by navigation sequence / connection generation;
-- profile identity changes cannot silently retain an unrelated inherited server start.
+- profile identity changes discard the previous account's inherited or navigated server start before a new explicit start can be entered.
 
 A failure must leave the previously verified pane state intact whenever the surrounding navigation path supports that behavior; it must not manufacture a successful empty listing.
 
@@ -189,7 +193,7 @@ The maintained parity target is behavioral rather than pixel-identical:
 
 | Capability | Windows | Linux |
 | --- | --- | --- |
-| List bookmarks | Native manager | Native X11 overlay |
+| List bookmarks | Native manager | Native X11 overlay with bounded viewport |
 | Add local bookmark | Yes | Yes |
 | Add remote bookmark | Connected session only | Connected session only |
 | Delete bookmark | Confirmed | Confirmed through existing destructive-action policy |
@@ -198,7 +202,7 @@ The maintained parity target is behavioral rather than pixel-identical:
 | Remote account binding | Yes | Yes |
 | Stale-session protection | Engine + connection generation | Engine + serialized Linux action/session behavior |
 | Profile local start requires real listing | Yes | Yes |
-| Profile remote start rejects account drift | Yes | Yes |
+| Profile remote start rejects account drift | Yes | Yes, one-time reset per identity change |
 
 ## Regression coverage
 
@@ -207,6 +211,10 @@ The implementation is protected by Go unit tests and source-level regression con
 - `internal/config/bookmarks_test.go` — CRUD, validation, non-secret persisted schema, account binding and corrupt-state fail-closed behavior;
 - `internal/config/profile_start_directory_binding_test.go` — inherited remote-start reset and explicit-new-path behavior across identity changes;
 - `internal/profilebinding/*_test.go` — canonical endpoint/account identity semantics;
+- `internal/desktop/profile_start_linux_test.go` — repaint safety, inherited/navigated old-account reset and explicit-new-path behavior after the identity boundary;
+- `internal/desktop/profile_cycle_linux_test.go` — connected/busy profile-switch guards and normal idle profile loading;
+- `internal/desktop/bookmark_prompt_linux_test.go` — bookmark-name child-prompt classification;
+- `internal/desktop/bookmark_viewport_linux_test.go` — viewport clamping, later-row reachability and hit-test padding/offset behavior;
 - desktop tests for shared bookmark wording and Site Manager navigation privacy;
 - `scripts/test_navigation_bookmarks_contract.py` — cross-layer Engine/config/Windows/Linux/documentation wiring and security invariants.
 

--- a/docs/NAVIGATION-BOOKMARKS.md
+++ b/docs/NAVIGATION-BOOKMARKS.md
@@ -1,0 +1,221 @@
+# Navigation bookmarks and profile start directories
+
+Ghost FTP implements navigation bookmarks and explicit local/server start directories in the **post-0.0.3 source line**, targeted for the next public release. This source capability is **not retroactively part of the already published Ghost FTP 0.0.3 release**. Root `VERSION` remains **0.0.3** until the normal versioned release lifecycle explicitly advances it.
+
+The feature is intentionally narrow: it improves repeated navigation without turning path metadata into credentials, weakening connection identity boundaries, or creating hidden Site Manager profiles.
+
+## Scope
+
+Two related navigation mechanisms are maintained:
+
+1. **Bookmarks** are reusable navigation entries independent of Site Manager profiles. A bookmark is either local or remote.
+2. **Profile start directories** are the explicit default local and remote directories saved with one Site Manager profile.
+
+Both Windows and Linux expose bookmark navigation. Profile start directories reuse the existing profile fields and are guarded so a saved server path cannot silently cross to another account identity.
+
+## Security model
+
+### Bookmarks are non-secret metadata
+
+`internal/model/bookmark.go` defines the persisted bookmark model. It contains only:
+
+- stable bookmark ID;
+- display name;
+- kind (`local` or `remote`);
+- path;
+- for remote bookmarks only: protocol, host, port and username.
+
+The bookmark model does **not** contain password, passphrase, private-key contents/path, host-key fingerprint, profile ID, access token or other authentication/trust material. Username is treated as account identity, not as a credential.
+
+This distinction is deliberate. A remote server path such as `/home/alice/site` can be safe only when associated with the same login identity that created it. The account metadata exists to reject cross-account reuse, not to reconnect automatically.
+
+### Account identity is stricter than endpoint identity
+
+Remote bookmark and profile-start binding use `profilebinding.AccountMatches` rather than endpoint-only comparison. The identity boundary is:
+
+```text
+protocol + canonical host + port + exact username
+```
+
+Host/protocol canonicalization follows the shared profile-binding rules, while username remains exact. Changing only the username is therefore enough to invalidate an inherited server path.
+
+Endpoint-only matching remains appropriate for server-scoped data such as host-key identity, but it is not sufficient authority for account-scoped navigation.
+
+## Bookmark persistence
+
+`internal/config/bookmarks.go` owns bookmark persistence in `bookmarks.json` under the normal local Ghost FTP state directory.
+
+The store enforces the following contract:
+
+- maximum 256 bookmarks;
+- generated IDs are fixed-length random hexadecimal identities;
+- names are trimmed, valid UTF-8, bounded, and reject NUL/newline characters;
+- local paths must be absolute and are cleaned with platform-local path semantics;
+- a local bookmark is rejected if network/account fields are supplied;
+- remote paths pass the shared remote-path validator;
+- remote protocol/host/port/username pass the shared connection validator;
+- duplicate IDs and malformed persisted entries fail closed;
+- an existing corrupt bookmark state must not silently become an empty collection during a later save;
+- list results are stable-sorted by name, kind and ID.
+
+Persistence uses the existing durable state-store behavior, including the previous-generation file used by that store. A missing bookmark file means an empty collection; an unreadable/corrupt existing state is treated as an error instead of authorizing destructive replacement.
+
+## Creating bookmarks
+
+### Local bookmark
+
+`Engine.SaveLocalBookmark(id, name, path)` persists only local navigation metadata. The local path is validated by the bookmark store. No profile or connection identity is involved.
+
+### Remote bookmark
+
+`Engine.SaveRemoteBookmark(id, name, path)` requires a real active remote connection. The Engine reads the active `remote.Config()` and binds the bookmark to that actual connection's protocol, host, port and username.
+
+The desktop UI does not get to provide or forge this identity. This prevents stale text fields from creating a bookmark that claims to belong to a session that is not actually active.
+
+Saving a bookmark has no `SaveProfile` side effect. A bookmark created while using Quick Connect therefore remains a bookmark and **does not create a hidden persistent Site Manager profile**.
+
+## Opening bookmarks
+
+All bookmark activation goes through `Engine.NavigateBookmark(ctx, id)`. The desktop panes must not treat stored paths as already-proven navigation authority.
+
+### Local navigation
+
+For a local bookmark, `NavigateBookmark` performs a real bounded local directory list through the local manager. Only a successful list returns a canonical local base and item snapshot for UI commit. A stale, missing or inaccessible local directory therefore returns an actionable error instead of changing the pane to an unverified path.
+
+### Remote navigation
+
+For a remote bookmark, the Engine performs all of the following before returning success:
+
+1. require an active remote connection;
+2. compare bookmark identity with the current connection using `RemoteBookmarkMatchesAccount` / `AccountMatches`;
+3. capture the remote connection identity;
+4. perform a real `RemoteList` of the bookmark path through the active session;
+5. capture connection identity again after the list;
+6. reject the result if the connection identity changed;
+7. re-read active connection configuration and re-check the bookmark/account match.
+
+This double revalidation closes the reconnect race: a request started on one session cannot commit navigation state after the application has reconnected to another server/account.
+
+## Windows desktop behavior
+
+Windows exposes **Bookmarks** as a real desktop navigation entry backed by `internal/desktop/bookmark_manager_windows.go`.
+
+The native manager supports:
+
+- **Open** selected bookmark;
+- **Add local** from the currently verified local path;
+- **Add remote** from the current remote path only while connected;
+- **Delete** with confirmation;
+- **Close**.
+
+Opening a local bookmark uses the normal local navigation sequence/cancellation guard. Opening a remote bookmark additionally captures the desktop `connectionGeneration`; the callback is discarded when its sequence is stale, the connection generation changed, or the client disconnected before UI commit.
+
+Remote identity is therefore defended twice: once by the Engine's account/session verification and again by the desktop generation guard that protects visible state from stale asynchronous completion.
+
+## Linux desktop behavior
+
+Linux exposes **Bookmarks** as a native X11 header control and modal overlay through `internal/desktop/bookmark_linux.go`.
+
+The overlay supports the same functional actions as Windows:
+
+- open selected bookmark;
+- add current local directory;
+- add current remote directory when connected;
+- delete selected bookmark;
+- close.
+
+Keyboard and mouse handling are routed through the established Linux prompt/modal dispatcher. Bookmark naming prompts feed the same Engine save methods used by Windows, and bookmark activation goes through `Engine.NavigateBookmark` rather than directly trusting the stored path.
+
+The Bookmarks control is rendered through the existing workspace/file-filter extension path and has a matching click handler; it is not a decorative or dead control.
+
+## Profile start directories
+
+Site Manager profiles already contain `LocalPath` and `RemotePath`. The navigation feature treats these values as explicit requested start locations, not as unconditional UI state.
+
+### Identity-changing profile edits
+
+When an existing profile's account identity changes, an inherited remote path is not automatically carried across that boundary. Configuration tests cover:
+
+- host/account identity change resetting an inherited FTPS/FTP remote start to `/`;
+- SFTP reset using protocol default `.`;
+- an explicitly supplied new remote start for the new identity remaining valid.
+
+This preserves user intent while preventing an old account's directory from silently becoming the start directory of a different login.
+
+### Windows profile start behavior
+
+Windows applies a saved remote start only when the selected profile still matches the connection fields through the same strict account-identity contract, including username. A user who selects a profile and then edits the login identity cannot silently inherit that profile's unrelated remote path.
+
+The local start path is validated through actual local listing behavior before it becomes authoritative pane state.
+
+### Linux profile start behavior
+
+`internal/desktop/profile_start_linux.go` compensates for legacy `cycleProfile()` behavior that copies profile paths into editable fields immediately.
+
+The guard runs on the UI goroutine before the Bookmarks header is painted and treats those copied values as drafts:
+
+- the previous verified local base is restored immediately;
+- the requested profile local start is passed to `refreshLocal`;
+- only successful local listing may commit the resulting canonical base;
+- a remote start is retained only while protocol/host/port/username still match the selected profile;
+- editing the selected profile's account fields resets the remote start to the protocol default (`/` for FTP/FTPS, `.` for SFTP).
+
+This keeps a stale local or server path from becoming visible authority merely because a profile row was selected.
+
+## Error and stale-state behavior
+
+The feature is fail-closed around navigation authority:
+
+- missing/corrupt bookmark state returns an error;
+- invalid bookmark input is rejected before persistence;
+- unavailable local paths fail during fresh listing;
+- unavailable server paths fail during `RemoteList`;
+- remote bookmark account mismatch is rejected;
+- disconnect/reconnect during remote navigation invalidates the operation;
+- Windows stale async callbacks are rejected by navigation sequence / connection generation;
+- profile identity changes cannot silently retain an unrelated inherited server start.
+
+A failure must leave the previously verified pane state intact whenever the surrounding navigation path supports that behavior; it must not manufacture a successful empty listing.
+
+## Privacy
+
+Bookmarks and start directories are local application state. The feature adds no telemetry, analytics, remote Ghost FTP service, synchronization backend or mandatory account.
+
+Paths and usernames may themselves be sensitive metadata, so UI and diagnostics should avoid exposing them outside the explicit navigation surfaces. Authentication secrets remain governed by the existing protected-profile secret handling and are never copied into `bookmarks.json`.
+
+## Cross-platform parity
+
+The maintained parity target is behavioral rather than pixel-identical:
+
+| Capability | Windows | Linux |
+| --- | --- | --- |
+| List bookmarks | Native manager | Native X11 overlay |
+| Add local bookmark | Yes | Yes |
+| Add remote bookmark | Connected session only | Connected session only |
+| Delete bookmark | Confirmed | Confirmed through existing destructive-action policy |
+| Open local bookmark via `NavigateBookmark` | Yes | Yes |
+| Open remote bookmark via `NavigateBookmark` | Yes | Yes |
+| Remote account binding | Yes | Yes |
+| Stale-session protection | Engine + connection generation | Engine + serialized Linux action/session behavior |
+| Profile local start requires real listing | Yes | Yes |
+| Profile remote start rejects account drift | Yes | Yes |
+
+## Regression coverage
+
+The implementation is protected by Go unit tests and source-level regression contracts, including:
+
+- `internal/config/bookmarks_test.go` — CRUD, validation, non-secret persisted schema, account binding and corrupt-state fail-closed behavior;
+- `internal/config/profile_start_directory_binding_test.go` — inherited remote-start reset and explicit-new-path behavior across identity changes;
+- `internal/profilebinding/*_test.go` — canonical endpoint/account identity semantics;
+- desktop tests for shared bookmark wording and Site Manager navigation privacy;
+- `scripts/test_navigation_bookmarks_contract.py` — cross-layer Engine/config/Windows/Linux/documentation wiring and security invariants.
+
+The regression contract intentionally checks that visible desktop controls have real handlers and that source documentation continues to distinguish this post-0.0.3 work from the already published 0.0.3 binaries.
+
+## Release boundary
+
+This document describes implemented source behavior on the feature-development line. It does not authorize publication by itself.
+
+Before the capability is called part of a public release, the normal Ghost FTP lifecycle still requires exact-head tests/builds, platform packaging/install gates, review/merge, version advancement, release publication, remote read-back and canonical retention verification.
+
+Root `VERSION` remains **0.0.3** during this work. The eventual successor version must be created as a new immutable public release identity rather than rewriting the existing 0.0.3 release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 - Release shape: **14 platform artifacts / 17 public files**
 - Product website: **https://ghostftp.com**
 
-The root [`VERSION`](../VERSION) file is the authoritative production version source. Active documentation describes the current 0.0.3 public line. Superseded release identities are removed only after the successor has passed source gates, publication, remote read-back and the canonical retention workflow.
+The root [`VERSION`](../VERSION) file is the authoritative production version source. Release-bound documentation describes the current 0.0.3 public line. Documents that explicitly say **post-0.0.3 source line** may describe implemented work targeted for a future release and do not retroactively change the published 0.0.3 binaries. Superseded release identities are removed only after the successor has passed source gates, publication, remote read-back and the canonical retention workflow.
 
 ## Start here
 
@@ -29,6 +29,7 @@ The root [`VERSION`](../VERSION) file is the authoritative production version so
 | Understand security boundaries | [`SECURITY.md`](SECURITY.md) |
 | Understand privacy/no-telemetry behavior | [`PRIVACY.md`](PRIVACY.md) |
 | Understand architecture/Core ownership | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| Understand post-0.0.3 navigation bookmarks/profile starts | [`NAVIGATION-BOOKMARKS.md`](NAVIGATION-BOOKMARKS.md) |
 | Verify Windows/Linux parity | [`PLATFORM-PARITY.md`](PLATFORM-PARITY.md) |
 | Validate a downloaded release | [`RELEASE-VERIFICATION.md`](RELEASE-VERIFICATION.md) |
 | Understand release/version lifecycle | [`VERSIONING.md`](VERSIONING.md) and [`GITHUB-RELEASES.md`](GITHUB-RELEASES.md) |
@@ -70,12 +71,15 @@ See [`REFERENCE-UI.md`](REFERENCE-UI.md) for provenance and the rule that mockup
 - Validated local settings for concurrency, upload/download KiB/s ceilings, timeout, retry, overwrite policy, delete confirmation, appearance and language.
 - No telemetry, analytics, advertising, tracking or hidden product backend.
 
+Post-0.0.3 source capabilities are deliberately kept outside this public 0.0.3 list. Their implementation and acceptance boundaries are documented separately in [`ROADMAP.md`](ROADMAP.md), [`QUEUE-PRIORITY.md`](QUEUE-PRIORITY.md) and [`NAVIGATION-BOOKMARKS.md`](NAVIGATION-BOOKMARKS.md).
+
 ## Product and architecture
 
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — components, ownership and trust boundaries.
 - [`PLATFORM-PARITY.md`](PLATFORM-PARITY.md) — Windows/Linux parity contract.
 - [`REFERENCE-UI.md`](REFERENCE-UI.md) — native desktop UI and authentic evidence.
 - [`SETTINGS.md`](SETTINGS.md) — validated settings and persistence behavior.
+- [`NAVIGATION-BOOKMARKS.md`](NAVIGATION-BOOKMARKS.md) — post-0.0.3 bookmark and profile-start source/security contract.
 - [`LOCALIZATION.md`](LOCALIZATION.md) — 24-language local localization model.
 - [`DEPENDENCIES.md`](DEPENDENCIES.md) — dependency and external-tool policy.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -128,14 +128,23 @@ See [Queue priority and reordering](QUEUE-PRIORITY.md) for the detailed source a
 
 ### P1 — navigation bookmarks and profile start directories
 
-Allow reusable local/server bookmarks plus explicit default local/server directories per site profile.
+**Status: implemented in the post-0.0.3 source line and targeted for the next public release.** This does not retroactively add the capability to the already published 0.0.3 binaries.
 
-Acceptance requirements:
+Implemented source contract:
 
-- bookmarks store paths, never credentials;
-- stale local paths and unavailable server paths produce actionable errors;
-- profile identity changes cannot inherit unrelated server paths silently;
-- quick-connect bookmarks do not create hidden persistent profiles.
+- reusable bookmarks are explicit local or remote navigation metadata and never contain passwords, passphrases, private-key data/paths, fingerprints or hidden profile references;
+- local bookmarks require absolute validated paths and are freshly listed before a desktop pane commits navigation;
+- remote bookmark creation reads protocol/host/port/username from the real active Engine connection rather than trusting editable UI text;
+- remote bookmark activation uses `AccountMatches` and revalidates connection identity both before and after a fresh server listing, so reconnect/account changes fail closed;
+- quick-connect bookmark creation has no `SaveProfile` side effect and therefore creates no hidden persistent Site Manager profile;
+- existing corrupt bookmark state fails closed instead of silently becoming an empty collection during a later save;
+- profile remote starts are account-bound: an inherited path is reset when profile identity changes, while a newly explicit path for the new identity is preserved;
+- Windows uses a native bookmark manager and adds desktop `connectionGeneration` protection around remote async navigation commits;
+- Linux uses a native X11 bookmark overlay with full key/mouse/prompt dispatch and turns legacy profile-path copies into drafts that require a real local listing before commit;
+- Windows and Linux expose Add local, Add remote, Open and Delete behavior through the same Engine/config contract;
+- `scripts/test_navigation_bookmarks_contract.py` plus Go unit tests protect non-secret persistence, account/session binding, profile-start isolation, UI wiring and release-boundary documentation.
+
+See [Navigation bookmarks and profile start directories](NAVIGATION-BOOKMARKS.md) for the detailed source, security, privacy, parity and release-boundary contract.
 
 ### P1 — stronger interrupted-transfer resume
 

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bren-wp/Ghost-FTP/internal/config"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+type BookmarkNavigation struct {
+	Bookmark  model.Bookmark
+	LocalBase string
+	Items     []model.Item
+}
+
+func (e *Engine) SaveLocalBookmark(id, name, path string) (model.Bookmark, error) {
+	return e.bookmarks.Save(model.BookmarkInput{
+		ID: id, Name: name, Kind: model.BookmarkKindLocal, Path: path,
+	})
+}
+
+// SaveRemoteBookmark binds navigation metadata to the real active server
+// account held by the remote manager. UI text is deliberately not accepted as
+// host/account identity, and no profile is created as a side effect.
+func (e *Engine) SaveRemoteBookmark(id, name, path string) (model.Bookmark, error) {
+	cfg, connected := e.remote.Config()
+	if !connected {
+		return model.Bookmark{}, errors.New("remote bookmark zahtijeva aktivnu vezu")
+	}
+	return e.bookmarks.Save(model.BookmarkInput{
+		ID: id, Name: name, Kind: model.BookmarkKindRemote, Path: path,
+		Protocol: cfg.Protocol, Host: cfg.Host, Port: cfg.Port, Username: cfg.Username,
+	})
+}
+
+// NavigateBookmark proves the target before any desktop pane commits it. Local
+// bookmarks must successfully list as a real directory. Remote bookmarks must
+// match the active account, list through that session, and still see the same
+// connection identity after listing; reconnect/account changes therefore cannot
+// turn a stale bookmark into navigation authority for another server context.
+func (e *Engine) NavigateBookmark(ctx context.Context, id string) (BookmarkNavigation, error) {
+	bookmark, err := e.bookmarks.Get(id)
+	if err != nil {
+		return BookmarkNavigation{}, err
+	}
+
+	switch bookmark.Kind {
+	case model.BookmarkKindLocal:
+		base, items, err := e.local.ListContext(ctx, bookmark.Path)
+		if err != nil {
+			return BookmarkNavigation{}, err
+		}
+		return BookmarkNavigation{Bookmark: bookmark, LocalBase: base, Items: items}, nil
+
+	case model.BookmarkKindRemote:
+		cfg, connected := e.remote.Config()
+		if !connected {
+			return BookmarkNavigation{}, errors.New("remote bookmark zahtijeva aktivnu vezu")
+		}
+		if !config.RemoteBookmarkMatchesAccount(bookmark, cfg) {
+			return BookmarkNavigation{}, errors.New("remote bookmark pripada drugom server računu")
+		}
+		identityBefore, err := e.remote.ConnectionIdentity()
+		if err != nil {
+			return BookmarkNavigation{}, err
+		}
+		items, err := e.RemoteList(ctx, bookmark.Path)
+		if err != nil {
+			return BookmarkNavigation{}, err
+		}
+		identityAfter, err := e.remote.ConnectionIdentity()
+		if err != nil {
+			return BookmarkNavigation{}, err
+		}
+		if identityBefore != identityAfter {
+			return BookmarkNavigation{}, errors.New("veza se promijenila tijekom otvaranja bookmarka")
+		}
+		cfgAfter, connected := e.remote.Config()
+		if !connected || !config.RemoteBookmarkMatchesAccount(bookmark, cfgAfter) {
+			return BookmarkNavigation{}, errors.New("veza se promijenila tijekom otvaranja bookmarka")
+		}
+		return BookmarkNavigation{Bookmark: bookmark, Items: items}, nil
+	default:
+		return BookmarkNavigation{}, errors.New("vrsta bookmarka je neispravna")
+	}
+}

--- a/internal/api/engine.go
+++ b/internal/api/engine.go
@@ -72,13 +72,8 @@ func (e *Engine) ChoosePrivateKey() (string, error)        { return platform.Cho
 func (e *Engine) Profiles() ([]model.PublicProfile, error) { return e.profiles.List() }
 func (e *Engine) RemoveProfile(id string) error            { return e.profiles.Remove(id) }
 func (e *Engine) Bookmarks() ([]model.Bookmark, error)      { return e.bookmarks.List() }
-func (e *Engine) SaveBookmark(in model.BookmarkInput) (model.Bookmark, error) {
-	return e.bookmarks.Save(in)
-}
-func (e *Engine) RemoveBookmark(id string) error { return e.bookmarks.Remove(id) }
-func (e *Engine) Settings() (model.Settings, error) {
-	return e.settings.Get()
-}
+func (e *Engine) RemoveBookmark(id string) error            { return e.bookmarks.Remove(id) }
+func (e *Engine) Settings() (model.Settings, error)         { return e.settings.Get() }
 func (e *Engine) SetSettings(v model.Settings) (model.Settings, error) {
 	saved, err := e.settings.Set(v)
 	if err == nil {

--- a/internal/api/engine.go
+++ b/internal/api/engine.go
@@ -21,6 +21,7 @@ import (
 type Engine struct {
 	dataDir   string
 	profiles  *config.Profiles
+	bookmarks *config.Bookmarks
 	settings  *config.SettingsStore
 	local     *localfs.Service
 	remote    *remote.Manager
@@ -45,9 +46,10 @@ func New(dataDir, exePath string) (*Engine, error) {
 	cleanupLegacyDiagnostics(dataDir)
 	store := config.New(dataDir)
 	p := config.NewProfiles(store)
+	b := config.NewBookmarks(store)
 	ss := config.NewSettings(store)
 	r := remote.NewManager(p, ss, dataDir, exePath)
-	e := &Engine{dataDir: dataDir, profiles: p, settings: ss, local: localfs.New(), remote: r}
+	e := &Engine{dataDir: dataDir, profiles: p, bookmarks: b, settings: ss, local: localfs.New(), remote: r}
 	e.transfers = transfer.New(r, ss)
 	return e, nil
 }
@@ -69,7 +71,14 @@ func (e *Engine) ChooseDirectory() (string, error)         { return platform.Cho
 func (e *Engine) ChoosePrivateKey() (string, error)        { return platform.ChoosePrivateKey() }
 func (e *Engine) Profiles() ([]model.PublicProfile, error) { return e.profiles.List() }
 func (e *Engine) RemoveProfile(id string) error            { return e.profiles.Remove(id) }
-func (e *Engine) Settings() (model.Settings, error)        { return e.settings.Get() }
+func (e *Engine) Bookmarks() ([]model.Bookmark, error)      { return e.bookmarks.List() }
+func (e *Engine) SaveBookmark(in model.BookmarkInput) (model.Bookmark, error) {
+	return e.bookmarks.Save(in)
+}
+func (e *Engine) RemoveBookmark(id string) error { return e.bookmarks.Remove(id) }
+func (e *Engine) Settings() (model.Settings, error) {
+	return e.settings.Get()
+}
 func (e *Engine) SetSettings(v model.Settings) (model.Settings, error) {
 	saved, err := e.settings.Set(v)
 	if err == nil {
@@ -105,6 +114,14 @@ func (e *Engine) Disconnect(ctx context.Context) error {
 }
 
 func (e *Engine) Probe(ctx context.Context) error { return e.remote.Probe(ctx) }
+
+// ActiveConnection returns only the remote manager's sanitized public
+// connection descriptor. Password and passphrase are cleared before the manager
+// publishes m.cfg, so navigation features can bind to the real active account
+// without consulting mutable UI text or exposing credentials.
+func (e *Engine) ActiveConnection() (model.ConnectionConfig, bool) {
+	return e.remote.Config()
+}
 
 func (e *Engine) LocalList(ctx context.Context, path string) (string, []model.Item, error) {
 	return e.local.ListContext(ctx, path)

--- a/internal/api/engine.go
+++ b/internal/api/engine.go
@@ -71,9 +71,9 @@ func (e *Engine) ChooseDirectory() (string, error)         { return platform.Cho
 func (e *Engine) ChoosePrivateKey() (string, error)        { return platform.ChoosePrivateKey() }
 func (e *Engine) Profiles() ([]model.PublicProfile, error) { return e.profiles.List() }
 func (e *Engine) RemoveProfile(id string) error            { return e.profiles.Remove(id) }
-func (e *Engine) Bookmarks() ([]model.Bookmark, error)      { return e.bookmarks.List() }
-func (e *Engine) RemoveBookmark(id string) error            { return e.bookmarks.Remove(id) }
-func (e *Engine) Settings() (model.Settings, error)         { return e.settings.Get() }
+func (e *Engine) Bookmarks() ([]model.Bookmark, error)     { return e.bookmarks.List() }
+func (e *Engine) RemoveBookmark(id string) error           { return e.bookmarks.Remove(id) }
+func (e *Engine) Settings() (model.Settings, error)        { return e.settings.Get() }
 func (e *Engine) SetSettings(v model.Settings) (model.Settings, error) {
 	saved, err := e.settings.Set(v)
 	if err == nil {

--- a/internal/config/bookmarks.go
+++ b/internal/config/bookmarks.go
@@ -137,6 +137,22 @@ func (b *Bookmarks) List() ([]model.Bookmark, error) {
 	return append([]model.Bookmark(nil), items...), nil
 }
 
+func (b *Bookmarks) Get(id string) (model.Bookmark, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	items, err := b.loadLocked()
+	if err != nil {
+		return model.Bookmark{}, err
+	}
+	id = strings.TrimSpace(id)
+	for _, item := range items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return model.Bookmark{}, errors.New("bookmark nije pronađen")
+}
+
 func (b *Bookmarks) Save(in model.BookmarkInput) (model.Bookmark, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/config/bookmarks.go
+++ b/internal/config/bookmarks.go
@@ -1,0 +1,218 @@
+package config
+
+import (
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/profilebinding"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+const (
+	bookmarksFile = "bookmarks.json"
+	maxBookmarks  = 256
+)
+
+type Bookmarks struct {
+	store *Store
+	mu    sync.Mutex
+}
+
+func NewBookmarks(store *Store) *Bookmarks { return &Bookmarks{store: store} }
+
+func validBookmarkID(id string) bool {
+	if len(id) != 24 {
+		return false
+	}
+	_, err := hex.DecodeString(id)
+	return err == nil
+}
+
+func normalizeBookmark(b model.Bookmark) (model.Bookmark, error) {
+	b.ID = strings.TrimSpace(b.ID)
+	b.Name = strings.TrimSpace(b.Name)
+	b.Kind = strings.ToLower(strings.TrimSpace(b.Kind))
+	if !validBookmarkID(b.ID) {
+		return model.Bookmark{}, errors.New("bookmark ima neispravan identitet")
+	}
+	if b.Name == "" || len(b.Name) > 120 || !utf8.ValidString(b.Name) || strings.ContainsAny(b.Name, "\x00\r\n") {
+		return model.Bookmark{}, errors.New("naziv bookmarka je neispravan")
+	}
+	if b.Path == "" || len(b.Path) > 32767 || !utf8.ValidString(b.Path) || strings.ContainsAny(b.Path, "\x00\r\n") {
+		return model.Bookmark{}, errors.New("putanja bookmarka je neispravna")
+	}
+
+	switch b.Kind {
+	case model.BookmarkKindLocal:
+		if !filepath.IsAbs(b.Path) {
+			return model.Bookmark{}, errors.New("lokalni bookmark mora koristiti apsolutnu putanju")
+		}
+		b.Path = filepath.Clean(b.Path)
+		// A local bookmark is machine-local navigation metadata. Network/account
+		// fields are rejected instead of silently persisting irrelevant identity.
+		if b.Protocol != "" || b.Host != "" || b.Port != 0 || b.Username != "" {
+			return model.Bookmark{}, errors.New("lokalni bookmark ne smije sadržavati mrežni identitet")
+		}
+	case model.BookmarkKindRemote:
+		if err := security.ValidateRemotePath(b.Path); err != nil {
+			return model.Bookmark{}, err
+		}
+		b.Protocol = strings.ToLower(strings.TrimSpace(b.Protocol))
+		b.Host = strings.TrimSpace(b.Host)
+		if err := security.ValidateConnection(b.Protocol, b.Host, b.Username, b.Port); err != nil {
+			return model.Bookmark{}, err
+		}
+	default:
+		return model.Bookmark{}, errors.New("vrsta bookmarka je neispravna")
+	}
+	return b, nil
+}
+
+func (b *Bookmarks) loadLocked() ([]model.Bookmark, error) {
+	var items []model.Bookmark
+	source, err := b.store.Read(bookmarksFile, []model.Bookmark{}, &items)
+	if err != nil {
+		return nil, err
+	}
+	if source == "fallback" {
+		// Missing state means an empty bookmark collection. Existing state that
+		// could not be decoded is different: fail closed so a later Save cannot
+		// silently replace recoverable user metadata with an empty generation.
+		for _, name := range []string{bookmarksFile, bookmarksFile + ".previous"} {
+			if _, statErr := os.Lstat(filepath.Join(b.store.Dir(), name)); statErr == nil {
+				return nil, errors.New("spremljene bookmarke nije moguće pročitati")
+			} else if !errors.Is(statErr, os.ErrNotExist) {
+				return nil, statErr
+			}
+		}
+		return []model.Bookmark{}, nil
+	}
+	if len(items) > maxBookmarks {
+		return nil, errors.New("spremljeno je previše bookmarka")
+	}
+	seen := make(map[string]struct{}, len(items))
+	for i := range items {
+		normalized, err := normalizeBookmark(items[i])
+		if err != nil {
+			return nil, errors.New("spremljeni bookmark je neispravan: " + err.Error())
+		}
+		if _, exists := seen[normalized.ID]; exists {
+			return nil, errors.New("spremljeni bookmark identitet je dupliciran")
+		}
+		seen[normalized.ID] = struct{}{}
+		items[i] = normalized
+	}
+	return items, nil
+}
+
+func sortBookmarks(items []model.Bookmark) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left := strings.ToLower(items[i].Name)
+		right := strings.ToLower(items[j].Name)
+		if left != right {
+			return left < right
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func (b *Bookmarks) List() ([]model.Bookmark, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	items, err := b.loadLocked()
+	if err != nil {
+		return nil, err
+	}
+	sortBookmarks(items)
+	return append([]model.Bookmark(nil), items...), nil
+}
+
+func (b *Bookmarks) Save(in model.BookmarkInput) (model.Bookmark, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	items, err := b.loadLocked()
+	if err != nil {
+		return model.Bookmark{}, err
+	}
+
+	id := strings.TrimSpace(in.ID)
+	index := -1
+	if id != "" {
+		for i := range items {
+			if items[i].ID == id {
+				index = i
+				break
+			}
+		}
+		if index < 0 {
+			return model.Bookmark{}, errors.New("bookmark za izmjenu nije pronađen")
+		}
+	} else {
+		if len(items) >= maxBookmarks {
+			return model.Bookmark{}, errors.New("dosegnut je maksimalan broj bookmarka")
+		}
+		id, err = randomID()
+		if err != nil {
+			return model.Bookmark{}, err
+		}
+	}
+
+	bookmark, err := normalizeBookmark(model.Bookmark{
+		ID: id, Name: in.Name, Kind: in.Kind, Path: in.Path,
+		Protocol: in.Protocol, Host: in.Host, Port: in.Port, Username: in.Username,
+	})
+	if err != nil {
+		return model.Bookmark{}, err
+	}
+	if index >= 0 {
+		items[index] = bookmark
+	} else {
+		items = append(items, bookmark)
+	}
+	sortBookmarks(items)
+	if err := b.store.Write(bookmarksFile, items); err != nil {
+		return model.Bookmark{}, err
+	}
+	return bookmark, nil
+}
+
+func (b *Bookmarks) Remove(id string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	items, err := b.loadLocked()
+	if err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	for i := range items {
+		if items[i].ID != id {
+			continue
+		}
+		items = append(items[:i], items[i+1:]...)
+		return b.store.Write(bookmarksFile, items)
+	}
+	return errors.New("bookmark nije pronađen")
+}
+
+// RemoteBookmarkMatchesAccount prevents one server-side path from being reused
+// by another account on the same endpoint. Username is navigation identity here,
+// not a credential; no password, key, passphrase or trust secret is persisted.
+func RemoteBookmarkMatchesAccount(bookmark model.Bookmark, cfg model.ConnectionConfig) bool {
+	if bookmark.Kind != model.BookmarkKindRemote {
+		return false
+	}
+	return profilebinding.AccountMatches(
+		bookmark.Protocol, bookmark.Host, bookmark.Port, bookmark.Username,
+		cfg.Protocol, cfg.Host, cfg.Port, cfg.Username,
+	)
+}

--- a/internal/config/bookmarks_test.go
+++ b/internal/config/bookmarks_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestBookmarksSaveListUpdateRemoveLocal(t *testing.T) {
+	dir := t.TempDir()
+	store := New(dir)
+	bookmarks := NewBookmarks(store)
+	path := filepath.Join(dir, "projects", "..", "projects")
+
+	saved, err := bookmarks.Save(model.BookmarkInput{
+		Name: " Projects ", Kind: model.BookmarkKindLocal, Path: path,
+	})
+	if err != nil {
+		t.Fatalf("Save local bookmark: %v", err)
+	}
+	if saved.Name != "Projects" || saved.Path != filepath.Clean(path) || saved.ID == "" {
+		t.Fatalf("unexpected normalized bookmark: %#v", saved)
+	}
+
+	items, err := bookmarks.List()
+	if err != nil || len(items) != 1 || items[0].ID != saved.ID {
+		t.Fatalf("List = %#v, %v", items, err)
+	}
+
+	updated, err := bookmarks.Save(model.BookmarkInput{
+		ID: saved.ID, Name: "Work", Kind: model.BookmarkKindLocal, Path: dir,
+	})
+	if err != nil {
+		t.Fatalf("Update local bookmark: %v", err)
+	}
+	if updated.ID != saved.ID || updated.Name != "Work" {
+		t.Fatalf("update changed identity or name: %#v", updated)
+	}
+	if err := bookmarks.Remove(saved.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	items, err = bookmarks.List()
+	if err != nil || len(items) != 0 {
+		t.Fatalf("List after remove = %#v, %v", items, err)
+	}
+}
+
+func TestBookmarksRejectRelativeLocalAndNetworkFieldsOnLocal(t *testing.T) {
+	bookmarks := NewBookmarks(New(t.TempDir()))
+	if _, err := bookmarks.Save(model.BookmarkInput{Name: "bad", Kind: model.BookmarkKindLocal, Path: "relative/path"}); err == nil {
+		t.Fatal("relative local bookmark was accepted")
+	}
+	if _, err := bookmarks.Save(model.BookmarkInput{
+		Name: "bad", Kind: model.BookmarkKindLocal, Path: t.TempDir(), Host: "example.com",
+	}); err == nil {
+		t.Fatal("local bookmark with network identity was accepted")
+	}
+}
+
+func TestRemoteBookmarksAreAccountBoundAndPersistNoSecretSchema(t *testing.T) {
+	dir := t.TempDir()
+	bookmarks := NewBookmarks(New(dir))
+	saved, err := bookmarks.Save(model.BookmarkInput{
+		Name: "Web root", Kind: model.BookmarkKindRemote, Path: "/public_html",
+		Protocol: "SFTP", Host: " Example.COM. ", Port: 22, Username: "alice",
+	})
+	if err != nil {
+		t.Fatalf("Save remote bookmark: %v", err)
+	}
+	if saved.Protocol != "sftp" || saved.Host != "Example.COM." {
+		t.Fatalf("unexpected public identity normalization: %#v", saved)
+	}
+	if !RemoteBookmarkMatchesAccount(saved, model.ConnectionConfig{Protocol: "sftp", Host: "example.com", Port: 22, Username: "alice"}) {
+		t.Fatal("canonical same-account connection did not match remote bookmark")
+	}
+	if RemoteBookmarkMatchesAccount(saved, model.ConnectionConfig{Protocol: "sftp", Host: "example.com", Port: 22, Username: "bob"}) {
+		t.Fatal("remote bookmark crossed account boundary")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, bookmarksFile))
+	if err != nil {
+		t.Fatalf("Read persisted bookmarks: %v", err)
+	}
+	text := strings.ToLower(string(data))
+	for _, forbidden := range []string{"password", "passphrase", "privatekey", "fingerprint", "profileid"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("non-secret bookmark file contains forbidden field %q: %s", forbidden, text)
+		}
+	}
+}
+
+func TestBookmarksCorruptExistingStateFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	bookmarks := NewBookmarks(New(dir))
+	if err := os.WriteFile(filepath.Join(dir, bookmarksFile), []byte("{not-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bookmarks.List(); err == nil {
+		t.Fatal("corrupt existing bookmark state silently became an empty list")
+	}
+	if _, err := bookmarks.Save(model.BookmarkInput{Name: "new", Kind: model.BookmarkKindLocal, Path: dir}); err == nil {
+		t.Fatal("save replaced corrupt bookmark state instead of failing closed")
+	}
+}
+
+func TestBookmarksRejectUnknownEditAndMissingRemove(t *testing.T) {
+	bookmarks := NewBookmarks(New(t.TempDir()))
+	if _, err := bookmarks.Save(model.BookmarkInput{
+		ID: strings.Repeat("a", 24), Name: "missing", Kind: model.BookmarkKindLocal, Path: t.TempDir(),
+	}); err == nil {
+		t.Fatal("unknown bookmark edit was accepted")
+	}
+	if err := bookmarks.Remove(strings.Repeat("b", 24)); err == nil {
+		t.Fatal("missing bookmark removal was accepted")
+	}
+}

--- a/internal/config/profile_start_directory_binding_test.go
+++ b/internal/config/profile_start_directory_binding_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestProfileRemoteStartDoesNotSilentlyCrossAccountIdentity(t *testing.T) {
+	profiles := NewProfiles(New(t.TempDir()))
+	first, err := profiles.Save(model.ProfileInput{
+		Name: "Site", Protocol: "ftps", Host: "old.example.com", Port: 21,
+		Username: "alice", RemotePath: "/alice-root", LocalPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("initial Save: %v", err)
+	}
+
+	changed, err := profiles.Save(model.ProfileInput{
+		ID: first.ID, Name: "Site", Protocol: "ftps", Host: "new.example.com", Port: 21,
+		Username: "alice", RemotePath: first.RemotePath, LocalPath: first.LocalPath,
+	})
+	if err != nil {
+		t.Fatalf("identity-changing Save: %v", err)
+	}
+	if changed.RemotePath != "/" {
+		t.Fatalf("inherited stale remote start = %q, want protocol default /", changed.RemotePath)
+	}
+}
+
+func TestProfileExplicitNewRemoteStartSurvivesIdentityChange(t *testing.T) {
+	profiles := NewProfiles(New(t.TempDir()))
+	first, err := profiles.Save(model.ProfileInput{
+		Name: "Site", Protocol: "sftp", Host: "host.example.com", Port: 22,
+		Username: "alice", RemotePath: "/home/alice", LocalPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("initial Save: %v", err)
+	}
+
+	changed, err := profiles.Save(model.ProfileInput{
+		ID: first.ID, Name: "Site", Protocol: "sftp", Host: "host.example.com", Port: 22,
+		Username: "bob", RemotePath: "/home/bob", LocalPath: first.LocalPath,
+	})
+	if err != nil {
+		t.Fatalf("explicit new start Save: %v", err)
+	}
+	if changed.RemotePath != "/home/bob" {
+		t.Fatalf("explicit new remote start = %q, want /home/bob", changed.RemotePath)
+	}
+}
+
+func TestProfileInheritedSFTPRemoteStartResetsToDot(t *testing.T) {
+	profiles := NewProfiles(New(t.TempDir()))
+	first, err := profiles.Save(model.ProfileInput{
+		Name: "Site", Protocol: "sftp", Host: "one.example.com", Port: 22,
+		Username: "alice", RemotePath: "/srv/site", LocalPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("initial Save: %v", err)
+	}
+
+	changed, err := profiles.Save(model.ProfileInput{
+		ID: first.ID, Name: "Site", Protocol: "sftp", Host: "two.example.com", Port: 22,
+		Username: "alice", RemotePath: first.RemotePath, LocalPath: first.LocalPath,
+	})
+	if err != nil {
+		t.Fatalf("identity-changing Save: %v", err)
+	}
+	if changed.RemotePath != "." {
+		t.Fatalf("inherited SFTP remote start = %q, want protocol default .", changed.RemotePath)
+	}
+}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -148,6 +148,13 @@ func sameProfilePrivateKey(a, b model.Profile) bool {
 	)
 }
 
+func defaultRemoteStart(protocol string) string {
+	if strings.EqualFold(strings.TrimSpace(protocol), "sftp") {
+		return "."
+	}
+	return "/"
+}
+
 func (p *Profiles) List() ([]model.PublicProfile, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -217,12 +224,19 @@ func (p *Profiles) Save(in model.ProfileInput) (model.PublicProfile, error) {
 	x.RemotePath = in.RemotePath
 	x.LocalPath = in.LocalPath
 	if x.RemotePath == "" {
-		if x.Protocol == "sftp" {
-			x.RemotePath = "."
-		} else {
-			x.RemotePath = "/"
-		}
+		x.RemotePath = defaultRemoteStart(x.Protocol)
 	}
+
+	// Remote start paths belong to one server account namespace. A desktop edit
+	// commonly submits the currently displayed old path together with a changed
+	// host/port/username. If that value is byte-for-byte the previous saved path,
+	// treat it as inherited stale state and reset to the new protocol's safe
+	// default. A genuinely different path remains an explicit new value and is
+	// validated below.
+	if idx >= 0 && !sameProfileAccount(previous, x) && x.RemotePath == previous.RemotePath {
+		x.RemotePath = defaultRemoteStart(x.Protocol)
+	}
+
 	if x.Name == "" || len(x.Name) > 120 || !utf8.ValidString(x.Name) || strings.ContainsAny(x.Name, "\x00\r\n") {
 		return model.PublicProfile{}, errors.New("naziv profila je neispravan")
 	}

--- a/internal/desktop/bookmark_linux.go
+++ b/internal/desktop/bookmark_linux.go
@@ -295,7 +295,7 @@ func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
 
 func (u *linuxDesktop) bookmarkRowAt(x, y int) int {
 	state := linuxBookmarkStateFor(u)
-	if !state.rows.contains(x, y) {
+	if !state.rows.contains(x, y) || y < state.rows.top+4 {
 		return -1
 	}
 	visualRow := (y - state.rows.top - 4) / 32

--- a/internal/desktop/bookmark_linux.go
+++ b/internal/desktop/bookmark_linux.go
@@ -17,14 +17,14 @@ import (
 )
 
 type linuxBookmarkUIState struct {
-	items      []model.Bookmark
-	selected   int
-	list       linuxRect
-	open       linuxRect
-	addLocal   linuxRect
-	addRemote  linuxRect
-	delete     linuxRect
-	close      linuxRect
+	items     []model.Bookmark
+	selected  int
+	list      linuxRect
+	open      linuxRect
+	addLocal  linuxRect
+	addRemote linuxRect
+	delete    linuxRect
+	close     linuxRect
 }
 
 var linuxBookmarkUIStates sync.Map
@@ -45,6 +45,7 @@ func (u *linuxDesktop) bookmarksHeaderRect() linuxRect {
 }
 
 func (u *linuxDesktop) renderBookmarksHeaderButton() error {
+	u.enforceLinuxProfileStartDirectories()
 	words := bookmarkWordsForLanguage(u.language)
 	return u.drawButton(u.bookmarksHeaderRect(), words.Title, !u.busy, false)
 }
@@ -113,8 +114,8 @@ func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
 	words := bookmarkWordsForLanguage(u.language)
 	width := min(780, u.width-80)
 	height := min(470, u.height-80)
-	if width < 560 {
-		width = 560
+	if width < 660 {
+		width = 660
 	}
 	if height < 340 {
 		height = 340

--- a/internal/desktop/bookmark_linux.go
+++ b/internal/desktop/bookmark_linux.go
@@ -1,0 +1,325 @@
+//go:build linux
+
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/i18n"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/usererror"
+)
+
+type linuxBookmarkUIState struct {
+	items      []model.Bookmark
+	selected   int
+	list       linuxRect
+	open       linuxRect
+	addLocal   linuxRect
+	addRemote  linuxRect
+	delete     linuxRect
+	close      linuxRect
+}
+
+var linuxBookmarkUIStates sync.Map
+
+func linuxBookmarkStateFor(u *linuxDesktop) *linuxBookmarkUIState {
+	if value, ok := linuxBookmarkUIStates.Load(u); ok {
+		return value.(*linuxBookmarkUIState)
+	}
+	state := &linuxBookmarkUIState{selected: -1}
+	actual, _ := linuxBookmarkUIStates.LoadOrStore(u, state)
+	return actual.(*linuxBookmarkUIState)
+}
+
+func (u *linuxDesktop) bookmarksHeaderRect() linuxRect {
+	right := u.layout.settings.left - 8
+	width := 118
+	return linuxRectWH(right-width, u.layout.settings.top, width, u.layout.settings.bottom-u.layout.settings.top)
+}
+
+func (u *linuxDesktop) renderBookmarksHeaderButton() error {
+	words := bookmarkWordsForLanguage(u.language)
+	return u.drawButton(u.bookmarksHeaderRect(), words.Title, !u.busy, false)
+}
+
+func (u *linuxDesktop) handleBookmarksHeaderMouse(x, y int) bool {
+	if !u.bookmarksHeaderRect().contains(x, y) {
+		return false
+	}
+	if !u.busy {
+		u.openLinuxBookmarks("")
+	}
+	return true
+}
+
+func (u *linuxDesktop) openLinuxBookmarks(selectID string) {
+	if u.busy {
+		return
+	}
+	items, err := u.engine.Bookmarks()
+	if err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+	state := linuxBookmarkStateFor(u)
+	state.items = items
+	state.selected = -1
+	if len(items) != 0 {
+		state.selected = 0
+	}
+	if selectID != "" {
+		for index := range items {
+			if items[index].ID == selectID {
+				state.selected = index
+				break
+			}
+		}
+	}
+	u.promptKind = linuxPromptBookmarkManager
+	u.promptTitle = bookmarkWordsForLanguage(u.language).Title
+	u.promptValue = ""
+}
+
+func linuxBookmarkName(pathValue string, remote bool) string {
+	pathValue = strings.TrimSpace(pathValue)
+	if remote {
+		cleaned := cleanRemote(pathValue)
+		if cleaned == "/" || cleaned == "." {
+			return cleaned
+		}
+		name := path.Base(cleaned)
+		if name != "" && name != "." && name != "/" {
+			return name
+		}
+		return cleaned
+	}
+	cleaned := filepath.Clean(pathValue)
+	name := filepath.Base(cleaned)
+	if name != "" && name != "." {
+		return name
+	}
+	return cleaned
+}
+
+func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
+	state := linuxBookmarkStateFor(u)
+	words := bookmarkWordsForLanguage(u.language)
+	width := min(780, u.width-80)
+	height := min(470, u.height-80)
+	if width < 560 {
+		width = 560
+	}
+	if height < 340 {
+		height = 340
+	}
+	left := (u.width - width) / 2
+	top := (u.height - height) / 2
+	panel := linuxRectWH(left, top, width, height)
+	if err := u.drawPanel(panel); err != nil {
+		return err
+	}
+	if err := u.x.text(left+20, top+30, strings.ToUpper(words.Title), premiumTheme.Text, premiumTheme.Panel); err != nil {
+		return err
+	}
+
+	listTop := top + 48
+	listBottom := top + height - 86
+	state.list = linuxRectWH(left+20, listTop, width-40, listBottom-listTop)
+	if err := u.x.fillRect(state.list.left, state.list.top, state.list.right-state.list.left, state.list.bottom-state.list.top, premiumTheme.List); err != nil {
+		return err
+	}
+	if err := u.x.strokeRect(state.list.left, state.list.top, state.list.right-state.list.left, state.list.bottom-state.list.top, premiumTheme.Border); err != nil {
+		return err
+	}
+	if len(state.items) == 0 {
+		if err := u.x.text(state.list.left+12, state.list.top+26, words.Empty, premiumTheme.Muted, premiumTheme.List); err != nil {
+			return err
+		}
+	} else {
+		rowH := 32
+		maxRows := (state.list.bottom - state.list.top - 8) / rowH
+		for index := 0; index < len(state.items) && index < maxRows; index++ {
+			item := state.items[index]
+			rowTop := state.list.top + 4 + index*rowH
+			background := premiumTheme.List
+			if index == state.selected {
+				background = premiumTheme.Selection
+				if err := u.x.fillRect(state.list.left+1, rowTop, state.list.right-state.list.left-2, rowH, background); err != nil {
+					return err
+				}
+			}
+			kind := u.tr("section.local")
+			identity := ""
+			if item.Kind == model.BookmarkKindRemote {
+				kind = u.tr("section.remote")
+				identity = item.Username + "@" + item.Host + " · "
+			}
+			line := fmt.Sprintf("%s  ·  %s  ·  %s%s", kind, item.Name, identity, item.Path)
+			if err := u.x.text(state.list.left+10, rowTop+21, linuxTrimForUI(line, max(24, (state.list.right-state.list.left-20)/7)), premiumTheme.Text, background); err != nil {
+				return err
+			}
+		}
+	}
+
+	buttonTop := top + height - 58
+	buttonGap := 8
+	state.open = linuxRectWH(left+20, buttonTop, 104, 32)
+	state.addLocal = linuxRectWH(state.open.right+buttonGap, buttonTop, 132, 32)
+	state.addRemote = linuxRectWH(state.addLocal.right+buttonGap, buttonTop, 132, 32)
+	state.delete = linuxRectWH(state.addRemote.right+buttonGap, buttonTop, 104, 32)
+	state.close = linuxRectWH(left+width-124, buttonTop, 104, 32)
+	hasSelection := state.selected >= 0 && state.selected < len(state.items)
+	if err := u.drawButton(state.open, words.Open, hasSelection && !u.busy, true); err != nil {
+		return err
+	}
+	if err := u.drawButton(state.addLocal, words.AddLocal, strings.TrimSpace(u.localCurrent) != "" && !u.busy, false); err != nil {
+		return err
+	}
+	if err := u.drawButton(state.addRemote, words.AddRemote, u.connected && strings.TrimSpace(u.remoteCurrent) != "" && !u.busy, false); err != nil {
+		return err
+	}
+	if err := u.drawButton(state.delete, words.Delete, hasSelection && !u.busy, false); err != nil {
+		return err
+	}
+	return u.drawButton(state.close, words.Close, !u.busy, false)
+}
+
+func (u *linuxDesktop) bookmarkRowAt(y int) int {
+	state := linuxBookmarkStateFor(u)
+	if !state.list.contains(state.list.left+1, y) {
+		return -1
+	}
+	index := (y - state.list.top - 4) / 32
+	if index < 0 || index >= len(state.items) {
+		return -1
+	}
+	return index
+}
+
+func (u *linuxDesktop) handleBookmarkManagerMouse(x, y int) bool {
+	state := linuxBookmarkStateFor(u)
+	if index := u.bookmarkRowAt(y); state.list.contains(x, y) && index >= 0 {
+		state.selected = index
+		return true
+	}
+	switch {
+	case state.open.contains(x, y):
+		u.openSelectedLinuxBookmark()
+	case state.addLocal.contains(x, y):
+		if !u.busy && strings.TrimSpace(u.localCurrent) != "" {
+			words := bookmarkWordsForLanguage(u.language)
+			u.openPrompt(linuxPromptBookmarkLocalName, words.AddLocal+" · "+words.Name, linuxBookmarkName(u.localCurrent, false))
+		}
+	case state.addRemote.contains(x, y):
+		if !u.busy && u.connected && strings.TrimSpace(u.remoteCurrent) != "" {
+			words := bookmarkWordsForLanguage(u.language)
+			u.openPrompt(linuxPromptBookmarkRemoteName, words.AddRemote+" · "+words.Name, linuxBookmarkName(u.remoteCurrent, true))
+		}
+	case state.delete.contains(x, y):
+		u.deleteSelectedLinuxBookmark()
+	case state.close.contains(x, y):
+		u.closePrompt()
+	default:
+		return true
+	}
+	return true
+}
+
+func (u *linuxDesktop) handleBookmarkManagerKey(sym uint32) bool {
+	state := linuxBookmarkStateFor(u)
+	switch sym {
+	case x11KeyEscape:
+		u.closePrompt()
+	case x11KeyUp:
+		if state.selected > 0 {
+			state.selected--
+		}
+	case x11KeyDown:
+		if state.selected+1 < len(state.items) {
+			state.selected++
+		}
+	case x11KeyReturn:
+		u.openSelectedLinuxBookmark()
+	case x11KeyDelete:
+		u.deleteSelectedLinuxBookmark()
+	}
+	return true
+}
+
+func (u *linuxDesktop) saveLinuxBookmark(remote bool, name string) {
+	words := bookmarkWordsForLanguage(u.language)
+	var (
+		saved model.Bookmark
+		err   error
+	)
+	if remote {
+		if !u.connected {
+			u.setStatus(i18n.T(u.language, "error.generic"))
+			return
+		}
+		saved, err = u.engine.SaveRemoteBookmark("", name, u.remoteCurrent)
+	} else {
+		saved, err = u.engine.SaveLocalBookmark("", name, u.localCurrent)
+	}
+	if err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+	u.setStatus(words.Saved)
+	u.openLinuxBookmarks(saved.ID)
+}
+
+func (u *linuxDesktop) deleteSelectedLinuxBookmark() {
+	state := linuxBookmarkStateFor(u)
+	if u.busy || state.selected < 0 || state.selected >= len(state.items) {
+		return
+	}
+	item := state.items[state.selected]
+	if !u.destructiveConfirmed("bookmark:"+item.ID, item.Name) {
+		return
+	}
+	if err := u.engine.RemoveBookmark(item.ID); err != nil {
+		u.setStatus(usererror.MessageFor(u.language, err, i18n.T(u.language, "error.generic")))
+		return
+	}
+	words := bookmarkWordsForLanguage(u.language)
+	u.setStatus(words.Removed)
+	u.openLinuxBookmarks("")
+}
+
+func (u *linuxDesktop) openSelectedLinuxBookmark() {
+	state := linuxBookmarkStateFor(u)
+	if u.busy || state.selected < 0 || state.selected >= len(state.items) {
+		return
+	}
+	bookmark := state.items[state.selected]
+	if bookmark.Kind == model.BookmarkKindRemote && !u.connected {
+		u.setStatus(i18n.T(u.language, "error.generic"))
+		return
+	}
+	u.closePrompt()
+	words := bookmarkWordsForLanguage(u.language)
+	u.setStatus(words.Open + ": " + bookmark.Name)
+	if bookmark.Kind == model.BookmarkKindLocal {
+		u.startAction(linuxActionLocalRefresh, func() linuxUIResult {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			result, err := u.engine.NavigateBookmark(ctx, bookmark.ID)
+			return linuxUIResult{localBase: result.LocalBase, localItems: result.Items, err: err}
+		})
+		return
+	}
+	u.startAction(linuxActionRemoteRefresh, func() linuxUIResult {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		result, err := u.engine.NavigateBookmark(ctx, bookmark.ID)
+		return linuxUIResult{localBase: result.Bookmark.Path, remoteItems: result.Items, err: err}
+	})
+}

--- a/internal/desktop/bookmark_linux.go
+++ b/internal/desktop/bookmark_linux.go
@@ -17,14 +17,19 @@ import (
 )
 
 type linuxBookmarkUIState struct {
-	items     []model.Bookmark
-	selected  int
-	list      linuxRect
-	open      linuxRect
-	addLocal  linuxRect
-	addRemote linuxRect
-	delete    linuxRect
-	close     linuxRect
+	items        []model.Bookmark
+	selected     int
+	firstVisible int
+	visibleRows  int
+	list         linuxRect
+	rows         linuxRect
+	scrollUp     linuxRect
+	scrollDown   linuxRect
+	open         linuxRect
+	addLocal     linuxRect
+	addRemote    linuxRect
+	delete       linuxRect
+	close        linuxRect
 }
 
 var linuxBookmarkUIStates sync.Map
@@ -36,6 +41,77 @@ func linuxBookmarkStateFor(u *linuxDesktop) *linuxBookmarkUIState {
 	state := &linuxBookmarkUIState{selected: -1}
 	actual, _ := linuxBookmarkUIStates.LoadOrStore(u, state)
 	return actual.(*linuxBookmarkUIState)
+}
+
+func (state *linuxBookmarkUIState) ensureSelectionVisible() {
+	if state == nil {
+		return
+	}
+	rows := state.visibleRows
+	if rows < 1 {
+		rows = 1
+	}
+	if len(state.items) == 0 {
+		state.selected = -1
+		state.firstVisible = 0
+		return
+	}
+	if state.selected < 0 {
+		state.selected = 0
+	}
+	if state.selected >= len(state.items) {
+		state.selected = len(state.items) - 1
+	}
+	maxFirst := len(state.items) - rows
+	if maxFirst < 0 {
+		maxFirst = 0
+	}
+	if state.firstVisible < 0 {
+		state.firstVisible = 0
+	}
+	if state.firstVisible > maxFirst {
+		state.firstVisible = maxFirst
+	}
+	if state.selected < state.firstVisible {
+		state.firstVisible = state.selected
+	}
+	if state.selected >= state.firstVisible+rows {
+		state.firstVisible = state.selected - rows + 1
+	}
+	if state.firstVisible > maxFirst {
+		state.firstVisible = maxFirst
+	}
+}
+
+func (state *linuxBookmarkUIState) scrollViewport(delta int) {
+	if state == nil || len(state.items) == 0 || delta == 0 {
+		return
+	}
+	rows := state.visibleRows
+	if rows < 1 {
+		rows = 1
+	}
+	maxFirst := len(state.items) - rows
+	if maxFirst < 0 {
+		maxFirst = 0
+	}
+	state.firstVisible += delta
+	if state.firstVisible < 0 {
+		state.firstVisible = 0
+	}
+	if state.firstVisible > maxFirst {
+		state.firstVisible = maxFirst
+	}
+	if state.selected < state.firstVisible {
+		state.selected = state.firstVisible
+	}
+	lastVisible := state.firstVisible + rows - 1
+	if lastVisible >= len(state.items) {
+		lastVisible = len(state.items) - 1
+	}
+	if state.selected > lastVisible {
+		state.selected = lastVisible
+	}
 }
 
 func (u *linuxDesktop) bookmarksHeaderRect() linuxRect {
@@ -72,6 +148,8 @@ func (u *linuxDesktop) openLinuxBookmarks(selectID string) {
 	state := linuxBookmarkStateFor(u)
 	state.items = items
 	state.selected = -1
+	state.firstVisible = 0
+	state.visibleRows = 0
 	if len(items) != 0 {
 		state.selected = 0
 	}
@@ -139,20 +217,43 @@ func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
 	if err := u.x.strokeRect(state.list.left, state.list.top, state.list.right-state.list.left, state.list.bottom-state.list.top, premiumTheme.Border); err != nil {
 		return err
 	}
+	rowH := 32
+	state.visibleRows = (state.list.bottom - state.list.top - 8) / rowH
+	if state.visibleRows < 1 {
+		state.visibleRows = 1
+	}
+	state.ensureSelectionVisible()
+	state.rows = state.list
+	state.scrollUp = linuxRect{}
+	state.scrollDown = linuxRect{}
+	if len(state.items) > state.visibleRows {
+		scrollWidth := 28
+		state.rows.right = state.list.right - scrollWidth - 8
+		state.scrollUp = linuxRectWH(state.list.right-scrollWidth-5, state.list.top+5, scrollWidth, 28)
+		state.scrollDown = linuxRectWH(state.list.right-scrollWidth-5, state.list.bottom-33, scrollWidth, 28)
+		if err := u.drawButton(state.scrollUp, "^", state.firstVisible > 0 && !u.busy, false); err != nil {
+			return err
+		}
+		if err := u.drawButton(state.scrollDown, "v", state.firstVisible+state.visibleRows < len(state.items) && !u.busy, false); err != nil {
+			return err
+		}
+	}
 	if len(state.items) == 0 {
-		if err := u.x.text(state.list.left+12, state.list.top+26, words.Empty, premiumTheme.Muted, premiumTheme.List); err != nil {
+		if err := u.x.text(state.rows.left+12, state.rows.top+26, words.Empty, premiumTheme.Muted, premiumTheme.List); err != nil {
 			return err
 		}
 	} else {
-		rowH := 32
-		maxRows := (state.list.bottom - state.list.top - 8) / rowH
-		for index := 0; index < len(state.items) && index < maxRows; index++ {
+		for visualRow := 0; visualRow < state.visibleRows; visualRow++ {
+			index := state.firstVisible + visualRow
+			if index >= len(state.items) {
+				break
+			}
 			item := state.items[index]
-			rowTop := state.list.top + 4 + index*rowH
+			rowTop := state.rows.top + 4 + visualRow*rowH
 			background := premiumTheme.List
 			if index == state.selected {
 				background = premiumTheme.Selection
-				if err := u.x.fillRect(state.list.left+1, rowTop, state.list.right-state.list.left-2, rowH, background); err != nil {
+				if err := u.x.fillRect(state.rows.left+1, rowTop, state.rows.right-state.rows.left-2, rowH, background); err != nil {
 					return err
 				}
 			}
@@ -163,7 +264,7 @@ func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
 				identity = item.Username + "@" + item.Host + " · "
 			}
 			line := fmt.Sprintf("%s  ·  %s  ·  %s%s", kind, item.Name, identity, item.Path)
-			if err := u.x.text(state.list.left+10, rowTop+21, linuxTrimForUI(line, max(24, (state.list.right-state.list.left-20)/7)), premiumTheme.Text, background); err != nil {
+			if err := u.x.text(state.rows.left+10, rowTop+21, linuxTrimForUI(line, max(24, (state.rows.right-state.rows.left-20)/7)), premiumTheme.Text, background); err != nil {
 				return err
 			}
 		}
@@ -192,12 +293,16 @@ func (u *linuxDesktop) renderBookmarkManagerOverlay() error {
 	return u.drawButton(state.close, words.Close, !u.busy, false)
 }
 
-func (u *linuxDesktop) bookmarkRowAt(y int) int {
+func (u *linuxDesktop) bookmarkRowAt(x, y int) int {
 	state := linuxBookmarkStateFor(u)
-	if !state.list.contains(state.list.left+1, y) {
+	if !state.rows.contains(x, y) {
 		return -1
 	}
-	index := (y - state.list.top - 4) / 32
+	visualRow := (y - state.rows.top - 4) / 32
+	if visualRow < 0 || visualRow >= state.visibleRows {
+		return -1
+	}
+	index := state.firstVisible + visualRow
 	if index < 0 || index >= len(state.items) {
 		return -1
 	}
@@ -206,8 +311,21 @@ func (u *linuxDesktop) bookmarkRowAt(y int) int {
 
 func (u *linuxDesktop) handleBookmarkManagerMouse(x, y int) bool {
 	state := linuxBookmarkStateFor(u)
-	if index := u.bookmarkRowAt(y); state.list.contains(x, y) && index >= 0 {
+	if state.scrollUp.contains(x, y) {
+		if !u.busy {
+			state.scrollViewport(-1)
+		}
+		return true
+	}
+	if state.scrollDown.contains(x, y) {
+		if !u.busy {
+			state.scrollViewport(1)
+		}
+		return true
+	}
+	if index := u.bookmarkRowAt(x, y); index >= 0 {
 		state.selected = index
+		state.ensureSelectionVisible()
 		return true
 	}
 	switch {
@@ -241,10 +359,12 @@ func (u *linuxDesktop) handleBookmarkManagerKey(sym uint32) bool {
 	case x11KeyUp:
 		if state.selected > 0 {
 			state.selected--
+			state.ensureSelectionVisible()
 		}
 	case x11KeyDown:
 		if state.selected+1 < len(state.items) {
 			state.selected++
+			state.ensureSelectionVisible()
 		}
 	case x11KeyReturn:
 		u.openSelectedLinuxBookmark()

--- a/internal/desktop/bookmark_manager_windows.go
+++ b/internal/desktop/bookmark_manager_windows.go
@@ -1,0 +1,435 @@
+//go:build windows
+
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+)
+
+const (
+	idBookmarks = 97
+
+	bookmarkIDList      = 8201
+	bookmarkIDOpen      = 8202
+	bookmarkIDAddLocal  = 8203
+	bookmarkIDAddRemote = 8204
+	bookmarkIDDelete    = 8205
+	bookmarkIDClose     = 8206
+
+	bookmarkWindowStyle = 0x00C80000 // WS_CAPTION | WS_SYSMENU
+)
+
+type bookmarkManagerState struct {
+	parent    *app
+	hwnd      uintptr
+	list      uintptr
+	open      uintptr
+	addLocal  uintptr
+	addRemote uintptr
+	delete    uintptr
+	close     uintptr
+	items     []model.Bookmark
+	selected  int
+	closed    bool
+	openAfter *model.Bookmark
+}
+
+var (
+	bookmarkManagerStates sync.Map
+	bookmarkManagerOnce   sync.Once
+	bookmarkManagerClass  = "GhostFTP.Bookmarks"
+	bookmarkManagerProc   = syscall.NewCallback(bookmarkManagerWndProc)
+)
+
+func bookmarkManagerWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
+	value, ok := bookmarkManagerStates.Load(hwnd)
+	if ok {
+		state := value.(*bookmarkManagerState)
+		switch message {
+		case wmCommand:
+			id := int(wParam & 0xffff)
+			notify := int((wParam >> 16) & 0xffff)
+			if id == bookmarkIDList && notify == siteLBNSelChange {
+				state.readSelection()
+				return 0
+			}
+			if id == bookmarkIDList && notify == siteLBNDblClk {
+				state.readSelection()
+				state.openCurrent()
+				return 0
+			}
+			if notify == bnClicked {
+				switch id {
+				case bookmarkIDOpen:
+					state.openCurrent()
+					return 0
+				case bookmarkIDAddLocal:
+					state.addCurrent(false)
+					return 0
+				case bookmarkIDAddRemote:
+					state.addCurrent(true)
+					return 0
+				case bookmarkIDDelete:
+					state.deleteCurrent()
+					return 0
+				case bookmarkIDClose:
+					destroyWindow.Call(hwnd)
+					return 0
+				}
+			}
+		case wmDrawItem:
+			if lParam != 0 {
+				d := drawItemFromLParam(lParam)
+				if state.parent.drawButton(&d) {
+					return 1
+				}
+			}
+		case siteWMCtlColorListBox:
+			setTextColor.Call(wParam, textColor())
+			setBkColor.Call(wParam, listColor())
+			return state.parent.panelBrush
+		case wmCtlColorEdit, wmCtlColorBtn, wmCtlColorStatic:
+			setTextColor.Call(wParam, textColor())
+			setBkColor.Call(wParam, windowColor())
+			return state.parent.brush
+		case wmClose:
+			destroyWindow.Call(hwnd)
+			return 0
+		case wmDestroy:
+			for _, button := range []uintptr{state.open, state.addLocal, state.addRemote, state.delete, state.close} {
+				delete(state.parent.buttons, button)
+			}
+			state.closed = true
+			return 0
+		}
+	}
+	result, _, _ := defWindowProcW.Call(hwnd, uintptr(message), wParam, lParam)
+	return result
+}
+
+func bookmarkDefaultName(bookmarkPath string, remote bool) string {
+	bookmarkPath = strings.TrimSpace(bookmarkPath)
+	if remote {
+		cleaned := cleanRemote(bookmarkPath)
+		if cleaned == "/" || cleaned == "." {
+			return cleaned
+		}
+		if name := path.Base(cleaned); name != "" && name != "." && name != "/" {
+			return name
+		}
+		return cleaned
+	}
+	cleaned := filepath.Clean(bookmarkPath)
+	if name := filepath.Base(cleaned); name != "" && name != "." {
+		return name
+	}
+	return cleaned
+}
+
+func bookmarkDisplayLabel(item model.Bookmark) string {
+	kind := "Local"
+	identity := ""
+	if item.Kind == model.BookmarkKindRemote {
+		kind = "Remote"
+		identity = item.Username + "@" + item.Host + "  ·  "
+	}
+	return "[" + kind + "]  " + item.Name + "  ·  " + identity + item.Path
+}
+
+func (state *bookmarkManagerState) loadItems(selectID string) error {
+	items, err := state.parent.engine.Bookmarks()
+	if err != nil {
+		return err
+	}
+	state.items = items
+	sendMessageW.Call(state.list, siteLBResetContent, 0, 0)
+	selected := -1
+	for index, item := range items {
+		label := bookmarkDisplayLabel(item)
+		sendMessageW.Call(state.list, siteLBAddString, 0, uintptr(unsafe.Pointer(wstr(label))))
+		if item.ID == selectID {
+			selected = index
+		}
+	}
+	state.selected = selected
+	if selected >= 0 {
+		sendMessageW.Call(state.list, siteLBSetCurSel, uintptr(selected), 0)
+	}
+	state.updateButtons()
+	return nil
+}
+
+func (state *bookmarkManagerState) readSelection() {
+	index, _, _ := sendMessageW.Call(state.list, siteLBGetCurSel, 0, 0)
+	if int32(index) < 0 || int(index) >= len(state.items) {
+		state.selected = -1
+	} else {
+		state.selected = int(index)
+	}
+	state.updateButtons()
+}
+
+func (state *bookmarkManagerState) updateButtons() {
+	hasSelection := state.selected >= 0 && state.selected < len(state.items)
+	setControlEnabled(state.open, hasSelection && !state.parent.connectionBusy)
+	setControlEnabled(state.delete, hasSelection)
+	setControlEnabled(state.addLocal, strings.TrimSpace(state.parent.localCurrent) != "")
+	setControlEnabled(state.addRemote, state.parent.connected && !state.parent.connectionBusy && strings.TrimSpace(state.parent.remoteCurrent) != "")
+}
+
+func (state *bookmarkManagerState) addCurrent(remote bool) {
+	words := bookmarkWordsForLanguage(state.parent.languageCode())
+	bookmarkPath := state.parent.localCurrent
+	title := words.AddLocal
+	if remote {
+		if !state.parent.connected || state.parent.connectionBusy {
+			return
+		}
+		bookmarkPath = state.parent.remoteCurrent
+		title = words.AddRemote
+	}
+	bookmarkPath = strings.TrimSpace(bookmarkPath)
+	if bookmarkPath == "" {
+		return
+	}
+	platform.SetDialogActionLabels(words.Saved, words.Close)
+	name, ok := platform.PromptDialog("Ghost FTP — "+words.Title, words.Name+":", bookmarkDefaultName(bookmarkPath, remote))
+	platform.SetDialogActionLabels(okLabel(state.parent.languageCode()), state.parent.tr("common.cancel"))
+	if !ok || strings.TrimSpace(name) == "" {
+		return
+	}
+	var (
+		saved model.Bookmark
+		err   error
+	)
+	if remote {
+		saved, err = state.parent.engine.SaveRemoteBookmark("", name, bookmarkPath)
+	} else {
+		saved, err = state.parent.engine.SaveLocalBookmark("", name, bookmarkPath)
+	}
+	if err != nil {
+		platform.ErrorDialog("Ghost FTP — "+words.Title, title, state.parent.userMessage(err, "error.generic"))
+		return
+	}
+	if err := state.loadItems(saved.ID); err != nil {
+		platform.ErrorDialog("Ghost FTP — "+words.Title, title, state.parent.userMessage(err, "error.generic"))
+		return
+	}
+	state.parent.setStatus(words.Saved)
+}
+
+func (state *bookmarkManagerState) deleteCurrent() {
+	if state.selected < 0 || state.selected >= len(state.items) {
+		return
+	}
+	item := state.items[state.selected]
+	words := bookmarkWordsForLanguage(state.parent.languageCode())
+	if !platform.ConfirmDialog("Ghost FTP — "+words.Title, words.Delete+"?", item.Name+"\n"+item.Path) {
+		return
+	}
+	if err := state.parent.engine.RemoveBookmark(item.ID); err != nil {
+		platform.ErrorDialog("Ghost FTP — "+words.Title, words.Delete, state.parent.userMessage(err, "error.generic"))
+		return
+	}
+	if err := state.loadItems(""); err != nil {
+		platform.ErrorDialog("Ghost FTP — "+words.Title, words.Delete, state.parent.userMessage(err, "error.generic"))
+		return
+	}
+	state.parent.setStatus(words.Removed)
+}
+
+func (state *bookmarkManagerState) openCurrent() {
+	if state.selected < 0 || state.selected >= len(state.items) || state.parent.connectionBusy {
+		return
+	}
+	item := state.items[state.selected]
+	if item.Kind == model.BookmarkKindRemote && !state.parent.connected {
+		return
+	}
+	state.openAfter = &item
+	destroyWindow.Call(state.hwnd)
+}
+
+func (state *bookmarkManagerState) createControls(hinst uintptr) error {
+	parent := state.parent
+	words := bookmarkWordsForLanguage(parent.languageCode())
+	mk := func(class, text string, style uint32, x, y, width, height, id int) uintptr {
+		hwnd, _, _ := createWindowExW.Call(
+			0,
+			uintptr(unsafe.Pointer(wstr(class))),
+			uintptr(unsafe.Pointer(wstr(text))),
+			uintptr(wsChild|wsVisible|style),
+			uintptr(parent.scale(x)), uintptr(parent.scale(y)), uintptr(parent.scale(width)), uintptr(parent.scale(height)),
+			state.hwnd, uintptr(id), hinst, 0,
+		)
+		if hwnd != 0 && parent.font != 0 {
+			sendMessageW.Call(hwnd, wmSetFont, parent.font, 1)
+		}
+		if hwnd != 0 {
+			applyDarkControl(hwnd, class)
+		}
+		return hwnd
+	}
+	state.list = mk("LISTBOX", "", wsBorder|wsTabStop|wsVScroll|siteLBSNotify|siteLBSNoIntegralHeight, 20, 20, 700, 330, bookmarkIDList)
+	state.open = parent.registerButton(mk("BUTTON", words.Open, wsTabStop|bsOwnerDraw, 20, 370, 118, 34, bookmarkIDOpen), iconOpenLocal, words.Open, buttonAccent)
+	state.addLocal = parent.registerButton(mk("BUTTON", words.AddLocal, wsTabStop|bsOwnerDraw, 148, 370, 138, 34, bookmarkIDAddLocal), iconSave, words.AddLocal, buttonDefault)
+	state.addRemote = parent.registerButton(mk("BUTTON", words.AddRemote, wsTabStop|bsOwnerDraw, 296, 370, 138, 34, bookmarkIDAddRemote), iconSave, words.AddRemote, buttonDefault)
+	state.delete = parent.registerButton(mk("BUTTON", words.Delete, wsTabStop|bsOwnerDraw, 444, 370, 118, 34, bookmarkIDDelete), iconDelete, words.Delete, buttonDanger)
+	state.close = parent.registerButton(mk("BUTTON", words.Close, wsTabStop|bsOwnerDraw, 572, 370, 148, 34, bookmarkIDClose), iconCancel, words.Close, buttonSubtle)
+	for _, control := range []uintptr{state.list, state.open, state.addLocal, state.addRemote, state.delete, state.close} {
+		if control == 0 {
+			return fmt.Errorf("bookmark manager control initialization failed")
+		}
+	}
+	return state.loadItems("")
+}
+
+func (a *app) openBookmarkManager() {
+	if a == nil || a.hwnd == 0 || a.connectionBusy {
+		return
+	}
+	hinst, _, _ := getModuleHandleW.Call(0)
+	bookmarkManagerOnce.Do(func() {
+		cursor, _, _ := loadCursorW.Call(0, 32512)
+		icon, _, _ := loadIconW.Call(hinst, 1)
+		class := wndClassEx{
+			CbSize: uint32(unsafe.Sizeof(wndClassEx{})), WndProc: bookmarkManagerProc,
+			Instance: hinst, Icon: icon, Cursor: cursor, Background: a.brush,
+			ClassName: wstr(bookmarkManagerClass), IconSm: icon,
+		}
+		registerClassExW.Call(uintptr(unsafe.Pointer(&class)))
+	})
+
+	logicalW, logicalH := 760, 470
+	pixelW, pixelH := a.scale(logicalW), a.scale(logicalH)
+	screenW, _, _ := getSystemMetrics.Call(smCxScreen)
+	screenH, _, _ := getSystemMetrics.Call(smCyScreen)
+	x := max(0, (int(screenW)-pixelW)/2)
+	y := max(0, (int(screenH)-pixelH)/2)
+	words := bookmarkWordsForLanguage(a.languageCode())
+	hwnd, _, _ := createWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(wstr(bookmarkManagerClass))),
+		uintptr(unsafe.Pointer(wstr("Ghost FTP — "+words.Title))),
+		bookmarkWindowStyle,
+		uintptr(x), uintptr(y), uintptr(pixelW), uintptr(pixelH),
+		a.hwnd, 0, hinst, 0,
+	)
+	if hwnd == 0 {
+		platform.ErrorDialog("Ghost FTP", words.Title, a.tr("error.generic"))
+		return
+	}
+	state := &bookmarkManagerState{parent: a, hwnd: hwnd, selected: -1}
+	bookmarkManagerStates.Store(hwnd, state)
+	defer bookmarkManagerStates.Delete(hwnd)
+	applyDarkTitleBar(hwnd)
+	if err := state.createControls(hinst); err != nil {
+		destroyWindow.Call(hwnd)
+		platform.ErrorDialog("Ghost FTP", words.Title, a.userMessage(err, "error.generic"))
+		return
+	}
+	enableWindow.Call(a.hwnd, 0)
+	showWindow.Call(hwnd, swShow)
+	updateWindow.Call(hwnd)
+	var message msg
+	for !state.closed {
+		result, _, callErr := getMessageW.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
+		if int32(result) == -1 {
+			if callErr != nil && callErr != syscall.Errno(0) {
+				a.setStatus(callErr.Error())
+			}
+			break
+		}
+		if result == 0 {
+			postQuitMessage.Call(0)
+			break
+		}
+		translateMessage.Call(uintptr(unsafe.Pointer(&message)))
+		dispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
+	}
+	enableWindow.Call(a.hwnd, 1)
+	showWindow.Call(a.hwnd, swShow)
+	if state.openAfter != nil {
+		a.navigateBookmark(*state.openAfter)
+	}
+}
+
+func (a *app) navigateBookmark(bookmark model.Bookmark) {
+	words := bookmarkWordsForLanguage(a.languageCode())
+	if bookmark.Kind == model.BookmarkKindLocal {
+		if a.localNavCancel != nil {
+			a.localNavCancel()
+		}
+		a.localNavSeq++
+		seq := a.localNavSeq
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		a.localNavCancel = cancel
+		a.goSafe(func() {
+			defer cancel()
+			result, err := a.engine.NavigateBookmark(ctx, bookmark.ID)
+			a.dispatch(func() {
+				if seq != a.localNavSeq {
+					return
+				}
+				a.localNavCancel = nil
+				if err != nil {
+					a.setStatus(a.userMessage(err, "error.generic"))
+					return
+				}
+				a.localCurrent = result.LocalBase
+				a.localItems = append(a.localItems[:0], result.Items...)
+				setText(a.localPath, a.localCurrent)
+				fillItems(a.localList, a.localItems)
+				a.updateActionControls()
+				a.setStatus(words.Open + ": " + result.Bookmark.Name)
+			})
+		})
+		return
+	}
+	if bookmark.Kind != model.BookmarkKindRemote || !a.connected || a.connectionBusy {
+		return
+	}
+	if a.remoteNavCancel != nil {
+		a.remoteNavCancel()
+	}
+	a.remoteNavSeq++
+	seq := a.remoteNavSeq
+	generation := a.connectionGeneration
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	a.remoteNavCancel = cancel
+	a.goSafe(func() {
+		defer cancel()
+		result, err := a.engine.NavigateBookmark(ctx, bookmark.ID)
+		a.dispatch(func() {
+			if seq != a.remoteNavSeq || generation != a.connectionGeneration || !a.connected {
+				return
+			}
+			a.remoteNavCancel = nil
+			if err != nil {
+				if a.suppressExpectedDisconnectError(err) {
+					return
+				}
+				a.setStatus(a.userMessage(err, "error.generic"))
+				a.checkConnectionAfterError()
+				return
+			}
+			a.remoteCurrent = cleanRemote(result.Bookmark.Path)
+			a.remoteItems = append(a.remoteItems[:0], result.Items...)
+			setText(a.remotePath, a.remoteCurrent)
+			fillItems(a.remoteList, a.remoteItems)
+			a.updateActionControls()
+			a.setStatus(words.Open + ": " + result.Bookmark.Name)
+		})
+	})
+}

--- a/internal/desktop/bookmark_manager_windows.go
+++ b/internal/desktop/bookmark_manager_windows.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/bren-wp/Ghost-FTP/internal/config"
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 	"github.com/bren-wp/Ghost-FTP/internal/platform"
 )
@@ -34,6 +35,7 @@ type bookmarkManagerState struct {
 	parent    *app
 	hwnd      uintptr
 	list      uintptr
+	listBrush uintptr
 	open      uintptr
 	addLocal  uintptr
 	addRemote uintptr
@@ -98,6 +100,9 @@ func bookmarkManagerWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr
 		case siteWMCtlColorListBox:
 			setTextColor.Call(wParam, textColor())
 			setBkColor.Call(wParam, listColor())
+			if state.listBrush != 0 {
+				return state.listBrush
+			}
 			return state.parent.panelBrush
 		case wmCtlColorEdit, wmCtlColorBtn, wmCtlColorStatic:
 			setTextColor.Call(wParam, textColor())
@@ -109,6 +114,10 @@ func bookmarkManagerWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr
 		case wmDestroy:
 			for _, button := range []uintptr{state.open, state.addLocal, state.addRemote, state.delete, state.close} {
 				delete(state.parent.buttons, button)
+			}
+			if state.listBrush != 0 {
+				deleteObject.Call(state.listBrush)
+				state.listBrush = 0
 			}
 			state.closed = true
 			return 0
@@ -137,11 +146,11 @@ func bookmarkDefaultName(bookmarkPath string, remote bool) string {
 	return cleaned
 }
 
-func bookmarkDisplayLabel(item model.Bookmark) string {
-	kind := "Local"
+func (state *bookmarkManagerState) displayLabel(item model.Bookmark) string {
+	kind := state.parent.tr("section.local")
 	identity := ""
 	if item.Kind == model.BookmarkKindRemote {
-		kind = "Remote"
+		kind = state.parent.tr("section.remote")
 		identity = item.Username + "@" + item.Host + "  ·  "
 	}
 	return "[" + kind + "]  " + item.Name + "  ·  " + identity + item.Path
@@ -156,7 +165,7 @@ func (state *bookmarkManagerState) loadItems(selectID string) error {
 	sendMessageW.Call(state.list, siteLBResetContent, 0, 0)
 	selected := -1
 	for index, item := range items {
-		label := bookmarkDisplayLabel(item)
+		label := state.displayLabel(item)
 		sendMessageW.Call(state.list, siteLBAddString, 0, uintptr(unsafe.Pointer(wstr(label))))
 		if item.ID == selectID {
 			selected = index
@@ -182,7 +191,12 @@ func (state *bookmarkManagerState) readSelection() {
 
 func (state *bookmarkManagerState) updateButtons() {
 	hasSelection := state.selected >= 0 && state.selected < len(state.items)
-	setControlEnabled(state.open, hasSelection && !state.parent.connectionBusy)
+	openEnabled := hasSelection && !state.parent.connectionBusy
+	if openEnabled && state.items[state.selected].Kind == model.BookmarkKindRemote {
+		cfg, connected := state.parent.engine.ActiveConnection()
+		openEnabled = connected && state.parent.connected && config.RemoteBookmarkMatchesAccount(state.items[state.selected], cfg)
+	}
+	setControlEnabled(state.open, openEnabled)
 	setControlEnabled(state.delete, hasSelection)
 	setControlEnabled(state.addLocal, strings.TrimSpace(state.parent.localCurrent) != "")
 	setControlEnabled(state.addRemote, state.parent.connected && !state.parent.connectionBusy && strings.TrimSpace(state.parent.remoteCurrent) != "")
@@ -203,9 +217,13 @@ func (state *bookmarkManagerState) addCurrent(remote bool) {
 	if bookmarkPath == "" {
 		return
 	}
-	platform.SetDialogActionLabels(words.Saved, words.Close)
-	name, ok := platform.PromptDialog("Ghost FTP — "+words.Title, words.Name+":", bookmarkDefaultName(bookmarkPath, remote))
-	platform.SetDialogActionLabels(okLabel(state.parent.languageCode()), state.parent.tr("common.cancel"))
+	name, ok := platform.PromptDialogWithLabels(
+		"Ghost FTP — "+words.Title,
+		words.Name+":",
+		bookmarkDefaultName(bookmarkPath, remote),
+		okLabel(state.parent.languageCode()),
+		state.parent.tr("common.cancel"),
+	)
 	if !ok || strings.TrimSpace(name) == "" {
 		return
 	}
@@ -254,8 +272,11 @@ func (state *bookmarkManagerState) openCurrent() {
 		return
 	}
 	item := state.items[state.selected]
-	if item.Kind == model.BookmarkKindRemote && !state.parent.connected {
-		return
+	if item.Kind == model.BookmarkKindRemote {
+		cfg, connected := state.parent.engine.ActiveConnection()
+		if !connected || !state.parent.connected || !config.RemoteBookmarkMatchesAccount(item, cfg) {
+			return
+		}
 	}
 	state.openAfter = &item
 	destroyWindow.Call(state.hwnd)
@@ -280,6 +301,10 @@ func (state *bookmarkManagerState) createControls(hinst uintptr) error {
 			applyDarkControl(hwnd, class)
 		}
 		return hwnd
+	}
+	state.listBrush, _, _ = createSolidBrush.Call(listColor())
+	if state.listBrush == 0 {
+		return fmt.Errorf("bookmark manager list brush initialization failed")
 	}
 	state.list = mk("LISTBOX", "", wsBorder|wsTabStop|wsVScroll|siteLBSNotify|siteLBSNoIntegralHeight, 20, 20, 700, 330, bookmarkIDList)
 	state.open = parent.registerButton(mk("BUTTON", words.Open, wsTabStop|bsOwnerDraw, 20, 370, 118, 34, bookmarkIDOpen), iconOpenLocal, words.Open, buttonAccent)

--- a/internal/desktop/bookmark_prompt_linux_test.go
+++ b/internal/desktop/bookmark_prompt_linux_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package desktop
+
+import "testing"
+
+func TestLinuxBookmarkNamePromptClassification(t *testing.T) {
+	u := &linuxDesktop{}
+	for _, kind := range []int{linuxPromptBookmarkLocalName, linuxPromptBookmarkRemoteName} {
+		u.promptKind = kind
+		if !u.bookmarkNamePrompt() {
+			t.Fatalf("prompt kind %d must be treated as a bookmark naming child", kind)
+		}
+	}
+	for _, kind := range []int{linuxPromptNone, linuxPromptBookmarkManager, linuxPromptLocalRename} {
+		u.promptKind = kind
+		if u.bookmarkNamePrompt() {
+			t.Fatalf("prompt kind %d must not be treated as a bookmark naming child", kind)
+		}
+	}
+}

--- a/internal/desktop/bookmark_viewport_linux_test.go
+++ b/internal/desktop/bookmark_viewport_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package desktop
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func linuxBookmarkTestItems(count int) []model.Bookmark {
+	items := make([]model.Bookmark, count)
+	for i := range items {
+		items[i] = model.Bookmark{ID: fmt.Sprintf("bookmark-%d", i), Name: fmt.Sprintf("Bookmark %d", i)}
+	}
+	return items
+}
+
+func TestLinuxBookmarkViewportKeepsKeyboardSelectionVisible(t *testing.T) {
+	state := &linuxBookmarkUIState{
+		items:        linuxBookmarkTestItems(20),
+		selected:     12,
+		firstVisible: 0,
+		visibleRows:  5,
+	}
+	state.ensureSelectionVisible()
+	if state.firstVisible != 8 {
+		t.Fatalf("firstVisible = %d, want 8 for selected row 12 in a five-row viewport", state.firstVisible)
+	}
+
+	state.selected = 2
+	state.ensureSelectionVisible()
+	if state.firstVisible != 2 {
+		t.Fatalf("viewport did not follow upward keyboard selection: got %d, want 2", state.firstVisible)
+	}
+}
+
+func TestLinuxBookmarkViewportMouseScrollReachesLaterRows(t *testing.T) {
+	state := &linuxBookmarkUIState{
+		items:        linuxBookmarkTestItems(20),
+		selected:     0,
+		firstVisible: 0,
+		visibleRows:  5,
+	}
+	state.scrollViewport(3)
+	if state.firstVisible != 3 || state.selected != 3 {
+		t.Fatalf("scroll down did not advance selectable viewport: first=%d selected=%d", state.firstVisible, state.selected)
+	}
+
+	state.scrollViewport(100)
+	if state.firstVisible != 15 || state.selected != 15 {
+		t.Fatalf("viewport did not clamp to final page: first=%d selected=%d", state.firstVisible, state.selected)
+	}
+
+	state.selected = 19
+	state.ensureSelectionVisible()
+	if state.firstVisible != 15 {
+		t.Fatalf("last bookmark is not visible on final page: first=%d", state.firstVisible)
+	}
+}
+
+func TestLinuxBookmarkViewportClampsAfterCollectionShrinks(t *testing.T) {
+	state := &linuxBookmarkUIState{
+		items:        linuxBookmarkTestItems(4),
+		selected:     9,
+		firstVisible: 8,
+		visibleRows:  5,
+	}
+	state.ensureSelectionVisible()
+	if state.selected != 3 || state.firstVisible != 0 {
+		t.Fatalf("shrunk collection was not clamped: first=%d selected=%d", state.firstVisible, state.selected)
+	}
+}

--- a/internal/desktop/bookmark_viewport_linux_test.go
+++ b/internal/desktop/bookmark_viewport_linux_test.go
@@ -72,3 +72,26 @@ func TestLinuxBookmarkViewportClampsAfterCollectionShrinks(t *testing.T) {
 		t.Fatalf("shrunk collection was not clamped: first=%d selected=%d", state.firstVisible, state.selected)
 	}
 }
+
+func TestLinuxBookmarkRowHitTestRejectsPaddingAndUsesViewportOffset(t *testing.T) {
+	u := &linuxDesktop{}
+	state := &linuxBookmarkUIState{
+		items:        linuxBookmarkTestItems(20),
+		selected:     7,
+		firstVisible: 7,
+		visibleRows:  5,
+		rows:         linuxRectWH(100, 200, 400, 168),
+	}
+	linuxBookmarkUIStates.Store(u, state)
+	t.Cleanup(func() { linuxBookmarkUIStates.Delete(u) })
+
+	if got := u.bookmarkRowAt(110, 202); got != -1 {
+		t.Fatalf("top padding selected bookmark %d, want no row", got)
+	}
+	if got := u.bookmarkRowAt(110, 204); got != 7 {
+		t.Fatalf("first visible row mapped to %d, want bookmark 7", got)
+	}
+	if got := u.bookmarkRowAt(110, 236); got != 8 {
+		t.Fatalf("second visible row mapped to %d, want bookmark 8", got)
+	}
+}

--- a/internal/desktop/bookmark_words.go
+++ b/internal/desktop/bookmark_words.go
@@ -1,0 +1,41 @@
+package desktop
+
+import "github.com/bren-wp/Ghost-FTP/internal/i18n"
+
+type bookmarkWords struct {
+	Title, AddLocal, AddRemote, Open, Delete, Close, Name, Empty, Saved, Removed string
+}
+
+var bookmarkWordCatalog = map[string]bookmarkWords{
+	"en": {"Bookmarks", "Add local", "Add remote", "Open", "Delete", "Close", "Name", "No bookmarks yet.", "Bookmark saved.", "Bookmark removed."},
+	"hr": {"Oznake", "Dodaj lokalnu", "Dodaj udaljenu", "Otvori", "Izbriši", "Zatvori", "Naziv", "Još nema oznaka.", "Oznaka je spremljena.", "Oznaka je uklonjena."},
+	"de": {"Lesezeichen", "Lokal hinzufügen", "Remote hinzufügen", "Öffnen", "Löschen", "Schließen", "Name", "Noch keine Lesezeichen.", "Lesezeichen gespeichert.", "Lesezeichen entfernt."},
+	"fr": {"Favoris", "Ajouter local", "Ajouter distant", "Ouvrir", "Supprimer", "Fermer", "Nom", "Aucun favori.", "Favori enregistré.", "Favori supprimé."},
+	"es": {"Marcadores", "Añadir local", "Añadir remoto", "Abrir", "Eliminar", "Cerrar", "Nombre", "Aún no hay marcadores.", "Marcador guardado.", "Marcador eliminado."},
+	"tr": {"Yer imleri", "Yerel ekle", "Uzak ekle", "Aç", "Sil", "Kapat", "Ad", "Henüz yer imi yok.", "Yer imi kaydedildi.", "Yer imi kaldırıldı."},
+	"el": {"Σελιδοδείκτες", "Προσθήκη τοπικού", "Προσθήκη απομακρυσμένου", "Άνοιγμα", "Διαγραφή", "Κλείσιμο", "Όνομα", "Δεν υπάρχουν σελιδοδείκτες.", "Ο σελιδοδείκτης αποθηκεύτηκε.", "Ο σελιδοδείκτης αφαιρέθηκε."},
+	"pt": {"Favoritos", "Adicionar local", "Adicionar remoto", "Abrir", "Eliminar", "Fechar", "Nome", "Ainda não há favoritos.", "Favorito guardado.", "Favorito removido."},
+	"zh": {"书签", "添加本地", "添加远程", "打开", "删除", "关闭", "名称", "暂无书签。", "书签已保存。", "书签已删除。"},
+	"ru": {"Закладки", "Добавить локальную", "Добавить удалённую", "Открыть", "Удалить", "Закрыть", "Имя", "Закладок пока нет.", "Закладка сохранена.", "Закладка удалена."},
+	"hi": {"बुकमार्क", "लोकल जोड़ें", "रिमोट जोड़ें", "खोलें", "हटाएँ", "बंद करें", "नाम", "अभी कोई बुकमार्क नहीं है।", "बुकमार्क सहेजा गया।", "बुकमार्क हटाया गया।"},
+	"ja": {"ブックマーク", "ローカルを追加", "リモートを追加", "開く", "削除", "閉じる", "名前", "ブックマークはまだありません。", "ブックマークを保存しました。", "ブックマークを削除しました。"},
+	"it": {"Segnalibri", "Aggiungi locale", "Aggiungi remoto", "Apri", "Elimina", "Chiudi", "Nome", "Nessun segnalibro.", "Segnalibro salvato.", "Segnalibro rimosso."},
+	"pl": {"Zakładki", "Dodaj lokalną", "Dodaj zdalną", "Otwórz", "Usuń", "Zamknij", "Nazwa", "Brak zakładek.", "Zakładka zapisana.", "Zakładka usunięta."},
+	"nl": {"Bladwijzers", "Lokaal toevoegen", "Extern toevoegen", "Openen", "Verwijderen", "Sluiten", "Naam", "Nog geen bladwijzers.", "Bladwijzer opgeslagen.", "Bladwijzer verwijderd."},
+	"cs": {"Záložky", "Přidat místní", "Přidat vzdálenou", "Otevřít", "Smazat", "Zavřít", "Název", "Zatím žádné záložky.", "Záložka uložena.", "Záložka odstraněna."},
+	"uk": {"Закладки", "Додати локальну", "Додати віддалену", "Відкрити", "Видалити", "Закрити", "Назва", "Закладок ще немає.", "Закладку збережено.", "Закладку видалено."},
+	"sv": {"Bokmärken", "Lägg till lokal", "Lägg till fjärr", "Öppna", "Ta bort", "Stäng", "Namn", "Inga bokmärken ännu.", "Bokmärket sparades.", "Bokmärket togs bort."},
+	"ro": {"Marcaje", "Adaugă local", "Adaugă la distanță", "Deschide", "Șterge", "Închide", "Nume", "Nu există încă marcaje.", "Marcaj salvat.", "Marcaj eliminat."},
+	"hu": {"Könyvjelzők", "Helyi hozzáadása", "Távoli hozzáadása", "Megnyitás", "Törlés", "Bezárás", "Név", "Még nincsenek könyvjelzők.", "Könyvjelző mentve.", "Könyvjelző eltávolítva."},
+	"da": {"Bogmærker", "Tilføj lokal", "Tilføj ekstern", "Åbn", "Slet", "Luk", "Navn", "Ingen bogmærker endnu.", "Bogmærke gemt.", "Bogmærke fjernet."},
+	"fi": {"Kirjanmerkit", "Lisää paikallinen", "Lisää etä", "Avaa", "Poista", "Sulje", "Nimi", "Ei vielä kirjanmerkkejä.", "Kirjanmerkki tallennettu.", "Kirjanmerkki poistettu."},
+	"no": {"Bokmerker", "Legg til lokal", "Legg til ekstern", "Åpne", "Slett", "Lukk", "Navn", "Ingen bokmerker ennå.", "Bokmerke lagret.", "Bokmerke fjernet."},
+	"ko": {"북마크", "로컬 추가", "원격 추가", "열기", "삭제", "닫기", "이름", "아직 북마크가 없습니다.", "북마크가 저장되었습니다.", "북마크가 삭제되었습니다."},
+}
+
+func bookmarkWordsForLanguage(language string) bookmarkWords {
+	if words, ok := bookmarkWordCatalog[i18n.Normalize(language)]; ok {
+		return words
+	}
+	return bookmarkWordCatalog[i18n.DefaultLanguage]
+}

--- a/internal/desktop/bookmark_words_test.go
+++ b/internal/desktop/bookmark_words_test.go
@@ -1,0 +1,21 @@
+package desktop
+
+import "testing"
+
+func TestBookmarkWordCatalogCoversSupportedLanguages(t *testing.T) {
+	languages := []string{"en", "hr", "de", "fr", "es", "tr", "el", "pt", "zh", "ru", "hi", "ja", "it", "pl", "nl", "cs", "uk", "sv", "ro", "hu", "da", "fi", "no", "ko"}
+	for _, language := range languages {
+		words := bookmarkWordsForLanguage(language)
+		if words.Title == "" || words.AddLocal == "" || words.AddRemote == "" || words.Open == "" || words.Delete == "" || words.Close == "" || words.Name == "" {
+			t.Fatalf("bookmark copy incomplete for %q: %#v", language, words)
+		}
+	}
+}
+
+func TestBookmarkWordsFallbackToEnglish(t *testing.T) {
+	got := bookmarkWordsForLanguage("xx")
+	want := bookmarkWordsForLanguage("en")
+	if got != want {
+		t.Fatalf("fallback = %#v, want %#v", got, want)
+	}
+}

--- a/internal/desktop/commands_windows.go
+++ b/internal/desktop/commands_windows.go
@@ -22,6 +22,8 @@ func (a *app) command(id int) {
 		a.disconnectNow()
 	case idSiteManager:
 		a.openSiteManager()
+	case idBookmarks:
+		a.openBookmarkManager()
 	case idChooseKey:
 		a.choosePrivateKey()
 	case idSaveProfile:

--- a/internal/desktop/connection_profiles_windows.go
+++ b/internal/desktop/connection_profiles_windows.go
@@ -211,9 +211,9 @@ func (a *app) currentEndpointMatchesProfile(p model.PublicProfile) bool {
 	if err != nil {
 		return false
 	}
-	return profilebinding.EndpointMatches(
-		p.Protocol, p.Host, p.Port,
-		a.protocolValue(), getText(a.host), port,
+	return profilebinding.AccountMatches(
+		p.Protocol, p.Host, p.Port, p.Username,
+		a.protocolValue(), getText(a.host), port, getText(a.user),
 	)
 }
 

--- a/internal/desktop/file_filter_linux.go
+++ b/internal/desktop/file_filter_linux.go
@@ -83,6 +83,12 @@ func (u *linuxDesktop) fileFilterLabel(remote bool) string {
 }
 
 func (u *linuxDesktop) renderFileFilterControls() error {
+	// Bookmarks are application-level navigation, so keep their header entry
+	// visible even when recursive search or directory comparison temporarily owns
+	// the file-filter row below.
+	if err := u.renderBookmarksHeaderButton(); err != nil {
+		return err
+	}
 	// Empty linuxUIResult notifications are used only to wake the established UI
 	// loop after recursive-search or comparison work. Reconcile on the UI
 	// goroutine before ordinary row-indexed controls are painted.
@@ -110,6 +116,9 @@ func (u *linuxDesktop) renderFileFilterControls() error {
 }
 
 func (u *linuxDesktop) handleFileFilterMouse(x, y int) bool {
+	if u.handleBookmarksHeaderMouse(x, y) {
+		return true
+	}
 	if u.handleDirectoryComparisonMouseLinux(x, y) {
 		return true
 	}

--- a/internal/desktop/gui_linux.go
+++ b/internal/desktop/gui_linux.go
@@ -1337,8 +1337,8 @@ func runLinuxGUI(engine *api.Engine, version string) error {
 				u.selectedTransfer = -1
 			}
 			if err := u.renderAll(); err != nil {
-					return err
-				}
+				return err
+			}
 		}
 	}
 }

--- a/internal/desktop/gui_linux.go
+++ b/internal/desktop/gui_linux.go
@@ -471,7 +471,7 @@ func (u *linuxDesktop) renderQuickConnect() error {
 	if u.profileIndex >= 0 && u.profileIndex < len(u.profiles) {
 		profileLabel = u.profiles[u.profileIndex].Name
 	}
-	if err := u.drawButton(u.layout.profile, profileLabel, len(u.profiles) > 0, false); err != nil {
+	if err := u.drawButton(u.layout.profile, profileLabel, len(u.profiles) > 0 && !u.busy && !u.connected, false); err != nil {
 		return err
 	}
 	if err := u.drawButton(u.layout.saveProfile, u.tr("profile.save"), u.host != "" && !u.busy, false); err != nil {
@@ -871,7 +871,7 @@ func (u *linuxDesktop) cycleProtocol() {
 }
 
 func (u *linuxDesktop) cycleProfile() {
-	if len(u.profiles) == 0 {
+	if u.busy || u.connected || len(u.profiles) == 0 {
 		return
 	}
 	u.profileIndex = (u.profileIndex + 1) % len(u.profiles)
@@ -1337,8 +1337,8 @@ func runLinuxGUI(engine *api.Engine, version string) error {
 				u.selectedTransfer = -1
 			}
 			if err := u.renderAll(); err != nil {
-				return err
-			}
+					return err
+				}
 		}
 	}
 }

--- a/internal/desktop/gui_linux_actions.go
+++ b/internal/desktop/gui_linux_actions.go
@@ -51,6 +51,22 @@ func (u *linuxDesktop) recursiveSearchPrompt() bool {
 	return u.promptKind == linuxPromptLocalRecursiveSearch || u.promptKind == linuxPromptRemoteRecursiveSearch
 }
 
+func (u *linuxDesktop) bookmarkNamePrompt() bool {
+	return u.promptKind == linuxPromptBookmarkLocalName || u.promptKind == linuxPromptBookmarkRemoteName
+}
+
+func (u *linuxDesktop) cancelPrompt() {
+	returnToBookmarks := u.bookmarkNamePrompt()
+	u.closePrompt()
+	u.setStatus(u.tr("common.cancel"))
+	if returnToBookmarks {
+		// Add-local/add-remote naming is a child step of the bookmark manager.
+		// Cancelling the child returns to that manager, matching the Windows
+		// modal flow instead of unexpectedly closing the whole bookmark task.
+		u.openLinuxBookmarks("")
+	}
+}
+
 func (u *linuxDesktop) promptCanSubmit() bool {
 	return !u.busy && (u.filterPrompt() || strings.TrimSpace(u.promptValue) != "")
 }
@@ -64,8 +80,7 @@ func (u *linuxDesktop) handlePromptKey(sym uint32) bool {
 	}
 	switch sym {
 	case x11KeyEscape:
-		u.closePrompt()
-		u.setStatus(u.tr("common.cancel"))
+		u.cancelPrompt()
 	case x11KeyReturn:
 		u.submitPrompt()
 	case x11KeyBackSpace, x11KeyDelete:
@@ -139,8 +154,7 @@ func (u *linuxDesktop) handlePromptMouse(x, y int) bool {
 		return true
 	}
 	if u.layout.promptCancel.contains(x, y) {
-		u.closePrompt()
-		u.setStatus(u.tr("common.cancel"))
+		u.cancelPrompt()
 		return true
 	}
 	return true

--- a/internal/desktop/gui_linux_actions.go
+++ b/internal/desktop/gui_linux_actions.go
@@ -23,6 +23,9 @@ const (
 	linuxPromptRemoteFilter
 	linuxPromptLocalRecursiveSearch
 	linuxPromptRemoteRecursiveSearch
+	linuxPromptBookmarkManager
+	linuxPromptBookmarkLocalName
+	linuxPromptBookmarkRemoteName
 )
 
 func (u *linuxDesktop) openPrompt(kind int, title, initial string) {
@@ -56,6 +59,9 @@ func (u *linuxDesktop) handlePromptKey(sym uint32) bool {
 	if u.promptKind == linuxPromptNone {
 		return false
 	}
+	if u.promptKind == linuxPromptBookmarkManager {
+		return u.handleBookmarkManagerKey(sym)
+	}
 	switch sym {
 	case x11KeyEscape:
 		u.closePrompt()
@@ -77,6 +83,9 @@ func (u *linuxDesktop) handlePromptKey(sym uint32) bool {
 func (u *linuxDesktop) renderPromptOverlay() error {
 	if u.promptKind == linuxPromptNone {
 		return nil
+	}
+	if u.promptKind == linuxPromptBookmarkManager {
+		return u.renderBookmarkManagerOverlay()
 	}
 	width := min(620, u.width-80)
 	height := 158
@@ -122,6 +131,9 @@ func (u *linuxDesktop) handlePromptMouse(x, y int) bool {
 	if u.promptKind == linuxPromptNone {
 		return false
 	}
+	if u.promptKind == linuxPromptBookmarkManager {
+		return u.handleBookmarkManagerMouse(x, y)
+	}
 	if u.layout.promptOK.contains(x, y) {
 		u.submitPrompt()
 		return true
@@ -143,6 +155,10 @@ func (u *linuxDesktop) submitPrompt() {
 	}
 	u.closePrompt()
 	switch kind {
+	case linuxPromptBookmarkLocalName:
+		u.saveLinuxBookmark(false, value)
+	case linuxPromptBookmarkRemoteName:
+		u.saveLinuxBookmark(true, value)
 	case linuxPromptLocalFilter:
 		u.applyLinuxFileFilter(false, value)
 	case linuxPromptRemoteFilter:

--- a/internal/desktop/profile_cycle_linux_test.go
+++ b/internal/desktop/profile_cycle_linux_test.go
@@ -10,12 +10,12 @@ import (
 
 func linuxProfileCycleTestDesktop() *linuxDesktop {
 	return &linuxDesktop{
-		profileIndex: -1,
-		protocol:     "ftps",
-		host:         "before.example",
-		port:         "21",
-		username:     "before",
-		localCurrent: "/before-local",
+		profileIndex:  -1,
+		protocol:      "ftps",
+		host:          "before.example",
+		port:          "21",
+		username:      "before",
+		localCurrent:  "/before-local",
 		remoteCurrent: "/before-remote",
 		profiles: []model.PublicProfile{{
 			ID:         "profile-1",

--- a/internal/desktop/profile_cycle_linux_test.go
+++ b/internal/desktop/profile_cycle_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func linuxProfileCycleTestDesktop() *linuxDesktop {
+	return &linuxDesktop{
+		profileIndex: -1,
+		protocol:     "ftps",
+		host:         "before.example",
+		port:         "21",
+		username:     "before",
+		localCurrent: "/before-local",
+		remoteCurrent: "/before-remote",
+		profiles: []model.PublicProfile{{
+			ID:         "profile-1",
+			Name:       "Profile One",
+			Protocol:   "sftp",
+			Host:       "after.example",
+			Port:       22,
+			Username:   "after",
+			LocalPath:  "/after-local",
+			RemotePath: ".",
+		}},
+	}
+}
+
+func TestLinuxProfileCycleBlockedWhileConnected(t *testing.T) {
+	u := linuxProfileCycleTestDesktop()
+	u.connected = true
+	u.cycleProfile()
+	if u.profileIndex != -1 || u.selectedProfileID != "" || u.host != "before.example" || u.remoteCurrent != "/before-remote" {
+		t.Fatalf("profile switching mutated an active connection draft: index=%d id=%q host=%q remote=%q", u.profileIndex, u.selectedProfileID, u.host, u.remoteCurrent)
+	}
+}
+
+func TestLinuxProfileCycleBlockedWhileBusy(t *testing.T) {
+	u := linuxProfileCycleTestDesktop()
+	u.busy = true
+	u.cycleProfile()
+	if u.profileIndex != -1 || u.selectedProfileID != "" || u.host != "before.example" || u.localCurrent != "/before-local" {
+		t.Fatalf("profile switching mutated busy state: index=%d id=%q host=%q local=%q", u.profileIndex, u.selectedProfileID, u.host, u.localCurrent)
+	}
+}
+
+func TestLinuxProfileCycleLoadsProfileWhenIdleAndDisconnected(t *testing.T) {
+	u := linuxProfileCycleTestDesktop()
+	u.cycleProfile()
+	if u.profileIndex != 0 || u.selectedProfileID != "profile-1" || u.protocol != "sftp" || u.host != "after.example" || u.port != "22" || u.username != "after" || u.localCurrent != "/after-local" || u.remoteCurrent != "." {
+		t.Fatalf("idle profile cycle did not load expected draft: %+v", u)
+	}
+}

--- a/internal/desktop/profile_start_linux.go
+++ b/internal/desktop/profile_start_linux.go
@@ -14,6 +14,8 @@ import (
 type linuxProfileStartState struct {
 	initialized       bool
 	selectedProfileID string
+	accountKey        string
+	inheritedRemote   string
 	verifiedLocal     string
 	verifiedRemote    string
 }
@@ -59,31 +61,58 @@ func (u *linuxDesktop) linuxProfileMatchesConnectionFields(profile model.PublicP
 	)
 }
 
+func (u *linuxDesktop) linuxEditableAccountKey() string {
+	if u == nil {
+		return ""
+	}
+	portText := strings.TrimSpace(u.port)
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return "invalid\x00" + strings.ToLower(strings.TrimSpace(u.protocol)) + "\x00" + strings.ToLower(strings.TrimSpace(u.host)) + "\x00" + portText + "\x00" + u.username
+	}
+	return profilebinding.EndpointKey(u.protocol, u.host, port) + "\x00" + u.username
+}
+
 // enforceLinuxProfileStartDirectories runs on the UI goroutine before the
 // bookmark header is painted. cycleProfile historically copied start paths
-// directly into the editable path fields. This guard turns those copies into
+// directly into the editable path fields. This guard turns local copies into
 // drafts: the previous verified local base is restored immediately and the
 // configured local start is committed only by refreshLocal after LocalList
-// succeeds. Remote starts remain usable as the post-connect listing target only
-// while protocol/host/port/username still match the selected profile.
+// succeeds.
+//
+// Remote starts are event-bound rather than repaint-bound. Selecting a profile
+// installs that profile's saved/default remote start once. If the editable
+// protocol/host/port/username later crosses an account boundary, the inherited
+// remote start is reset only while it is still unchanged. A user-edited remote
+// path is therefore treated as an explicit start for the new account and is
+// never overwritten merely because the window repaints.
 func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
 	if u == nil {
 		return
 	}
 	state := linuxProfileStartStateFor(u)
+	currentAccountKey := u.linuxEditableAccountKey()
 	if !state.initialized {
 		state.initialized = true
 		state.selectedProfileID = u.selectedProfileID
+		state.accountKey = currentAccountKey
 		state.verifiedLocal = u.localCurrent
 		state.verifiedRemote = u.remoteCurrent
+		if profile, ok := u.selectedLinuxProfile(); ok {
+			state.inheritedRemote = strings.TrimSpace(profile.RemotePath)
+			if state.inheritedRemote == "" {
+				state.inheritedRemote = linuxProtocolRemoteDefault(u.protocol)
+			}
+		}
 		return
 	}
 
 	profile, hasProfile := u.selectedLinuxProfile()
 	if u.selectedProfileID != state.selectedProfileID {
 		previousLocal := state.verifiedLocal
-		previousRemote := state.verifiedRemote
 		state.selectedProfileID = u.selectedProfileID
+		state.accountKey = currentAccountKey
+		state.inheritedRemote = ""
 
 		if !hasProfile {
 			return
@@ -98,25 +127,23 @@ func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
 			}
 		}
 
-		remoteTarget := strings.TrimSpace(profile.RemotePath)
-		if remoteTarget != "" && u.remoteCurrent == profile.RemotePath {
-			u.remoteCurrent = previousRemote
+		state.inheritedRemote = strings.TrimSpace(profile.RemotePath)
+		if state.inheritedRemote == "" {
+			state.inheritedRemote = linuxProtocolRemoteDefault(u.protocol)
 		}
+		u.remoteCurrent = state.inheritedRemote
 	}
 
-	if hasProfile && !u.connected {
-		if u.linuxProfileMatchesConnectionFields(profile) {
-			if strings.TrimSpace(profile.RemotePath) != "" {
-				u.remoteCurrent = profile.RemotePath
-			} else {
-				u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
-			}
-		} else {
-			// A selected profile can be edited before Connect. Once its account
-			// identity no longer matches, never carry the selected account's server
-			// directory into that different login.
+	if hasProfile && !u.connected && currentAccountKey != state.accountKey {
+		if u.remoteCurrent == state.inheritedRemote {
 			u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
+			state.inheritedRemote = u.remoteCurrent
+		} else {
+			// The remote path no longer equals the profile-derived value, so it is
+			// an explicit user edit for the new account and must survive repaint.
+			state.inheritedRemote = ""
 		}
+		state.accountKey = currentAccountKey
 	}
 
 	// Only non-busy states can represent a completed listing. A failed local

--- a/internal/desktop/profile_start_linux.go
+++ b/internal/desktop/profile_start_linux.go
@@ -17,7 +17,6 @@ type linuxProfileStartState struct {
 	accountKey        string
 	inheritedRemote   string
 	verifiedLocal     string
-	verifiedRemote    string
 }
 
 var linuxProfileStartStates sync.Map
@@ -81,11 +80,12 @@ func (u *linuxDesktop) linuxEditableAccountKey() string {
 // succeeds.
 //
 // Remote starts are event-bound rather than repaint-bound. Selecting a profile
-// installs that profile's saved/default remote start once. If the editable
-// protocol/host/port/username later crosses an account boundary, the inherited
-// remote start is reset only while it is still unchanged. A user-edited remote
-// path is therefore treated as an explicit start for the new account and is
-// never overwritten merely because the window repaints.
+// installs that profile's saved/default remote start once. Any later change to
+// protocol/host/port/username resets that inherited server path exactly once to
+// the new protocol default. After the identity change has been observed, a user
+// can enter an explicit Remote Path and ordinary repaints will not overwrite it.
+// This prevents any navigated or inherited path from the previous account from
+// silently becoming navigation authority for the new account.
 func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
 	if u == nil {
 		return
@@ -97,7 +97,6 @@ func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
 		state.selectedProfileID = u.selectedProfileID
 		state.accountKey = currentAccountKey
 		state.verifiedLocal = u.localCurrent
-		state.verifiedRemote = u.remoteCurrent
 		if profile, ok := u.selectedLinuxProfile(); ok {
 			state.inheritedRemote = strings.TrimSpace(profile.RemotePath)
 			if state.inheritedRemote == "" {
@@ -135,24 +134,20 @@ func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
 	}
 
 	if hasProfile && !u.connected && currentAccountKey != state.accountKey {
-		if u.remoteCurrent == state.inheritedRemote {
-			u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
-			state.inheritedRemote = u.remoteCurrent
-		} else {
-			// The remote path no longer equals the profile-derived value, so it is
-			// an explicit user edit for the new account and must survive repaint.
-			state.inheritedRemote = ""
-		}
+		// Account identity changed. Always discard the previous account's saved,
+		// navigated, or typed server path once at this boundary. A new explicit
+		// path entered after this transition survives subsequent repaints because
+		// accountKey is updated here and this block will not run again until the
+		// identity changes again.
+		u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
+		state.inheritedRemote = u.remoteCurrent
 		state.accountKey = currentAccountKey
 	}
 
-	// Only non-busy states can represent a completed listing. A failed local
-	// refresh leaves localCurrent at the previously verified base, while a
+	// Only non-busy states can represent a completed local listing. A failed
+	// local refresh leaves localCurrent at the previously verified base, while a
 	// successful one commits the canonical LocalList result before this point.
 	if !u.busy {
 		state.verifiedLocal = u.localCurrent
-		if u.connected {
-			state.verifiedRemote = u.remoteCurrent
-		}
 	}
 }

--- a/internal/desktop/profile_start_linux.go
+++ b/internal/desktop/profile_start_linux.go
@@ -1,0 +1,131 @@
+//go:build linux
+
+package desktop
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/profilebinding"
+)
+
+type linuxProfileStartState struct {
+	initialized       bool
+	selectedProfileID string
+	verifiedLocal     string
+	verifiedRemote    string
+}
+
+var linuxProfileStartStates sync.Map
+
+func linuxProfileStartStateFor(u *linuxDesktop) *linuxProfileStartState {
+	if value, ok := linuxProfileStartStates.Load(u); ok {
+		return value.(*linuxProfileStartState)
+	}
+	state := &linuxProfileStartState{}
+	actual, _ := linuxProfileStartStates.LoadOrStore(u, state)
+	return actual.(*linuxProfileStartState)
+}
+
+func (u *linuxDesktop) selectedLinuxProfile() (model.PublicProfile, bool) {
+	if u == nil || u.selectedProfileID == "" {
+		return model.PublicProfile{}, false
+	}
+	for index := range u.profiles {
+		if u.profiles[index].ID == u.selectedProfileID {
+			return u.profiles[index], true
+		}
+	}
+	return model.PublicProfile{}, false
+}
+
+func linuxProtocolRemoteDefault(protocol string) string {
+	if strings.EqualFold(strings.TrimSpace(protocol), "sftp") {
+		return "."
+	}
+	return "/"
+}
+
+func (u *linuxDesktop) linuxProfileMatchesConnectionFields(profile model.PublicProfile) bool {
+	port, err := strconv.Atoi(strings.TrimSpace(u.port))
+	if err != nil {
+		return false
+	}
+	return profilebinding.AccountMatches(
+		profile.Protocol, profile.Host, profile.Port, profile.Username,
+		u.protocol, u.host, port, u.username,
+	)
+}
+
+// enforceLinuxProfileStartDirectories runs on the UI goroutine before the
+// bookmark header is painted. cycleProfile historically copied start paths
+// directly into the editable path fields. This guard turns those copies into
+// drafts: the previous verified local base is restored immediately and the
+// configured local start is committed only by refreshLocal after LocalList
+// succeeds. Remote starts remain usable as the post-connect listing target only
+// while protocol/host/port/username still match the selected profile.
+func (u *linuxDesktop) enforceLinuxProfileStartDirectories() {
+	if u == nil {
+		return
+	}
+	state := linuxProfileStartStateFor(u)
+	if !state.initialized {
+		state.initialized = true
+		state.selectedProfileID = u.selectedProfileID
+		state.verifiedLocal = u.localCurrent
+		state.verifiedRemote = u.remoteCurrent
+		return
+	}
+
+	profile, hasProfile := u.selectedLinuxProfile()
+	if u.selectedProfileID != state.selectedProfileID {
+		previousLocal := state.verifiedLocal
+		previousRemote := state.verifiedRemote
+		state.selectedProfileID = u.selectedProfileID
+
+		if !hasProfile {
+			return
+		}
+
+		localTarget := strings.TrimSpace(profile.LocalPath)
+		if localTarget != "" && u.localCurrent == profile.LocalPath {
+			u.localCurrent = previousLocal
+			u.selectedLocal = -1
+			if !u.busy {
+				u.refreshLocal(profile.LocalPath)
+			}
+		}
+
+		remoteTarget := strings.TrimSpace(profile.RemotePath)
+		if remoteTarget != "" && u.remoteCurrent == profile.RemotePath {
+			u.remoteCurrent = previousRemote
+		}
+	}
+
+	if hasProfile && !u.connected {
+		if u.linuxProfileMatchesConnectionFields(profile) {
+			if strings.TrimSpace(profile.RemotePath) != "" {
+				u.remoteCurrent = profile.RemotePath
+			} else {
+				u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
+			}
+		} else {
+			// A selected profile can be edited before Connect. Once its account
+			// identity no longer matches, never carry the selected account's server
+			// directory into that different login.
+			u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)
+		}
+	}
+
+	// Only non-busy states can represent a completed listing. A failed local
+	// refresh leaves localCurrent at the previously verified base, while a
+	// successful one commits the canonical LocalList result before this point.
+	if !u.busy {
+		state.verifiedLocal = u.localCurrent
+		if u.connected {
+			state.verifiedRemote = u.remoteCurrent
+		}
+	}
+}

--- a/internal/desktop/profile_start_linux_test.go
+++ b/internal/desktop/profile_start_linux_test.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package desktop
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestLinuxProtocolRemoteDefaultMatchesTransportSemantics(t *testing.T) {
+	for _, test := range []struct {
+		protocol string
+		want     string
+	}{
+		{protocol: "ftp", want: "/"},
+		{protocol: "ftps", want: "/"},
+		{protocol: " SFTP ", want: "."},
+	} {
+		if got := linuxProtocolRemoteDefault(test.protocol); got != test.want {
+			t.Fatalf("linuxProtocolRemoteDefault(%q) = %q, want %q", test.protocol, got, test.want)
+		}
+	}
+}
+
+func TestLinuxProfileConnectionMatchIncludesExactUsername(t *testing.T) {
+	profile := model.PublicProfile{
+		Protocol: "SFTP",
+		Host:     "Example.COM.",
+		Port:     22,
+		Username: "alice",
+	}
+	u := &linuxDesktop{
+		protocol: "sftp",
+		host:     "example.com",
+		port:     "22",
+		username: "alice",
+	}
+	if !u.linuxProfileMatchesConnectionFields(profile) {
+		t.Fatal("canonical same-account fields did not match selected profile")
+	}
+
+	u.username = "bob"
+	if u.linuxProfileMatchesConnectionFields(profile) {
+		t.Fatal("profile remote start crossed username/account boundary")
+	}
+}
+
+func TestLinuxProfileConnectionMatchRejectsInvalidEditablePort(t *testing.T) {
+	profile := model.PublicProfile{
+		Protocol: "ftps",
+		Host:     "ftp.example.com",
+		Port:     21,
+		Username: "alice",
+	}
+	u := &linuxDesktop{
+		protocol: "ftps",
+		host:     "ftp.example.com",
+		port:     "not-a-port",
+		username: "alice",
+	}
+	if u.linuxProfileMatchesConnectionFields(profile) {
+		t.Fatal("invalid editable port was accepted as profile identity")
+	}
+}

--- a/internal/desktop/profile_start_linux_test.go
+++ b/internal/desktop/profile_start_linux_test.go
@@ -98,7 +98,6 @@ func TestLinuxProfileRemoteStartDoesNotOverwriteManualEditOnRepaint(t *testing.T
 		selectedProfileID: u.selectedProfileID,
 		accountKey:        u.linuxEditableAccountKey(),
 		inheritedRemote:   "/saved-home",
-		verifiedRemote:    "/",
 	}
 	installLinuxProfileStartTestState(t, u, state)
 
@@ -118,7 +117,6 @@ func TestLinuxProfileRemoteStartResetsInheritedPathOnAccountChange(t *testing.T)
 		selectedProfileID: u.selectedProfileID,
 		accountKey:        oldAccountKey,
 		inheritedRemote:   "/saved-home",
-		verifiedRemote:    "/",
 	}
 	installLinuxProfileStartTestState(t, u, state)
 
@@ -130,7 +128,7 @@ func TestLinuxProfileRemoteStartResetsInheritedPathOnAccountChange(t *testing.T)
 	}
 }
 
-func TestLinuxProfileExplicitRemoteStartSurvivesAccountChange(t *testing.T) {
+func TestLinuxProfileRemoteStartResetsNavigatedOldAccountPathOnAccountChange(t *testing.T) {
 	u, _ := linuxProfileStartTestDesktop()
 	oldAccountKey := u.linuxEditableAccountKey()
 	state := &linuxProfileStartState{
@@ -138,15 +136,38 @@ func TestLinuxProfileExplicitRemoteStartSurvivesAccountChange(t *testing.T) {
 		selectedProfileID: u.selectedProfileID,
 		accountKey:        oldAccountKey,
 		inheritedRemote:   "/saved-home",
-		verifiedRemote:    "/",
 	}
 	installLinuxProfileStartTestState(t, u, state)
 
-	u.remoteCurrent = "/new-account-home"
+	u.remoteCurrent = "/navigated-on-old-account"
 	u.username = "bob"
 	u.enforceLinuxProfileStartDirectories()
 
+	if u.remoteCurrent != "/" {
+		t.Fatalf("navigated old-account path crossed account boundary: got %q, want /", u.remoteCurrent)
+	}
+}
+
+func TestLinuxProfileExplicitRemoteStartSurvivesRepaintAfterAccountChange(t *testing.T) {
+	u, _ := linuxProfileStartTestDesktop()
+	oldAccountKey := u.linuxEditableAccountKey()
+	state := &linuxProfileStartState{
+		initialized:       true,
+		selectedProfileID: u.selectedProfileID,
+		accountKey:        oldAccountKey,
+		inheritedRemote:   "/saved-home",
+	}
+	installLinuxProfileStartTestState(t, u, state)
+
+	u.username = "bob"
+	u.enforceLinuxProfileStartDirectories()
+	if u.remoteCurrent != "/" {
+		t.Fatalf("account change did not reset remote start before explicit edit: got %q", u.remoteCurrent)
+	}
+
+	u.remoteCurrent = "/new-account-home"
+	u.enforceLinuxProfileStartDirectories()
 	if u.remoteCurrent != "/new-account-home" {
-		t.Fatalf("explicit new remote start was overwritten: got %q", u.remoteCurrent)
+		t.Fatalf("explicit new-account remote start was overwritten on repaint: got %q", u.remoteCurrent)
 	}
 }

--- a/internal/desktop/profile_start_linux_test.go
+++ b/internal/desktop/profile_start_linux_test.go
@@ -63,3 +63,90 @@ func TestLinuxProfileConnectionMatchRejectsInvalidEditablePort(t *testing.T) {
 		t.Fatal("invalid editable port was accepted as profile identity")
 	}
 }
+
+func linuxProfileStartTestDesktop() (*linuxDesktop, model.PublicProfile) {
+	profile := model.PublicProfile{
+		ID:         "profile-1",
+		Protocol:   "ftps",
+		Host:       "ftp.example.com",
+		Port:       21,
+		Username:   "alice",
+		RemotePath: "/saved-home",
+	}
+	u := &linuxDesktop{
+		protocol:          profile.Protocol,
+		host:              profile.Host,
+		port:              "21",
+		username:          profile.Username,
+		profiles:          []model.PublicProfile{profile},
+		selectedProfileID: profile.ID,
+		remoteCurrent:     profile.RemotePath,
+	}
+	return u, profile
+}
+
+func installLinuxProfileStartTestState(t *testing.T, u *linuxDesktop, state *linuxProfileStartState) {
+	t.Helper()
+	linuxProfileStartStates.Store(u, state)
+	t.Cleanup(func() { linuxProfileStartStates.Delete(u) })
+}
+
+func TestLinuxProfileRemoteStartDoesNotOverwriteManualEditOnRepaint(t *testing.T) {
+	u, _ := linuxProfileStartTestDesktop()
+	state := &linuxProfileStartState{
+		initialized:       true,
+		selectedProfileID: u.selectedProfileID,
+		accountKey:        u.linuxEditableAccountKey(),
+		inheritedRemote:   "/saved-home",
+		verifiedRemote:    "/",
+	}
+	installLinuxProfileStartTestState(t, u, state)
+
+	u.remoteCurrent = "/manually-edited"
+	u.enforceLinuxProfileStartDirectories()
+
+	if u.remoteCurrent != "/manually-edited" {
+		t.Fatalf("repaint overwrote explicit remote path: got %q", u.remoteCurrent)
+	}
+}
+
+func TestLinuxProfileRemoteStartResetsInheritedPathOnAccountChange(t *testing.T) {
+	u, _ := linuxProfileStartTestDesktop()
+	oldAccountKey := u.linuxEditableAccountKey()
+	state := &linuxProfileStartState{
+		initialized:       true,
+		selectedProfileID: u.selectedProfileID,
+		accountKey:        oldAccountKey,
+		inheritedRemote:   "/saved-home",
+		verifiedRemote:    "/",
+	}
+	installLinuxProfileStartTestState(t, u, state)
+
+	u.username = "bob"
+	u.enforceLinuxProfileStartDirectories()
+
+	if u.remoteCurrent != "/" {
+		t.Fatalf("inherited remote start crossed account boundary: got %q, want /", u.remoteCurrent)
+	}
+}
+
+func TestLinuxProfileExplicitRemoteStartSurvivesAccountChange(t *testing.T) {
+	u, _ := linuxProfileStartTestDesktop()
+	oldAccountKey := u.linuxEditableAccountKey()
+	state := &linuxProfileStartState{
+		initialized:       true,
+		selectedProfileID: u.selectedProfileID,
+		accountKey:        oldAccountKey,
+		inheritedRemote:   "/saved-home",
+		verifiedRemote:    "/",
+	}
+	installLinuxProfileStartTestState(t, u, state)
+
+	u.remoteCurrent = "/new-account-home"
+	u.username = "bob"
+	u.enforceLinuxProfileStartDirectories()
+
+	if u.remoteCurrent != "/new-account-home" {
+		t.Fatalf("explicit new remote start was overwritten: got %q", u.remoteCurrent)
+	}
+}

--- a/internal/desktop/sidebar_windows.go
+++ b/internal/desktop/sidebar_windows.go
@@ -17,6 +17,7 @@ const (
 
 var (
 	sidebarDiagnostics     sync.Map
+	sidebarBookmarks       sync.Map
 	sidebarGetWindowRect   = user32.NewProc("GetWindowRect")
 	sidebarMapWindowPoints = user32.NewProc("MapWindowPoints")
 )
@@ -52,11 +53,54 @@ func (a *app) ensureSidebarDiagnostics() uintptr {
 	return hwnd
 }
 
+func (a *app) ensureSidebarBookmarks() uintptr {
+	if a == nil || a.hwnd == 0 {
+		return 0
+	}
+	if value, ok := sidebarBookmarks.Load(a.hwnd); ok {
+		if hwnd, ok := value.(uintptr); ok && hwnd != 0 {
+			return hwnd
+		}
+	}
+	hinst, _, _ := getModuleHandleW.Call(0)
+	label := bookmarkWordsForLanguage(a.languageCode()).Title
+	hwnd, _, _ := createWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(wstr("BUTTON"))),
+		uintptr(unsafe.Pointer(wstr(label))),
+		uintptr(wsChild|wsVisible|wsTabStop|bsOwnerDraw),
+		0, 0, 1, 1,
+		a.hwnd, idBookmarks, hinst, 0,
+	)
+	if hwnd == 0 {
+		return 0
+	}
+	if a.font != 0 {
+		sendMessageW.Call(hwnd, wmSetFont, a.font, 1)
+	}
+	applyDarkControl(hwnd, "BUTTON")
+	a.registerToolbarButton(hwnd, iconOpenLocal, label, buttonSubtle)
+	sidebarBookmarks.Store(a.hwnd, hwnd)
+	return hwnd
+}
+
 func (a *app) sidebarDiagnosticsButton() uintptr {
 	if a == nil {
 		return 0
 	}
 	value, ok := sidebarDiagnostics.Load(a.hwnd)
+	if !ok {
+		return 0
+	}
+	hwnd, _ := value.(uintptr)
+	return hwnd
+}
+
+func (a *app) sidebarBookmarksButton() uintptr {
+	if a == nil {
+		return 0
+	}
+	value, ok := sidebarBookmarks.Load(a.hwnd)
 	if !ok {
 		return 0
 	}
@@ -149,8 +193,10 @@ func (a *app) applyApplicationSidebar() {
 		return
 	}
 	diagnostics := a.ensureSidebarDiagnostics()
+	bookmarks := a.ensureSidebarBookmarks()
 	labels := navigationLabelsForLanguage(a.languageCode())
 	a.setSidebarButtonVisual(a.siteManagerBtn, iconOpenLocal, labels.SiteManager, buttonDefault)
+	a.setSidebarButtonVisual(bookmarks, iconOpenLocal, bookmarkWordsForLanguage(a.languageCode()).Title, buttonSubtle)
 	a.setSidebarButtonVisual(a.settingsBtn, iconSettings, a.tr("common.settings"), buttonSubtle)
 	a.setSidebarButtonVisual(diagnostics, iconDiagnostics, labels.Diagnostics, buttonSubtle)
 	a.setSidebarButtonVisual(a.aboutBtn, iconInfo, a.tr("common.about"), buttonSubtle)
@@ -158,7 +204,7 @@ func (a *app) applyApplicationSidebar() {
 	// Rail controls are always anchored explicitly, including state-only passes.
 	a.move(a.languageCombo, applicationSidebarX, 54, applicationSidebarWidth, 29)
 	y := 96
-	for _, control := range []uintptr{a.siteManagerBtn, a.settingsBtn, diagnostics, a.aboutBtn} {
+	for _, control := range []uintptr{a.siteManagerBtn, bookmarks, a.settingsBtn, diagnostics, a.aboutBtn} {
 		a.move(control, applicationSidebarX, y, applicationSidebarWidth, applicationSidebarCardH)
 		y += applicationSidebarCardH + applicationSidebarCardGap
 	}

--- a/internal/model/bookmark.go
+++ b/internal/model/bookmark.go
@@ -1,0 +1,32 @@
+package model
+
+const (
+	BookmarkKindLocal  = "local"
+	BookmarkKindRemote = "remote"
+)
+
+// Bookmark is deliberately non-secret navigation metadata. Remote bookmarks
+// carry only the account identity needed to prevent a path from being reused by
+// a different login on the same host; credentials and trust material never
+// belong in this model.
+type Bookmark struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Path     string `json:"path"`
+	Protocol string `json:"protocol,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type BookmarkInput struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Path     string `json:"path"`
+	Protocol string `json:"protocol,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
+}

--- a/scripts/capture_windows_screenshots.ps1
+++ b/scripts/capture_windows_screenshots.ps1
@@ -240,6 +240,20 @@ try {
     [GhostFtpCaptureNative]::PostMessage($siteManager, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
     Start-Sleep -Milliseconds 350
 
+    # Bookmarks is a separate native modal manager. Capture it through the same
+    # real WM_COMMAND route used by the main window so the evidence proves the
+    # visible feature surface and its window lifecycle, not a generated mockup.
+    $bookmarksCommand = 97
+    if (-not [GhostFtpCaptureNative]::PostMessage($main, $wmCommand, [IntPtr]$bookmarksCommand, [IntPtr]::Zero)) {
+        throw "Could not request the Ghost FTP Bookmarks manager."
+    }
+    $bookmarksWindow = Find-ProcessWindow -ProcessId $process.Id -TitleContains "Bookmarks"
+    [GhostFtpCaptureNative]::SetForegroundWindow($bookmarksWindow) | Out-Null
+    Start-Sleep -Milliseconds 700
+    Save-WindowScreenshot -Window $bookmarksWindow -Path (Join-Path $OutputDirectory "Ghost-FTP-bookmarks.png")
+    [GhostFtpCaptureNative]::PostMessage($bookmarksWindow, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
+    Start-Sleep -Milliseconds 350
+
     # Open the actual Settings card through its owner-drawn button. The first
     # appearance selector exercises the shared theme-aware option-dialog shell.
     $bmClick = 0x00F5

--- a/scripts/test_authentic_ui_workflow_contract.py
+++ b/scripts/test_authentic_ui_workflow_contract.py
@@ -40,10 +40,19 @@ class AuthenticUIWorkflowContractTests(unittest.TestCase):
         for name in (
             "Ghost-FTP-main-workspace.png",
             "Ghost-FTP-site-manager.png",
+            "Ghost-FTP-bookmarks.png",
             "Ghost-FTP-settings.png",
             "Ghost-FTP-about.png",
         ):
             self.assertIn(name, workflow)
+
+    def test_bookmarks_manager_is_captured_through_real_runtime_command(self) -> None:
+        capture = (ROOT / "scripts" / "capture_windows_screenshots.ps1").read_text(encoding="utf-8")
+        self.assertIn("$bookmarksCommand = 97", capture)
+        self.assertIn('TitleContains "Bookmarks"', capture)
+        self.assertIn('Ghost-FTP-bookmarks.png', capture)
+        self.assertIn("PostMessage($main, $wmCommand", capture)
+        self.assertIn("PostMessage($bookmarksWindow, 0x0010", capture)
 
 
 if __name__ == "__main__":

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -98,9 +98,11 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "a.engine.NavigateBookmark(ctx, bookmark.ID)",
             "a.connectionGeneration",
             "generation != a.connectionGeneration",
-            "a.engine.SaveLocalBookmark",
-            "a.engine.SaveRemoteBookmark",
-            "a.engine.RemoveBookmark",
+            "state.parent.engine.SaveLocalBookmark",
+            "state.parent.engine.SaveRemoteBookmark",
+            "state.parent.engine.RemoveBookmark",
+            "state.parent.engine.ActiveConnection()",
+            "config.RemoteBookmarkMatchesAccount",
         ):
             self.assertIn(marker, manager)
         self.assertIn("case idBookmarks:", commands)

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -85,16 +85,18 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "u.localCurrent = previousLocal",
             "u.refreshLocal(profile.LocalPath)",
             "currentAccountKey != state.accountKey",
-            "u.remoteCurrent == state.inheritedRemote",
             "u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)",
-            'state.inheritedRemote = ""',
+            "state.inheritedRemote = u.remoteCurrent",
+            "state.accountKey = currentAccountKey",
+            "navigated, or typed server path once at this boundary",
             "protocol/host/port/username",
         ):
             self.assertIn(marker, linux)
         for marker in (
             "TestLinuxProfileRemoteStartDoesNotOverwriteManualEditOnRepaint",
             "TestLinuxProfileRemoteStartResetsInheritedPathOnAccountChange",
-            "TestLinuxProfileExplicitRemoteStartSurvivesAccountChange",
+            "TestLinuxProfileRemoteStartResetsNavigatedOldAccountPathOnAccountChange",
+            "TestLinuxProfileExplicitRemoteStartSurvivesRepaintAfterAccountChange",
         ):
             self.assertIn(marker, linux_tests)
         for marker in (

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class NavigationBookmarksContractTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_bookmark_model_remains_non_secret_navigation_metadata(self) -> None:
+        model = self.read("internal/model/bookmark.go")
+        for marker in (
+            "type Bookmark struct",
+            'Path     string `json:"path"`',
+            'Protocol string `json:"protocol,omitempty"`',
+            'Host     string `json:"host,omitempty"`',
+            'Port     int    `json:"port,omitempty"`',
+            'Username string `json:"username,omitempty"`',
+            "credentials and trust material never",
+        ):
+            self.assertIn(marker, model)
+        for forbidden in ("Password", "Passphrase", "PrivateKey", "Fingerprint", "ProfileID"):
+            self.assertNotIn(forbidden, model)
+
+    def test_persisted_bookmarks_validate_paths_identity_and_corrupt_state(self) -> None:
+        store = self.read("internal/config/bookmarks.go")
+        tests = self.read("internal/config/bookmarks_test.go")
+        for marker in (
+            "maxBookmarks  = 256",
+            "filepath.IsAbs(b.Path)",
+            "security.ValidateRemotePath(b.Path)",
+            "security.ValidateConnection(b.Protocol, b.Host, b.Username, b.Port)",
+            "profilebinding.AccountMatches(",
+            'bookmarksFile + ".previous"',
+            "spremljene bookmarke nije moguće pročitati",
+        ):
+            self.assertIn(marker, store)
+        for marker in (
+            "TestRemoteBookmarksAreAccountBoundAndPersistNoSecretSchema",
+            "TestBookmarksCorruptExistingStateFailsClosed",
+            '[]string{"password", "passphrase", "privatekey", "fingerprint", "profileid"}',
+            "remote bookmark crossed account boundary",
+        ):
+            self.assertIn(marker, tests)
+
+    def test_engine_remote_bookmark_uses_real_connection_and_revalidates_after_list(self) -> None:
+        api = self.read("internal/api/bookmarks.go")
+        for marker in (
+            "cfg, connected := e.remote.Config()",
+            "Protocol: cfg.Protocol, Host: cfg.Host, Port: cfg.Port, Username: cfg.Username",
+            "config.RemoteBookmarkMatchesAccount(bookmark, cfg)",
+            "identityBefore, err := e.remote.ConnectionIdentity()",
+            "items, err := e.RemoteList(ctx, bookmark.Path)",
+            "identityAfter, err := e.remote.ConnectionIdentity()",
+            "if identityBefore != identityAfter",
+            "config.RemoteBookmarkMatchesAccount(bookmark, cfgAfter)",
+        ):
+            self.assertIn(marker, api)
+        self.assertNotIn("SaveProfile", api, "quick-connect bookmark save must not create a hidden profile")
+
+    def test_profile_start_identity_changes_fail_closed(self) -> None:
+        binding = self.read("internal/profilebinding/binding.go")
+        config_tests = self.read("internal/config/profile_start_directory_binding_test.go")
+        linux = self.read("internal/desktop/profile_start_linux.go")
+        for marker in (
+            "func AccountMatches(",
+            "EndpointMatches(protocolA, hostA, portA, protocolB, hostB, portB) && usernameA == usernameB",
+        ):
+            self.assertIn(marker, binding)
+        for marker in (
+            "TestProfileRemoteStartDoesNotSilentlyCrossAccountIdentity",
+            "TestProfileExplicitNewRemoteStartSurvivesIdentityChange",
+            "TestProfileInheritedSFTPRemoteStartResetsToDot",
+        ):
+            self.assertIn(marker, config_tests)
+        for marker in (
+            "profilebinding.AccountMatches(",
+            "u.localCurrent = previousLocal",
+            "u.refreshLocal(profile.LocalPath)",
+            "u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)",
+            "protocol/host/port/username",
+        ):
+            self.assertIn(marker, linux)
+
+    def test_windows_bookmark_manager_is_real_and_generation_bound(self) -> None:
+        manager = self.read("internal/desktop/bookmark_manager_windows.go")
+        commands = self.read("internal/desktop/commands_windows.go")
+        for marker in (
+            "bookmarkIDOpen",
+            "bookmarkIDAddLocal",
+            "bookmarkIDAddRemote",
+            "bookmarkIDDelete",
+            "bookmarkIDClose",
+            "a.engine.NavigateBookmark(ctx, bookmark.ID)",
+            "a.connectionGeneration",
+            "generation != a.connectionGeneration",
+            "a.engine.SaveLocalBookmark",
+            "a.engine.SaveRemoteBookmark",
+            "a.engine.RemoveBookmark",
+        ):
+            self.assertIn(marker, manager)
+        self.assertIn("case idBookmarks:", commands)
+        self.assertIn("a.openBookmarkManager()", commands)
+
+    def test_linux_bookmark_manager_is_rendered_and_fully_dispatched(self) -> None:
+        bookmark = self.read("internal/desktop/bookmark_linux.go")
+        actions = self.read("internal/desktop/gui_linux_actions.go")
+        filters = self.read("internal/desktop/file_filter_linux.go")
+        for marker in (
+            "func (u *linuxDesktop) renderBookmarksHeaderButton() error",
+            "u.enforceLinuxProfileStartDirectories()",
+            "func (u *linuxDesktop) renderBookmarkManagerOverlay() error",
+            "func (u *linuxDesktop) handleBookmarkManagerMouse(x, y int) bool",
+            "func (u *linuxDesktop) handleBookmarkManagerKey(sym uint32) bool",
+            "u.engine.SaveRemoteBookmark",
+            "u.engine.SaveLocalBookmark",
+            "u.engine.NavigateBookmark(ctx, bookmark.ID)",
+            "u.engine.RemoveBookmark(item.ID)",
+        ):
+            self.assertIn(marker, bookmark)
+        for marker in (
+            "linuxPromptBookmarkManager",
+            "linuxPromptBookmarkLocalName",
+            "linuxPromptBookmarkRemoteName",
+            "return u.handleBookmarkManagerKey(sym)",
+            "return u.renderBookmarkManagerOverlay()",
+            "return u.handleBookmarkManagerMouse(x, y)",
+            "u.saveLinuxBookmark(false, value)",
+            "u.saveLinuxBookmark(true, value)",
+        ):
+            self.assertIn(marker, actions)
+        self.assertIn("u.renderBookmarksHeaderButton()", filters)
+        self.assertIn("u.handleBookmarksHeaderMouse(x, y)", filters)
+
+    def test_docs_keep_source_feature_separate_from_published_003(self) -> None:
+        roadmap = self.read("docs/ROADMAP.md")
+        detail = self.read("docs/NAVIGATION-BOOKMARKS.md")
+        changelog = self.read("CHANGELOG.md")
+        self.assertIn("navigation bookmarks and profile start directories", roadmap.lower())
+        self.assertIn("implemented in the post-0.0.3 source line", roadmap)
+        self.assertIn("targeted for the next public release", roadmap)
+        self.assertIn("post-0.0.3 source line", detail)
+        self.assertIn("not retroactively part of the already published Ghost FTP 0.0.3 release", detail)
+        self.assertIn("AccountMatches", detail)
+        self.assertIn("NavigateBookmark", detail)
+        self.assertIn("Root `VERSION` remains **0.0.3**", detail)
+        self.assertIn("Navigation bookmarks and profile start directories", changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -66,6 +66,7 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         binding = self.read("internal/profilebinding/binding.go")
         config_tests = self.read("internal/config/profile_start_directory_binding_test.go")
         linux = self.read("internal/desktop/profile_start_linux.go")
+        linux_tests = self.read("internal/desktop/profile_start_linux_test.go")
         for marker in (
             "func AccountMatches(",
             "EndpointMatches(protocolA, hostA, portA, protocolB, hostB, portB) && usernameA == usernameB",
@@ -81,10 +82,19 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "profilebinding.AccountMatches(",
             "u.localCurrent = previousLocal",
             "u.refreshLocal(profile.LocalPath)",
+            "currentAccountKey != state.accountKey",
+            "u.remoteCurrent == state.inheritedRemote",
             "u.remoteCurrent = linuxProtocolRemoteDefault(u.protocol)",
+            'state.inheritedRemote = ""',
             "protocol/host/port/username",
         ):
             self.assertIn(marker, linux)
+        for marker in (
+            "TestLinuxProfileRemoteStartDoesNotOverwriteManualEditOnRepaint",
+            "TestLinuxProfileRemoteStartResetsInheritedPathOnAccountChange",
+            "TestLinuxProfileExplicitRemoteStartSurvivesAccountChange",
+        ):
+            self.assertIn(marker, linux_tests)
 
     def test_windows_bookmark_manager_is_real_and_generation_bound(self) -> None:
         manager = self.read("internal/desktop/bookmark_manager_windows.go")
@@ -113,12 +123,20 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         actions = self.read("internal/desktop/gui_linux_actions.go")
         filters = self.read("internal/desktop/file_filter_linux.go")
         prompt_test = self.read("internal/desktop/bookmark_prompt_linux_test.go")
+        viewport_test = self.read("internal/desktop/bookmark_viewport_linux_test.go")
         for marker in (
             "func (u *linuxDesktop) renderBookmarksHeaderButton() error",
             "u.enforceLinuxProfileStartDirectories()",
             "func (u *linuxDesktop) renderBookmarkManagerOverlay() error",
             "func (u *linuxDesktop) handleBookmarkManagerMouse(x, y int) bool",
             "func (u *linuxDesktop) handleBookmarkManagerKey(sym uint32) bool",
+            "firstVisible int",
+            "visibleRows  int",
+            "func (state *linuxBookmarkUIState) ensureSelectionVisible()",
+            "func (state *linuxBookmarkUIState) scrollViewport(delta int)",
+            "state.scrollUp.contains(x, y)",
+            "state.scrollDown.contains(x, y)",
+            "func (u *linuxDesktop) bookmarkRowAt(x, y int) int",
             "u.engine.SaveRemoteBookmark",
             "u.engine.SaveLocalBookmark",
             "u.engine.NavigateBookmark(ctx, bookmark.ID)",
@@ -142,6 +160,8 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         ):
             self.assertIn(marker, actions)
         self.assertIn("TestLinuxBookmarkNamePromptClassification", prompt_test)
+        self.assertIn("TestLinuxBookmarkViewportKeepsKeyboardSelectionVisible", viewport_test)
+        self.assertIn("TestLinuxBookmarkViewportMouseScrollReachesLaterRows", viewport_test)
         self.assertIn("u.renderBookmarksHeaderButton()", filters)
         self.assertIn("u.handleBookmarksHeaderMouse(x, y)", filters)
 

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -67,6 +67,8 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         config_tests = self.read("internal/config/profile_start_directory_binding_test.go")
         linux = self.read("internal/desktop/profile_start_linux.go")
         linux_tests = self.read("internal/desktop/profile_start_linux_test.go")
+        gui = self.read("internal/desktop/gui_linux.go")
+        cycle_tests = self.read("internal/desktop/profile_cycle_linux_test.go")
         for marker in (
             "func AccountMatches(",
             "EndpointMatches(protocolA, hostA, portA, protocolB, hostB, portB) && usernameA == usernameB",
@@ -95,6 +97,17 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "TestLinuxProfileExplicitRemoteStartSurvivesAccountChange",
         ):
             self.assertIn(marker, linux_tests)
+        for marker in (
+            "len(u.profiles) > 0 && !u.busy && !u.connected",
+            "if u.busy || u.connected || len(u.profiles) == 0",
+        ):
+            self.assertIn(marker, gui)
+        for marker in (
+            "TestLinuxProfileCycleBlockedWhileConnected",
+            "TestLinuxProfileCycleBlockedWhileBusy",
+            "TestLinuxProfileCycleLoadsProfileWhenIdleAndDisconnected",
+        ):
+            self.assertIn(marker, cycle_tests)
 
     def test_windows_bookmark_manager_is_real_and_generation_bound(self) -> None:
         manager = self.read("internal/desktop/bookmark_manager_windows.go")
@@ -137,6 +150,7 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "state.scrollUp.contains(x, y)",
             "state.scrollDown.contains(x, y)",
             "func (u *linuxDesktop) bookmarkRowAt(x, y int) int",
+            "y < state.rows.top+4",
             "u.engine.SaveRemoteBookmark",
             "u.engine.SaveLocalBookmark",
             "u.engine.NavigateBookmark(ctx, bookmark.ID)",
@@ -162,6 +176,7 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         self.assertIn("TestLinuxBookmarkNamePromptClassification", prompt_test)
         self.assertIn("TestLinuxBookmarkViewportKeepsKeyboardSelectionVisible", viewport_test)
         self.assertIn("TestLinuxBookmarkViewportMouseScrollReachesLaterRows", viewport_test)
+        self.assertIn("TestLinuxBookmarkRowHitTestRejectsPaddingAndUsesViewportOffset", viewport_test)
         self.assertIn("u.renderBookmarksHeaderButton()", filters)
         self.assertIn("u.handleBookmarksHeaderMouse(x, y)", filters)
 

--- a/scripts/test_navigation_bookmarks_contract.py
+++ b/scripts/test_navigation_bookmarks_contract.py
@@ -112,6 +112,7 @@ class NavigationBookmarksContractTests(unittest.TestCase):
         bookmark = self.read("internal/desktop/bookmark_linux.go")
         actions = self.read("internal/desktop/gui_linux_actions.go")
         filters = self.read("internal/desktop/file_filter_linux.go")
+        prompt_test = self.read("internal/desktop/bookmark_prompt_linux_test.go")
         for marker in (
             "func (u *linuxDesktop) renderBookmarksHeaderButton() error",
             "u.enforceLinuxProfileStartDirectories()",
@@ -133,8 +134,14 @@ class NavigationBookmarksContractTests(unittest.TestCase):
             "return u.handleBookmarkManagerMouse(x, y)",
             "u.saveLinuxBookmark(false, value)",
             "u.saveLinuxBookmark(true, value)",
+            "func (u *linuxDesktop) bookmarkNamePrompt() bool",
+            "func (u *linuxDesktop) cancelPrompt()",
+            "returnToBookmarks := u.bookmarkNamePrompt()",
+            'u.openLinuxBookmarks("")',
+            "u.cancelPrompt()",
         ):
             self.assertIn(marker, actions)
+        self.assertIn("TestLinuxBookmarkNamePromptClassification", prompt_test)
         self.assertIn("u.renderBookmarksHeaderButton()", filters)
         self.assertIn("u.handleBookmarksHeaderMouse(x, y)", filters)
 

--- a/scripts/test_windows_visual_regressions.py
+++ b/scripts/test_windows_visual_regressions.py
@@ -99,7 +99,7 @@ class WindowsVisualRegressionTests(unittest.TestCase):
         self.assertIn("- 'release-prep/**'", workflow)
         self.assertIn("- 'VERSION'", workflow)
         self.assertIn("- 'internal/i18n/**'", workflow)
-        self.assertIn("Capture authentic main, Site Manager, Settings and About windows", workflow)
+        self.assertIn("Capture authentic main, Site Manager, Bookmarks, Settings and About windows", workflow)
         self.assertIn("Ghost-FTP-$version-Portable-x64.exe", workflow)
         self.assertIn("!startsWith(github.ref_name, 'release-prep/')", workflow)
 


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested/authorized for Ghost FTP.
- [x] Repository proprietary/source-available license and contribution boundary reviewed; this work remains inside the authorized Ghost FTP repository.

## Summary

Implements the P1 **navigation bookmarks and profile start directories** source capability for Windows and Linux without changing the published `0.0.3` release identity.

### Shared Engine/config behavior

- Adds bounded local `bookmarks.json` persistence with validation and corrupt-existing-state fail-closed behavior.
- Bookmark schema contains navigation metadata only: ID, name, kind, path and (for remote bookmarks) protocol/host/port/username.
- Passwords, passphrases, private-key data/paths, fingerprints and hidden profile references are not part of the bookmark schema.
- `Engine.SaveRemoteBookmark` binds account identity from the **real active remote connection**, not mutable desktop text fields.
- `Engine.NavigateBookmark` freshly lists targets before returning authority to commit pane state.
- Remote navigation checks account identity, captures connection identity, performs the server list, then revalidates connection identity and account after the list.
- Quick-connect bookmark creation does not create a hidden Site Manager profile.

### Profile start-directory isolation

- Remote start paths are bound to `protocol + canonical host + port + exact username` through `profilebinding.AccountMatches`.
- Editing an existing profile across an account boundary cannot silently inherit the old remote path; inherited state resets to the new protocol default (`/` for FTP/FTPS, `.` for SFTP).
- Linux remote starts are event-bound rather than repaint-bound: the selected profile installs its inherited path once, and subsequent repaints do not overwrite a manually edited Remote Path.
- A genuinely explicit new remote path for a newly edited account remains valid across account-field changes.
- Linux treats profile local-path copies as drafts: it restores the previous verified local base and requires a real local list before committing the selected profile local start.

### Windows UI

- Adds a native Bookmarks manager with **Open / Add local / Add remote / Delete / Close**.
- Adds a real Bookmarks sidebar entry and command handler.
- Local bookmark navigation uses the existing navigation sequence/cancellation guard.
- Remote UI commit additionally checks `connectionGeneration` so stale async work cannot update a reconnected workspace.

### Linux UI

- Adds a native X11 Bookmarks header control and modal overlay with Windows-equivalent actions.
- Keyboard, mouse, render and bookmark-name prompt routing use the established Linux modal/action dispatcher.
- The manager tracks a bounded viewport (`firstVisible` / `visibleRows`), keeps keyboard selection visible, and exposes mouse-accessible scroll controls so all persisted bookmarks remain reachable beyond the first visible page.
- Cancel/Escape from bookmark naming returns to the Bookmarks manager instead of abandoning the whole manager flow.
- Remote bookmark activation stays behind the shared Engine account/session revalidation.

### Authentic UI evidence

- Extends the real Windows screenshot capture pipeline to open Bookmarks through the runtime `WM_COMMAND` route and capture `Ghost-FTP-bookmarks.png`.
- Screenshot workflow verifies Main Workspace, Site Manager, Bookmarks, Settings and About captures as real PNG windows from the verified native production payload.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service added.
- [x] No Ghost FTP cloud/backend, hidden network destination or automatic external API added.
- [x] Bookmark persistence contains no authentication/trust secrets.
- [x] Remote bookmark paths are account-bound and stale-session navigation fails closed.
- [x] SFTP host-key and FTPS verification paths are unchanged.
- [x] No external Go module added.
- [x] `VERSION` remains `0.0.3`; this PR is post-0.0.3 source work targeted for the next public release.

## Regression coverage

Added/updated coverage includes:

- `internal/config/bookmarks_test.go`
- `internal/config/profile_start_directory_binding_test.go`
- `internal/desktop/profile_start_linux_test.go`
- `internal/desktop/bookmark_prompt_linux_test.go`
- `internal/desktop/bookmark_viewport_linux_test.go`
- `internal/desktop/bookmark_words_test.go`
- `scripts/test_navigation_bookmarks_contract.py`
- `scripts/test_authentic_ui_workflow_contract.py`
- `scripts/test_windows_visual_regressions.py`

The source-level navigation contract protects non-secret schema, persistence validation, corrupt-state rejection, active-account binding, connection-identity revalidation, Windows generation guards, Linux modal wiring, repaint-safe profile starts, Linux bookmark viewport behavior and release-boundary documentation.

## Documentation

- Adds `docs/NAVIGATION-BOOKMARKS.md` with detailed architecture, security, privacy, Windows/Linux parity, error semantics, regression coverage and release-boundary behavior.
- Updates Roadmap, documentation index and Unreleased changelog.
- Published Ghost FTP `0.0.3` remains unchanged.

## Validation

Exact-head validation is required before merge. Current gates for the final PR head are:

- [ ] `gofmt` clean
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] repository/platform/security/privacy/documentation/release audits
- [ ] full Python regression discovery
- [ ] Windows universal Setup/Portable production build
- [ ] Linux amd64/arm64/i386 production build
- [ ] canonical Linux distro packages
- [ ] native distro install matrix
- [ ] authentic Windows UI screenshots including Bookmarks

These boxes intentionally remain unchecked until the exact final head reports `completed/success`; an older green run does not satisfy a newer head.