### PR TITLE
Android: complete dark workspace and file management

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -6,15 +6,13 @@ on:
     paths:
       - 'android/**'
       - '.github/workflows/android-apk.yml'
-      - 'scripts/test_android_contract.py'
-      - 'scripts/test_android_passive_data_contract.py'
+      - 'scripts/test_android*.py'
   push:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android-apk.yml'
-      - 'scripts/test_android_contract.py'
-      - 'scripts/test_android_passive_data_contract.py'
+      - 'scripts/test_android*.py'
   workflow_dispatch:
 
 permissions:
@@ -52,8 +50,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python scripts/test_android_contract.py
-          python scripts/test_android_passive_data_contract.py
+          python -m unittest discover -s scripts -p 'test_android*.py'
       - name: Lint and build APK
         working-directory: android
         shell: bash

--- a/android/UI-UX.md
+++ b/android/UI-UX.md
@@ -1,0 +1,66 @@
+# Ghost FTP Android UI/UX
+
+The Android workspace uses the same canonical dark visual system as the Windows and Linux Ghost FTP distributions rather than a separate mobile brand.
+
+## Canonical dark palette
+
+Android maps the desktop `internal/uipalette.Dark` colors 1:1:
+
+- Window `#0B0F17`
+- Panel `#121824`
+- List `#161D2A`
+- Border `#2C3648`
+- Text `#F2F5FA`
+- Muted `#97A3B8`
+- Accent `#5B7CFA`
+- Accent strong `#7A98FF`
+- Success `#4AD79B`
+- Warning `#F2BA55`
+- Danger `#FF6878`
+- Selection `#202F50`
+
+`GhostTheme` owns runtime widget styling, list/spinner adapters, button states, badges, rounded panels and status colors. `colors.xml` and `Theme.GhostFTP` keep the Android system bars and window background aligned with that same palette.
+
+## Responsive workspace
+
+The app is deliberately one-column on phone-sized displays. At `screenWidthDp >= 700`, the Local and Server cards become equal-width side-by-side panes. Connection, saved-site and transfer/status cards remain full-width so controls retain usable touch targets.
+
+Each file pane contains its current path, navigation controls, file-management controls, saved-start/bookmark controls and a bounded list view. A normal tap on a directory opens it. Long-press selects either a file or directory for Rename/Delete without changing the normal navigation gesture.
+
+## Local file management
+
+Local operations stay inside the active Android Storage Access Framework tree. Ghost FTP does not request all-files storage access.
+
+- **New folder** uses `DocumentsContract.createDocument` with directory MIME type.
+- **Rename** uses `DocumentsContract.renameDocument` and verifies the resulting `COLUMN_DISPLAY_NAME`.
+- **Delete** uses `DocumentsContract.deleteDocument` only after explicit confirmation.
+- Create/Rename perform a fresh directory listing and reject an exact-name conflict before mutation.
+- After a successful mutation, Ghost FTP performs another fresh listing before the visible pane snapshot is replaced.
+
+## Remote file management
+
+Remote FTP/FTPS mutations use the same authenticated session and the same strict FTPS trust boundary as navigation and transfers.
+
+- **New folder** uses `MKD`.
+- **Rename** requires `RNFR` followed by confirmed `RNTO`.
+- **Delete file** uses `DELE`.
+- **Delete directory** uses non-recursive `RMD`; Ghost FTP does not recursively erase server directory trees.
+- Item names must be one safe path segment and cannot contain `/`, `\\`, NUL, CR/LF, `.` or `..`.
+- Transport I/O failures fail closed and invalidate an uncertain session. An ambiguous final rename also closes the connection rather than silently reusing it.
+- After a successful mutation, Ghost FTP freshly lists the current server directory before committing the visible pane snapshot.
+
+Destructive local, remote and saved-site deletion uses an explicit confirmation dialog.
+
+## Transfers
+
+Only selected files can be uploaded/downloaded. Directories are never silently treated as files. Existing staged upload, staged SAF download, fail-closed passive data setup, real-I/O progress reporting and active-transfer cancellation remain authoritative.
+
+During a transfer, the connection badge changes to **TRANSFER ACTIVE** and the Disconnect action becomes **Cancel transfer**. Progress text is derived from bytes actually read/written; final success still belongs to the staged commit path, not the progress counter.
+
+## Saved sites and bookmarks
+
+Saved sites remain non-secret. Passwords are memory-only. Local and server bookmarks can now also be explicitly removed from the mobile workspace. Quick Connect still does not create a hidden profile or bookmark.
+
+## Security boundary
+
+Android exposes FTP and strict FTPS only. SFTP remains intentionally absent until the Android implementation can provide strict host-key identity verification/pinning equivalent to desktop Ghost FTP. No telemetry, analytics, ads, hidden backend or external crash-reporting service is introduced by the UI layer.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId 'app.ghostftp.client'
         minSdk 26
         targetSdk 35
-        versionCode 3
+        versionCode 4
         versionName "${ghostFtpVersion}-dev"
     }
 

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -225,6 +225,57 @@ final class FtpSession implements Closeable {
         }
     }
 
