### PR TITLE
Android: make active FTP transfers cancellable

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -13,6 +13,8 @@ Native Android client source lives entirely under this `android/` directory.
 - Binary upload and download are implemented.
 - Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
 - Downloads are written to a temporary SAF `.ghostftp-download-<uuid>.part` document and receive the requested final local name only after the FTP transfer is confirmed complete and the storage provider accepts an exact-name commit.
+- An active upload/download can be cancelled from the existing connection action. While a transfer is active, **Disconnect** becomes **Cancel transfer**.
+- Cancelling a transfer hard-closes both the active data socket and FTP control socket and requires a fresh reconnect before any further server operation.
 - Host, username, protocol, port and the user-granted folder URI may be remembered. Passwords are memory-only and are cleared from the UI after connection.
 - Explicit saved sites store only non-secret connection identity and navigation metadata; Quick Connect never creates a hidden site.
 - A saved site can own a local SAF start folder, a remote start directory, local SAF bookmarks and remote path bookmarks.
@@ -41,9 +43,21 @@ The incoming data is written only to a temporary `.ghostftp-download-<uuid>.part
 
 Immediately before commit, Ghost FTP performs a second fresh SAF listing and again rejects an exact-name conflict. It then asks the provider to rename the staging document to the requested filename and reads back `COLUMN_DISPLAY_NAME`. A provider result such as `file (1)` is not treated as a successful download when `file` was requested. If final-name verification fails, Ghost FTP best-effort deletes the unverified result and reports failure.
 
-Any failure before final commit best-effort deletes the staging document. The download is reported as completed only after exact-name read-back succeeds. This is a local SAF commit-safety guarantee; active-transfer cancellation, resume, and FTP control-channel interruption recovery remain separate lifecycle work and are not implied by this staging contract.
+Any failure before final commit best-effort deletes the staging document. The download is reported as completed only after exact-name read-back succeeds. Active cancellation invalidates the UI transfer generation before cleanup, so a cancelled worker cannot later publish a stale normal-completion state.
 
 All local download work remains inside the user-granted Storage Access Framework tree. No broad or all-files storage permission is introduced.
+
+## Active transfer cancellation
+
+Cancellation is deliberately fail-closed. The FTP data-transfer methods hold the session's protocol lock while a transfer is active, so the UI does not attempt to acquire that same lock and send a graceful `ABOR` or `QUIT`. Instead, `cancelActiveTransfer()` is intentionally non-synchronized: it marks the session disconnected and closes the active passive-data socket and control socket directly. Closing those sockets interrupts blocked reads, writes, TLS data-channel setup, or a pending completion reply without freezing the Android UI behind the transfer lock.
+
+The same control connection is never reused after cancellation. FTP servers can emit delayed transfer replies and an interrupted control stream can be ambiguous; Ghost FTP therefore requires the user to reconnect before another remote operation. A normal idle Disconnect still uses the regular graceful close path.
+
+The UI uses a monotonically increasing transfer-generation token. Upload/download workers must still own the generation that started them before they can move through local staging checkpoints or publish a normal completion state. A Cancel request invalidates that generation immediately. If a network failure hard-closes the session for the same protocol-safety reason, the dead session is removed from UI state so a fresh Connect is possible.
+
+Cancellation does not claim a transactional rollback that FTP cannot guarantee. For an upload, a `.ghostftp-upload-*.part` object may remain if the connection is cut during the staged transfer. If cancellation races with the server's final rename acknowledgement, the remote commit can be ambiguous; the UI instructs the user to reconnect and refresh before retrying rather than risk a duplicate upload. For a download, cancellation before the local final-name commit best-effort deletes the SAF staging document. If the local provider has already completed and verified the final rename before cancellation takes effect, the completed local file is retained and the connection is still closed.
+
+Resume/restart-from-offset is not implemented by this cancellation contract. It remains separate transfer functionality and must not reuse a cancelled FTP session.
 
 ## Saved-site and bookmark security boundary
 

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -29,10 +29,11 @@ final class FtpSession implements Closeable {
     private final String host;
     private final int port;
     private final boolean secure;
-    private Socket controlSocket;
+    private volatile Socket controlSocket;
+    private volatile Socket activeDataSocket;
     private BufferedReader reader;
     private BufferedWriter writer;
-    private boolean connected;
+    private volatile boolean connected;
 
     FtpSession(String host, int port, boolean secure) {
         this.host = requireHost(host);
@@ -77,25 +78,43 @@ final class FtpSession implements Closeable {
         ensureConnected();
         String path = normalizeRemotePath(remotePath);
         Socket data = openPassiveDataSocket();
-        Reply start = command("MLSD " + sanitizeArgument(path));
+        Reply start;
+        try {
+            start = command("MLSD " + sanitizeArgument(path));
+        } catch (IOException e) {
+            releaseDataSocket(data);
+            hardClose();
+            throw new IOException("Directory listing could not start; the connection was closed.", e);
+        }
         if (start.code != 125 && start.code != 150) {
-            closeQuietly(data);
+            releaseDataSocket(data);
             throw new IOException("MLSD failed: " + start.message);
         }
 
         List<RemoteEntry> entries = new ArrayList<>();
-        try (BufferedReader dataReader = new BufferedReader(new InputStreamReader(data.getInputStream(), StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = dataReader.readLine()) != null) {
-                RemoteEntry entry = parseMlsd(line);
-                if (entry != null) {
-                    entries.add(entry);
+        try {
+            try (BufferedReader dataReader = new BufferedReader(new InputStreamReader(data.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = dataReader.readLine()) != null) {
+                    RemoteEntry entry = parseMlsd(line);
+                    if (entry != null) {
+                        entries.add(entry);
+                    }
                 }
             }
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Directory listing data transfer failed; the connection was closed.", e);
         } finally {
-            closeQuietly(data);
+            releaseDataSocket(data);
         }
-        expect(readReply(), 226, 250);
+
+        try {
+            expect(readReply(), 226, 250);
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Directory listing was not confirmed complete; the connection was closed.", e);
+        }
         return entries;
     }
 
@@ -107,9 +126,16 @@ final class FtpSession implements Closeable {
         String path = normalizeRemotePath(remotePath);
         String tempPath = uploadTempPath(path);
         Socket data = openPassiveDataSocket();
-        Reply start = command("STOR " + sanitizeArgument(tempPath));
+        Reply start;
+        try {
+            start = command("STOR " + sanitizeArgument(tempPath));
+        } catch (IOException e) {
+            releaseDataSocket(data);
+            hardClose();
+            throw new IOException("Upload could not start; the connection was closed.", e);
+        }
         if (start.code != 125 && start.code != 150) {
-            closeQuietly(data);
+            releaseDataSocket(data);
             throw new IOException("Upload rejected: " + start.message);
         }
 
@@ -117,12 +143,12 @@ final class FtpSession implements Closeable {
             try (OutputStream out = new BufferedOutputStream(data.getOutputStream())) {
                 copy(input, out);
                 out.flush();
-            } finally {
-                closeQuietly(data);
             }
         } catch (IOException e) {
             hardClose();
             throw new IOException("Upload data transfer failed before final commit; the connection was closed.", e);
+        } finally {
+            releaseDataSocket(data);
         }
 
         final Reply terminal;
@@ -166,18 +192,37 @@ final class FtpSession implements Closeable {
         }
         String path = normalizeRemotePath(remotePath);
         Socket data = openPassiveDataSocket();
-        Reply start = command("RETR " + sanitizeArgument(path));
+        Reply start;
+        try {
+            start = command("RETR " + sanitizeArgument(path));
+        } catch (IOException e) {
+            releaseDataSocket(data);
+            hardClose();
+            throw new IOException("Download could not start; the connection was closed.", e);
+        }
         if (start.code != 125 && start.code != 150) {
-            closeQuietly(data);
+            releaseDataSocket(data);
             throw new IOException("Download rejected: " + start.message);
         }
-        try (InputStream in = new BufferedInputStream(data.getInputStream())) {
-            copy(in, output);
-            output.flush();
+
+        try {
+            try (InputStream in = new BufferedInputStream(data.getInputStream())) {
+                copy(in, output);
+                output.flush();
+            }
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Download data transfer failed before local commit; the connection was closed.", e);
         } finally {
-            closeQuietly(data);
+            releaseDataSocket(data);
         }
-        expect(readReply(), 226, 250);
+
+        try {
+            expect(readReply(), 226, 250);
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Download was not confirmed complete; local final name was not committed and the connection was closed.", e);
+        }
     }
 
     synchronized String pwd() throws IOException {
@@ -192,8 +237,14 @@ final class FtpSession implements Closeable {
         return "/";
     }
 
-    synchronized boolean isConnected() {
+    boolean isConnected() {
         return connected;
+    }
+
+    void cancelActiveTransfer() {
+        connected = false;
+        closeQuietly(activeDataSocket);
+        closeQuietly(controlSocket);
     }
 
     @Override
@@ -220,9 +271,33 @@ final class FtpSession implements Closeable {
         }
 
         Socket plain = new Socket();
-        plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);
-        plain.setSoTimeout(READ_TIMEOUT_MS);
-        return secure ? wrapTls(plain) : plain;
+        activeDataSocket = plain;
+        if (!connected) {
+            releaseDataSocket(plain);
+            throw new IOException("Transfer was cancelled before the data connection opened.");
+        }
+        try {
+            plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);
+            plain.setSoTimeout(READ_TIMEOUT_MS);
+            if (!secure) {
+                if (!connected) {
+                    releaseDataSocket(plain);
+                    throw new IOException("Transfer was cancelled while the data connection opened.");
+                }
+                return plain;
+            }
+
+            SSLSocket tls = wrapTls(plain);
+            activeDataSocket = tls;
+            if (!connected) {
+                releaseDataSocket(tls);
+                throw new IOException("Transfer was cancelled while the protected data channel opened.");
+            }
+            return tls;
+        } catch (IOException e) {
+            releaseDataSocket(plain);
+            throw e;
+        }
     }
 
     private SSLSocket wrapTls(Socket plain) throws IOException {
@@ -380,8 +455,17 @@ final class FtpSession implements Closeable {
         }
     }
 
+    private void releaseDataSocket(Socket socket) {
+        closeQuietly(socket);
+        if (activeDataSocket == socket) {
+            activeDataSocket = null;
+        }
+    }
+
     private void hardClose() {
         connected = false;
+        closeQuietly(activeDataSocket);
+        activeDataSocket = null;
         closeQuietly(controlSocket);
         controlSocket = null;
         reader = null;

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -81,6 +81,8 @@ public final class MainActivity extends Activity {
     private int selectedRemote = -1;
     private FtpSession session;
     private boolean busy;
+    private volatile boolean transferActive;
+    private volatile long transferGeneration;
 
     @Override
     protected void onCreate(Bundle state) {
@@ -97,10 +99,12 @@ public final class MainActivity extends Activity {
 
     @Override
     protected void onDestroy() {
+        transferGeneration++;
+        transferActive = false;
         FtpSession current = session;
         session = null;
         connectedIdentityKey = null;
-        if (current != null) current.close();
+        if (current != null) current.cancelActiveTransfer();
         io.shutdownNow();
         super.onDestroy();
     }
@@ -472,6 +476,10 @@ public final class MainActivity extends Activity {
     }
 
     private void disconnect() {
+        if (transferActive) {
+            cancelTransfer();
+            return;
+        }
         if (busy) return;
         FtpSession current = session;
         session = null;
@@ -482,6 +490,22 @@ public final class MainActivity extends Activity {
         renderRemote();
         if (current != null) io.execute(current::close);
         setStatus("Disconnected.");
+        refreshButtons();
+    }
+
+    private void cancelTransfer() {
+        if (!transferActive) return;
+        transferGeneration++;
+        transferActive = false;
+        FtpSession current = session;
+        session = null;
+        connectedIdentityKey = null;
+        remoteEntries.clear();
+        selectedRemote = -1;
+        currentRemotePath = "/";
+        if (current != null) current.cancelActiveTransfer();
+        renderRemote();
+        setStatus("Cancelling active transfer. Connection closed; reconnect before another transfer.");
         refreshButtons();
     }
 
@@ -796,18 +820,26 @@ public final class MainActivity extends Activity {
         LocalEntry entry = localEntries.get(selectedLocal);
         Uri document = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.documentId);
         String remoteBase = currentRemotePath;
-        setBusy(true, "Uploading " + entry.name + "…");
+        long transferToken = beginTransfer("Uploading " + entry.name + "…");
         io.execute(() -> {
-            try (InputStream in = getContentResolver().openInputStream(document)) {
-                if (in == null) throw new IOException("Could not open local file.");
-                current.upload(FtpSession.joinRemote(remoteBase, entry.name), in);
+            try {
+                requireTransferCurrent(transferToken);
+                try (InputStream in = getContentResolver().openInputStream(document)) {
+                    if (in == null) throw new IOException("Could not open local file.");
+                    requireTransferCurrent(transferToken);
+                    current.upload(FtpSession.joinRemote(remoteBase, entry.name), in);
+                }
+                transferActive = false;
                 runOnUiThread(() -> {
-                    if (session != current) return;
+                    if (transferCancelled(transferToken) || session != current || !current.isConnected()) {
+                        setBusy(false, "Upload commit raced with cancellation or connection loss. Reconnect and refresh the server before retrying.");
+                        return;
+                    }
                     setBusy(false, "Upload completed: " + entry.name);
                     refreshRemote(currentRemotePath);
                 });
             } catch (Exception e) {
-                postError("Upload failed", e);
+                finishTransferFailure(transferToken, current, "Upload failed", e, false);
             }
         });
     }
@@ -820,24 +852,29 @@ public final class MainActivity extends Activity {
         String selectedDocumentId = currentDocumentId;
         Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
         String remoteBase = currentRemotePath;
-        setBusy(true, "Downloading " + entry.name + " to a staged local document…");
+        long transferToken = beginTransfer("Downloading " + entry.name + " to a staged local document…");
         io.execute(() -> {
             Uri staged = null;
             try {
+                requireTransferCurrent(transferToken);
                 ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,
                         "A local item with this exact name already exists. Remove or rename it before downloading.");
+                requireTransferCurrent(transferToken);
 
                 String stagedName = ".ghostftp-download-" + UUID.randomUUID() + ".part";
                 staged = DocumentsContract.createDocument(getContentResolver(), parent, "application/octet-stream", stagedName);
                 if (staged == null) throw new IOException("Could not create staged local download document.");
 
+                requireTransferCurrent(transferToken);
                 try (OutputStream out = getContentResolver().openOutputStream(staged, "w")) {
                     if (out == null) throw new IOException("Could not open staged local download document.");
                     current.download(FtpSession.joinRemote(remoteBase, entry.name), out);
                 }
+                requireTransferCurrent(transferToken);
 
                 ensureNoLocalNameConflict(selectedTree, selectedDocumentId, entry.name,
                         "A local item with the destination name appeared during download; staged data was not committed.");
+                requireTransferCurrent(transferToken);
 
                 Uri committed = DocumentsContract.renameDocument(getContentResolver(), staged, entry.name);
                 if (committed == null) throw new IOException("Storage provider rejected the final download name commit.");
@@ -847,9 +884,14 @@ public final class MainActivity extends Activity {
                     throw new IOException("Storage provider changed the requested final download name; commit was rejected.");
                 }
                 staged = null;
+                transferActive = false;
 
                 runOnUiThread(() -> {
-                    if (session != current) return;
+                    if (transferCancelled(transferToken) || session != current || !current.isConnected()) {
+                        refreshLocal();
+                        setBusy(false, "Download committed before cancellation or connection loss took effect. Connection closed; reconnect before another transfer.");
+                        return;
+                    }
                     setBusy(false, "Download completed and committed: " + entry.name);
                     refreshLocal();
                 });
@@ -857,8 +899,44 @@ public final class MainActivity extends Activity {
                 if (staged != null) {
                     try { DocumentsContract.deleteDocument(getContentResolver(), staged); } catch (Exception ignored) { }
                 }
-                postError("Download failed", e);
+                finishTransferFailure(transferToken, current, "Download failed", e, true);
             }
+        });
+    }
+
+    private long beginTransfer(String message) {
+        transferActive = true;
+        long token = ++transferGeneration;
+        setBusy(true, message);
+        return token;
+    }
+
+    private boolean transferCancelled(long token) {
+        return token != transferGeneration;
+    }
+
+    private void requireTransferCurrent(long token) throws IOException {
+        if (transferCancelled(token)) {
+            throw new IOException("Transfer cancelled.");
+        }
+    }
+
+    private void finishTransferFailure(long token, FtpSession current, String prefix, Exception e, boolean refreshLocalAfter) {
+        boolean cancelled = transferCancelled(token);
+        transferActive = false;
+        runOnUiThread(() -> {
+            if (session == current && !current.isConnected()) {
+                session = null;
+                connectedIdentityKey = null;
+                remoteEntries.clear();
+                selectedRemote = -1;
+                currentRemotePath = "/";
+                renderRemote();
+            }
+            if (refreshLocalAfter) refreshLocal();
+            setBusy(false, cancelled
+                    ? "Transfer cancelled. Connection closed; reconnect before another transfer."
+                    : prefix + ": " + safeMessage(e));
         });
     }
 
@@ -924,7 +1002,8 @@ public final class MainActivity extends Activity {
         boolean activeSite = profile != null;
         boolean connectedSite = activeSite && connected && connectedIdentityKey != null && profile.identityKey().equals(connectedIdentityKey);
         connect.setEnabled(!busy && !connected);
-        disconnect.setEnabled(!busy && connected);
+        disconnect.setText(transferActive ? "Cancel transfer" : "Disconnect");
+        disconnect.setEnabled(transferActive || (!busy && connected));
         upload.setEnabled(!busy && connected && selectedLocal >= 0);
         download.setEnabled(!busy && connected && selectedRemote >= 0 && treeUri != null);
         saveSite.setEnabled(!busy && !connected);

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -1033,7 +1033,18 @@ public final class MainActivity extends Activity {
     }
 
     private void postError(String prefix, Exception e) {
-        runOnUiThread(() -> setBusy(false, prefix + ": " + safeMessage(e)));
+        runOnUiThread(() -> {
+            FtpSession current = session;
+            if (current != null && !current.isConnected()) {
+                session = null;
+                connectedIdentityKey = null;
+                remoteEntries.clear();
+                selectedRemote = -1;
+                currentRemotePath = "/";
+                renderRemote();
+            }
+            setBusy(false, prefix + ": " + safeMessage(e));
+        });
     }
 
     private void setStatus(String value) {

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -142,6 +142,71 @@ class AndroidContractTests(unittest.TestCase):
         self.assertIn("if (name.equals(local.name)) throw new IOException(message);", helpers)
         self.assertIn("DocumentsContract.Document.COLUMN_DISPLAY_NAME", helpers)
 
+    def test_active_transfer_cancel_is_nonblocking_and_fail_closed(self) -> None:
+        ftp = self.read(f"{ANDROID_JAVA}/FtpSession.java")
+        activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
+
+        for marker in (
+            "private volatile Socket controlSocket;",
+            "private volatile Socket activeDataSocket;",
+            "private volatile boolean connected;",
+            "void cancelActiveTransfer()",
+            "closeQuietly(activeDataSocket);",
+            "closeQuietly(controlSocket);",
+            "activeDataSocket = plain;",
+            "activeDataSocket = tls;",
+            "private void releaseDataSocket(Socket socket)",
+        ):
+            self.assertIn(marker, ftp)
+        self.assertNotIn("synchronized void cancelActiveTransfer()", ftp)
+        self.assertIn("boolean isConnected()", ftp)
+        self.assertNotIn("synchronized boolean isConnected()", ftp)
+
+        cancel_start = ftp.index("void cancelActiveTransfer()")
+        cancel_end = ftp.index("@Override", cancel_start)
+        cancel = ftp[cancel_start:cancel_end]
+        self.assertIn("connected = false;", cancel)
+        self.assertLess(cancel.index("connected = false;"), cancel.index("closeQuietly(activeDataSocket);"))
+        self.assertLess(cancel.index("closeQuietly(activeDataSocket);"), cancel.index("closeQuietly(controlSocket);"))
+
+        download_start = ftp.index("synchronized void download(")
+        download_end = ftp.index("synchronized String pwd()", download_start)
+        download = ftp[download_start:download_end]
+        self.assertIn("Download data transfer failed before local commit; the connection was closed.", download)
+        self.assertIn("Download was not confirmed complete; local final name was not committed and the connection was closed.", download)
+        self.assertGreaterEqual(download.count("hardClose();"), 3)
+
+        for marker in (
+            "private volatile boolean transferActive;",
+            "private volatile long transferGeneration;",
+            'disconnect.setText(transferActive ? "Cancel transfer" : "Disconnect");',
+            "disconnect.setEnabled(transferActive || (!busy && connected));",
+            "long transferToken = beginTransfer(",
+            "requireTransferCurrent(transferToken);",
+            "finishTransferFailure(transferToken, current,",
+            "current.cancelActiveTransfer();",
+        ):
+            self.assertIn(marker, activity)
+        self.assertGreaterEqual(activity.count("long transferToken = beginTransfer("), 2)
+        self.assertGreaterEqual(activity.count("if (transferCancelled(transferToken) || session != current || !current.isConnected())"), 2)
+
+        disconnect_start = activity.index("private void disconnect()")
+        disconnect_end = activity.index("private void refreshRemote(", disconnect_start)
+        disconnect = activity[disconnect_start:disconnect_end]
+        self.assertIn("if (transferActive) {", disconnect)
+        self.assertIn("cancelTransfer();", disconnect)
+        self.assertLess(disconnect.index("if (transferActive) {"), disconnect.index("if (busy) return;"))
+        self.assertIn("transferGeneration++;", disconnect)
+        self.assertIn("session = null;", disconnect)
+        self.assertIn("current.cancelActiveTransfer();", disconnect)
+
+        destroy_start = activity.index("protected void onDestroy()")
+        destroy_end = activity.index("private void buildUi()", destroy_start)
+        destroy = activity[destroy_start:destroy_end]
+        self.assertIn("transferGeneration++;", destroy)
+        self.assertIn("current.cancelActiveTransfer();", destroy)
+        self.assertNotIn("current.close();", destroy)
+
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         for marker in (

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -207,6 +207,16 @@ class AndroidContractTests(unittest.TestCase):
         self.assertIn("current.cancelActiveTransfer();", destroy)
         self.assertNotIn("current.close();", destroy)
 
+        post_start = activity.index("private void postError(")
+        post_end = activity.index("private void setStatus(", post_start)
+        post_error = activity[post_start:post_end]
+        self.assertIn("FtpSession current = session;", post_error)
+        self.assertIn("if (current != null && !current.isConnected()) {", post_error)
+        self.assertIn("session = null;", post_error)
+        self.assertIn("connectedIdentityKey = null;", post_error)
+        self.assertIn("remoteEntries.clear();", post_error)
+        self.assertIn('currentRemotePath = "/";', post_error)
+
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         for marker in (


### PR DESCRIPTION
## Summary

Adds non-blocking, fail-closed cancellation for active Android FTP/FTPS uploads and downloads while preserving the existing staged upload/download commit guarantees.

### Active transfer lifecycle

- Reuses the existing connection action: while an upload/download is active, **Disconnect** becomes **Cancel transfer**.
- Tracks each transfer with a monotonically increasing generation token so a cancelled worker cannot later publish a stale normal-success state.
- `FtpSession.cancelActiveTransfer()` is intentionally non-synchronized: it marks the session disconnected and closes the active passive-data socket plus the FTP control socket without waiting for the synchronized transfer method to release its lock.
- Cancellation interrupts blocked data reads/writes, protected FTPS data-channel setup, or a pending FTP completion reply without freezing the Android UI behind the active transfer lock.
- A cancelled connection is never reused. The user must reconnect before another remote operation.
- Hard-closed sessions caused by ordinary network/MLSD/transfer failures are removed from UI state so a dead non-null session cannot block a fresh Connect.

### Commit-safety behavior

- Remote upload staging remains `STOR .ghostftp-upload-*.part -> confirmed 226/250 -> RNFR/RNTO`; there is still no direct `STOR` fallback to the requested final name.
- If cancellation races the server-side final upload rename acknowledgement, Ghost FTP does not claim rollback or normal success. It requires reconnect + refresh before retrying because the remote commit can be ambiguous.
- Local downloads retain SAF staging and exact-name verification. Cancellation before local final commit best-effort removes the staging document.
- If the local SAF provider has already completed and verified the final rename before cancellation takes effect, that verified local file is retained and the connection is still closed.
- Resume/restart-from-offset is not implemented or claimed by this PR.

### Security / privacy

- Strict FTPS certificate and hostname verification remains active on both control and protected passive data channels.
- Cancellation does not add a trust-all fallback, broad storage permission, telemetry, analytics, backend, ads, or a new dependency.
- No desktop Windows/Linux release contract is changed.

### Regression coverage

The Android contract guards non-synchronized cancellation, non-blocking connection-state reads, active data/control socket closure, passive-socket tracking, fail-closed transfer errors, Disconnect-to-Cancel UI ownership, generation invalidation/stale-success suppression, staged-download cleanup, Activity destruction, and dead-session UI cleanup.

## Validation

Exact PR head: `4b3ef99de06df572b02a6e2c39241d8976cc7c6d`.

- Ghost FTP Android APK run `34557898887`: `completed/success`.
- Ghost FTP CI run `34557898898`: `completed/success`.
- Android source contract, lint, real APK build, APK integrity verification and artifact upload: success.
- Core Go tests/vet, repository/platform, security/privacy/docs/release audits and Python regression suite: success.
- Linux production build/package verification/artifact upload: success.
- Windows universal production build, release artifact verification, Authenticode private-key smoke and artifact upload: success.
- Android artifact `10183264013` (`ghostftp-android-apk`) is bound to the exact PR head; workflow ZIP digest `sha256:49371975945f45fbfba21d7437b213f00b915b3aa3c2b0fbe52507a44889e3cc`.

Merge only with expected-head protection, then verify the actual post-merge `push` workflows on the resulting `main` SHA.