### PR TITLE
Android: stage remote uploads before final commit

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -11,6 +11,7 @@ Native Android client source lives entirely under this `android/` directory.
 - Local navigation uses Android Storage Access Framework (`ACTION_OPEN_DOCUMENT_TREE`); the app does not request all-files storage access.
 - Remote directory listing uses MLSD over EPSV/PASV.
 - Binary upload and download are implemented.
+- Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
 - Host, username, protocol, port and the user-granted folder URI may be remembered. Passwords are memory-only and are cleared from the UI after connection.
 - Explicit saved sites store only non-secret connection identity and navigation metadata; Quick Connect never creates a hidden site.
 - A saved site can own a local SAF start folder, a remote start directory, local SAF bookmarks and remote path bookmarks.
@@ -20,6 +21,16 @@ Native Android client source lives entirely under this `android/` directory.
 - Local starts/bookmarks are usable only while their persisted SAF read permission still exists and the provider can return a fresh directory listing.
 - Site/bookmark persistence is bounded to 50 sites and 50 bookmarks of each type per site.
 - No telemetry, analytics, ads, crash-reporting service or Ghost FTP backend is used.
+
+## Upload commit safety
+
+Android upload never writes the incoming stream directly to the requested final remote path. Ghost FTP generates a random `.ghostftp-upload-<uuid>.part` object in the same remote directory and sends `STOR` only to that staging path. The requested final path is used only after the data transfer has finished and the server has returned an accepted `226` or `250` completion reply.
+
+After confirmed transfer completion, Ghost FTP requires `RNFR` for the staging object and `RNTO` for the requested final path. There is no silent fallback to direct, non-atomic `STOR` when a server does not support this safe commit sequence. A rejected final rename is reported as an upload failure rather than as success.
+
+If the data stream or the completion reply fails in a way that can leave the FTP control channel state uncertain, Ghost FTP hard-closes that session instead of issuing further commands against a potentially desynchronized connection. A staging `.part` object can therefore remain on the server after a transport interruption, but the requested final remote name is not reported as successfully committed. When a rename is rejected after the transfer has been cleanly confirmed, Ghost FTP makes a best-effort attempt to delete the staging object.
+
+The staging flow uses the same existing passive-data transport. For FTPS, the staging upload therefore retains platform-trusted certificate validation and strict hostname verification on the protected data channel; it does not introduce a trust downgrade.
 
 ## Saved-site and bookmark security boundary
 

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
@@ -104,19 +105,58 @@ final class FtpSession implements Closeable {
             throw new IOException("Missing upload source.");
         }
         String path = normalizeRemotePath(remotePath);
+        String tempPath = uploadTempPath(path);
         Socket data = openPassiveDataSocket();
-        Reply start = command("STOR " + sanitizeArgument(path));
+        Reply start = command("STOR " + sanitizeArgument(tempPath));
         if (start.code != 125 && start.code != 150) {
             closeQuietly(data);
             throw new IOException("Upload rejected: " + start.message);
         }
-        try (OutputStream out = new BufferedOutputStream(data.getOutputStream())) {
-            copy(input, out);
-            out.flush();
-        } finally {
-            closeQuietly(data);
+
+        try {
+            try (OutputStream out = new BufferedOutputStream(data.getOutputStream())) {
+                copy(input, out);
+                out.flush();
+            } finally {
+                closeQuietly(data);
+            }
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Upload data transfer failed before final commit; the connection was closed.", e);
         }
-        expect(readReply(), 226, 250);
+
+        final Reply terminal;
+        try {
+            terminal = readReply();
+            expect(terminal, 226, 250);
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Upload was not confirmed complete; final remote name was not committed and the connection was closed.", e);
+        }
+
+        final Reply renameFrom;
+        try {
+            renameFrom = command("RNFR " + sanitizeArgument(tempPath));
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Upload completed to staging, but final rename could not be started; the connection was closed.", e);
+        }
+        if (renameFrom.code != 350) {
+            deleteRemoteBestEffort(tempPath);
+            throw new IOException("Server does not support safe staged upload commit: " + renameFrom.message);
+        }
+
+        final Reply renameTo;
+        try {
+            renameTo = command("RNTO " + sanitizeArgument(path));
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Upload staging rename lost connection before final commit confirmation.", e);
+        }
+        if (renameTo.code != 250) {
+            deleteRemoteBestEffort(tempPath);
+            throw new IOException("Server rejected final staged upload commit: " + renameTo.message);
+        }
     }
 
     synchronized void download(String remotePath, OutputStream output) throws IOException {
@@ -162,14 +202,10 @@ final class FtpSession implements Closeable {
             try {
                 command("QUIT");
             } catch (IOException ignored) {
-                // Socket close below is authoritative.
+                // Hard close below is authoritative.
             }
         }
-        connected = false;
-        closeQuietly(controlSocket);
-        controlSocket = null;
-        reader = null;
-        writer = null;
+        hardClose();
     }
 
     private Socket openPassiveDataSocket() throws IOException {
@@ -326,6 +362,30 @@ final class FtpSession implements Closeable {
             value = value.replace("//", "/");
         }
         return value;
+    }
+
+    private static String uploadTempPath(String finalPath) throws IOException {
+        String parent = parentRemote(finalPath);
+        return joinRemote(parent, ".ghostftp-upload-" + UUID.randomUUID() + ".part");
+    }
+
+    private void deleteRemoteBestEffort(String path) {
+        if (!connected || writer == null) {
+            return;
+        }
+        try {
+            command("DELE " + sanitizeArgument(path));
+        } catch (IOException ignored) {
+            hardClose();
+        }
+    }
+
+    private void hardClose() {
+        connected = false;
+        closeQuietly(controlSocket);
+        controlSocket = null;
+        reader = null;
+        writer = null;
     }
 
     private static String sanitizeArgument(String value) throws IOException {

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -83,6 +83,29 @@ class AndroidContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, ftp)
 
