### PR TITLE
Android: wire transfer progress to real I/O

### DIFF
--- a/android/TRANSFER-PROGRESS.md
+++ b/android/TRANSFER-PROGRESS.md
@@ -1,0 +1,29 @@
+# Android transfer progress
+
+Ghost FTP Android reports transfer progress from bytes that actually pass through the active upload/download stream. It does not advance a progress value from a timer and it does not invent a total size.
+
+## Byte ownership
+
+For uploads, `ProgressStreams` wraps the local `InputStream`. The counter advances only when the FTP transfer code actually reads bytes from that stream. The selected local entry size is supplied as the expected total when Android's Storage Access Framework reported a positive size.
+
+For downloads, `ProgressStreams` wraps the SAF destination `OutputStream`. The counter advances only when bytes are actually written toward the staged local document. The MLSD file size is supplied as the expected total only when it is positive.
+
+A zero or unavailable size is treated as unknown. In that case the UI can show transferred bytes and a measured rate, but it does not show a percentage or ETA. If observed transferred bytes exceed a claimed total, `TransferProgress` stops treating that total as trustworthy rather than presenting an impossible percentage.
+
+## Status semantics
+
+Progress text such as `Uploading` or `Downloading` describes the data-stream phase only. Reaching 100% of a known byte total is not the same as a completed Ghost FTP operation.
+
+Upload success still requires the existing staged remote commit contract: the server must confirm data completion and accept the final `RNFR`/`RNTO` commit. Download success still requires the staged SAF document to pass the final conflict check, rename to the requested name, and exact `COLUMN_DISPLAY_NAME` read-back.
+
+The final `Upload completed` and `Download completed and committed` statuses remain owned by those commit paths, not by the progress counter.
+
+## Cancellation and stale callbacks
+
+Every progress sink is bound to the existing transfer generation token and the exact active `FtpSession`. A progress callback is ignored when the transfer is no longer active, its generation was cancelled, the visible session changed, or the connection is no longer valid.
+
+This means a cancelled transfer or reconnect cannot be overwritten by late progress from an older worker. Cancellation continues to use the existing fail-closed transport abort and reconnect requirement.
+
+## Security and privacy
+
+Progress accounting is local-only. `TransferProgress` and `ProgressStreams` open no network connection, emit no telemetry, and add no analytics or crash-reporting dependency. FTP/FTPS transport, certificate/hostname verification, passive-data fail-closed behavior, staging, path validation, and credential handling are unchanged by this feature.

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -821,11 +821,13 @@ public final class MainActivity extends Activity {
         Uri document = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.documentId);
         String remoteBase = currentRemotePath;
         long transferToken = beginTransfer("Uploading " + entry.name + "…");