+    synchronized void makeDirectory(String parentPath, String name) throws IOException {
+        ensureConnected();
+        String path = joinRemote(normalizeRemotePath(parentPath), requireLeafName(name));
+        Reply reply = mutationCommand("MKD " + sanitizeArgument(path), "Remote folder creation failed; the connection was closed.");
+        if (reply.code != 257 && reply.code != 250) {
+            throw new IOException("Server rejected remote folder creation: " + reply.message);
+        }
+    }
+
+    synchronized void renameRemote(String remotePath, String newName) throws IOException {
+        ensureConnected();
+        String source = normalizeRemotePath(remotePath);
+        if ("/".equals(source)) {
+            throw new IOException("The remote root cannot be renamed.");
+        }
+        String target = joinRemote(parentRemote(source), requireLeafName(newName));
+        if (source.equals(target)) {
+            return;
+        }
+
+        Reply from = mutationCommand("RNFR " + sanitizeArgument(source), "Remote rename could not start; the connection was closed.");
+        if (from.code != 350) {
+            throw new IOException("Server rejected remote rename source: " + from.message);
+        }
+
+        final Reply to;
+        try {
+            to = command("RNTO " + sanitizeArgument(target));
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException("Remote rename lost the connection before commit confirmation.", e);
+        }
+        if (to.code != 250) {
+            hardClose();
+            throw new IOException("Server rejected remote rename commit; the connection was closed to avoid reusing ambiguous rename state: " + to.message);
+        }
+    }
+
+    synchronized void deleteRemote(String remotePath, boolean directory) throws IOException {
+        ensureConnected();
+        String path = normalizeRemotePath(remotePath);
+        if ("/".equals(path)) {
+            throw new IOException("The remote root cannot be deleted.");
+        }
+        String verb = directory ? "RMD " : "DELE ";
+        Reply reply = mutationCommand(verb + sanitizeArgument(path), "Remote delete failed; the connection was closed.");
+        if (reply.code != 250 && reply.code != 200) {
+            throw new IOException("Server rejected remote delete: " + reply.message);
+        }
+    }
+
     synchronized String pwd() throws IOException {
         ensureConnected();
         Reply reply = command("PWD");
@@ -324,6 +375,15 @@ final class FtpSession implements Closeable {
         writer.write("\r\n");
         writer.flush();
         return readReply();
+    }
+
+    private Reply mutationCommand(String command, String failureMessage) throws IOException {
+        try {
+            return command(command);
+        } catch (IOException e) {
+            hardClose();
+            throw new IOException(failureMessage, e);
+        }
     }
 
     private Reply readReply() throws IOException {
@@ -446,6 +506,16 @@ final class FtpSession implements Closeable {
             value = value.replace("//", "/");
         }
         return value;
+    }
+
+    private static String requireLeafName(String value) throws IOException {
+        String name = value == null ? "" : value.trim();
+        if (name.isEmpty() || ".".equals(name) || "..".equals(name)
+                || name.indexOf('/') >= 0 || name.indexOf('\\') >= 0
+                || name.indexOf('\0') >= 0 || name.indexOf('\r') >= 0 || name.indexOf('\n') >= 0) {
+            throw new IOException("Remote item name must be one safe path segment.");
+        }
+        return name;
     }
 
     private static String uploadTempPath(String finalPath) throws IOException {

--- a/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
+++ b/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
@@ -1,0 +1,171 @@
+package app.ghostftp.client;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import java.util.List;
+
+final class GhostTheme {
+    static final int WINDOW = Color.rgb(0x0B, 0x0F, 0x17);
+    static final int PANEL = Color.rgb(0x12, 0x18, 0x24);
+    static final int LIST = Color.rgb(0x16, 0x1D, 0x2A);
+    static final int BORDER = Color.rgb(0x2C, 0x36, 0x48);
+    static final int TEXT = Color.rgb(0xF2, 0xF5, 0xFA);
+    static final int MUTED = Color.rgb(0x97, 0xA3, 0xB8);
+    static final int ACCENT = Color.rgb(0x5B, 0x7C, 0xFA);
+    static final int ACCENT_STRONG = Color.rgb(0x7A, 0x98, 0xFF);
+    static final int SUCCESS = Color.rgb(0x4A, 0xD7, 0x9B);
+    static final int WARN = Color.rgb(0xF2, 0xBA, 0x55);
+    static final int DANGER = Color.rgb(0xFF, 0x68, 0x78);
+    static final int SELECTION = Color.rgb(0x20, 0x2F, 0x50);
+
+    private GhostTheme() {
+    }
+
+    static void stylePrimaryButton(Button button) {
+        styleButton(button, ACCENT, TEXT, ACCENT_STRONG);
+    }
+
+    static void styleSecondaryButton(Button button) {
+        styleButton(button, LIST, TEXT, SELECTION);
+    }
+
+    static void styleDangerButton(Button button) {
+        styleButton(button, Color.rgb(0x3A, 0x1D, 0x27), DANGER, Color.rgb(0x51, 0x25, 0x31));
+    }
+
+    static void styleButton(Button button, int fill, int textColor, int rippleColor) {
+        button.setAllCaps(false);
+        button.setTextColor(textColor);
+        button.setTextSize(13f);
+        button.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        button.setGravity(Gravity.CENTER);
+        button.setMinHeight(dp(button.getContext(), 44));
+        button.setPadding(dp(button.getContext(), 10), 0, dp(button.getContext(), 10), 0);
+        button.setBackground(ripple(button.getContext(), fill, BORDER, rippleColor, 10));
+    }
+
+    static void styleField(EditText edit) {
+        edit.setTextColor(TEXT);
+        edit.setHintTextColor(MUTED);
+        edit.setTextSize(14f);
+        edit.setSingleLine(true);
+        edit.setMinHeight(dp(edit.getContext(), 48));
+        edit.setPadding(dp(edit.getContext(), 12), dp(edit.getContext(), 4), dp(edit.getContext(), 12), dp(edit.getContext(), 4));
+        edit.setBackground(rounded(edit.getContext(), LIST, BORDER, 10));
+    }
+
+    static void styleSpinner(Spinner spinner) {
+        spinner.setPadding(dp(spinner.getContext(), 8), 0, dp(spinner.getContext(), 8), 0);
+        spinner.setMinimumHeight(dp(spinner.getContext(), 48));
+        spinner.setBackground(rounded(spinner.getContext(), LIST, BORDER, 10));
+        spinner.setPopupBackgroundDrawable(rounded(spinner.getContext(), PANEL, BORDER, 10));
+    }
+
+    static void styleList(ListView list) {
+        list.setBackground(rounded(list.getContext(), LIST, BORDER, 12));
+        list.setDividerHeight(0);
+        list.setPadding(dp(list.getContext(), 4), dp(list.getContext(), 4), dp(list.getContext(), 4), dp(list.getContext(), 4));
+        list.setClipToPadding(false);
+        list.setSelector(rounded(list.getContext(), SELECTION, ACCENT, 8));
+    }
+
+    static void styleBadge(TextView view, int color) {
+        view.setTextColor(color);
+        view.setTextSize(11f);
+        view.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        view.setGravity(Gravity.CENTER);
+        view.setPadding(dp(view.getContext(), 10), dp(view.getContext(), 6), dp(view.getContext(), 10), dp(view.getContext(), 6));
+        view.setBackground(rounded(view.getContext(), SELECTION, color, 999));
+    }
+
+    static ArrayAdapter<String> spinnerAdapter(Context context, List<String> values) {
+        return new GhostArrayAdapter(context, values, true);
+    }
+
+    static ArrayAdapter<String> listAdapter(Context context, List<String> values) {
+        return new GhostArrayAdapter(context, values, false);
+    }
+
+    static GradientDrawable rounded(Context context, int fill, int stroke, int radiusDp) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(fill);
+        drawable.setCornerRadius(dp(context, radiusDp));
+        drawable.setStroke(dp(context, 1), stroke);
+        return drawable;
+    }
+
+    static int statusColor(String status) {
+        String value = status == null ? "" : status.toLowerCase(java.util.Locale.ROOT);
+        if (value.contains("failed") || value.contains("error") || value.contains("rejected")
+                || value.contains("unavailable") || value.contains("lost") || value.contains("cancelled")) {
+            return DANGER;
+        }
+        if (value.contains("warning") || value.contains("unencrypted") || value.contains("stale")
+                || value.contains("reconnect") || value.contains("session only")) {
+            return WARN;
+        }
+        if (value.contains("completed") || value.contains("connected") || value.contains("saved")
+                || value.contains("updated") || value.contains("added") || value.contains("opened")
+                || value.contains("created") || value.contains("renamed") || value.contains("deleted")) {
+            return SUCCESS;
+        }
+        return MUTED;
+    }
+
+    static int dp(Context context, int value) {
+        return Math.round(value * context.getResources().getDisplayMetrics().density);
+    }
+
+    private static RippleDrawable ripple(Context context, int fill, int stroke, int rippleColor, int radiusDp) {
+        GradientDrawable content = rounded(context, fill, stroke, radiusDp);
+        return new RippleDrawable(ColorStateList.valueOf(rippleColor), content, null);
+    }
+
+    private static final class GhostArrayAdapter extends ArrayAdapter<String> {
+        private final Context context;
+        private final boolean spinner;
+
+        GhostArrayAdapter(Context context, List<String> values, boolean spinner) {
+            super(context, spinner ? android.R.layout.simple_spinner_item : android.R.layout.simple_list_item_1, values);
+            this.context = context;
+            this.spinner = spinner;
+            if (spinner) setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            return style(super.getView(position, convertView, parent), false);
+        }
+
+        @Override
+        public View getDropDownView(int position, View convertView, ViewGroup parent) {
+            return style(super.getDropDownView(position, convertView, parent), true);
+        }
+
+        private View style(View view, boolean dropDown) {
+            if (!(view instanceof TextView)) return view;
+            TextView text = (TextView) view;
+            text.setTextColor(TEXT);
+            text.setTextSize(spinner ? 14f : 13.5f);
+            text.setGravity(Gravity.CENTER_VERTICAL);
+            text.setMinHeight(dp(context, spinner ? 46 : 42));
+            text.setPadding(dp(context, 12), dp(context, 7), dp(context, 12), dp(context, 7));
+            text.setBackgroundColor(dropDown ? PANEL : Color.TRANSPARENT);
+            return text;
+        }
+    }
+}

--- a/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
+++ b/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
@@ -69,8 +69,7 @@ final class GhostTheme {
     }
 
     static void styleSpinner(Spinner spinner) {
-        spinner.setPadding(dp(spinner.getContext(), 8), 0, dp(spinner.getContext(), 8), 0);
-        spinner.setMinimumHeight(dp(spinner.getContext(), 48));
+        spinner.setPadding(dp(spinner.getContext(), 8), dp(spinner.getContext(), 6), dp(spinner.getContext(), 8), dp(spinner.getContext(), 6));
         spinner.setBackground(rounded(spinner.getContext(), LIST, BORDER, 10));
         spinner.setPopupBackgroundDrawable(rounded(spinner.getContext(), PANEL, BORDER, 10));
     }

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -2,11 +2,12 @@ package app.ghostftp.client;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.UriPermission;
 import android.database.Cursor;
-import android.graphics.Color;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.DocumentsContract;
@@ -26,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.UUID;
@@ -55,6 +57,7 @@ public final class MainActivity extends Activity {
     private TextView localPath;
     private TextView remotePath;
     private TextView status;
+    private TextView connectionState;
     private ListView localList;
     private ListView remoteList;
     private Button connect;
@@ -65,10 +68,18 @@ public final class MainActivity extends Activity {
     private Button deleteSite;
     private Button localSetStart;
     private Button localAddBookmark;
+    private Button localRemoveBookmark;
     private Button localOpenBookmark;
+    private Button localNewFolder;
+    private Button localRename;
+    private Button localDelete;
     private Button remoteSetStart;
     private Button remoteAddBookmark;
+    private Button remoteRemoveBookmark;
     private Button remoteOpenBookmark;
+    private Button remoteNewFolder;
+    private Button remoteRename;
+    private Button remoteDelete;
 
     private SiteProfileStore profileStore;
     private String activeProfileId;
@@ -112,126 +123,233 @@ public final class MainActivity extends Activity {
     private void buildUi() {
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
-        int pad = dp(14);
-        root.setPadding(pad, pad, pad, pad);
-        root.setBackgroundColor(Color.rgb(16, 19, 23));
-        root.addView(label("GHOST FTP · ANDROID", 22, Color.WHITE));
-        root.addView(label("Private FTP/FTPS client · no telemetry · passwords are never saved", 13, Color.LTGRAY));
+        int pad = dp(12);
+        root.setPadding(pad, pad, pad, dp(24));
+        root.setBackgroundColor(GhostTheme.WINDOW);
 
-        root.addView(section("SAVED SITES"));
+        LinearLayout header = card("GHOST FTP", "ANDROID · PRIVATE FTP/FTPS CLIENT");
+        TextView intro = label("No telemetry · passwords stay in memory · strict FTPS hostname verification", 12, GhostTheme.MUTED);
+        intro.setPadding(0, dp(4), 0, dp(10));
+        header.addView(intro, matchWrap());
+        connectionState = label("DISCONNECTED", 11, GhostTheme.MUTED);
+        GhostTheme.styleBadge(connectionState, GhostTheme.MUTED);
+        header.addView(connectionState, wrapWrap());
+        root.addView(header, cardParams());
+
+        LinearLayout sites = card("SAVED SITES", "Quick Connect stays transient until you explicitly save a site.");
         siteSpinner = new Spinner(this);
-        root.addView(siteSpinner, matchWrap());
+        GhostTheme.styleSpinner(siteSpinner);
+        sites.addView(siteSpinner, matchWrapSpaced());
         profileName = field("Site name", false);
-        root.addView(profileName, matchWrap());
+        sites.addView(profileName, matchWrapSpaced());
         LinearLayout siteActions = row();
         Button loadSite = button("Load");
-        saveSite = button("Save / update");
-        deleteSite = button("Delete");
-        siteActions.addView(loadSite, weighted());
-        siteActions.addView(saveSite, weighted());
-        siteActions.addView(deleteSite, weighted());
-        root.addView(siteActions, matchWrap());
+        saveSite = primaryButton("Save / update");
+        deleteSite = dangerButton("Delete");
+        siteActions.addView(loadSite, weightedSpaced());
+        siteActions.addView(saveSite, weightedSpaced());
+        siteActions.addView(deleteSite, weightedSpaced());
+        sites.addView(siteActions, matchWrap());
         loadSite.setOnClickListener(v -> loadSelectedSite());
         saveSite.setOnClickListener(v -> saveOrUpdateSite());
         deleteSite.setOnClickListener(v -> deleteActiveSite());
+        root.addView(sites, cardParams());
 
-        root.addView(section("QUICK CONNECT / SITE CONNECTION"));
+        LinearLayout connection = card("CONNECTION", "Use FTPS whenever the server supports it. Plain FTP is unencrypted.");
         protocol = new Spinner(this);
-        protocol.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, new String[]{"FTPS", "FTP"}));
-        root.addView(protocol, matchWrap());
+        GhostTheme.styleSpinner(protocol);
+        protocol.setAdapter(GhostTheme.spinnerAdapter(this, Arrays.asList("FTPS", "FTP")));
+        connection.addView(protocol, matchWrapSpaced());
+
+        LinearLayout endpoint = row();
         host = field("Server host", false);
         port = field("Port", false);
         port.setInputType(InputType.TYPE_CLASS_NUMBER);
+        endpoint.addView(host, weightedSpaced());
+        endpoint.addView(port, fixedWidthSpaced(94));
+        connection.addView(endpoint, matchWrap());
+
+        LinearLayout credentials = row();
         username = field("Username", false);
         password = field("Password (memory only)", true);
-        root.addView(host, matchWrap());
-        root.addView(port, matchWrap());
-        root.addView(username, matchWrap());
-        root.addView(password, matchWrap());
+        credentials.addView(username, weightedSpaced());
+        credentials.addView(password, weightedSpaced());
+        connection.addView(credentials, matchWrap());
 
-        LinearLayout connection = row();
-        connect = button("Connect");
-        disconnect = button("Disconnect");
-        connection.addView(connect, weighted());
-        connection.addView(disconnect, weighted());
-        root.addView(connection, matchWrap());
+        LinearLayout connectionActions = row();
+        connect = primaryButton("Connect");
+        disconnect = dangerButton("Disconnect");
+        connectionActions.addView(connect, weightedSpaced());
+        connectionActions.addView(disconnect, weightedSpaced());
+        connection.addView(connectionActions, matchWrap());
         connect.setOnClickListener(v -> connect());
         disconnect.setOnClickListener(v -> disconnect());
+        root.addView(connection, cardParams());
 
-        root.addView(section("LOCAL STORAGE"));
-        localPath = label("No folder selected", 14, Color.LTGRAY);
-        root.addView(localPath);
-        LinearLayout localActions = row();
+        LinearLayout paneHost = new LinearLayout(this);
+        boolean wide = getResources().getConfiguration().screenWidthDp >= 700;
+        paneHost.setOrientation(wide ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
+        LinearLayout localPane = buildLocalPane();
+        LinearLayout remotePane = buildRemotePane();
+        if (wide) {
+            paneHost.addView(localPane, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            paneHost.addView(remotePane, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+        } else {
+            paneHost.addView(localPane, matchWrap());
+            paneHost.addView(remotePane, matchWrap());
+        }
+        root.addView(paneHost, matchWrap());
+
+        LinearLayout transfers = card("TRANSFERS", "Selected local files upload to the current server directory; selected server files download into the active SAF folder.");
+        LinearLayout transferActions = row();
+        upload = primaryButton("Upload →");
+        download = primaryButton("← Download");
+        transferActions.addView(upload, weightedSpaced());
+        transferActions.addView(download, weightedSpaced());
+        transfers.addView(transferActions, matchWrap());
+        upload.setOnClickListener(v -> uploadSelected());
+        download.setOnClickListener(v -> downloadSelected());
+        status = label("Ready.", 13, GhostTheme.MUTED);
+        status.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        status.setPadding(dp(12), dp(12), dp(12), dp(12));
+        status.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 10));
+        transfers.addView(status, matchWrapSpaced());
+        root.addView(transfers, cardParams());
+
+        TextView footer = label("Local access stays inside Android Storage Access Framework grants. SFTP remains hidden until Android has strict host-key identity verification equivalent to desktop Ghost FTP.", 11, GhostTheme.MUTED);
+        footer.setPadding(dp(4), dp(4), dp(4), dp(8));
+        root.addView(footer, matchWrap());
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.setFillViewport(true);
+        scroll.setBackgroundColor(GhostTheme.WINDOW);
+        scroll.addView(root);
+        setContentView(scroll);
+    }
+
+    private LinearLayout buildLocalPane() {
+        LinearLayout pane = card("LOCAL", "Tap a folder to open it. Long-press any item to select it for Rename/Delete.");
+        localPath = label("No folder selected", 13, GhostTheme.MUTED);
+        localPath.setPadding(dp(8), dp(8), dp(8), dp(8));
+        localPath.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 8));
+        pane.addView(localPath, matchWrapSpaced());
+
+        LinearLayout nav = row();
         Button choose = button("Choose folder");
         Button localUp = button("Up");
-        localActions.addView(choose, weighted());
-        localActions.addView(localUp, weighted());
-        root.addView(localActions, matchWrap());
+        Button localRefresh = button("Refresh");
+        nav.addView(choose, weightedSpaced());
+        nav.addView(localUp, weightedSpaced());
+        nav.addView(localRefresh, weightedSpaced());
+        pane.addView(nav, matchWrap());
         choose.setOnClickListener(v -> chooseFolder());
         localUp.setOnClickListener(v -> localUp());
+        localRefresh.setOnClickListener(v -> refreshLocal());
 
-        LinearLayout localProfileActions = row();
-        localSetStart = button("Set site start");
+        LinearLayout manage = row();
+        localNewFolder = button("New folder");
+        localRename = button("Rename");
+        localDelete = dangerButton("Delete");
+        manage.addView(localNewFolder, weightedSpaced());
+        manage.addView(localRename, weightedSpaced());
+        manage.addView(localDelete, weightedSpaced());
+        pane.addView(manage, matchWrap());
+        localNewFolder.setOnClickListener(v -> createLocalFolder());
+        localRename.setOnClickListener(v -> renameLocalSelected());
+        localDelete.setOnClickListener(v -> deleteLocalSelected());
+
+        LinearLayout bookmarkActions = row();
+        localSetStart = button("Set start");
         localAddBookmark = button("Add bookmark");
-        localProfileActions.addView(localSetStart, weighted());
-        localProfileActions.addView(localAddBookmark, weighted());
-        root.addView(localProfileActions, matchWrap());
+        localRemoveBookmark = dangerButton("Remove bookmark");
+        bookmarkActions.addView(localSetStart, weightedSpaced());
+        bookmarkActions.addView(localAddBookmark, weightedSpaced());
+        bookmarkActions.addView(localRemoveBookmark, weightedSpaced());
+        pane.addView(bookmarkActions, matchWrap());
         localSetStart.setOnClickListener(v -> setLocalStart());
         localAddBookmark.setOnClickListener(v -> addLocalBookmark());
+        localRemoveBookmark.setOnClickListener(v -> removeLocalBookmark());
+
         localBookmarkSpinner = new Spinner(this);
-        root.addView(localBookmarkSpinner, matchWrap());
+        GhostTheme.styleSpinner(localBookmarkSpinner);
+        pane.addView(localBookmarkSpinner, matchWrapSpaced());
         localOpenBookmark = button("Open local bookmark");
-        root.addView(localOpenBookmark, matchWrap());
+        pane.addView(localOpenBookmark, matchWrapSpaced());
         localOpenBookmark.setOnClickListener(v -> openLocalBookmark());
 
         localList = new ListView(this);
-        root.addView(localList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(220)));
+        GhostTheme.styleList(localList);
+        pane.addView(localList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(270)));
         localList.setOnItemClickListener((parent, view, position, id) -> selectLocal(position));