+    def test_upload_stages_before_final_remote_name_commit(self) -> None:
+        ftp = self.read(f"{ANDROID_JAVA}/FtpSession.java")
+        upload_start = ftp.index("synchronized void upload(")
+        upload_end = ftp.index("synchronized void download(", upload_start)
+        upload = ftp[upload_start:upload_end]
+        for marker in (
+            "String tempPath = uploadTempPath(path);",
+            'command("STOR " + sanitizeArgument(tempPath))',
+            "expect(terminal, 226, 250);",
+            'command("RNFR " + sanitizeArgument(tempPath))',
+            'command("RNTO " + sanitizeArgument(path))',
+            "deleteRemoteBestEffort(tempPath);",
+            "hardClose();",
+        ):
+            self.assertIn(marker, upload)
+        self.assertNotIn('command("STOR " + sanitizeArgument(path))', upload)
+        completion = upload.index("expect(terminal, 226, 250);")
+        rename_from = upload.index('command("RNFR " + sanitizeArgument(tempPath))')
+        rename_to = upload.index('command("RNTO " + sanitizeArgument(path))')
+        self.assertLess(completion, rename_from)
+        self.assertLess(rename_from, rename_to)
+        self.assertIn('".ghostftp-upload-" + UUID.randomUUID() + ".part"', ftp)
+
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         for marker in (


### PR DESCRIPTION
## Summary

Hardens Android FTP/FTPS uploads so an interrupted transfer cannot leave a partial object under the requested final remote filename.

### Staged upload contract

- Generates a random same-directory `.ghostftp-upload-<uuid>.part` path for each upload.
- Sends `STOR` only to the staging path; there is no direct `STOR` fallback to the requested final path.
- Requires the server's successful transfer completion reply (`226` or `250`) before any final-name commit is attempted.
- Commits only with `RNFR <staging>` followed by `RNTO <final>`.
- A server that rejects the safe rename sequence produces an upload failure rather than silently falling back to a non-atomic upload.
- Rename rejection after a cleanly confirmed transfer triggers best-effort staging cleanup.
- Data-stream/completion failures that may leave the FTP control stream desynchronized hard-close the session instead of issuing unsafe follow-up commands.
- A transport interruption may therefore leave a `.part` staging object, but the requested final filename is never reported as successfully committed.

### Security / compatibility

- Existing strict FTPS certificate and hostname verification is unchanged on both control and protected passive data channels.
- No trust-all fallback, telemetry, backend or new dependency is introduced.
- Public Ghost FTP 0.0.3 Windows/Linux release artifacts are unchanged.

### Regression coverage

Android contract tests enforce `STOR staging -> confirmed 226/250 -> RNFR staging -> RNTO final` ordering and reject a regression back to direct `STOR` on the final path.

## Validation

Exact PR head: `69a092caa2619c067a434b42e7d7ee471365acdc`

- Ghost FTP Android APK run `34556007401`: `completed/success`.
- Ghost FTP CI run `34556007388`: `completed/success`.
- Android source contract, lint, real APK build, APK integrity verification and artifact upload: success.
- Core Go tests/vet, repository/platform, security/privacy/docs/release audits and Python regression suite: success.
- Linux production build/package verification/artifact upload: success.
- Windows universal production build, release artifact verification, Authenticode private-key smoke and artifact upload: success.
- Android artifact `10182592530` (`ghostftp-android-apk`) is bound to the exact PR head; workflow ZIP digest `sha256:1dea0ed863d1141a1fcc8721b1fd592066999fd5b21bc13dc1c1a0ac2001dc2e`.

Merge only with expected-head protection, then verify actual post-merge `push` workflows on the resulting `main` SHA.