### PR TITLE
Android: stage local downloads before final name commit

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -12,6 +12,7 @@ Native Android client source lives entirely under this `android/` directory.
 - Remote directory listing uses MLSD over EPSV/PASV.
 - Binary upload and download are implemented.
 - Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
+- Downloads are written to a temporary SAF `.ghostftp-download-<uuid>.part` document and receive the requested final local name only after the FTP transfer is confirmed complete and the storage provider accepts an exact-name commit.
 - Host, username, protocol, port and the user-granted folder URI may be remembered. Passwords are memory-only and are cleared from the UI after connection.
 - Explicit saved sites store only non-secret connection identity and navigation metadata; Quick Connect never creates a hidden site.
 - A saved site can own a local SAF start folder, a remote start directory, local SAF bookmarks and remote path bookmarks.
@@ -31,6 +32,18 @@ After confirmed transfer completion, Ghost FTP requires `RNFR` for the staging o
 If the data stream or the completion reply fails in a way that can leave the FTP control channel state uncertain, Ghost FTP hard-closes that session instead of issuing further commands against a potentially desynchronized connection. A staging `.part` object can therefore remain on the server after a transport interruption, but the requested final remote name is not reported as successfully committed. When a rename is rejected after the transfer has been cleanly confirmed, Ghost FTP makes a best-effort attempt to delete the staging object.
 
 The staging flow uses the same existing passive-data transport. For FTPS, the staging upload therefore retains platform-trusted certificate validation and strict hostname verification on the protected data channel; it does not introduce a trust downgrade.