+        localList.setOnItemLongClickListener((parent, view, position, id) -> {
+            if (busy || position < 0 || position >= localEntries.size()) return true;
+            selectedLocal = position;
+            renderLocal();
+            setStatus("Selected local item for management: " + localEntries.get(position).name);
+            return true;
+        });
+        return pane;
+    }
 
-        root.addView(section("SERVER"));
-        remotePath = label(currentRemotePath, 14, Color.LTGRAY);
-        root.addView(remotePath);
-        LinearLayout remoteActions = row();
+    private LinearLayout buildRemotePane() {
+        LinearLayout pane = card("SERVER", "Tap a folder to open it. Long-press any item to select it for Rename/Delete.");
+        remotePath = label(currentRemotePath, 13, GhostTheme.MUTED);
+        remotePath.setPadding(dp(8), dp(8), dp(8), dp(8));
+        remotePath.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 8));
+        pane.addView(remotePath, matchWrapSpaced());
+
+        LinearLayout nav = row();
         Button remoteRefresh = button("Refresh");
         Button remoteUp = button("Up");
-        remoteActions.addView(remoteRefresh, weighted());
-        remoteActions.addView(remoteUp, weighted());
-        root.addView(remoteActions, matchWrap());
+        remoteNewFolder = button("New folder");
+        nav.addView(remoteRefresh, weightedSpaced());
+        nav.addView(remoteUp, weightedSpaced());
+        nav.addView(remoteNewFolder, weightedSpaced());
+        pane.addView(nav, matchWrap());
         remoteRefresh.setOnClickListener(v -> refreshRemote(currentRemotePath));
         remoteUp.setOnClickListener(v -> remoteUp());
