### PR TITLE
Android: add transfer abort path [superseded]

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -13,6 +13,7 @@ Native Android client source lives entirely under this `android/` directory.
 - Binary upload and download are implemented.
 - Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
 - Downloads are written to a temporary SAF `.ghostftp-download-<uuid>.part` document and receive the requested final local name only after the FTP transfer is confirmed complete and the storage provider accepts an exact-name commit.
+- Active upload/download transfers can be cancelled from the connection button. Cancellation closes the active data and control transports, invalidates the session, and requires reconnecting before further server work.
 - Host, username, protocol, port and the user-granted folder URI may be remembered. Passwords are memory-only and are cleared from the UI after connection.
 - Explicit saved sites store only non-secret connection identity and navigation metadata; Quick Connect never creates a hidden site.
 - A saved site can own a local SAF start folder, a remote start directory, local SAF bookmarks and remote path bookmarks.
@@ -41,9 +42,17 @@ The incoming data is written only to a temporary `.ghostftp-download-<uuid>.part
 
 Immediately before commit, Ghost FTP performs a second fresh SAF listing and again rejects an exact-name conflict. It then asks the provider to rename the staging document to the requested filename and reads back `COLUMN_DISPLAY_NAME`. A provider result such as `file (1)` is not treated as a successful download when `file` was requested. If final-name verification fails, Ghost FTP best-effort deletes the unverified result and reports failure.
 
-Any failure before final commit best-effort deletes the staging document. The download is reported as completed only after exact-name read-back succeeds. This is a local SAF commit-safety guarantee; active-transfer cancellation, resume, and FTP control-channel interruption recovery remain separate lifecycle work and are not implied by this staging contract.
+Any failure before final commit best-effort deletes the staging document. The download is reported as completed only after exact-name read-back succeeds. All local download work remains inside the user-granted Storage Access Framework tree. No broad or all-files storage permission is introduced.
 
-All local download work remains inside the user-granted Storage Access Framework tree. No broad or all-files storage permission is introduced.
+## Active transfer cancellation
+
+During an active upload or download, the existing **Disconnect** control becomes **Cancel transfer**. Cancellation is deliberately fail-closed: Ghost FTP invalidates the active transfer generation, detaches the current session from visible UI state, and closes both the passive data socket and the FTP control socket. The cancelled connection is not reused; the user reconnects before performing further server operations.
+
+The transport abort path is intentionally not synchronized on the long-running upload/download monitor. This allows the UI thread to close sockets while a worker is blocked in network I/O. The worker can unwind afterward, but generation/session guards prevent its stale completion or error callback from converting the cancelled operation into a visible success or replacing the cancellation status.
+
+For a staged download, the worker's failure path best-effort deletes the local `.ghostftp-download-*.part` document after the socket abort. For a staged upload, cancellation can leave the remote `.ghostftp-upload-*.part` object because Ghost FTP does not issue cleanup commands over a control connection that it has intentionally invalidated. The requested final remote name is still not committed by the cancellation path.
+
+Cancellation is not resume. Ghost FTP does not currently continue a partially transferred Android upload/download after reconnect, and it does not claim FTP `ABOR` interoperability across servers. Closing the transport and requiring a fresh session is the authoritative cancellation boundary.
 
 ## Saved-site and bookmark security boundary
 

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -29,10 +29,11 @@ final class FtpSession implements Closeable {
     private final String host;
     private final int port;
     private final boolean secure;
-    private Socket controlSocket;
+    private volatile Socket controlSocket;
+    private volatile Socket activeDataSocket;
     private BufferedReader reader;
     private BufferedWriter writer;
-    private boolean connected;
+    private volatile boolean connected;
 
     FtpSession(String host, int port, boolean secure) {
         this.host = requireHost(host);
@@ -79,6 +80,7 @@ final class FtpSession implements Closeable {
         Socket data = openPassiveDataSocket();
         Reply start = command("MLSD " + sanitizeArgument(path));
         if (start.code != 125 && start.code != 150) {
+            clearActiveDataSocket(data);
             closeQuietly(data);
             throw new IOException("MLSD failed: " + start.message);
         }
@@ -93,6 +95,7 @@ final class FtpSession implements Closeable {
                 }
             }
         } finally {
+            clearActiveDataSocket(data);
             closeQuietly(data);
         }
         expect(readReply(), 226, 250);
@@ -109,6 +112,7 @@ final class FtpSession implements Closeable {
         Socket data = openPassiveDataSocket();
         Reply start = command("STOR " + sanitizeArgument(tempPath));
         if (start.code != 125 && start.code != 150) {
+            clearActiveDataSocket(data);
             closeQuietly(data);
             throw new IOException("Upload rejected: " + start.message);
         }
@@ -118,6 +122,7 @@ final class FtpSession implements Closeable {
                 copy(input, out);
                 out.flush();
             } finally {
+                clearActiveDataSocket(data);
                 closeQuietly(data);
             }
         } catch (IOException e) {
@@ -168,6 +173,7 @@ final class FtpSession implements Closeable {
         Socket data = openPassiveDataSocket();
         Reply start = command("RETR " + sanitizeArgument(path));
         if (start.code != 125 && start.code != 150) {
+            clearActiveDataSocket(data);
             closeQuietly(data);
             throw new IOException("Download rejected: " + start.message);
         }
@@ -175,6 +181,7 @@ final class FtpSession implements Closeable {
             copy(in, output);
             output.flush();
         } finally {
+            clearActiveDataSocket(data);
             closeQuietly(data);
         }
         expect(readReply(), 226, 250);
@@ -192,19 +199,16 @@ final class FtpSession implements Closeable {
         return "/";
     }
 
-    synchronized boolean isConnected() {
+    boolean isConnected() {
         return connected;
     }
 
+    void cancelActiveTransfer() {
+        hardClose();
+    }
+
     @Override
-    public synchronized void close() {
-        if (writer != null && connected) {
-            try {
-                command("QUIT");
-            } catch (IOException ignored) {
-                // Hard close below is authoritative.
-            }
-        }
+    public void close() {
         hardClose();
     }
 
@@ -220,9 +224,23 @@ final class FtpSession implements Closeable {
         }
 
         Socket plain = new Socket();
-        plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);
-        plain.setSoTimeout(READ_TIMEOUT_MS);
-        return secure ? wrapTls(plain) : plain;
+        activeDataSocket = plain;
+        try {
+            plain.connect(new InetSocketAddress(host, dataPort), CONNECT_TIMEOUT_MS);
+            plain.setSoTimeout(READ_TIMEOUT_MS);
+            if (!secure) {
+                return plain;
+            }
+            SSLSocket tls = wrapTls(plain);
+            if (activeDataSocket == plain) {
+                activeDataSocket = tls;
+            }
+            return tls;
+        } catch (IOException e) {
+            clearActiveDataSocket(plain);
+            closeQuietly(plain);
+            throw e;
+        }
     }
 
     private SSLSocket wrapTls(Socket plain) throws IOException {
@@ -380,10 +398,20 @@ final class FtpSession implements Closeable {
         }
     }
 
+    private void clearActiveDataSocket(Socket socket) {
+        if (activeDataSocket == socket) {
+            activeDataSocket = null;
+        }
+    }
+
     private void hardClose() {
         connected = false;
-        closeQuietly(controlSocket);
+        Socket data = activeDataSocket;
+        activeDataSocket = null;
+        Socket control = controlSocket;
         controlSocket = null;
+        closeQuietly(data);
+        closeQuietly(control);
         reader = null;
         writer = null;
     }

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -81,6 +81,8 @@ public final class MainActivity extends Activity {
     private int selectedRemote = -1;
     private FtpSession session;
     private boolean busy;
+    private boolean transferActive;
+    private long transferGeneration;
 
     @Override
     protected void onCreate(Bundle state) {
@@ -98,9 +100,11 @@ public final class MainActivity extends Activity {
     @Override
     protected void onDestroy() {
         FtpSession current = session;
+        transferGeneration++;
+        transferActive = false;
         session = null;
         connectedIdentityKey = null;
-        if (current != null) current.close();
+        if (current != null) current.cancelActiveTransfer();
         io.shutdownNow();
         super.onDestroy();
     }
@@ -472,6 +476,10 @@ public final class MainActivity extends Activity {
     }
 
     private void disconnect() {
+        if (transferActive) {
+            cancelActiveTransfer();
+            return;
+        }
         if (busy) return;
         FtpSession current = session;
         session = null;
@@ -480,9 +488,24 @@ public final class MainActivity extends Activity {
         selectedRemote = -1;
         currentRemotePath = "/";
         renderRemote();
-        if (current != null) io.execute(current::close);
+        if (current != null) current.close();
         setStatus("Disconnected.");
         refreshButtons();
+    }
+
+    private void cancelActiveTransfer() {
+        FtpSession current = session;
+        if (!transferActive || current == null) return;
+        transferGeneration++;
+        transferActive = false;
+        session = null;
+        connectedIdentityKey = null;
+        remoteEntries.clear();
+        selectedRemote = -1;
+        currentRemotePath = "/";
+        current.cancelActiveTransfer();
+        renderRemote();
+        setBusy(false, "Transfer cancelled. Connection closed; reconnect before continuing.");
     }
 
     private void refreshRemote(String target) {
@@ -796,18 +819,19 @@ public final class MainActivity extends Activity {
         LocalEntry entry = localEntries.get(selectedLocal);
         Uri document = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.documentId);
         String remoteBase = currentRemotePath;
-        setBusy(true, "Uploading " + entry.name + "…");
+        long generation = beginTransfer("Uploading " + entry.name + "…");
         io.execute(() -> {
             try (InputStream in = getContentResolver().openInputStream(document)) {
                 if (in == null) throw new IOException("Could not open local file.");
                 current.upload(FtpSession.joinRemote(remoteBase, entry.name), in);
                 runOnUiThread(() -> {
-                    if (session != current) return;
+                    if (!transferIsCurrent(current, generation)) return;
+                    transferActive = false;
                     setBusy(false, "Upload completed: " + entry.name);
                     refreshRemote(currentRemotePath);
                 });
             } catch (Exception e) {
-                postError("Upload failed", e);
+                postTransferError("Upload failed", current, generation, e);
             }
         });
     }
@@ -820,7 +844,7 @@ public final class MainActivity extends Activity {
         String selectedDocumentId = currentDocumentId;
         Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
         String remoteBase = currentRemotePath;
-        setBusy(true, "Downloading " + entry.name + " to a staged local document…");
+        long generation = beginTransfer("Downloading " + entry.name + " to a staged local document…");
         io.execute(() -> {
             Uri staged = null;
             try {
@@ -849,7 +873,8 @@ public final class MainActivity extends Activity {
                 staged = null;
 
                 runOnUiThread(() -> {
-                    if (session != current) return;
+                    if (!transferIsCurrent(current, generation)) return;
+                    transferActive = false;
                     setBusy(false, "Download completed and committed: " + entry.name);
                     refreshLocal();
                 });
@@ -857,8 +882,35 @@ public final class MainActivity extends Activity {
                 if (staged != null) {
                     try { DocumentsContract.deleteDocument(getContentResolver(), staged); } catch (Exception ignored) { }
                 }
-                postError("Download failed", e);
+                postTransferError("Download failed", current, generation, e);
             }
+        });
+    }
+
+    private long beginTransfer(String message) {
+        transferGeneration++;
+        transferActive = true;
+        setBusy(true, message);
+        return transferGeneration;
+    }
+
+    private boolean transferIsCurrent(FtpSession current, long generation) {
+        return transferActive && transferGeneration == generation && session == current;
+    }
+
+    private void postTransferError(String prefix, FtpSession current, long generation, Exception e) {
+        runOnUiThread(() -> {
+            if (transferGeneration != generation) return;
+            transferActive = false;
+            if (session == current && !current.isConnected()) {
+                session = null;
+                connectedIdentityKey = null;
+                remoteEntries.clear();
+                selectedRemote = -1;
+                currentRemotePath = "/";
+                renderRemote();
+            }
+            setBusy(false, prefix + ": " + safeMessage(e));
         });
     }
 
@@ -920,11 +972,13 @@ public final class MainActivity extends Activity {
 
     private void refreshButtons() {
         boolean connected = session != null && session.isConnected();
+        boolean canCancelTransfer = transferActive && session != null;
         SiteProfile profile = activeProfile();
         boolean activeSite = profile != null;
         boolean connectedSite = activeSite && connected && connectedIdentityKey != null && profile.identityKey().equals(connectedIdentityKey);
         connect.setEnabled(!busy && !connected);
-        disconnect.setEnabled(!busy && connected);
+        disconnect.setText(canCancelTransfer ? "Cancel transfer" : "Disconnect");
+        disconnect.setEnabled(canCancelTransfer || (!busy && connected));
         upload.setEnabled(!busy && connected && selectedLocal >= 0);
         download.setEnabled(!busy && connected && selectedRemote >= 0 && treeUri != null);
         saveSite.setEnabled(!busy && !connected);

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -142,6 +142,45 @@ class AndroidContractTests(unittest.TestCase):
         self.assertIn("if (name.equals(local.name)) throw new IOException(message);", helpers)
         self.assertIn("DocumentsContract.Document.COLUMN_DISPLAY_NAME", helpers)
 
+    def test_active_transfer_cancel_closes_transport_and_blocks_stale_success(self) -> None:
+        ftp = self.read(f"{ANDROID_JAVA}/FtpSession.java")
+        activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
+        self.assertIn("private volatile Socket activeDataSocket;", ftp)
+        self.assertIn("void cancelActiveTransfer() {\n        hardClose();\n    }", ftp)
+        self.assertNotIn("synchronized void cancelActiveTransfer()", ftp)
+        hard_close_start = ftp.index("private void hardClose()")
+        hard_close_end = ftp.index("private static String sanitizeArgument", hard_close_start)
+        hard_close = ftp[hard_close_start:hard_close_end]
+        self.assertIn("Socket data = activeDataSocket;", hard_close)
+        self.assertIn("Socket control = controlSocket;", hard_close)
+        self.assertIn("closeQuietly(data);", hard_close)
+        self.assertIn("closeQuietly(control);", hard_close)
+        self.assertIn("activeDataSocket = plain;", ftp)
+
+        for marker in (
+            "private boolean transferActive;",
+            "private long transferGeneration;",
+            'disconnect.setText(canCancelTransfer ? "Cancel transfer" : "Disconnect");',
+            "disconnect.setEnabled(canCancelTransfer || (!busy && connected));",
+            "current.cancelActiveTransfer();",
+            "transferGeneration++;",
+            "if (!transferIsCurrent(current, generation)) return;",
+            "if (transferGeneration != generation) return;",
+            "session = null;",
+            "connectedIdentityKey = null;",
+            'setBusy(false, "Transfer cancelled. Connection closed; reconnect before continuing.");',
+        ):
+            self.assertIn(marker, activity)
+
+        cancel_start = activity.index("private void cancelActiveTransfer()")
+        cancel_end = activity.index("private void refreshRemote(", cancel_start)
+        cancel = activity[cancel_start:cancel_end]
+        generation = cancel.index("transferGeneration++;")
+        detach = cancel.index("session = null;")
+        close = cancel.index("current.cancelActiveTransfer();")
+        self.assertLess(generation, detach)
+        self.assertLess(detach, close)
+
     def test_password_is_memory_only_and_storage_uses_saf(self) -> None:
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         for marker in (


### PR DESCRIPTION
Superseded by the newer Android transfer lifecycle and passive-data fail-closed work already merged into `main` at `5427d57c5b21211528d62962832f1433ab55f3da`.

The current `main` already contains the intended cancellation contract with stronger integration:
- active transfer state + generation token,
- existing Disconnect control becomes `Cancel transfer`,
- non-synchronized transport abort closes active passive data and control sockets,
- cancelled session is invalidated and requires reconnect,
- upload/download worker paths use generation guards to reject stale callbacks,
- staged SAF download cleanup remains fail-closed,
- passive data setup/transfer/completion errors now also close uncertain FTP sessions.

Keeping this older branch open would duplicate the same feature against an obsolete base (`4af3c190...`) and could discard the newer passive-data hardening. No merge is required from this PR.