+        TransferProgress progress = transferProgress(entry.size, "Uploading", current, transferToken);
         io.execute(() -> {
             try {
                 requireTransferCurrent(transferToken);
-                try (InputStream in = getContentResolver().openInputStream(document)) {
-                    if (in == null) throw new IOException("Could not open local file.");
+                InputStream source = getContentResolver().openInputStream(document);
+                if (source == null) throw new IOException("Could not open local file.");
+                try (InputStream in = ProgressStreams.input(source, progress::onTransferred)) {
                     requireTransferCurrent(transferToken);
                     current.upload(FtpSession.joinRemote(remoteBase, entry.name), in);
                 }
@@ -853,6 +855,7 @@ public final class MainActivity extends Activity {
         Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
         String remoteBase = currentRemotePath;
         long transferToken = beginTransfer("Downloading " + entry.name + " to a staged local document…");
+        TransferProgress progress = transferProgress(entry.size, "Downloading", current, transferToken);
         io.execute(() -> {
             Uri staged = null;
             try {
@@ -866,8 +869,9 @@ public final class MainActivity extends Activity {
                 if (staged == null) throw new IOException("Could not create staged local download document.");
 
                 requireTransferCurrent(transferToken);
-                try (OutputStream out = getContentResolver().openOutputStream(staged, "w")) {
-                    if (out == null) throw new IOException("Could not open staged local download document.");
+                OutputStream destination = getContentResolver().openOutputStream(staged, "w");
+                if (destination == null) throw new IOException("Could not open staged local download document.");
+                try (OutputStream out = ProgressStreams.output(destination, progress::onTransferred)) {
                     current.download(FtpSession.joinRemote(remoteBase, entry.name), out);
                 }
                 requireTransferCurrent(transferToken);
@@ -902,6 +906,13 @@ public final class MainActivity extends Activity {
                 finishTransferFailure(transferToken, current, "Download failed", e, true);
             }
         });
+    }
+
+    private TransferProgress transferProgress(long totalBytes, String action, FtpSession current, long token) {
+        return new TransferProgress(totalBytes, action, text -> runOnUiThread(() -> {
+            if (!transferActive || transferCancelled(token) || session != current || !current.isConnected()) return;
+            setStatus(text);
+        }));
     }
 
     private long beginTransfer(String message) {

--- a/android/app/src/main/java/app/ghostftp/client/ProgressStreams.java
+++ b/android/app/src/main/java/app/ghostftp/client/ProgressStreams.java
@@ -1,0 +1,80 @@
+package app.ghostftp.client;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+final class ProgressStreams {
+    interface Listener {
+        void onTransferred(long bytes);
+    }
+
+    private ProgressStreams() {
+    }
+
+    static InputStream input(InputStream source, Listener listener) {
+        return new CountingInputStream(source, listener);
+    }
+
+    static OutputStream output(OutputStream destination, Listener listener) {
+        return new CountingOutputStream(destination, listener);
+    }
+
+    private static final class CountingInputStream extends FilterInputStream {
+        private final Listener listener;
+        private long transferred;
+
+        CountingInputStream(InputStream source, Listener listener) {
+            super(source);
+            this.listener = listener;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = super.read();
+            if (value != -1) publish(1L);
+            return value;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            int read = super.read(buffer, offset, length);
+            if (read > 0) publish(read);
+            return read;
+        }
+
+        private void publish(long bytes) {
+            transferred += bytes;
+            if (listener != null) listener.onTransferred(transferred);
+        }
+    }
+
+    private static final class CountingOutputStream extends FilterOutputStream {
+        private final Listener listener;
+        private long transferred;
+
+        CountingOutputStream(OutputStream destination, Listener listener) {
+            super(destination);
+            this.listener = listener;
+        }
+
+        @Override
+        public void write(int value) throws IOException {
+            out.write(value);
+            publish(1L);
+        }
+
+        @Override
+        public void write(byte[] buffer, int offset, int length) throws IOException {
+            out.write(buffer, offset, length);
+            if (length > 0) publish(length);
+        }
+
+        private void publish(long bytes) {
+            transferred += bytes;
+            if (listener != null) listener.onTransferred(transferred);
+        }
+    }
+}

--- a/scripts/test_android_transfer_progress_contract.py
+++ b/scripts/test_android_transfer_progress_contract.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+JAVA = ROOT / "android/app/src/main/java/app/ghostftp/client"
+
+
+class AndroidTransferProgressContractTests(unittest.TestCase):
+    def read(self, name: str) -> str:
+        return (JAVA / name).read_text(encoding="utf-8")
+
+    def test_progress_streams_count_real_io_bytes(self) -> None:
+        streams = self.read("ProgressStreams.java")
+        self.assertIn("extends FilterInputStream", streams)
+        self.assertIn("extends FilterOutputStream", streams)
+        self.assertIn("int read = super.read(buffer, offset, length);", streams)
+        self.assertIn("if (read > 0) publish(read);", streams)
+        self.assertIn("out.write(buffer, offset, length);", streams)
+        self.assertIn("if (length > 0) publish(length);", streams)
+        self.assertIn("transferred += bytes;", streams)
+        self.assertNotIn("Thread.sleep", streams)
+        self.assertNotIn("Timer", streams)
+
+    def test_runtime_uses_known_entry_size_without_inventing_totals(self) -> None:
+        activity = self.read("MainActivity.java")
+        progress = self.read("TransferProgress.java")
+        self.assertIn('transferProgress(entry.size, "Uploading", current, transferToken)', activity)
+        self.assertIn('transferProgress(entry.size, "Downloading", current, transferToken)', activity)
+        self.assertIn("this.totalBytes = totalBytes > 0L ? totalBytes : -1L;", progress)
+        self.assertIn("boolean trustworthyTotal = totalBytes > 0L && transferredBytes <= totalBytes;", progress)
+        self.assertIn("if (trustworthyTotal)", progress)
+        self.assertIn("if (trustworthyTotal && transferredBytes < totalBytes)", progress)
+
+    def test_progress_wraps_actual_upload_and_download_streams(self) -> None:
+        activity = self.read("MainActivity.java")
+        upload_start = activity.index("private void uploadSelected()")
+        download_start = activity.index("private void downloadSelected()", upload_start)
+        helper_start = activity.index("private TransferProgress transferProgress", download_start)
+        upload = activity[upload_start:download_start]
+        download = activity[download_start:helper_start]
+        self.assertIn("ProgressStreams.input(source, progress::onTransferred)", upload)
+        self.assertIn("current.upload(FtpSession.joinRemote(remoteBase, entry.name), in);", upload)
+        self.assertLess(upload.index("ProgressStreams.input"), upload.index("current.upload("))
+        self.assertIn("ProgressStreams.output(destination, progress::onTransferred)", download)
+        self.assertIn("current.download(FtpSession.joinRemote(remoteBase, entry.name), out);", download)
+        self.assertLess(download.index("ProgressStreams.output"), download.index("current.download("))
+
+    def test_progress_ui_is_guarded_by_transfer_generation_and_session(self) -> None:
+        activity = self.read("MainActivity.java")
+        helper_start = activity.index("private TransferProgress transferProgress")
+        helper_end = activity.index("private long beginTransfer", helper_start)
+        helper = activity[helper_start:helper_end]
+        for marker in (
+            "!transferActive",
+            "transferCancelled(token)",
+            "session != current",
+            "!current.isConnected()",
+            "setStatus(text);",
+        ):
+            self.assertIn(marker, helper)
+
+    def test_progress_never_replaces_final_commit_semantics(self) -> None:
+        activity = self.read("MainActivity.java")
+        upload_start = activity.index("private void uploadSelected()")
+        download_start = activity.index("private void downloadSelected()", upload_start)
+        helper_start = activity.index("private TransferProgress transferProgress", download_start)
+        upload = activity[upload_start:download_start]
+        download = activity[download_start:helper_start]
+        self.assertLess(upload.index("current.upload("), upload.index('"Upload completed: "'))
+        self.assertLess(download.index("current.download("), download.index("DocumentsContract.renameDocument"))
+        self.assertLess(download.index("queryDocumentDisplayName(committed)"), download.index('"Download completed and committed: "'))
+
+    def test_progress_has_no_network_or_telemetry_side_channel(self) -> None:
+        combined = (self.read("TransferProgress.java") + self.read("ProgressStreams.java")).lower()
+        for forbidden in (
+            "http://",
+            "https://",
+            "socket(",
+            "analytics",
+            "telemetry",
+            "firebase",
+            "crashlytics",
+        ):
+            self.assertNotIn(forbidden, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the Android transfer-progress feature merged in #236 by giving it real runtime ownership. Progress now comes from bytes that actually pass through active upload/download streams rather than from an unused formatting model.

### Runtime progress contract

- Upload progress wraps the real local `InputStream`; the counter advances only as FTP actually reads bytes.
- Download progress wraps the real SAF `OutputStream`; the counter advances only as bytes are actually written to the staged local document.
- Positive local/MLSD entry sizes are supplied as expected totals; zero/unavailable sizes remain unknown.
- Existing `TransferProgress` suppresses percentage/ETA when the total is unknown or no longer trustworthy.
- Progress UI updates are guarded by the existing transfer generation, exact session identity, active-transfer state and live connection.
- Cancel/reconnect cannot be overwritten by stale progress callbacks.

### Completion semantics

Progress never owns final success. Upload completion still requires confirmed FTP data completion plus the staged `RNFR`/`RNTO` commit. Download completion still requires staged SAF conflict checking, exact-name rename and `COLUMN_DISPLAY_NAME` verification.

A known byte counter may reach 100% before the final commit phase; the UI remains `Uploading` / `Downloading` until the existing authoritative commit path reports completion.

### Security / scope

- `FtpSession.java` is unchanged by this PR.
- Strict FTPS certificate/hostname verification, passive-data fail-closed behavior, active-transfer cancellation and staged upload/download contracts remain unchanged.
- Progress accounting is local-only; no telemetry, analytics, backend, external network destination or dependency is added.

### Regression coverage

Adds `scripts/test_android_transfer_progress_contract.py` covering real stream byte accounting, known/unknown total semantics, upload/download runtime ownership, generation/session guards, final commit ordering and absence of progress-side network/telemetry behavior.

Detailed semantics are documented in `android/TRANSFER-PROGRESS.md`.

## Validation

Exact PR head: `181ba24ba544566337b96c71396a1720b07fa8de`.

- Ghost FTP Android APK run `34559551749`: `completed/success`.
- Ghost FTP CI run `34559551781`: `completed/success`.
- Android source contract, lint, real APK build, APK integrity verification and artifact upload: success.
- Core Go tests/vet, repository/platform, security/privacy/docs/release audits and Python regression suite: success.
- Linux production build/package verification/artifact upload: success.
- Windows universal production build, release artifact verification, Authenticode private-key smoke and artifact upload: success.
- Android artifact `10183830743` (`ghostftp-android-apk`) is bound to the exact PR head; workflow ZIP digest `sha256:86b505fb29e2a4a8a91374b0a48592ddde9ff07a1d7a83c8828420d8da4836cc`.

Merge only with expected-head protection, then verify actual post-merge `push` workflows on the resulting `main` SHA.