### PR TITLE
Android: fail closed on passive data setup errors

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -7,12 +7,14 @@ on:
       - 'android/**'
       - '.github/workflows/android-apk.yml'
       - 'scripts/test_android_contract.py'
+      - 'scripts/test_android_passive_data_contract.py'
   push:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android-apk.yml'
       - 'scripts/test_android_contract.py'
+      - 'scripts/test_android_passive_data_contract.py'
   workflow_dispatch:
 
 permissions:
@@ -51,6 +53,7 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/test_android_contract.py
+          python scripts/test_android_passive_data_contract.py
       - name: Lint and build APK
         working-directory: android
         shell: bash

--- a/android/README.md
+++ b/android/README.md
@@ -10,6 +10,7 @@ Native Android client source lives entirely under this `android/` directory.
 - FTP remains available for compatibility but is explicitly unencrypted.
 - Local navigation uses Android Storage Access Framework (`ACTION_OPEN_DOCUMENT_TREE`); the app does not request all-files storage access.
 - Remote directory listing uses MLSD over EPSV/PASV.
+- Passive data-channel setup is fail-closed: malformed EPSV/PASV replies, invalid passive ports, TCP data-connect failures and FTPS data-channel TLS failures close the FTP session and require reconnect.
 - Binary upload and download are implemented.
 - Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
 - Downloads are written to a temporary SAF `.ghostftp-download-<uuid>.part` document and receive the requested final local name only after the FTP transfer is confirmed complete and the storage provider accepts an exact-name commit.
@@ -58,6 +59,16 @@ The UI uses a monotonically increasing transfer-generation token. Upload/downloa
 Cancellation does not claim a transactional rollback that FTP cannot guarantee. For an upload, a `.ghostftp-upload-*.part` object may remain if the connection is cut during the staged transfer. If cancellation races with the server's final rename acknowledgement, the remote commit can be ambiguous; the UI instructs the user to reconnect and refresh before retrying rather than risk a duplicate upload. For a download, cancellation before the local final-name commit best-effort deletes the SAF staging document. If the local provider has already completed and verified the final rename before cancellation takes effect, the completed local file is retained and the connection is still closed.
 
 Resume/restart-from-offset is not implemented by this cancellation contract. It remains separate transfer functionality and must not reuse a cancelled FTP session.