+
+## Download commit safety
+
+Android download does not create the requested final local filename before the server has confirmed transfer completion. Before transfer starts, Ghost FTP performs a fresh SAF listing of the selected destination directory and rejects an exact-name conflict rather than asking the storage provider to overwrite or auto-rename an existing object.
+
+The incoming data is written only to a temporary `.ghostftp-download-<uuid>.part` SAF document. `FtpSession.download()` returns only after the remote data stream has finished and the FTP server has returned an accepted `226` or `250` completion reply, so the final local-name commit is not attempted before that protocol confirmation.
+
+Immediately before commit, Ghost FTP performs a second fresh SAF listing and again rejects an exact-name conflict. It then asks the provider to rename the staging document to the requested filename and reads back `COLUMN_DISPLAY_NAME`. A provider result such as `file (1)` is not treated as a successful download when `file` was requested. If final-name verification fails, Ghost FTP best-effort deletes the unverified result and reports failure.
+
+Any failure before final commit best-effort deletes the staging document. The download is reported as completed only after exact-name read-back succeeds. This is a local SAF commit-safety guarantee; active-transfer cancellation, resume, and FTP control-channel interruption recovery remain separate lifecycle work and are not implied by this staging contract.
+
+All local download work remains inside the user-granted Storage Access Framework tree. No broad or all-files storage permission is introduced.
 
 ## Saved-site and bookmark security boundary
 

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -816,30 +816,73 @@ public final class MainActivity extends Activity {
         FtpSession current = session;
         if (busy || current == null || selectedRemote < 0 || selectedRemote >= remoteEntries.size() || treeUri == null) return;
         RemoteEntry entry = remoteEntries.get(selectedRemote);
-        Uri parent = DocumentsContract.buildDocumentUriUsingTree(treeUri, currentDocumentId);
+        Uri selectedTree = treeUri;
+        String selectedDocumentId = currentDocumentId;
+        Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
         String remoteBase = currentRemotePath;
-        setBusy(true, "Downloading " + entry.name + "…");
+        setBusy(true, "Downloading " + entry.name + " to a staged local document…");
         io.execute(() -> {
-            Uri created = null;
+            Uri staged = null;
             try {
-                created = DocumentsContract.createDocument(getContentResolver(), parent, "application/octet-stream", entry.name);
-                if (created == null) throw new IOException("Could not create local destination file.");
-                try (OutputStream out = getContentResolver().openOutputStream(created, "w")) {
-                    if (out == null) throw new IOException("Could not open local destination file.");
+                ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,
+                        "A local item with this exact name already exists. Remove or rename it before downloading.");
+
+                String stagedName = ".ghostftp-download-" + UUID.randomUUID() + ".part";
+                staged = DocumentsContract.createDocument(getContentResolver(), parent, "application/octet-stream", stagedName);
+                if (staged == null) throw new IOException("Could not create staged local download document.");
+
+                try (OutputStream out = getContentResolver().openOutputStream(staged, "w")) {
+                    if (out == null) throw new IOException("Could not open staged local download document.");
                     current.download(FtpSession.joinRemote(remoteBase, entry.name), out);
                 }
+
+                ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,
+                        "A local item with the destination name appeared during download; staged data was not committed.");
+
+                Uri committed = DocumentsContract.renameDocument(getContentResolver(), staged, entry.name);
+                if (committed == null) throw new IOException("Storage provider rejected the final download name commit.");
+                staged = committed;
+                String committedName = queryDocumentDisplayName(committed);
+                if (!entry.name.equals(committedName)) {
+                    throw new IOException("Storage provider changed the requested final download name; commit was rejected.");
+                }
+                staged = null;
+
                 runOnUiThread(() -> {
                     if (session != current) return;
-                    setBusy(false, "Download completed: " + entry.name);
+                    setBusy(false, "Download completed and committed: " + entry.name);
                     refreshLocal();
                 });
             } catch (Exception e) {
-                if (created != null) {
-                    try { DocumentsContract.deleteDocument(getContentResolver(), created); } catch (Exception ignored) { }
+                if (staged != null) {
+                    try { DocumentsContract.deleteDocument(getContentResolver(), staged); } catch (Exception ignored) { }
                 }
                 postError("Download failed", e);
             }
         });
+    }
+
+    private void ensureNoLocalNameConflict(Uri rootTreeUri, String documentId, String name, String message) throws IOException {
+        List<LocalEntry> fresh = queryChildren(rootTreeUri, documentId);
+        for (LocalEntry local : fresh) {
+            if (name.equals(local.name)) throw new IOException(message);
+        }
+    }
+
+    private String queryDocumentDisplayName(Uri document) throws IOException {
+        String[] projection = {DocumentsContract.Document.COLUMN_DISPLAY_NAME};
+        try (Cursor cursor = getContentResolver().query(document, projection, null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
+                throw new IOException("Storage provider could not verify the committed download name.");
+            }
+            String name = cursor.getString(0);
+            if (name == null || name.isEmpty()) {
+                throw new IOException("Storage provider returned an empty committed download name.");
+            }
+            return name;
+        } catch (SecurityException e) {
+            throw new IOException("Storage permission was lost while verifying the committed download.", e);
+        }
     }
 
     private void clearLocalRoot() {

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -109,8 +109,10 @@ class AndroidContractTests(unittest.TestCase):
     def test_download_stages_saf_document_before_final_name_commit(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         download_start = activity.index("private void downloadSelected()")
-        download_end = activity.index("private void clearLocalRoot()", download_start)
-        download = activity[download_start:download_end]
+        helper_start = activity.index("private void ensureNoLocalNameConflict(", download_start)
+        helper_end = activity.index("private void clearLocalRoot()", helper_start)
+        download = activity[download_start:helper_start]
+        helpers = activity[helper_start:helper_end]
         for marker in (
             '".ghostftp-download-" + UUID.randomUUID() + ".part"',
             "ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,",
@@ -136,10 +138,9 @@ class AndroidContractTests(unittest.TestCase):
         self.assertLess(second_conflict, rename)
         self.assertLess(rename, verify)
         self.assertLess(verify, success)
-        helper = activity[download_end:activity.index("private void renderLocal()", download_end)]
-        self.assertIn("List<LocalEntry> fresh = queryChildren(rootTreeUri, documentId);", helper)
-        self.assertIn("if (name.equals(local.name)) throw new IOException(message);", helper)
-        self.assertIn("DocumentsContract.Document.COLUMN_DISPLAY_NAME", helper)
+        self.assertIn("List<LocalEntry> fresh = queryChildren(rootTreeUri, documentId);", helpers)
+        self.assertIn("if (name.equals(local.name)) throw new IOException(message);", helpers)
+        self.assertIn("DocumentsContract.Document.COLUMN_DISPLAY_NAME", helpers)
 
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -106,6 +106,41 @@ class AndroidContractTests(unittest.TestCase):
         self.assertLess(rename_from, rename_to)
         self.assertIn('".ghostftp-upload-" + UUID.randomUUID() + ".part"', ftp)
 
+    def test_download_stages_saf_document_before_final_name_commit(self) -> None:
+        activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
+        download_start = activity.index("private void downloadSelected()")
+        download_end = activity.index("private void clearLocalRoot()", download_start)
+        download = activity[download_start:download_end]
+        for marker in (
+            '".ghostftp-download-" + UUID.randomUUID() + ".part"',
+            "ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,",
+            "current.download(FtpSession.joinRemote(remoteBase, entry.name), out);",
+            "DocumentsContract.renameDocument(getContentResolver(), staged, entry.name)",
+            "queryDocumentDisplayName(committed)",
+            "DocumentsContract.deleteDocument(getContentResolver(), staged)",
+        ):
+            self.assertIn(marker, download)
+        self.assertGreaterEqual(download.count("ensureNoLocalNameConflict("), 2)
+        self.assertNotIn(
+            'DocumentsContract.createDocument(getContentResolver(), parent, "application/octet-stream", entry.name)',
+            download,
+        )
+        create = download.index("DocumentsContract.createDocument")
+        transfer = download.index("current.download(")
+        second_conflict = download.rindex("ensureNoLocalNameConflict(")
+        rename = download.index("DocumentsContract.renameDocument")
+        verify = download.index("queryDocumentDisplayName(committed)")
+        success = download.index('setBusy(false, "Download completed and committed: "')
+        self.assertLess(create, transfer)
+        self.assertLess(transfer, second_conflict)
+        self.assertLess(second_conflict, rename)
+        self.assertLess(rename, verify)
+        self.assertLess(verify, success)
+        helper = activity[download_end:activity.index("private void renderLocal()", download_end)]
+        self.assertIn("List<LocalEntry> fresh = queryChildren(rootTreeUri, documentId);", helper)
+        self.assertIn("if (name.equals(local.name)) throw new IOException(message);", helper)
+        self.assertIn("DocumentsContract.Document.COLUMN_DISPLAY_NAME", helper)
+
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         for marker in (


### PR DESCRIPTION
## Summary

Hardens Android FTP/FTPS downloads so the requested final local filename is not exposed until the remote transfer has completed successfully and the Android Storage Access Framework provider accepts an exact-name commit.

### Staged local download contract

- Captures the selected SAF tree/document identity before starting the worker.
- Performs a fresh SAF listing before transfer and rejects an existing exact-name destination instead of overwriting or accepting provider auto-renaming.
- Creates only a temporary `.ghostftp-download-<uuid>.part` SAF document before the transfer.
- Writes the remote payload into that staging document.
- `FtpSession.download()` returns only after the server accepts transfer completion with `226` or `250`, so final local-name commit is attempted only after protocol completion.
- Performs a second fresh exact-name conflict check immediately before commit.
- Commits with `DocumentsContract.renameDocument()` only after the confirmed download.
- Reads back `COLUMN_DISPLAY_NAME` and requires the exact requested filename; a provider result such as `file (1)` is rejected rather than reported as success.
- Any failure best-effort deletes the staging/unverified result.
- UI success is emitted only after exact-name read-back succeeds.

### Security / scope

- All local writes remain inside the user-granted SAF tree; no broad/all-files storage permission is added.
- Strict FTPS certificate/hostname verification and the staged remote upload contract are unchanged.
- No telemetry, backend or new dependency is introduced.
- Active-transfer cancellation/resume and FTP control-channel interruption recovery remain separate lifecycle work and are not claimed by this PR.
- Public Ghost FTP 0.0.3 Windows/Linux release artifacts remain unchanged.

### Regression coverage

The Android source contract enforces staging-before-final-name order, two fresh conflict checks, exact provider name read-back, staging cleanup, and rejects direct creation of the requested final filename before transfer completion.

## Validation

Exact PR head: `8590b16db7b14eaa085ef2a6e7a6d5e7c4a45cc2`

- Ghost FTP Android APK run `34556785281`: `completed/success`.
- Ghost FTP CI run `34556785373`: `completed/success`.
- Android source contract, lint, real APK build, APK integrity verification and artifact upload: success.
- Core Go tests/vet, repository/platform, security/privacy/docs/release audits and Python regression suite: success.
- Linux production build/package verification/artifact upload: success.
- Windows universal production build, release artifact verification, Authenticode private-key smoke and artifact upload: success.
- Android artifact `10182867287` (`ghostftp-android-apk`) is bound to the exact PR head; workflow ZIP digest `sha256:4305190359ccb3be9b935822a9f533ff2df7f0bb13737907eb47432f7a16300e`.

Merge only with expected-head protection, then verify actual post-merge `push` workflows on the resulting `main` SHA.