+        remoteNewFolder.setOnClickListener(v -> createRemoteFolder());
 
-        LinearLayout remoteProfileActions = row();
-        remoteSetStart = button("Set site start");
+        LinearLayout manage = row();
+        remoteRename = button("Rename");
+        remoteDelete = dangerButton("Delete");
+        manage.addView(remoteRename, weightedSpaced());
+        manage.addView(remoteDelete, weightedSpaced());
+        pane.addView(manage, matchWrap());
+        remoteRename.setOnClickListener(v -> renameRemoteSelected());
+        remoteDelete.setOnClickListener(v -> deleteRemoteSelected());
+
+        LinearLayout bookmarkActions = row();
+        remoteSetStart = button("Set start");
         remoteAddBookmark = button("Add bookmark");
-        remoteProfileActions.addView(remoteSetStart, weighted());
-        remoteProfileActions.addView(remoteAddBookmark, weighted());
-        root.addView(remoteProfileActions, matchWrap());
+        remoteRemoveBookmark = dangerButton("Remove bookmark");
+        bookmarkActions.addView(remoteSetStart, weightedSpaced());
+        bookmarkActions.addView(remoteAddBookmark, weightedSpaced());
+        bookmarkActions.addView(remoteRemoveBookmark, weightedSpaced());
+        pane.addView(bookmarkActions, matchWrap());
         remoteSetStart.setOnClickListener(v -> setRemoteStart());
         remoteAddBookmark.setOnClickListener(v -> addRemoteBookmark());
+        remoteRemoveBookmark.setOnClickListener(v -> removeRemoteBookmark());
+
         remoteBookmarkSpinner = new Spinner(this);
-        root.addView(remoteBookmarkSpinner, matchWrap());
+        GhostTheme.styleSpinner(remoteBookmarkSpinner);
+        pane.addView(remoteBookmarkSpinner, matchWrapSpaced());
         remoteOpenBookmark = button("Open server bookmark");
-        root.addView(remoteOpenBookmark, matchWrap());
+        pane.addView(remoteOpenBookmark, matchWrapSpaced());
         remoteOpenBookmark.setOnClickListener(v -> openRemoteBookmark());
 
         remoteList = new ListView(this);
-        root.addView(remoteList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(220)));
+        GhostTheme.styleList(remoteList);
+        pane.addView(remoteList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(270)));
         remoteList.setOnItemClickListener((parent, view, position, id) -> selectRemote(position));
-
-        LinearLayout transfers = row();
-        upload = button("Upload →");
-        download = button("← Download");
-        transfers.addView(upload, weighted());
-        transfers.addView(download, weighted());
-        root.addView(transfers, matchWrap());
-        upload.setOnClickListener(v -> uploadSelected());
-        download.setOnClickListener(v -> downloadSelected());
-
-        status = label("Ready.", 13, Color.LTGRAY);
-        root.addView(status);
-        ScrollView scroll = new ScrollView(this);
-        scroll.addView(root);
-        setContentView(scroll);
+        remoteList.setOnItemLongClickListener((parent, view, position, id) -> {
+            if (busy || position < 0 || position >= remoteEntries.size()) return true;
+            selectedRemote = position;
+            renderRemote();
+            setStatus("Selected server item for management: " + remoteEntries.get(position).name);
+            return true;
+        });
+        return pane;
     }
 
     private void restorePreferences() {
@@ -266,7 +384,7 @@ public final class MainActivity extends Activity {
             labels.add(profile.toString());
             if (profile.id.equals(activeProfileId)) selected = i + 1;
         }
-        siteSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, labels));
+        siteSpinner.setAdapter(GhostTheme.spinnerAdapter(this, labels));
         siteSpinner.setSelection(selected);
     }
 
@@ -278,8 +396,8 @@ public final class MainActivity extends Activity {
             local.addAll(profile.localBookmarks);
             remote.addAll(profile.remoteBookmarks);
         }
-        localBookmarkSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, local));
-        remoteBookmarkSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, remote));
+        localBookmarkSpinner.setAdapter(GhostTheme.spinnerAdapter(this, local));
+        remoteBookmarkSpinner.setAdapter(GhostTheme.spinnerAdapter(this, remote));
         refreshButtons();
     }
 
@@ -396,13 +514,15 @@ public final class MainActivity extends Activity {
             setStatus("Load a saved site before deleting it.");
             return;
         }
-        profiles.remove(profile);
-        profileStore.save(profiles);
-        activeProfileId = null;
-        profileName.setText("");
-        renderSites();
-        renderBookmarks();
-        setStatus("Saved site deleted. Quick Connect settings were not converted into another profile.");
+        confirm("Delete saved site?", "Delete “" + profile.name + "”? Passwords are not stored, but its start directories and bookmarks will be removed.", () -> {
+            profiles.remove(profile);
+            profileStore.save(profiles);
+            activeProfileId = null;
+            profileName.setText("");
+            renderSites();
+            renderBookmarks();
+            setStatus("Saved site deleted. Quick Connect settings were not converted into another profile.");
+        });
     }
 
     private void replaceProfile(SiteProfile next) {
@@ -505,7 +625,7 @@ public final class MainActivity extends Activity {
         currentRemotePath = "/";
         if (current != null) current.cancelActiveTransfer();
         renderRemote();
-        setStatus("Cancelling active transfer. Connection closed; reconnect before another transfer.");
+        setStatus("Transfer cancelled. Connection closed; reconnect before another transfer.");
         refreshButtons();
     }
 
@@ -561,6 +681,103 @@ public final class MainActivity extends Activity {
         }
     }
 