+
+## Passive data-channel failure boundary
+
+Every listing, upload and download depends on a new passive data channel negotiated through EPSV with PASV fallback. Ghost FTP treats failure during that channel setup as a session-boundary failure rather than assuming the existing control stream remains safe for another operation.
+
+If EPSV/PASV negotiation cannot be completed, the passive reply is malformed, the passive port cannot be parsed or validated, the TCP data connection fails, or an FTPS data-channel TLS handshake fails, `openPassiveDataSocket()` closes the active data socket and hard-closes the FTP control session before returning the error. The Android UI then discards the dead session through the existing reconnect lifecycle.
+
+This policy is deliberately conservative. It can require reconnect even when a particular server might have kept its control channel usable, but it avoids reusing a session after an ambiguous transport setup failure. There is no fallback to an unprotected FTPS data channel, no disabled hostname verification, and no acceptance of an invalid passive port.
+
+The EPSV parser converts malformed/non-numeric ports into checked I/O failures rather than allowing a runtime parsing exception to escape outside the session cleanup path. The dedicated passive-data regression contract is executed by the Android APK workflow alongside the broader Android source contract.
 
 ## Saved-site and bookmark security boundary
 

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -260,28 +260,28 @@ final class FtpSession implements Closeable {
     }
 
     private Socket openPassiveDataSocket() throws IOException {
-        Reply epsv = command("EPSV");
-        int dataPort;
-        if (epsv.code == 229) {
-            dataPort = parseEpsvPort(epsv.message);
-        } else {
-            Reply pasv = command("PASV");
-            expect(pasv, 227);
-            dataPort = parsePasvPort(pasv.message);
-        }
-
-        Socket plain = new Socket();
-        activeDataSocket = plain;
-        if (!connected) {
-            releaseDataSocket(plain);
-            throw new IOException("Transfer was cancelled before the data connection opened.");
-        }
+        Socket plain = null;
         try {
+            Reply epsv = command("EPSV");
+            int dataPort;
+            if (epsv.code == 229) {
+                dataPort = parseEpsvPort(epsv.message);
+            } else {
+                Reply pasv = command("PASV");
+                expect(pasv, 227);
+                dataPort = parsePasvPort(pasv.message);
+            }
+
+            plain = new Socket();
+            activeDataSocket = plain;
+            if (!connected) {
+                throw new IOException("Transfer was cancelled before the data connection opened.");
+            }
+
             plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);
             plain.setSoTimeout(READ_TIMEOUT_MS);
             if (!secure) {
                 if (!connected) {
-                    releaseDataSocket(plain);
                     throw new IOException("Transfer was cancelled while the data connection opened.");
                 }
                 return plain;
@@ -290,13 +290,15 @@ final class FtpSession implements Closeable {
             SSLSocket tls = wrapTls(plain);
             activeDataSocket = tls;
             if (!connected) {
-                releaseDataSocket(tls);
                 throw new IOException("Transfer was cancelled while the protected data channel opened.");
             }
             return tls;
         } catch (IOException e) {
-            releaseDataSocket(plain);
-            throw e;
+            if (plain != null) {
+                releaseDataSocket(plain);
+            }
+            hardClose();
+            throw new IOException("Passive data connection setup failed; the FTP session was closed.", e);
         }
     }
 
@@ -377,12 +379,19 @@ final class FtpSession implements Closeable {
             throw new IOException("Invalid EPSV response.");
         }
         String payload = message.substring(open + 1, close);
+        if (payload.isEmpty()) {
+            throw new IOException("Invalid EPSV response.");
+        }
         char delimiter = payload.charAt(0);
         String[] parts = payload.split(java.util.regex.Pattern.quote(String.valueOf(delimiter)), -1);
         if (parts.length < 4) {
             throw new IOException("Invalid EPSV response.");
         }
-        return requirePort(Integer.parseInt(parts[3]));
+        try {
+            return requirePort(Integer.parseInt(parts[3]));
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid EPSV port.", e);
+        }
     }
 
     private static int parsePasvPort(String message) throws IOException {

--- a/scripts/test_android_passive_data_contract.py
+++ b/scripts/test_android_passive_data_contract.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+FTP = ROOT / "android/app/src/main/java/app/ghostftp/client/FtpSession.java"
+
+
+class AndroidPassiveDataContractTests(unittest.TestCase):
+    def test_passive_data_setup_failure_closes_session(self) -> None:
+        ftp = FTP.read_text(encoding="utf-8")
+        start = ftp.index("private Socket openPassiveDataSocket()")
+        end = ftp.index("private SSLSocket wrapTls(", start)
+        passive = ftp[start:end]
+
+        for marker in (
+            'command("EPSV")',
+            'command("PASV")',
+            "parseEpsvPort(epsv.message)",
+            "parsePasvPort(pasv.message)",
+            "plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);",
+            "SSLSocket tls = wrapTls(plain);",
+            "catch (IOException e)",
+            "hardClose();",
+            'throw new IOException("Passive data connection setup failed; the FTP session was closed.", e);',
+        ):
+            self.assertIn(marker, passive)
+
+        catch_pos = passive.index("catch (IOException e)")
+        hard_close_pos = passive.index("hardClose();", catch_pos)
+        throw_pos = passive.index("Passive data connection setup failed", hard_close_pos)
+        self.assertLess(catch_pos, hard_close_pos)
+        self.assertLess(hard_close_pos, throw_pos)
+
+    def test_invalid_epsv_port_is_checked_io_failure(self) -> None:
+        ftp = FTP.read_text(encoding="utf-8")
+        start = ftp.index("private static int parseEpsvPort(")
+        end = ftp.index("private static int parsePasvPort(", start)
+        epsv = ftp[start:end]
+
+        self.assertIn("if (payload.isEmpty())", epsv)
+        self.assertIn("catch (NumberFormatException e)", epsv)
+        self.assertIn('throw new IOException("Invalid EPSV port.", e);', epsv)
+        self.assertNotIn("return requirePort(Integer.parseInt(parts[3]));\n    }", epsv)
+
+    def test_ftps_data_channel_keeps_strict_hostname_verification(self) -> None:
+        ftp = FTP.read_text(encoding="utf-8")
+        self.assertIn('parameters.setEndpointIdentificationAlgorithm("HTTPS")', ftp)
+        self.assertIn("tls.startHandshake();", ftp)
+        for forbidden in ("X509TrustManager", "HostnameVerifier", "TrustManager[]"):
+            self.assertNotIn(forbidden, ftp)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Hardens Android FTP/FTPS passive data-channel setup so an ambiguous or malformed EPSV/PASV/TCP/TLS failure cannot leave the control session available for silent reuse.

### Runtime behavior

- `openPassiveDataSocket()` now owns fail-closed cleanup for the entire passive setup sequence.
- EPSV/PASV command failures, malformed replies, invalid passive ports, TCP data-connect failures and FTPS data-channel TLS handshake failures close the active data socket and hard-close the FTP control session before returning the error.
- Invalid/non-numeric EPSV ports are converted into checked `IOException` failures instead of escaping as `NumberFormatException` outside the cleanup path.
- Cancellation during passive setup still enters the same fail-closed reconnect-required state.
- Existing staged upload/download commit behavior and active-transfer cancellation semantics remain unchanged.

### Security / privacy

- Strict FTPS certificate and hostname verification remains enabled on protected passive data channels.
- There is no downgrade to plaintext data after FTPS negotiation failure and no trust-all fallback.
- No new permission, telemetry, backend, ad/analytics SDK or dependency is introduced.
- The policy is intentionally conservative: reconnect is preferred over reusing a control session after uncertain data-channel setup state.

### Regression coverage

- Adds `scripts/test_android_passive_data_contract.py`.
- The Android APK workflow executes that contract alongside the existing Android source contract and tracks the new test path in PR/push triggers.
- Regression coverage requires fail-closed cleanup, checked EPSV port parsing and retained strict FTPS hostname verification.

## Validation

Exact PR head: `3b0830aec464a62a40ec09eb9608fc8dbc92bc4f`.

- Ghost FTP Android APK run `34558420825`: `completed/success`.
- Ghost FTP CI run `34558420784`: `completed/success`.
- Android source contracts, lint, real APK build, APK integrity verification and artifact upload: success.
- Core Go tests/vet, repository/platform, security/privacy/docs/release audits and Python regression suite: success.
- Linux production build/package verification/artifact upload: success.
- Windows universal production build, release artifact verification, Authenticode private-key smoke and artifact upload: success.
- Android artifact `10183439047` (`ghostftp-android-apk`) is bound to the exact PR head; workflow ZIP digest `sha256:55286ed333a7f85c792bcc892c7863220d899425e22fed82774949f7fe795010`.

Merge only with expected-head protection, then verify actual post-merge `push` workflows on the resulting `main` SHA.