+    private void createRemoteFolder() {
+        FtpSession current = session;
+        if (busy || current == null || !current.isConnected()) return;
+        promptName("New server folder", "", "Create", name -> {
+            String safe;
+            try {
+                safe = requireLeafName(name);
+            } catch (IllegalArgumentException e) {
+                setStatus(e.getMessage());
+                return;
+            }
+            String base = currentRemotePath;
+            setBusy(true, "Creating server folder…");
+            io.execute(() -> {
+                try {
+                    current.makeDirectory(base, safe);
+                    List<RemoteEntry> fresh = current.list(base);
+                    runOnUiThread(() -> commitRemoteMutation(current, base, fresh, "Server folder created: " + safe));
+                } catch (Exception e) {
+                    postError("Create server folder failed", e);
+                }
+            });
+        });
+    }
+
+    private void renameRemoteSelected() {
+        FtpSession current = session;
+        if (busy || current == null || !current.isConnected() || selectedRemote < 0 || selectedRemote >= remoteEntries.size()) return;
+        RemoteEntry entry = remoteEntries.get(selectedRemote);
+        String base = currentRemotePath;
+        final String source;
+        try {
+            source = FtpSession.joinRemote(base, entry.name);
+        } catch (IOException e) {
+            setStatus(e.getMessage());
+            return;
+        }
+        promptName("Rename server item", entry.name, "Rename", name -> {
+            String safe;
+            try {
+                safe = requireLeafName(name);
+            } catch (IllegalArgumentException e) {
+                setStatus(e.getMessage());
+                return;
+            }
+            if (safe.equals(entry.name)) return;
+            setBusy(true, "Renaming server item…");
+            io.execute(() -> {
+                try {
+                    current.renameRemote(source, safe);
+                    List<RemoteEntry> fresh = current.list(base);
+                    runOnUiThread(() -> commitRemoteMutation(current, base, fresh, "Server item renamed to: " + safe));
+                } catch (Exception e) {
+                    postError("Rename server item failed", e);
+                }
+            });
+        });
+    }
+
+    private void deleteRemoteSelected() {
+        FtpSession current = session;
+        if (busy || current == null || !current.isConnected() || selectedRemote < 0 || selectedRemote >= remoteEntries.size()) return;
+        RemoteEntry entry = remoteEntries.get(selectedRemote);
+        String base = currentRemotePath;
+        final String target;
+        try {
+            target = FtpSession.joinRemote(base, entry.name);
+        } catch (IOException e) {
+            setStatus(e.getMessage());
+            return;
+        }
+        confirm("Delete server item?", "Delete “" + entry.name + "”? Remote directory deletion is non-recursive and succeeds only if the server accepts RMD.", () -> {
+            setBusy(true, "Deleting server item…");
+            io.execute(() -> {
+                try {
+                    current.deleteRemote(target, entry.directory);
+                    List<RemoteEntry> fresh = current.list(base);
+                    runOnUiThread(() -> commitRemoteMutation(current, base, fresh, "Server item deleted: " + entry.name));
+                } catch (Exception e) {
+                    postError("Delete server item failed", e);
+                }
+            });
+        });
+    }
+
+    private void commitRemoteMutation(FtpSession current, String base, List<RemoteEntry> fresh, String message) {
+        if (session != current || !current.isConnected() || !currentRemotePath.equals(base)) {
+            setBusy(false, "Server operation completed, but the visible session/path changed. Refresh before continuing.");
+            return;
+        }
+        remoteEntries.clear();
+        remoteEntries.addAll(fresh);
+        selectedRemote = -1;
+        renderRemote();
+        setBusy(false, message);
+    }
+
     private void setRemoteStart() {
         SiteProfile profile = requireConnectedActiveProfile();
         if (profile == null) return;
@@ -578,6 +795,24 @@ public final class MainActivity extends Activity {
         profileStore.save(profiles);
         renderBookmarks();
         setStatus("Server bookmark added for this site identity only.");
+    }
+
+    private void removeRemoteBookmark() {
+        SiteProfile profile = activeProfile();
+        if (profile == null) {
+            setStatus("Load a saved site before removing a server bookmark.");
+            return;
+        }
+        int index = remoteBookmarkSpinner.getSelectedItemPosition();
+        if (index < 0 || index >= profile.remoteBookmarks.size()) {
+            setStatus("No server bookmark selected.");
+            return;
+        }
+        SiteProfile next = profile.withoutRemoteBookmark(index);
+        replaceProfile(next);
+        profileStore.save(profiles);
+        renderBookmarks();
+        setStatus("Server bookmark removed.");
     }
 
     private void openRemoteBookmark() {
@@ -757,6 +992,106 @@ public final class MainActivity extends Activity {
         }
     }
 
+    private void createLocalFolder() {
+        if (busy || treeUri == null || currentDocumentId == null) return;
+        promptName("New local folder", "", "Create", name -> {
+            String safe;
+            try {
+                safe = requireLeafName(name);
+            } catch (IllegalArgumentException e) {
+                setStatus(e.getMessage());
+                return;
+            }
+            Uri selectedTree = treeUri;
+            String selectedParent = currentDocumentId;
+            Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedParent);
+            setBusy(true, "Creating local folder…");
+            io.execute(() -> {
+                Uri created = null;
+                try {
+                    ensureNoLocalNameConflict(selectedTree, selectedParent, safe, "A local item with this name already exists.");
+                    created = DocumentsContract.createDocument(getContentResolver(), parent, DocumentsContract.Document.MIME_TYPE_DIR, safe);
+                    if (created == null) throw new IOException("Storage provider rejected local folder creation.");
+                    String actual = queryDocumentDisplayName(created);
+                    if (!safe.equals(actual)) {
+                        try { DocumentsContract.deleteDocument(getContentResolver(), created); } catch (Exception ignored) { }
+                        throw new IOException("Storage provider changed the requested folder name; creation was rejected.");
+                    }
+                    List<LocalEntry> fresh = queryChildren(selectedTree, selectedParent);
+                    runOnUiThread(() -> commitLocalMutation(selectedTree, selectedParent, fresh, "Local folder created: " + safe));
+                } catch (Exception e) {
+                    postError("Create local folder failed", e);
+                }
+            });
+        });
+    }
+
+    private void renameLocalSelected() {
+        if (busy || treeUri == null || currentDocumentId == null || selectedLocal < 0 || selectedLocal >= localEntries.size()) return;
+        LocalEntry entry = localEntries.get(selectedLocal);
+        promptName("Rename local item", entry.name, "Rename", name -> {
+            String safe;
+            try {
+                safe = requireLeafName(name);
+            } catch (IllegalArgumentException e) {
+                setStatus(e.getMessage());
+                return;
+            }
+            if (safe.equals(entry.name)) return;
+            Uri selectedTree = treeUri;
+            String selectedParent = currentDocumentId;
+            Uri document = DocumentsContract.buildDocumentUriUsingTree(selectedTree, entry.documentId);
+            setBusy(true, "Renaming local item…");
+            io.execute(() -> {
+                Uri renamed = null;
+                try {
+                    ensureNoLocalNameConflict(selectedTree, selectedParent, safe, "A local item with this name already exists.");
+                    renamed = DocumentsContract.renameDocument(getContentResolver(), document, safe);
+                    if (renamed == null) throw new IOException("Storage provider rejected local rename.");
+                    String actual = queryDocumentDisplayName(renamed);
+                    if (!safe.equals(actual)) throw new IOException("Storage provider changed the requested rename result.");
+                    List<LocalEntry> fresh = queryChildren(selectedTree, selectedParent);
+                    runOnUiThread(() -> commitLocalMutation(selectedTree, selectedParent, fresh, "Local item renamed to: " + safe));
+                } catch (Exception e) {
+                    postError("Rename local item failed", e);
+                }
+            });
+        });
+    }
+
+    private void deleteLocalSelected() {
+        if (busy || treeUri == null || currentDocumentId == null || selectedLocal < 0 || selectedLocal >= localEntries.size()) return;
+        LocalEntry entry = localEntries.get(selectedLocal);
+        confirm("Delete local item?", "Delete “" + entry.name + "” from the selected Android storage provider?", () -> {
+            Uri selectedTree = treeUri;
+            String selectedParent = currentDocumentId;
+            Uri document = DocumentsContract.buildDocumentUriUsingTree(selectedTree, entry.documentId);
+            setBusy(true, "Deleting local item…");
+            io.execute(() -> {
+                try {
+                    boolean deleted = DocumentsContract.deleteDocument(getContentResolver(), document);
+                    if (!deleted) throw new IOException("Storage provider rejected local delete.");
+                    List<LocalEntry> fresh = queryChildren(selectedTree, selectedParent);
+                    runOnUiThread(() -> commitLocalMutation(selectedTree, selectedParent, fresh, "Local item deleted: " + entry.name));
+                } catch (Exception e) {
+                    postError("Delete local item failed", e);
+                }
+            });
+        });
+    }
+
+    private void commitLocalMutation(Uri selectedTree, String selectedParent, List<LocalEntry> fresh, String message) {
+        if (treeUri == null || !treeUri.equals(selectedTree) || !selectedParent.equals(currentDocumentId)) {
+            setBusy(false, "Local operation completed, but the visible folder changed. Refresh before continuing.");
+            return;
+        }
+        localEntries.clear();
+        localEntries.addAll(fresh);
+        selectedLocal = -1;
+        renderLocal();
+        setBusy(false, message);
+    }
+
     private void setLocalStart() {
         SiteProfile profile = activeProfile();
         if (profile == null) {
@@ -792,6 +1127,24 @@ public final class MainActivity extends Activity {
         setStatus("Local SAF bookmark added. It contains no credentials.");
     }
 
+    private void removeLocalBookmark() {
+        SiteProfile profile = activeProfile();
+        if (profile == null) {
+            setStatus("Load a saved site before removing a local bookmark.");
+            return;
+        }
+        int index = localBookmarkSpinner.getSelectedItemPosition();
+        if (index < 0 || index >= profile.localBookmarks.size()) {
+            setStatus("No local bookmark selected.");
+            return;
+        }
+        SiteProfile next = profile.withoutLocalBookmark(index);
+        replaceProfile(next);
+        profileStore.save(profiles);
+        renderBookmarks();
+        setStatus("Local bookmark removed.");
+    }
+
     private void openLocalBookmark() {
         SiteProfile profile = activeProfile();
         if (profile == null) {
@@ -818,6 +1171,10 @@ public final class MainActivity extends Activity {
         FtpSession current = session;
         if (busy || current == null || selectedLocal < 0 || selectedLocal >= localEntries.size()) return;
         LocalEntry entry = localEntries.get(selectedLocal);
+        if (entry.directory) {
+            setStatus("Select a local file, not a directory, to upload.");
+            return;
+        }
         Uri document = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.documentId);
         String remoteBase = currentRemotePath;
         long transferToken = beginTransfer("Uploading " + entry.name + "…");
@@ -850,6 +1207,10 @@ public final class MainActivity extends Activity {
         FtpSession current = session;
         if (busy || current == null || selectedRemote < 0 || selectedRemote >= remoteEntries.size() || treeUri == null) return;
         RemoteEntry entry = remoteEntries.get(selectedRemote);
+        if (entry.directory) {
+            setStatus("Select a server file, not a directory, to download.");
+            return;
+        }
         Uri selectedTree = treeUri;
         String selectedDocumentId = currentDocumentId;
         Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
@@ -962,15 +1323,15 @@ public final class MainActivity extends Activity {
         String[] projection = {DocumentsContract.Document.COLUMN_DISPLAY_NAME};
         try (Cursor cursor = getContentResolver().query(document, projection, null, null, null)) {
             if (cursor == null || !cursor.moveToFirst()) {
-                throw new IOException("Storage provider could not verify the committed download name.");
+                throw new IOException("Storage provider could not verify the committed item name.");
             }
             String name = cursor.getString(0);
             if (name == null || name.isEmpty()) {
-                throw new IOException("Storage provider returned an empty committed download name.");
+                throw new IOException("Storage provider returned an empty committed item name.");
             }
             return name;
         } catch (SecurityException e) {
-            throw new IOException("Storage permission was lost while verifying the committed download.", e);
+            throw new IOException("Storage permission was lost while verifying the committed item.", e);
         }
     }
 
@@ -987,17 +1348,20 @@ public final class MainActivity extends Activity {
         List<String> labels = new ArrayList<>();
         for (int i = 0; i < localEntries.size(); i++) {
             LocalEntry e = localEntries.get(i);
-            labels.add((i == selectedLocal ? "› " : "  ") + (e.directory ? "DIR   " : "FILE  ") + e.name + (e.directory ? "" : "  (" + e.size + " B)"));
+            labels.add((i == selectedLocal ? "●  " : "   ") + (e.directory ? "▸  " : "   ") + e.name + (e.directory ? "" : "   " + TransferProgress.formatBytes(e.size)));
         }
-        localList.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, labels));
+        localList.setAdapter(GhostTheme.listAdapter(this, labels));
         refreshButtons();
     }
 
     private void renderRemote() {
         remotePath.setText(currentRemotePath);
         List<String> labels = new ArrayList<>();
-        for (int i = 0; i < remoteEntries.size(); i++) labels.add((i == selectedRemote ? "› " : "  ") + remoteEntries.get(i));
-        remoteList.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, labels));
+        for (int i = 0; i < remoteEntries.size(); i++) {
+            RemoteEntry e = remoteEntries.get(i);
+            labels.add((i == selectedRemote ? "●  " : "   ") + (e.directory ? "▸  " : "   ") + e.name + (e.directory ? "" : "   " + TransferProgress.formatBytes(e.size)));
+        }
+        remoteList.setAdapter(GhostTheme.listAdapter(this, labels));
         refreshButtons();
     }
 
@@ -1009,22 +1373,47 @@ public final class MainActivity extends Activity {
 
     private void refreshButtons() {
         boolean connected = session != null && session.isConnected();
+        boolean selectedLocalItem = selectedLocal >= 0 && selectedLocal < localEntries.size();
+        boolean selectedRemoteItem = selectedRemote >= 0 && selectedRemote < remoteEntries.size();
+        boolean selectedLocalFile = selectedLocalItem && !localEntries.get(selectedLocal).directory;
+        boolean selectedRemoteFile = selectedRemoteItem && !remoteEntries.get(selectedRemote).directory;
         SiteProfile profile = activeProfile();
         boolean activeSite = profile != null;
         boolean connectedSite = activeSite && connected && connectedIdentityKey != null && profile.identityKey().equals(connectedIdentityKey);
-        connect.setEnabled(!busy && !connected);
+
+        setEnabled(connect, !busy && !connected);
         disconnect.setText(transferActive ? "Cancel transfer" : "Disconnect");
-        disconnect.setEnabled(transferActive || (!busy && connected));
-        upload.setEnabled(!busy && connected && selectedLocal >= 0);
-        download.setEnabled(!busy && connected && selectedRemote >= 0 && treeUri != null);
-        saveSite.setEnabled(!busy && !connected);
-        deleteSite.setEnabled(!busy && !connected && activeSite);
-        localSetStart.setEnabled(!busy && activeSite && persistedCurrentTreeUri().length() > 0);
-        localAddBookmark.setEnabled(!busy && activeSite && persistedCurrentTreeUri().length() > 0);
-        localOpenBookmark.setEnabled(!busy && activeSite && !profile.localBookmarks.isEmpty());
-        remoteSetStart.setEnabled(!busy && connectedSite);
-        remoteAddBookmark.setEnabled(!busy && connectedSite);
-        remoteOpenBookmark.setEnabled(!busy && connectedSite && !profile.remoteBookmarks.isEmpty());
+        setEnabled(disconnect, transferActive || (!busy && connected));
+        setEnabled(upload, !busy && connected && selectedLocalFile);
+        setEnabled(download, !busy && connected && selectedRemoteFile && treeUri != null);
+        setEnabled(saveSite, !busy && !connected);
+        setEnabled(deleteSite, !busy && !connected && activeSite);
+        setEnabled(localNewFolder, !busy && treeUri != null && currentDocumentId != null);
+        setEnabled(localRename, !busy && selectedLocalItem);
+        setEnabled(localDelete, !busy && selectedLocalItem);
+        setEnabled(localSetStart, !busy && activeSite && !persistedCurrentTreeUri().isEmpty());
+        setEnabled(localAddBookmark, !busy && activeSite && !persistedCurrentTreeUri().isEmpty());
+        setEnabled(localRemoveBookmark, !busy && activeSite && !profile.localBookmarks.isEmpty());
+        setEnabled(localOpenBookmark, !busy && activeSite && !profile.localBookmarks.isEmpty());
+        setEnabled(remoteNewFolder, !busy && connected);
+        setEnabled(remoteRename, !busy && connected && selectedRemoteItem);
+        setEnabled(remoteDelete, !busy && connected && selectedRemoteItem);
+        setEnabled(remoteSetStart, !busy && connectedSite);
+        setEnabled(remoteAddBookmark, !busy && connectedSite);
+        setEnabled(remoteRemoveBookmark, !busy && activeSite && !profile.remoteBookmarks.isEmpty());
+        setEnabled(remoteOpenBookmark, !busy && connectedSite && !profile.remoteBookmarks.isEmpty());
+
+        if (transferActive) {
+            connectionState.setText("TRANSFER ACTIVE");
+            GhostTheme.styleBadge(connectionState, GhostTheme.WARN);
+        } else if (connected) {
+            boolean secure = "FTPS".equals(protocol.getSelectedItem().toString());
+            connectionState.setText(secure ? "FTPS CONNECTED" : "FTP CONNECTED");
+            GhostTheme.styleBadge(connectionState, secure ? GhostTheme.SUCCESS : GhostTheme.WARN);
+        } else {
+            connectionState.setText("DISCONNECTED");
+            GhostTheme.styleBadge(connectionState, GhostTheme.MUTED);
+        }
     }
 
     private int parsePort() {
@@ -1059,7 +1448,9 @@ public final class MainActivity extends Activity {
     }
 
     private void setStatus(String value) {
-        status.setText(value == null ? "" : value.replace('\n', ' ').replace('\r', ' '));
+        String safe = value == null ? "" : value.replace('\n', ' ').replace('\r', ' ');
+        status.setText(safe);
+        status.setTextColor(GhostTheme.statusColor(safe));
     }
 
     private static String safeMessage(Exception e) {
@@ -1067,10 +1458,20 @@ public final class MainActivity extends Activity {
         return value == null || value.trim().isEmpty() ? e.getClass().getSimpleName() : value.replace('\n', ' ').replace('\r', ' ');
     }
 
-    private TextView section(String text) {
-        TextView view = label(text, 15, Color.rgb(94, 214, 200));
-        view.setPadding(0, dp(18), 0, dp(6));
-        return view;
+    private LinearLayout card(String title, String hint) {
+        LinearLayout card = new LinearLayout(this);
+        card.setOrientation(LinearLayout.VERTICAL);
+        card.setPadding(dp(14), dp(14), dp(14), dp(14));
+        card.setBackground(GhostTheme.rounded(this, GhostTheme.PANEL, GhostTheme.BORDER, 14));
+        TextView heading = label(title, 15, GhostTheme.TEXT);
+        heading.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        card.addView(heading, matchWrap());
+        if (hint != null && !hint.isEmpty()) {
+            TextView help = label(hint, 11, GhostTheme.MUTED);
+            help.setPadding(0, dp(4), 0, dp(10));
+            card.addView(help, matchWrap());
+        }
+        return card;
     }
 
     private TextView label(String text, int sp, int color) {
@@ -1084,9 +1485,7 @@ public final class MainActivity extends Activity {
     private EditText field(String hint, boolean secret) {
         EditText edit = new EditText(this);
         edit.setHint(hint);
-        edit.setTextColor(Color.WHITE);
-        edit.setHintTextColor(Color.GRAY);
-        edit.setSingleLine(true);
+        GhostTheme.styleField(edit);
         if (secret) edit.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
         return edit;
     }
@@ -1094,7 +1493,21 @@ public final class MainActivity extends Activity {
     private Button button(String text) {
         Button b = new Button(this);
         b.setText(text);
-        b.setAllCaps(false);
+        GhostTheme.styleSecondaryButton(b);
+        return b;
+    }
+
+    private Button primaryButton(String text) {
+        Button b = new Button(this);
+        b.setText(text);
+        GhostTheme.stylePrimaryButton(b);
+        return b;
+    }
+
+    private Button dangerButton(String text) {
+        Button b = new Button(this);
+        b.setText(text);
+        GhostTheme.styleDangerButton(b);
         return b;
     }
 
@@ -1104,9 +1517,85 @@ public final class MainActivity extends Activity {
         return r;
     }
 
-    private LinearLayout.LayoutParams weighted() { return new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f); }
-    private LinearLayout.LayoutParams matchWrap() { return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT); }
-    private int dp(int value) { return Math.round(value * getResources().getDisplayMetrics().density); }
+    private void promptName(String title, String initial, String positive, NameAction action) {
+        EditText input = field("Name", false);
+        input.setText(initial == null ? "" : initial);
+        input.setSelectAllOnFocus(true);
+        LinearLayout holder = new LinearLayout(this);
+        holder.setPadding(dp(18), dp(4), dp(18), 0);
+        holder.addView(input, matchWrap());
+        new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setView(holder)
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton(positive, (dialog, which) -> action.run(input.getText().toString()))
+                .show();
+    }
+
+    private void confirm(String title, String message, Runnable action) {
+        new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setMessage(message)
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton("Delete", (dialog, which) -> action.run())
+                .show();
+    }
+
+    private static String requireLeafName(String value) {
+        String name = value == null ? "" : value.trim();
+        if (name.isEmpty() || ".".equals(name) || "..".equals(name)
+                || name.indexOf('/') >= 0 || name.indexOf('\\') >= 0
+                || name.indexOf('\0') >= 0 || name.indexOf('\r') >= 0 || name.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Name must be one safe path segment without / or \\ characters.");
+        }
+        return name;
+    }
+
+    private void setEnabled(Button button, boolean enabled) {
+        if (button == null) return;
+        button.setEnabled(enabled);
+        button.setAlpha(enabled ? 1f : 0.45f);
+    }
+
+    private LinearLayout.LayoutParams weightedSpaced() {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        params.setMargins(dp(3), dp(3), dp(3), dp(3));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams fixedWidthSpaced(int widthDp) {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(dp(widthDp), ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setMargins(dp(3), dp(3), dp(3), dp(3));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams matchWrapSpaced() {
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, dp(4), 0, dp(4));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams cardParams() {
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, 0, 0, dp(10));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams matchWrap() {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private LinearLayout.LayoutParams wrapWrap() {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private int dp(int value) {
+        return GhostTheme.dp(this, value);
+    }
+
+    private interface NameAction {
+        void run(String name);
+    }
 
     private static final class LocalEntry {
         final String documentId;

--- a/android/app/src/main/java/app/ghostftp/client/SiteProfile.java
+++ b/android/app/src/main/java/app/ghostftp/client/SiteProfile.java
@@ -85,12 +85,28 @@ final class SiteProfile {
                 remoteStartPath, next, remoteBookmarks);
     }
 
+    SiteProfile withoutLocalBookmark(int index) {
+        if (index < 0 || index >= localBookmarks.size()) return this;
+        List<String> next = new ArrayList<>(localBookmarks);
+        next.remove(index);
+        return new SiteProfile(id, name, protocol, host, port, username, localStartTreeUri,
+                remoteStartPath, next, remoteBookmarks);
+    }
+
     SiteProfile withRemoteBookmark(String path) {
         String normalized = normalizeRemotePath(path);
         List<String> next = new ArrayList<>(remoteBookmarks);
         if (!next.contains(normalized)) {
             next.add(normalized);
         }
+        return new SiteProfile(id, name, protocol, host, port, username, localStartTreeUri,
+                remoteStartPath, localBookmarks, next);
+    }
+
+    SiteProfile withoutRemoteBookmark(int index) {
+        if (index < 0 || index >= remoteBookmarks.size()) return this;
+        List<String> next = new ArrayList<>(remoteBookmarks);
+        next.remove(index);
         return new SiteProfile(id, name, protocol, host, port, username, localStartTreeUri,
                 remoteStartPath, localBookmarks, next);
     }

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ghost_window">#0B0F17</color>
+    <color name="ghost_panel">#121824</color>
+    <color name="ghost_list">#161D2A</color>
+    <color name="ghost_border">#2C3648</color>
+    <color name="ghost_text">#F2F5FA</color>
+    <color name="ghost_muted">#97A3B8</color>
+    <color name="ghost_accent">#5B7CFA</color>
+    <color name="ghost_accent_strong">#7A98FF</color>
+    <color name="ghost_success">#4AD79B</color>
+    <color name="ghost_warn">#F2BA55</color>
+    <color name="ghost_danger">#FF6878</color>
+    <color name="ghost_selection">#202F50</color>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,9 +3,13 @@
     <style name="Theme.GhostFTP" parent="android:style/Theme.Material.NoActionBar">
         <item name="android:fontFamily">sans</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:statusBarColor">#101317</item>
-        <item name="android:navigationBarColor">#101317</item>
-        <item name="android:windowBackground">#101317</item>
-        <item name="android:colorAccent">#5ED6C8</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:statusBarColor">@color/ghost_window</item>
+        <item name="android:navigationBarColor">@color/ghost_window</item>
+        <item name="android:windowBackground">@color/ghost_window</item>
+        <item name="android:colorAccent">@color/ghost_accent</item>
+        <item name="android:textColorPrimary">@color/ghost_text</item>
+        <item name="android:textColorSecondary">@color/ghost_muted</item>
+        <item name="android:windowNoTitle">true</item>
     </style>
 </resources>

--- a/scripts/test_android_dark_ui_contract.py
+++ b/scripts/test_android_dark_ui_contract.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+JAVA = ROOT / "android/app/src/main/java/app/ghostftp/client"
+
+
+class AndroidDarkUiContractTests(unittest.TestCase):
+    def read(self, rel: str) -> str:
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_android_palette_matches_canonical_desktop_dark_theme(self) -> None:
+        colors = self.read("android/app/src/main/res/values/colors.xml")
+        expected = {
+            "ghost_window": "#0B0F17",
+            "ghost_panel": "#121824",
+            "ghost_list": "#161D2A",
+            "ghost_border": "#2C3648",
+            "ghost_text": "#F2F5FA",
+            "ghost_muted": "#97A3B8",
+            "ghost_accent": "#5B7CFA",
+            "ghost_accent_strong": "#7A98FF",
+            "ghost_success": "#4AD79B",
+            "ghost_warn": "#F2BA55",
+            "ghost_danger": "#FF6878",
+            "ghost_selection": "#202F50",
+        }
+        for name, value in expected.items():
+            self.assertIn(f'<color name="{name}">{value}</color>', colors)
+
+        desktop = self.read("internal/uipalette/palette.go")
+        for rgb in (
+            "RGB{0x0B, 0x0F, 0x17}",
+            "RGB{0x12, 0x18, 0x24}",
+            "RGB{0x16, 0x1D, 0x2A}",
+            "RGB{0x2C, 0x36, 0x48}",
+            "RGB{0xF2, 0xF5, 0xFA}",
+            "RGB{0x97, 0xA3, 0xB8}",
+            "RGB{0x5B, 0x7C, 0xFA}",
+            "RGB{0x7A, 0x98, 0xFF}",
+            "RGB{0x4A, 0xD7, 0x9B}",
+            "RGB{0xF2, 0xBA, 0x55}",
+            "RGB{0xFF, 0x68, 0x78}",
+            "RGB{0x20, 0x2F, 0x50}",
+        ):
+            self.assertIn(rgb, desktop)
+
+    def test_theme_resources_use_canonical_palette(self) -> None:
+        styles = self.read("android/app/src/main/res/values/styles.xml")
+        for marker in (
+            "@color/ghost_window",
+            "@color/ghost_accent",
+            "@color/ghost_text",
+            "@color/ghost_muted",
+            "android:windowLightStatusBar\">false",
+            "android:windowLightNavigationBar\">false",
+        ):
+            self.assertIn(marker, styles)
+
+    def test_runtime_workspace_uses_dark_theme_and_responsive_panes(self) -> None:
+        activity = (JAVA / "MainActivity.java").read_text(encoding="utf-8")
+        theme = (JAVA / "GhostTheme.java").read_text(encoding="utf-8")
+        for marker in (
+            "GhostTheme.WINDOW",
+            "GhostTheme.PANEL",
+            "GhostTheme.LIST",
+            "GhostTheme.styleSpinner",
+            "GhostTheme.styleList",
+            "GhostTheme.spinnerAdapter",
+            "GhostTheme.listAdapter",
+            "screenWidthDp >= 700",
+            'connectionState.setText("TRANSFER ACTIVE")',
+            'connectionState.setText(secure ? "FTPS CONNECTED" : "FTP CONNECTED")',
+            'card("LOCAL"',
+            'card("SERVER"',
+            'card("TRANSFERS"',
+        ):
+            self.assertIn(marker, activity)
+        self.assertNotIn("Color.rgb(16, 19, 23)", activity)
+        self.assertNotIn("Color.rgb(94, 214, 200)", activity)
+        self.assertIn("RippleDrawable", theme)
+        self.assertIn("statusColor", theme)
+
+    def test_lists_support_navigation_and_long_press_management_selection(self) -> None:
+        activity = (JAVA / "MainActivity.java").read_text(encoding="utf-8")
+        self.assertIn("localList.setOnItemClickListener", activity)
+        self.assertIn("localList.setOnItemLongClickListener", activity)
+        self.assertIn("remoteList.setOnItemClickListener", activity)
+        self.assertIn("remoteList.setOnItemLongClickListener", activity)
+        self.assertIn("Selected local item for management", activity)
+        self.assertIn("Selected server item for management", activity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_android_file_management_contract.py
+++ b/scripts/test_android_file_management_contract.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+JAVA = ROOT / "android/app/src/main/java/app/ghostftp/client"
+
+
+class AndroidFileManagementContractTests(unittest.TestCase):
+    def read(self, name: str) -> str:
+        return (JAVA / name).read_text(encoding="utf-8")
+
+    def test_remote_mutations_have_explicit_commands_and_safe_names(self) -> None:
+        ftp = self.read("FtpSession.java")
+        for marker in (
+            "synchronized void makeDirectory(",
+            'mutationCommand("MKD " + sanitizeArgument(path)',
+            "synchronized void renameRemote(",
+            'mutationCommand("RNFR " + sanitizeArgument(source)',
+            'command("RNTO " + sanitizeArgument(target))',
+            "synchronized void deleteRemote(",
+            'String verb = directory ? "RMD " : "DELE ";',
+            "private static String requireLeafName(",
+            "name.indexOf('/') >= 0",
+            "name.indexOf('\\\\') >= 0",
+            '".".equals(name)',
+            '"..".equals(name)',
+        ):
+            self.assertIn(marker, ftp)
+        rename_start = ftp.index("synchronized void renameRemote(")
+        rename_end = ftp.index("synchronized void deleteRemote(", rename_start)
+        rename = ftp[rename_start:rename_end]
+        self.assertIn("hardClose();", rename)
+        self.assertIn("ambiguous rename state", rename)
+
+    def test_local_file_management_stays_inside_saf(self) -> None:
+        activity = self.read("MainActivity.java")
+        for marker in (
+            "private void createLocalFolder()",
+            "private void renameLocalSelected()",
+            "private void deleteLocalSelected()",
+            "DocumentsContract.Document.MIME_TYPE_DIR",
+            "DocumentsContract.createDocument",
+            "DocumentsContract.renameDocument",
+            "DocumentsContract.deleteDocument",
+            "queryDocumentDisplayName",
+            "ensureNoLocalNameConflict",
+            "commitLocalMutation",
+        ):
+            self.assertIn(marker, activity)
+        for forbidden in (
+            "MANAGE_EXTERNAL_STORAGE",
+            "Environment.getExternalStorage",
+            "java.io.File(",
+        ):
+            self.assertNotIn(forbidden, activity)
+
+    def test_remote_mutations_refresh_before_visible_commit(self) -> None:
+        activity = self.read("MainActivity.java")
+        for method, operation in (
+            ("createRemoteFolder", "current.makeDirectory(base, safe);"),
+            ("renameRemoteSelected", "current.renameRemote(source, safe);"),
+            ("deleteRemoteSelected", "current.deleteRemote(target, entry.directory);"),
+        ):
+            start = activity.index(f"private void {method}()")
+            next_method = activity.find("\n    private void ", start + 20)
+            block = activity[start: next_method if next_method > start else len(activity)]
+            self.assertIn(operation, block)
+            self.assertIn("List<RemoteEntry> fresh = current.list(base);", block)
+            self.assertLess(block.index(operation), block.index("List<RemoteEntry> fresh = current.list(base);"))
+        self.assertIn("private void commitRemoteMutation(", activity)
+        self.assertIn("session != current", activity)
+        self.assertIn("!currentRemotePath.equals(base)", activity)
+
+    def test_destructive_actions_require_confirmation_and_bookmarks_can_be_removed(self) -> None:
+        activity = self.read("MainActivity.java")
+        model = self.read("SiteProfile.java")
+        self.assertIn('confirm("Delete local item?"', activity)
+        self.assertIn('confirm("Delete server item?"', activity)
+        self.assertIn('confirm("Delete saved site?"', activity)
+        self.assertIn("private void removeLocalBookmark()", activity)
+        self.assertIn("private void removeRemoteBookmark()", activity)
+        self.assertIn("withoutLocalBookmark(index)", activity)
+        self.assertIn("withoutRemoteBookmark(index)", activity)
+        self.assertIn("SiteProfile withoutLocalBookmark(int index)", model)
+        self.assertIn("SiteProfile withoutRemoteBookmark(int index)", model)
+
+    def test_directory_selection_does_not_accidentally_transfer_directory_as_file(self) -> None:
+        activity = self.read("MainActivity.java")
+        upload_start = activity.index("private void uploadSelected()")
+        download_start = activity.index("private void downloadSelected()", upload_start)
+        upload = activity[upload_start:download_start]
+        next_method = activity.index("private TransferProgress transferProgress", download_start)
+        download = activity[download_start:next_method]
+        self.assertIn("if (entry.directory)", upload)
+        self.assertIn("Select a local file, not a directory, to upload.", upload)
+        self.assertIn("if (entry.directory)", download)
+        self.assertIn("Select a server file, not a directory, to download.", download)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the Android source line as a polished Ghost FTP mobile workspace while preserving the existing transport/security contracts.

### UI / UX

- Uses the canonical Ghost FTP desktop dark palette 1:1 (`#0B0F17`, `#121824`, `#161D2A`, `#2C3648`, `#F2F5FA`, `#97A3B8`, `#5B7CFA`, `#7A98FF`, `#4AD79B`, `#F2BA55`, `#FF6878`, `#202F50`).
- Adds runtime-owned dark widget styling through `GhostTheme` instead of isolated resource-only colors.
- Adds responsive cards and a phone/tablet workspace: Local + Server become equal-width panes at `screenWidthDp >= 700`.
- Adds connection/transfer status badge, clearer progress/status hierarchy, consistent primary/secondary/danger actions and dark list/spinner adapters.
- Normal tap opens a directory; long-press selects either a file or directory for management.

### File management

- Local SAF: create folder, rename, delete, exact-name verification and fresh directory snapshots.
- Remote FTP/FTPS: MKD, RNFR/RNTO rename, DELE/RMD delete, safe one-segment name validation and fresh MLSD refresh before visible commit.
- Destructive saved-site/local/remote deletes require confirmation.
- Local and remote bookmarks can be explicitly removed.
- Directories are blocked from file upload/download paths rather than being treated as files.

### Existing safety preserved

- Strict FTPS certificate/hostname verification remains active on control and protected data channels.
- Staged remote upload, staged SAF download, real-I/O progress, fail-closed passive data setup and active-transfer cancellation remain authoritative.
- Passwords remain memory-only; saved sites are non-secret metadata only.
- Android continues to use SAF and does not request broad/all-files storage permission.
- No telemetry, analytics, ads, hidden backend or new external runtime dependency.
- SFTP remains intentionally hidden until Android has strict host-key identity verification/pinning equivalent to desktop Ghost FTP.
- Public already-published desktop 0.0.3 release identity is not modified.

### CI / APK

- Android APK workflow now runs the complete `test_android*.py` contract suite before lint/build.
- Adds dedicated canonical dark UI and file-management regression contracts.
- Android development APK versionCode advances to 4.

Merge only after exact-head Android APK + full Ghost FTP CI are `completed/success`, followed by actual post-merge push verification on the resulting `main` SHA.