### PR TITLE
Android: add mobile navigation workspace and runtime-owned surfaces

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/android-apk.yml'
       - 'scripts/test_android_contract.py'
       - 'scripts/test_android_passive_data_contract.py'
+      - 'scripts/test_android_mobile_navigation_contract.py'
   push:
     branches: [main]
     paths:
@@ -15,6 +16,7 @@ on:
       - '.github/workflows/android-apk.yml'
       - 'scripts/test_android_contract.py'
       - 'scripts/test_android_passive_data_contract.py'
+      - 'scripts/test_android_mobile_navigation_contract.py'
   workflow_dispatch:
 
 permissions:
@@ -54,6 +56,7 @@ jobs:
           set -euo pipefail
           python scripts/test_android_contract.py
           python scripts/test_android_passive_data_contract.py
+          python scripts/test_android_mobile_navigation_contract.py
       - name: Lint and build APK
         working-directory: android
         shell: bash

--- a/android/README.md
+++ b/android/README.md
@@ -5,6 +5,10 @@ Native Android client source lives entirely under this `android/` directory.
 ## Current source capability
 
 - Native Android Java UI with no AndroidX/runtime SDK dependency.
+- Phone layout uses a real left navigation drawer; tablet layouts at sufficient width use the same destinations as a persistent sidebar.
+- The active Android destinations are **Files**, **Sites**, **Bookmarks**, **Transfers**, **Settings** and **About**. Only one workspace is active at a time instead of compressing the desktop UI into one long page.
+- Navigation icons are local Android vector drawables. The runtime UI does not use emoji icons, externally hosted fonts or tracking assets.
+- **Remote Desktop is intentionally not shown on Android** because there is not yet a reviewed Android RDP runtime owner. There is no decorative Coming Soon RDP destination.
 - FTP and explicit FTPS Quick Connect.
 - FTPS uses the platform trust store and strict hostname verification on both control and protected passive data channels. There is no trust-all fallback.
 - FTP remains available for compatibility but is explicitly unencrypted.
@@ -14,18 +18,31 @@ Native Android client source lives entirely under this `android/` directory.
 - Binary upload and download are implemented.
 - Uploads are staged under a random same-directory `.ghostftp-upload-<uuid>.part` name and are committed to the requested remote name only after the FTP server confirms transfer completion and accepts `RNFR`/`RNTO`.
 - Downloads are written to a temporary SAF `.ghostftp-download-<uuid>.part` document and receive the requested final local name only after the FTP transfer is confirmed complete and the storage provider accepts an exact-name commit.
-- An active upload/download can be cancelled from the existing connection action. While a transfer is cancellable, **Disconnect** becomes **Cancel transfer**.
+- An active upload/download can be cancelled from the connection action and from the **Transfers** surface while the transfer is still cancellable.
 - Cancellation and final-name commit are serialized by an explicit transfer commit gate. A cancel that wins before finalization prevents the final remote/local name from being committed; once irreversible finalization has atomically started, the UI changes to **Finalizing…** and no longer claims that cancellation is possible.
 - Cancelling during active data I/O hard-closes both the active data socket and FTP control socket and requires a fresh reconnect before any further server operation.
 - Host, username, protocol, port and the user-granted folder URI may be remembered. Passwords are memory-only and are cleared from the UI after connection.
+- The **Settings** surface only exposes options with a real runtime owner: non-secret Quick Connect metadata persistence and Files-list size display. Security rows are informational and cannot weaken runtime verification.
 - Explicit saved sites store only non-secret connection identity and navigation metadata; Quick Connect never creates a hidden site.
 - A saved site can own a local SAF start folder, a remote start directory, local SAF bookmarks and remote path bookmarks.
+- The **Bookmarks** surface exposes explicit add/remove/open actions for that state; it does not create hidden bookmarks.
 - Changing a saved site's protocol/host/port/username identity clears its remote start directory and remote bookmarks instead of silently carrying server paths to a different endpoint.
 - A saved remote start directory is freshly listed before the connection becomes visible as connected; a stale/unavailable start path fails with an actionable error instead of falling back silently.
 - Opening a remote bookmark performs a fresh server listing before the visible remote path is committed.
 - Local starts/bookmarks are usable only while their persisted SAF read permission still exists and the provider can return a fresh directory listing.
 - Site/bookmark persistence is bounded to 50 sites and 50 bookmarks of each type per site.
+- The **Transfers** surface shows only real transfer lifecycle state. It does not advertise retry/resume/history/queue controls that have no Android runtime owner.
 - No telemetry, analytics, ads, crash-reporting service or Ghost FTP backend is used.
+
+See [`UI-UX.md`](UI-UX.md) for the phone navigation drawer, tablet persistent sidebar and per-surface runtime ownership contract.
+
+## Android release status
+
+Android is an active post-release source-development platform, but it is **not part of the already published Ghost FTP 0.0.3 public release**. Ghost FTP 0.0.3 remains the historical Windows/Linux release and is not rewritten to include Android.
+
+The Android build currently produced by CI is a development/debug-signed APK. It is suitable for installation, runtime validation and authentic emulator screenshots, but it must not be described as a production-signed Android public release. A future public Android release requires a protected production signing key and a separate release contract.
+
+The root repository `VERSION` therefore remains unchanged until a dedicated future release-prep PR updates the next release identity.
 
 ## Upload commit safety
 
@@ -89,6 +106,20 @@ Remote navigation state is bound to `(protocol, host, port, username)`. If that 
 
 SFTP is intentionally not exposed in the Android source line yet. Ghost FTP desktop requires strict host-key verification/pinning; Android will not present an SFTP option until equivalent host-key identity verification is implemented and tested. There is no silent fallback from SFTP to FTP/FTPS.
 
+Informational UI may report that Android SFTP is hidden. The actual protocol picker remains restricted to `FTPS` and `FTP`; documentation text is not a runtime SFTP implementation.
+
+## Remote Desktop security boundary
+
+Remote Desktop is not shown in the Android navigation because there is no reviewed Android RDP runtime owner yet. Ghost FTP does not expose a fake RDP destination or Coming Soon control in the main Android navigation.
+
+If Android RDP is introduced later, its launcher/engine availability, credential handling and security contract must be implemented and reviewed before a navigation item is added.
+
+## Authentic Android screenshots
+
+Project documentation must use screenshots captured from the real built APK running in an Android emulator or physical runtime. Mockups, Figma compositions and generated marketing renders must not be presented as application screenshots.
+
+The screenshot evidence must be tied to a source/build SHA and should cover the real surfaces that exist: Files, Sites, Bookmarks, Transfers and Settings/About. RDP must not be named or captured unless Android has a real runtime RDP surface.
+
 ## Build
 
 The canonical CI build uses Gradle 8.9 and Android SDK 35:
@@ -106,6 +137,8 @@ android/dist/Ghost-FTP-Android.apk
 The GitHub Actions workflow uploads that exact file as the `ghostftp-android-apk` artifact. The APK is generated by the Android toolchain; a placeholder or renamed non-APK file is not accepted.
 
 The current Android version name is derived from the repository `VERSION` plus the development suffix because Android development is not retroactively added to an already published desktop release.
+
+The Android source, passive-data and mobile-navigation regression contracts run before lint/build in the APK workflow.
 
 ## Release signing
 

--- a/android/UI-UX.md
+++ b/android/UI-UX.md
@@ -1,0 +1,107 @@
+# Ghost FTP Android UI/UX contract
+
+Ghost FTP Android is a mobile client, not a compressed copy of the desktop window. The Android shell deliberately exposes one active work surface at a time while preserving the same security and privacy invariants as the desktop source line where the underlying protocol feature exists.
+
+## Navigation model
+
+### Phone
+
+Phones use a real left navigation drawer opened by the local hamburger vector icon. The drawer contains only runtime-owned surfaces:
+
+- **Files**
+- **Sites**
+- **Bookmarks**
+- **Transfers**
+- **Settings**
+- **About**
+
+Selecting a destination hides all other surfaces and commits exactly one active workspace. The Back action closes an open drawer before leaving the Activity.
+
+### Tablet
+
+When Android reports at least 700 dp of screen width, the same navigation model is rendered as a persistent left sidebar. The content remains a single active surface; the wider layout does not re-create the desktop application as one long page.
+
+The Files surface may place local and remote panes side-by-side only when there is enough width. On narrower layouts they stack inside the Files surface rather than mixing unrelated Sites, Bookmarks, Settings or About controls into the same scroll flow.
+
+## Surface ownership
+
+### Files
+
+Files owns the active local and server directory views.
+
+Local storage is restricted to Android Storage Access Framework capabilities granted by the user. The surface provides the local current path, folder picker, Up, Refresh, a real directory listing and local file selection.
+
+The server pane displays the active remote path, Up, Refresh and the freshly listed remote entries for the active FTP/FTPS session. Upload and download actions are enabled only for actual file selections. Directory transfer is not implied by file buttons.
+
+Staged upload/download, exact-name commit verification, FTPS verification and transfer-generation protections are protocol/runtime contracts and are not weakened by the UI split.
+
+### Sites
+
+Sites owns Quick Connect and explicitly saved connection profiles.
+
+Quick Connect exposes only Android protocols that have complete runtime security ownership: FTP and explicit FTPS. FTPS keeps strict certificate and hostname verification. FTP remains visibly unencrypted by its runtime status messaging.
+
+Passwords remain memory-only. Saving a site never persists a password. Quick Connect never creates a hidden profile.
+
+Saved site identity continues to bind remote navigation state to protocol, canonical host, port and exact username. Changing that identity clears remote start-directory/bookmark state rather than silently carrying it to another endpoint.
+
+### Bookmarks
+
+Bookmarks owns local SAF navigation bookmarks, local site start folders, remote bookmarks and remote site start directories.
+
+Local bookmarks are persisted SAF capability URIs. They must still have a persisted permission and produce a fresh directory query before the visible local state is changed.
+
+Remote bookmarks remain account-bound. Opening one performs a fresh server listing before the visible remote path is committed. Quick Connect does not create hidden bookmarks.
+
+The Android UI exposes explicit Add, Remove and Open actions. Bookmark records remain non-secret.
+
+### Transfers
+
+Transfers owns only real transfer state.
+
+It shows the current transfer status/progress produced by actual bytes read or written and exposes **Cancel active transfer** only while the transfer is in a cancellable phase. Once the irreversible final-name commit gate has started, the control changes to **Finalizing…** and cancellation is disabled.
+
+There is no decorative retry, resume, completed-history or queue control in this surface. Those controls must not appear until a real Android runtime implementation owns them.
+
+### Settings
+
+Settings exposes only controls with an actual Android runtime owner.
+
+Current interactive settings are:
+
+- whether non-secret Quick Connect endpoint metadata is remembered;
+- whether file sizes are shown in Files lists.
+
+Disabling endpoint persistence removes stored host, username, protocol and port metadata. It never affects the password rule because passwords are never persisted.
+
+Security rows are informational and cannot weaken TLS verification, storage confinement, transfer staging or privacy behavior.
+
+### About
+
+About presents the Ghost FTP product identity, Android package/build identity, currently implemented Android protocol status and privacy information.
+
+The repository root version remains `0.0.3` until a dedicated future release-prep change. The current Android APK is a post-0.0.3 development/debug-signed artifact and must not be represented as part of the already published Windows/Linux 0.0.3 release.
+
+## Remote Desktop / RDP
+
+**Remote Desktop is not shown in Android navigation.** There is currently no reviewed Android RDP runtime owner with the required credential and launcher/engine security contract. Ghost FTP does not expose a decorative RDP button, a fake Coming Soon destination or a control that has no working implementation behind it.
+
+If Android RDP is introduced later, it requires a separate architecture/security review and must prove the actual runtime client/engine, availability detection and password handling before the navigation item can exist.
+
+## SFTP status
+
+Android SFTP is also fail-closed. The protocol picker exposes only `FTPS` and `FTP`; it does not offer an SFTP connection route until Android has strict host-key identity verification/pinning equivalent to the desktop security contract.
+
+Documentation may state that SFTP is intentionally hidden. That informational text must never be confused with a runtime SFTP option.
+
+## Visual system
+
+Ghost FTP Android uses the project dark palette and local Android resources. Navigation uses local vector drawables for hamburger, Files, Sites, Bookmarks, Transfers, Settings and About.
+
+The runtime UI must not depend on emoji icons, externally hosted fonts, tracking resources or decorative controls that look actionable but have no owner.
+
+## Screenshot evidence
+
+Documentation screenshots must come from a real build of the Android Activity running in an emulator or physical Android runtime. Generated mockups, Figma compositions and marketing renders must not be labeled as application screenshots.
+
+The screenshot workflow must record the source/build SHA, verify PNG files and capture the real surfaces that exist: Files, Sites, Bookmarks, Transfers and Settings/About. RDP must not be captured or named unless it becomes a real Android runtime surface.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,6 +16,10 @@ android {
         versionName "${ghostFtpVersion}-dev"
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix '.debug'

--- a/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
+++ b/android/app/src/main/java/app/ghostftp/client/GhostTheme.java
@@ -1,0 +1,170 @@
+package app.ghostftp.client;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import java.util.List;
+
+final class GhostTheme {
+    static final int WINDOW = Color.rgb(0x0B, 0x0F, 0x17);
+    static final int PANEL = Color.rgb(0x12, 0x18, 0x24);
+    static final int LIST = Color.rgb(0x16, 0x1D, 0x2A);
+    static final int BORDER = Color.rgb(0x2C, 0x36, 0x48);
+    static final int TEXT = Color.rgb(0xF2, 0xF5, 0xFA);
+    static final int MUTED = Color.rgb(0x97, 0xA3, 0xB8);
+    static final int ACCENT = Color.rgb(0x5B, 0x7C, 0xFA);
+    static final int ACCENT_STRONG = Color.rgb(0x7A, 0x98, 0xFF);
+    static final int SUCCESS = Color.rgb(0x4A, 0xD7, 0x9B);
+    static final int WARN = Color.rgb(0xF2, 0xBA, 0x55);
+    static final int DANGER = Color.rgb(0xFF, 0x68, 0x78);
+    static final int SELECTION = Color.rgb(0x20, 0x2F, 0x50);
+
+    private GhostTheme() {
+    }
+
+    static void stylePrimaryButton(Button button) {
+        styleButton(button, ACCENT, TEXT, ACCENT_STRONG);
+    }
+
+    static void styleSecondaryButton(Button button) {
+        styleButton(button, LIST, TEXT, SELECTION);
+    }
+
+    static void styleDangerButton(Button button) {
+        styleButton(button, Color.rgb(0x3A, 0x1D, 0x27), DANGER, Color.rgb(0x51, 0x25, 0x31));
+    }
+
+    static void styleButton(Button button, int fill, int textColor, int rippleColor) {
+        button.setAllCaps(false);
+        button.setTextColor(textColor);
+        button.setTextSize(13f);
+        button.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        button.setGravity(Gravity.CENTER);
+        button.setMinHeight(dp(button.getContext(), 44));
+        button.setPadding(dp(button.getContext(), 10), 0, dp(button.getContext(), 10), 0);
+        button.setBackground(ripple(button.getContext(), fill, BORDER, rippleColor, 10));
+    }
+
+    static void styleField(EditText edit) {
+        edit.setTextColor(TEXT);
+        edit.setHintTextColor(MUTED);
+        edit.setTextSize(14f);
+        edit.setSingleLine(true);
+        edit.setMinHeight(dp(edit.getContext(), 48));
+        edit.setPadding(dp(edit.getContext(), 12), dp(edit.getContext(), 4), dp(edit.getContext(), 12), dp(edit.getContext(), 4));
+        edit.setBackground(rounded(edit.getContext(), LIST, BORDER, 10));
+    }
+
+    static void styleSpinner(Spinner spinner) {
+        spinner.setPadding(dp(spinner.getContext(), 8), dp(spinner.getContext(), 6), dp(spinner.getContext(), 8), dp(spinner.getContext(), 6));
+        spinner.setBackground(rounded(spinner.getContext(), LIST, BORDER, 10));
+        spinner.setPopupBackgroundDrawable(rounded(spinner.getContext(), PANEL, BORDER, 10));
+    }
+
+    static void styleList(ListView list) {
+        list.setBackground(rounded(list.getContext(), LIST, BORDER, 12));
+        list.setDividerHeight(0);
+        list.setPadding(dp(list.getContext(), 4), dp(list.getContext(), 4), dp(list.getContext(), 4), dp(list.getContext(), 4));
+        list.setClipToPadding(false);
+        list.setSelector(rounded(list.getContext(), SELECTION, ACCENT, 8));
+    }
+
+    static void styleBadge(TextView view, int color) {
+        view.setTextColor(color);
+        view.setTextSize(11f);
+        view.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        view.setGravity(Gravity.CENTER);
+        view.setPadding(dp(view.getContext(), 10), dp(view.getContext(), 6), dp(view.getContext(), 10), dp(view.getContext(), 6));
+        view.setBackground(rounded(view.getContext(), SELECTION, color, 999));
+    }
+
+    static ArrayAdapter<String> spinnerAdapter(Context context, List<String> values) {
+        return new GhostArrayAdapter(context, values, true);
+    }
+
+    static ArrayAdapter<String> listAdapter(Context context, List<String> values) {
+        return new GhostArrayAdapter(context, values, false);
+    }
+
+    static GradientDrawable rounded(Context context, int fill, int stroke, int radiusDp) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(fill);
+        drawable.setCornerRadius(dp(context, radiusDp));
+        drawable.setStroke(dp(context, 1), stroke);
+        return drawable;
+    }
+
+    static int statusColor(String status) {
+        String value = status == null ? "" : status.toLowerCase(java.util.Locale.ROOT);
+        if (value.contains("failed") || value.contains("error") || value.contains("rejected")
+                || value.contains("unavailable") || value.contains("lost") || value.contains("cancelled")) {
+            return DANGER;
+        }
+        if (value.contains("warning") || value.contains("unencrypted") || value.contains("stale")
+                || value.contains("reconnect") || value.contains("session only")) {
+            return WARN;
+        }
+        if (value.contains("completed") || value.contains("connected") || value.contains("saved")
+                || value.contains("updated") || value.contains("added") || value.contains("opened")
+                || value.contains("created") || value.contains("renamed") || value.contains("deleted")) {
+            return SUCCESS;
+        }
+        return MUTED;
+    }
+
+    static int dp(Context context, int value) {
+        return Math.round(value * context.getResources().getDisplayMetrics().density);
+    }
+
+    private static RippleDrawable ripple(Context context, int fill, int stroke, int rippleColor, int radiusDp) {
+        GradientDrawable content = rounded(context, fill, stroke, radiusDp);
+        return new RippleDrawable(ColorStateList.valueOf(rippleColor), content, null);
+    }
+
+    private static final class GhostArrayAdapter extends ArrayAdapter<String> {
+        private final Context context;
+        private final boolean spinner;
+
+        GhostArrayAdapter(Context context, List<String> values, boolean spinner) {
+            super(context, spinner ? android.R.layout.simple_spinner_item : android.R.layout.simple_list_item_1, values);
+            this.context = context;
+            this.spinner = spinner;
+            if (spinner) setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            return style(super.getView(position, convertView, parent), false);
+        }
+
+        @Override
+        public View getDropDownView(int position, View convertView, ViewGroup parent) {
+            return style(super.getDropDownView(position, convertView, parent), true);
+        }
+
+        private View style(View view, boolean dropDown) {
+            if (!(view instanceof TextView)) return view;
+            TextView text = (TextView) view;
+            text.setTextColor(TEXT);
+            text.setTextSize(spinner ? 14f : 13.5f);
+            text.setGravity(Gravity.CENTER_VERTICAL);
+            text.setMinHeight(dp(context, spinner ? 46 : 42));
+            text.setPadding(dp(context, 12), dp(context, 7), dp(context, 12), dp(context, 7));
+            text.setBackgroundColor(dropDown ? PANEL : Color.TRANSPARENT);
+            return text;
+        }
+    }
+}

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -5,16 +5,22 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.UriPermission;
+import android.content.res.ColorStateList;
 import android.database.Cursor;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.DocumentsContract;
 import android.text.InputType;
+import android.view.Gravity;
+import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ScrollView;
@@ -36,12 +42,23 @@ import java.util.concurrent.Executors;
 public final class MainActivity extends Activity {
     private static final int REQUEST_TREE = 1001;
     private static final String PREFS = "ghostftp_android";
+    private static final int TABLET_SIDEBAR_MIN_DP = 700;
+
+    private enum Section {
+        FILES,
+        SITES,
+        BOOKMARKS,
+        TRANSFERS,
+        SETTINGS,
+        ABOUT
+    }
 
     private final ExecutorService io = Executors.newSingleThreadExecutor();
     private final List<LocalEntry> localEntries = new ArrayList<>();
     private final List<RemoteEntry> remoteEntries = new ArrayList<>();
     private final Deque<String> localParents = new ArrayDeque<>();
     private final List<SiteProfile> profiles = new ArrayList<>();
+    private final List<Button> navigationButtons = new ArrayList<>();
 
     private Spinner siteSpinner;
     private Spinner protocol;
@@ -54,7 +71,12 @@ public final class MainActivity extends Activity {
     private EditText password;
     private TextView localPath;
     private TextView remotePath;
+    private TextView bookmarkLocalCurrent;
+    private TextView bookmarkRemoteCurrent;
     private TextView status;
+    private TextView transferStatus;
+    private TextView sectionTitle;
+    private TextView connectionBadge;
     private ListView localList;
     private ListView remoteList;
     private Button connect;
@@ -65,10 +87,28 @@ public final class MainActivity extends Activity {
     private Button deleteSite;
     private Button localSetStart;
     private Button localAddBookmark;
+    private Button localRemoveBookmark;
     private Button localOpenBookmark;
     private Button remoteSetStart;
     private Button remoteAddBookmark;
+    private Button remoteRemoveBookmark;
     private Button remoteOpenBookmark;
+    private Button transferCancel;
+    private CheckBox rememberEndpointToggle;
+    private CheckBox showFileSizesToggle;
+
+    private FrameLayout contentHost;
+    private LinearLayout navigationPanel;
+    private View drawerScrim;
+    private ImageButton menuToggle;
+    private View filesSurface;
+    private View sitesSurface;
+    private View bookmarksSurface;
+    private View transfersSurface;
+    private View settingsSurface;
+    private View aboutSurface;
+    private boolean tabletLayout;
+    private Section activeSection = Section.FILES;
 
     private SiteProfileStore profileStore;
     private String activeProfileId;
@@ -81,6 +121,8 @@ public final class MainActivity extends Activity {
     private int selectedRemote = -1;
     private FtpSession session;
     private boolean busy;
+    private boolean rememberEndpoint = true;
+    private boolean showFileSizes = true;
     private volatile boolean transferActive;
     private volatile boolean transferFinalizing;
     private volatile long transferGeneration;
@@ -96,7 +138,10 @@ public final class MainActivity extends Activity {
         restorePreferences();
         renderSites();
         renderBookmarks();
+        renderLocal();
+        renderRemote();
         refreshButtons();
+        showSection(Section.FILES);
     }
 
     @Override
@@ -123,138 +168,471 @@ public final class MainActivity extends Activity {
         super.onDestroy();
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onBackPressed() {
+        if (!tabletLayout && navigationPanel != null && navigationPanel.getVisibility() == View.VISIBLE) {
+            closeNavigationDrawer();
+            return;
+        }
+        super.onBackPressed();
+    }
+
     private void buildUi() {
-        LinearLayout root = new LinearLayout(this);
-        root.setOrientation(LinearLayout.VERTICAL);
-        int pad = dp(14);
-        root.setPadding(pad, pad, pad, pad);
-        root.setBackgroundColor(Color.rgb(16, 19, 23));
-        root.addView(label("GHOST FTP · ANDROID", 22, Color.WHITE));
-        root.addView(label("Private FTP/FTPS client · no telemetry · passwords are never saved", 13, Color.LTGRAY));
+        tabletLayout = getResources().getConfiguration().screenWidthDp >= TABLET_SIDEBAR_MIN_DP;
 
-        root.addView(section("SAVED SITES"));
-        siteSpinner = new Spinner(this);
-        root.addView(siteSpinner, matchWrap());
-        profileName = field("Site name", false);
-        root.addView(profileName, matchWrap());
-        LinearLayout siteActions = row();
-        Button loadSite = button("Load");
-        saveSite = button("Save / update");
-        deleteSite = button("Delete");
-        siteActions.addView(loadSite, weighted());
-        siteActions.addView(saveSite, weighted());
-        siteActions.addView(deleteSite, weighted());
-        root.addView(siteActions, matchWrap());
-        loadSite.setOnClickListener(v -> loadSelectedSite());
-        saveSite.setOnClickListener(v -> saveOrUpdateSite());
-        deleteSite.setOnClickListener(v -> deleteActiveSite());
+        FrameLayout shell = new FrameLayout(this);
+        shell.setBackgroundColor(GhostTheme.WINDOW);
 
-        root.addView(section("QUICK CONNECT / SITE CONNECTION"));
+        if (tabletLayout) {
+            LinearLayout body = new LinearLayout(this);
+            body.setOrientation(LinearLayout.HORIZONTAL);
+            body.setBackgroundColor(GhostTheme.WINDOW);
+            navigationPanel = buildNavigationPanel();
+            body.addView(navigationPanel, new LinearLayout.LayoutParams(dp(236), ViewGroup.LayoutParams.MATCH_PARENT));
+            body.addView(buildMainColumn(), new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
+            shell.addView(body, new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        } else {
+            shell.addView(buildMainColumn(), new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+            drawerScrim = new View(this);
+            drawerScrim.setBackgroundColor(0x99000000);
+            drawerScrim.setVisibility(View.GONE);
+            drawerScrim.setOnClickListener(v -> closeNavigationDrawer());
+            shell.addView(drawerScrim, new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+            navigationPanel = buildNavigationPanel();
+            navigationPanel.setVisibility(View.GONE);
+            FrameLayout.LayoutParams drawerParams = new FrameLayout.LayoutParams(dp(286), ViewGroup.LayoutParams.MATCH_PARENT);
+            drawerParams.gravity = Gravity.START;
+            shell.addView(navigationPanel, drawerParams);
+        }
+
+        setContentView(shell);
+    }
+
+    private LinearLayout buildMainColumn() {
+        LinearLayout main = new LinearLayout(this);
+        main.setOrientation(LinearLayout.VERTICAL);
+        main.setBackgroundColor(GhostTheme.WINDOW);
+
+        LinearLayout appBar = new LinearLayout(this);
+        appBar.setOrientation(LinearLayout.HORIZONTAL);
+        appBar.setGravity(Gravity.CENTER_VERTICAL);
+        appBar.setPadding(dp(12), dp(10), dp(12), dp(10));
+        appBar.setBackgroundColor(GhostTheme.PANEL);
+
+        menuToggle = new ImageButton(this);
+        menuToggle.setImageResource(R.drawable.ic_menu);
+        menuToggle.setImageTintList(ColorStateList.valueOf(GhostTheme.TEXT));
+        menuToggle.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 10));
+        menuToggle.setContentDescription("Open navigation");
+        menuToggle.setPadding(dp(10), dp(10), dp(10), dp(10));
+        menuToggle.setOnClickListener(v -> openNavigationDrawer());
+        menuToggle.setVisibility(tabletLayout ? View.GONE : View.VISIBLE);
+        appBar.addView(menuToggle, new LinearLayout.LayoutParams(dp(44), dp(44)));
+
+        LinearLayout titleStack = new LinearLayout(this);
+        titleStack.setOrientation(LinearLayout.VERTICAL);
+        titleStack.setPadding(dp(12), 0, dp(8), 0);
+        TextView brand = label("GHOST FTP", 16, GhostTheme.TEXT);
+        brand.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        sectionTitle = label("Files", 12, GhostTheme.MUTED);
+        titleStack.addView(brand, matchWrap());
+        titleStack.addView(sectionTitle, matchWrap());
+        appBar.addView(titleStack, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+
+        connectionBadge = label("DISCONNECTED", 10, GhostTheme.MUTED);
+        GhostTheme.styleBadge(connectionBadge, GhostTheme.MUTED);
+        appBar.addView(connectionBadge, wrapWrap());
+        main.addView(appBar, matchWrap());
+
+        status = label("Ready.", 12, GhostTheme.MUTED);
+        status.setPadding(dp(14), dp(9), dp(14), dp(9));
+        status.setBackgroundColor(GhostTheme.WINDOW);
+        main.addView(status, matchWrap());
+
+        contentHost = new FrameLayout(this);
+        contentHost.setBackgroundColor(GhostTheme.WINDOW);
+        main.addView(contentHost, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+
+        filesSurface = buildFilesSurface();
+        sitesSurface = buildSitesSurface();
+        bookmarksSurface = buildBookmarksSurface();
+        transfersSurface = buildTransfersSurface();
+        settingsSurface = buildSettingsSurface();
+        aboutSurface = buildAboutSurface();
+        addSurface(filesSurface);
+        addSurface(sitesSurface);
+        addSurface(bookmarksSurface);
+        addSurface(transfersSurface);
+        addSurface(settingsSurface);
+        addSurface(aboutSurface);
+        return main;
+    }
+
+    private LinearLayout buildNavigationPanel() {
+        LinearLayout navigation = new LinearLayout(this);
+        navigation.setOrientation(LinearLayout.VERTICAL);
+        navigation.setPadding(dp(12), dp(18), dp(12), dp(18));
+        navigation.setBackgroundColor(GhostTheme.PANEL);
+
+        TextView product = label("Ghost FTP", 20, GhostTheme.TEXT);
+        product.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        navigation.addView(product, matchWrap());
+        TextView platform = label("Android development client", 11, GhostTheme.MUTED);
+        platform.setPadding(0, dp(2), 0, dp(18));
+        navigation.addView(platform, matchWrap());
+
+        navigation.addView(navButton("Files", R.drawable.ic_files, Section.FILES), navParams());
+        navigation.addView(navButton("Sites", R.drawable.ic_sites, Section.SITES), navParams());
+        navigation.addView(navButton("Bookmarks", R.drawable.ic_bookmarks, Section.BOOKMARKS), navParams());
+        navigation.addView(navButton("Transfers", R.drawable.ic_transfers, Section.TRANSFERS), navParams());
+        navigation.addView(navButton("Settings", R.drawable.ic_settings, Section.SETTINGS), navParams());
+        navigation.addView(navButton("About", R.drawable.ic_about, Section.ABOUT), navParams());
+
+        TextView privacy = label("No telemetry · no ads · no Ghost FTP cloud", 10, GhostTheme.MUTED);
+        privacy.setPadding(dp(4), dp(18), dp(4), 0);
+        navigation.addView(privacy, matchWrap());
+        return navigation;
+    }
+
+    private Button navButton(String text, int iconRes, Section section) {
+        Button button = new Button(this);
+        button.setText(text);
+        button.setAllCaps(false);
+        button.setGravity(Gravity.START | Gravity.CENTER_VERTICAL);
+        button.setCompoundDrawablesWithIntrinsicBounds(iconRes, 0, 0, 0);
+        button.setCompoundDrawablePadding(dp(12));
+        button.setCompoundDrawableTintList(ColorStateList.valueOf(GhostTheme.MUTED));
+        button.setTag(section);
+        button.setOnClickListener(v -> showSection((Section) v.getTag()));
+        navigationButtons.add(button);
+        styleNavigationButton(button, false);
+        return button;
+    }
+
+    private View buildFilesSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("Files", "Local SAF storage and the active FTP/FTPS server. Only this workspace owns file selection and transfer actions."));
+
+        LinearLayout panes = new LinearLayout(this);
+        boolean wideFiles = getResources().getConfiguration().screenWidthDp >= 900;
+        panes.setOrientation(wideFiles ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
+        LinearLayout localPane = buildLocalFilesCard();
+        LinearLayout remotePane = buildRemoteFilesCard();
+        if (wideFiles) {
+            panes.addView(localPane, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            LinearLayout.LayoutParams remoteParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+            remoteParams.setMargins(dp(10), 0, 0, 0);
+            panes.addView(remotePane, remoteParams);
+        } else {
+            panes.addView(localPane, cardParams());
+            panes.addView(remotePane, cardParams());
+        }
+        content.addView(panes, matchWrap());
+
+        LinearLayout transferCard = card("TRANSFER", "Transfer only the selected file. Staged upload/download and cancellation safety remain authoritative.");
+        LinearLayout actions = row();
+        upload = primaryButton("Upload →");
+        download = primaryButton("← Download");
+        actions.addView(upload, weightedSpaced());
+        actions.addView(download, weightedSpaced());
+        transferCard.addView(actions, matchWrap());
+        upload.setOnClickListener(v -> uploadSelected());
+        download.setOnClickListener(v -> downloadSelected());
+        content.addView(transferCard, cardParams());
+        return scrollSurface(content);
+    }
+
+    private LinearLayout buildLocalFilesCard() {
+        LinearLayout card = card("LOCAL", "Android Storage Access Framework only; Ghost FTP never requests broad all-files access.");
+        localPath = pathLabel("No folder selected");
+        card.addView(localPath, matchWrapSpaced());
+        LinearLayout actions = row();
+        Button choose = button("Choose folder");
+        Button up = button("Up");
+        Button refresh = button("Refresh");
+        actions.addView(choose, weightedSpaced());
+        actions.addView(up, weightedSpaced());
+        actions.addView(refresh, weightedSpaced());
+        card.addView(actions, matchWrap());
+        choose.setOnClickListener(v -> chooseFolder());
+        up.setOnClickListener(v -> localUp());
+        refresh.setOnClickListener(v -> refreshLocal());
+        localList = new ListView(this);
+        GhostTheme.styleList(localList);
+        card.addView(localList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(280)));
+        localList.setOnItemClickListener((parent, view, position, id) -> selectLocal(position));
+        return card;
+    }
+
+    private LinearLayout buildRemoteFilesCard() {
+        LinearLayout card = card("SERVER", "Fresh MLSD listings over the active FTP/FTPS session; FTPS keeps strict TLS and hostname verification.");
+        remotePath = pathLabel(currentRemotePath);
+        card.addView(remotePath, matchWrapSpaced());
+        LinearLayout actions = row();
+        Button up = button("Up");
+        Button refresh = button("Refresh");
+        actions.addView(up, weightedSpaced());
+        actions.addView(refresh, weightedSpaced());
+        card.addView(actions, matchWrap());
+        up.setOnClickListener(v -> remoteUp());
+        refresh.setOnClickListener(v -> refreshRemote(currentRemotePath));
+        remoteList = new ListView(this);
+        GhostTheme.styleList(remoteList);
+        card.addView(remoteList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(280)));
+        remoteList.setOnItemClickListener((parent, view, position, id) -> selectRemote(position));
+        return card;
+    }
+
+    private View buildSitesSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("Sites", "Quick Connect stays transient. Saved sites contain non-secret connection and navigation metadata only."));
+
+        LinearLayout connectionCard = card("QUICK CONNECT / CONNECTION", "Password is memory-only. Android currently exposes FTP and strict explicit FTPS; SFTP stays hidden until strict host-key verification exists.");
         protocol = new Spinner(this);
-        protocol.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, new String[]{"FTPS", "FTP"}));
-        root.addView(protocol, matchWrap());
+        GhostTheme.styleSpinner(protocol);
+        protocol.setAdapter(GhostTheme.spinnerAdapter(this, java.util.Arrays.asList(new String[]{"FTPS", "FTP"})));
+        connectionCard.addView(protocol, matchWrapSpaced());
         host = field("Server host", false);
         port = field("Port", false);
         port.setInputType(InputType.TYPE_CLASS_NUMBER);
         username = field("Username", false);
         password = field("Password (memory only)", true);
-        root.addView(host, matchWrap());
-        root.addView(port, matchWrap());
-        root.addView(username, matchWrap());
-        root.addView(password, matchWrap());
-
-        LinearLayout connection = row();
-        connect = button("Connect");
-        disconnect = button("Disconnect");
-        connection.addView(connect, weighted());
-        connection.addView(disconnect, weighted());
-        root.addView(connection, matchWrap());
+        connectionCard.addView(host, matchWrapSpaced());
+        LinearLayout credentials = row();
+        credentials.addView(port, fixedWidthSpaced(96));
+        credentials.addView(username, weightedSpaced());
+        connectionCard.addView(credentials, matchWrap());
+        connectionCard.addView(password, matchWrapSpaced());
+        LinearLayout connectionActions = row();
+        connect = primaryButton("Connect");
+        disconnect = dangerButton("Disconnect");
+        connectionActions.addView(connect, weightedSpaced());
+        connectionActions.addView(disconnect, weightedSpaced());
+        connectionCard.addView(connectionActions, matchWrap());
         connect.setOnClickListener(v -> connect());
         disconnect.setOnClickListener(v -> disconnect());
+        content.addView(connectionCard, cardParams());
 
-        root.addView(section("LOCAL STORAGE"));
-        localPath = label("No folder selected", 14, Color.LTGRAY);
-        root.addView(localPath);
+        LinearLayout savedCard = card("SAVED SITES", "Load, create, update or delete an explicit saved site. Quick Connect never creates hidden profiles.");
+        siteSpinner = new Spinner(this);
+        GhostTheme.styleSpinner(siteSpinner);
+        savedCard.addView(siteSpinner, matchWrapSpaced());
+        profileName = field("Site name", false);
+        savedCard.addView(profileName, matchWrapSpaced());
+        LinearLayout actions = row();
+        Button load = button("Load");
+        saveSite = primaryButton("Save / update");
+        deleteSite = dangerButton("Delete");
+        actions.addView(load, weightedSpaced());
+        actions.addView(saveSite, weightedSpaced());
+        actions.addView(deleteSite, weightedSpaced());
+        savedCard.addView(actions, matchWrap());
+        load.setOnClickListener(v -> loadSelectedSite());
+        saveSite.setOnClickListener(v -> saveOrUpdateSite());
+        deleteSite.setOnClickListener(v -> deleteActiveSite());
+        content.addView(savedCard, cardParams());
+        return scrollSurface(content);
+    }
+
+    private View buildBookmarksSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("Bookmarks", "Navigation state is explicit and account-bound. Quick Connect does not create hidden bookmarks."));
+
+        LinearLayout localCard = card("LOCAL SAF BOOKMARKS", "Local starts/bookmarks are SAF capability URIs and are freshly revalidated before navigation.");
+        bookmarkLocalCurrent = pathLabel("No folder selected");
+        localCard.addView(bookmarkLocalCurrent, matchWrapSpaced());
         LinearLayout localActions = row();
-        Button choose = button("Choose folder");
-        Button localUp = button("Up");
-        localActions.addView(choose, weighted());
-        localActions.addView(localUp, weighted());
-        root.addView(localActions, matchWrap());
-        choose.setOnClickListener(v -> chooseFolder());
-        localUp.setOnClickListener(v -> localUp());
-
-        LinearLayout localProfileActions = row();
-        localSetStart = button("Set site start");
-        localAddBookmark = button("Add bookmark");
-        localProfileActions.addView(localSetStart, weighted());
-        localProfileActions.addView(localAddBookmark, weighted());
-        root.addView(localProfileActions, matchWrap());
+        localSetStart = button("Set start");
+        localAddBookmark = primaryButton("Add");
+        localRemoveBookmark = dangerButton("Remove");
+        localActions.addView(localSetStart, weightedSpaced());
+        localActions.addView(localAddBookmark, weightedSpaced());
+        localActions.addView(localRemoveBookmark, weightedSpaced());
+        localCard.addView(localActions, matchWrap());
         localSetStart.setOnClickListener(v -> setLocalStart());
         localAddBookmark.setOnClickListener(v -> addLocalBookmark());
+        localRemoveBookmark.setOnClickListener(v -> removeLocalBookmark());
         localBookmarkSpinner = new Spinner(this);
-        root.addView(localBookmarkSpinner, matchWrap());
+        GhostTheme.styleSpinner(localBookmarkSpinner);
+        localCard.addView(localBookmarkSpinner, matchWrapSpaced());
         localOpenBookmark = button("Open local bookmark");
-        root.addView(localOpenBookmark, matchWrap());
+        localCard.addView(localOpenBookmark, matchWrapSpaced());
         localOpenBookmark.setOnClickListener(v -> openLocalBookmark());
+        content.addView(localCard, cardParams());
 
-        localList = new ListView(this);
-        root.addView(localList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(220)));
-        localList.setOnItemClickListener((parent, view, position, id) -> selectLocal(position));
-
-        root.addView(section("SERVER"));
-        remotePath = label(currentRemotePath, 14, Color.LTGRAY);
-        root.addView(remotePath);
+        LinearLayout remoteCard = card("SERVER BOOKMARKS", "Remote paths are bound to protocol, canonical host, port and exact username, and are freshly listed before visible commit.");
+        bookmarkRemoteCurrent = pathLabel(currentRemotePath);
+        remoteCard.addView(bookmarkRemoteCurrent, matchWrapSpaced());
         LinearLayout remoteActions = row();
-        Button remoteRefresh = button("Refresh");
-        Button remoteUp = button("Up");
-        remoteActions.addView(remoteRefresh, weighted());
-        remoteActions.addView(remoteUp, weighted());
-        root.addView(remoteActions, matchWrap());
-        remoteRefresh.setOnClickListener(v -> refreshRemote(currentRemotePath));
-        remoteUp.setOnClickListener(v -> remoteUp());
-
-        LinearLayout remoteProfileActions = row();
-        remoteSetStart = button("Set site start");
-        remoteAddBookmark = button("Add bookmark");
-        remoteProfileActions.addView(remoteSetStart, weighted());
-        remoteProfileActions.addView(remoteAddBookmark, weighted());
-        root.addView(remoteProfileActions, matchWrap());
+        remoteSetStart = button("Set start");
+        remoteAddBookmark = primaryButton("Add");
+        remoteRemoveBookmark = dangerButton("Remove");
+        remoteActions.addView(remoteSetStart, weightedSpaced());
+        remoteActions.addView(remoteAddBookmark, weightedSpaced());
+        remoteActions.addView(remoteRemoveBookmark, weightedSpaced());
+        remoteCard.addView(remoteActions, matchWrap());
         remoteSetStart.setOnClickListener(v -> setRemoteStart());
         remoteAddBookmark.setOnClickListener(v -> addRemoteBookmark());
+        remoteRemoveBookmark.setOnClickListener(v -> removeRemoteBookmark());
         remoteBookmarkSpinner = new Spinner(this);
-        root.addView(remoteBookmarkSpinner, matchWrap());
+        GhostTheme.styleSpinner(remoteBookmarkSpinner);
+        remoteCard.addView(remoteBookmarkSpinner, matchWrapSpaced());
         remoteOpenBookmark = button("Open server bookmark");
-        root.addView(remoteOpenBookmark, matchWrap());
+        remoteCard.addView(remoteOpenBookmark, matchWrapSpaced());
         remoteOpenBookmark.setOnClickListener(v -> openRemoteBookmark());
+        content.addView(remoteCard, cardParams());
+        return scrollSurface(content);
+    }
 
-        remoteList = new ListView(this);
-        root.addView(remoteList, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(220)));
-        remoteList.setOnItemClickListener((parent, view, position, id) -> selectRemote(position));
+    private View buildTransfersSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("Transfers", "This surface shows the real active transfer lifecycle. No decorative queue or fake history is displayed."));
+        LinearLayout card = card("ACTIVE TRANSFER", "Progress comes from actual bytes read/written. Cancellation is available only before the irreversible final-name commit gate.");
+        transferStatus = label("No active transfer.", 14, GhostTheme.MUTED);
+        transferStatus.setPadding(dp(10), dp(12), dp(10), dp(12));
+        transferStatus.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 10));
+        card.addView(transferStatus, matchWrapSpaced());
+        transferCancel = dangerButton("Cancel active transfer");
+        transferCancel.setOnClickListener(v -> cancelTransfer());
+        card.addView(transferCancel, matchWrapSpaced());
+        Button openFiles = button("Open Files");
+        openFiles.setOnClickListener(v -> showSection(Section.FILES));
+        card.addView(openFiles, matchWrapSpaced());
+        content.addView(card, cardParams());
+        return scrollSurface(content);
+    }
 
-        LinearLayout transfers = row();
-        upload = button("Upload →");
-        download = button("← Download");
-        transfers.addView(upload, weighted());
-        transfers.addView(download, weighted());
-        root.addView(transfers, matchWrap());
-        upload.setOnClickListener(v -> uploadSelected());
-        download.setOnClickListener(v -> downloadSelected());
+    private View buildSettingsSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("Settings", "Only settings with a real Android runtime owner are interactive."));
+        LinearLayout uiCard = card("UI / LOCAL PREFERENCES", "Ghost FTP Android uses the canonical dark brand palette. These options change actual local runtime behavior.");
+        rememberEndpointToggle = checkBox("Remember Quick Connect host, username, protocol and port");
+        rememberEndpointToggle.setOnClickListener(v -> {
+            rememberEndpoint = rememberEndpointToggle.isChecked();
+            savePreferences();
+            setStatus(rememberEndpoint
+                    ? "Quick Connect metadata will be remembered. Passwords remain memory-only."
+                    : "Quick Connect metadata persistence disabled and stored endpoint metadata cleared.");
+        });
+        uiCard.addView(rememberEndpointToggle, matchWrapSpaced());
+        showFileSizesToggle = checkBox("Show file sizes in Files lists");
+        showFileSizesToggle.setOnClickListener(v -> {
+            showFileSizes = showFileSizesToggle.isChecked();
+            savePreferences();
+            renderLocal();
+            renderRemote();
+            setStatus(showFileSizes ? "File sizes are visible." : "File sizes are hidden from list rows.");
+        });
+        uiCard.addView(showFileSizesToggle, matchWrapSpaced());
+        content.addView(uiCard, cardParams());
 
-        status = label("Ready.", 13, Color.LTGRAY);
-        root.addView(status);
-        ScrollView scroll = new ScrollView(this);
-        scroll.addView(root);
-        setContentView(scroll);
+        LinearLayout securityCard = card("SECURITY", "Runtime security policy is informational here and cannot be weakened from the UI.");
+        securityCard.addView(infoLine("FTPS", "Platform trust store + strict hostname verification"), matchWrapSpaced());
+        securityCard.addView(infoLine("Passwords", "Memory-only; never stored in site JSON/preferences"), matchWrapSpaced());
+        securityCard.addView(infoLine("Local storage", "Android SAF grants only; no all-files permission"), matchWrapSpaced());
+        securityCard.addView(infoLine("SFTP", "Hidden until strict Android host-key identity verification exists"), matchWrapSpaced());
+        securityCard.addView(infoLine("Privacy", "No telemetry, analytics, ads, fingerprinting or Ghost FTP cloud"), matchWrapSpaced());
+        content.addView(securityCard, cardParams());
+        return scrollSurface(content);
+    }
+
+    private View buildAboutSurface() {
+        LinearLayout content = surfaceContent();
+        content.addView(surfaceHeading("About", "Build identity and privacy/security status for this Android development client."));
+        LinearLayout card = card("GHOST FTP", "Private file transfer client for direct connections to servers you control.");
+        card.addView(infoLine("Version", BuildConfig.VERSION_NAME), matchWrapSpaced());
+        card.addView(infoLine("Package", BuildConfig.APPLICATION_ID), matchWrapSpaced());
+        card.addView(infoLine("Protocols", "FTP + strict explicit FTPS on Android source line"), matchWrapSpaced());
+        card.addView(infoLine("Public release", "0.0.3 remains the published Windows/Linux release; this APK is development source output"), matchWrapSpaced());
+        card.addView(infoLine("Data collection", "None: no telemetry, analytics, ads or hidden backend"), matchWrapSpaced());
+        content.addView(card, cardParams());
+        return scrollSurface(content);
+    }
+
+    private void addSurface(View surface) {
+        surface.setVisibility(View.GONE);
+        contentHost.addView(surface, new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    private void showSection(Section section) {
+        activeSection = section;
+        filesSurface.setVisibility(section == Section.FILES ? View.VISIBLE : View.GONE);
+        sitesSurface.setVisibility(section == Section.SITES ? View.VISIBLE : View.GONE);
+        bookmarksSurface.setVisibility(section == Section.BOOKMARKS ? View.VISIBLE : View.GONE);
+        transfersSurface.setVisibility(section == Section.TRANSFERS ? View.VISIBLE : View.GONE);
+        settingsSurface.setVisibility(section == Section.SETTINGS ? View.VISIBLE : View.GONE);
+        aboutSurface.setVisibility(section == Section.ABOUT ? View.VISIBLE : View.GONE);
+        sectionTitle.setText(sectionTitle(section));
+        refreshNavigationSelection();
+        if (!tabletLayout) closeNavigationDrawer();
+        refreshButtons();
+    }
+
+    private String sectionTitle(Section section) {
+        switch (section) {
+            case SITES:
+                return "Sites / Connections";
+            case BOOKMARKS:
+                return "Bookmarks";
+            case TRANSFERS:
+                return "Transfers";
+            case SETTINGS:
+                return "Settings";
+            case ABOUT:
+                return "About";
+            case FILES:
+            default:
+                return "Files";
+        }
+    }
+
+    private void refreshNavigationSelection() {
+        for (Button button : navigationButtons) {
+            Object tag = button.getTag();
+            styleNavigationButton(button, tag == activeSection);
+        }
+    }
+
+    private void styleNavigationButton(Button button, boolean active) {
+        button.setTextColor(active ? GhostTheme.TEXT : GhostTheme.MUTED);
+        button.setCompoundDrawableTintList(ColorStateList.valueOf(active ? GhostTheme.ACCENT_STRONG : GhostTheme.MUTED));
+        button.setBackground(GhostTheme.rounded(this, active ? GhostTheme.SELECTION : GhostTheme.PANEL,
+                active ? GhostTheme.ACCENT : GhostTheme.PANEL, 10));
+        button.setMinHeight(dp(48));
+        button.setPadding(dp(12), 0, dp(12), 0);
+    }
+
+    private void openNavigationDrawer() {
+        if (tabletLayout || navigationPanel == null) return;
+        drawerScrim.setVisibility(View.VISIBLE);
+        navigationPanel.setVisibility(View.VISIBLE);
+    }
+
+    private void closeNavigationDrawer() {
+        if (tabletLayout || navigationPanel == null) return;
+        navigationPanel.setVisibility(View.GONE);
+        drawerScrim.setVisibility(View.GONE);
     }
 
     private void restorePreferences() {
         SharedPreferences prefs = getSharedPreferences(PREFS, MODE_PRIVATE);
-        host.setText(prefs.getString("host", ""));
-        username.setText(prefs.getString("username", ""));
-        String savedProtocol = prefs.getString("protocol", "FTPS");
-        protocol.setSelection("FTP".equals(savedProtocol) ? 1 : 0);
-        port.setText(prefs.getString("port", "21"));
+        rememberEndpoint = prefs.getBoolean("rememberEndpoint", true);
+        showFileSizes = prefs.getBoolean("showFileSizes", true);
+        rememberEndpointToggle.setChecked(rememberEndpoint);
+        showFileSizesToggle.setChecked(showFileSizes);
+        if (rememberEndpoint) {
+            host.setText(prefs.getString("host", ""));
+            username.setText(prefs.getString("username", ""));
+            String savedProtocol = prefs.getString("protocol", "FTPS");
+            protocol.setSelection("FTP".equals(savedProtocol) ? 1 : 0);
+            port.setText(prefs.getString("port", "21"));
+        } else {
+            protocol.setSelection(0);
+            port.setText("21");
+        }
         String savedTree = prefs.getString("treeUri", "");
         if (!savedTree.isEmpty()) {
             tryActivateLocalTree(Uri.parse(savedTree), "Saved local folder is no longer available.", true);
@@ -262,13 +640,19 @@ public final class MainActivity extends Activity {
     }
 
     private void savePreferences() {
-        getSharedPreferences(PREFS, MODE_PRIVATE).edit()
-                .putString("host", host.getText().toString().trim())
-                .putString("username", username.getText().toString().trim())
-                .putString("protocol", protocol.getSelectedItem().toString())
-                .putString("port", port.getText().toString().trim())
-                .putString("treeUri", treeUri == null ? "" : treeUri.toString())
-                .apply();
+        SharedPreferences.Editor editor = getSharedPreferences(PREFS, MODE_PRIVATE).edit()
+                .putBoolean("rememberEndpoint", rememberEndpoint)
+                .putBoolean("showFileSizes", showFileSizes)
+                .putString("treeUri", treeUri == null ? "" : treeUri.toString());
+        if (rememberEndpoint) {
+            editor.putString("host", host.getText().toString().trim())
+                    .putString("username", username.getText().toString().trim())
+                    .putString("protocol", protocol.getSelectedItem().toString())
+                    .putString("port", port.getText().toString().trim());
+        } else {
+            editor.remove("host").remove("username").remove("protocol").remove("port");
+        }
+        editor.apply();
     }
 
     private void renderSites() {
@@ -280,7 +664,7 @@ public final class MainActivity extends Activity {
             labels.add(profile.toString());
             if (profile.id.equals(activeProfileId)) selected = i + 1;
         }
-        siteSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, labels));
+        siteSpinner.setAdapter(GhostTheme.spinnerAdapter(this, labels));
         siteSpinner.setSelection(selected);
     }
 
@@ -292,8 +676,12 @@ public final class MainActivity extends Activity {
             local.addAll(profile.localBookmarks);
             remote.addAll(profile.remoteBookmarks);
         }
-        localBookmarkSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, local));
-        remoteBookmarkSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, remote));
+        localBookmarkSpinner.setAdapter(GhostTheme.spinnerAdapter(this, local));
+        remoteBookmarkSpinner.setAdapter(GhostTheme.spinnerAdapter(this, remote));
+        if (bookmarkLocalCurrent != null) {
+            bookmarkLocalCurrent.setText(treeUri == null ? "No folder selected" : displayLocalPath());
+        }
+        if (bookmarkRemoteCurrent != null) bookmarkRemoteCurrent.setText(currentRemotePath);
         refreshButtons();
     }
 
@@ -622,6 +1010,27 @@ public final class MainActivity extends Activity {
         setStatus("Server bookmark added for this site identity only.");
     }
 
+    private void removeRemoteBookmark() {
+        SiteProfile profile = activeProfile();
+        if (profile == null) {
+            setStatus("Load a saved site before removing a server bookmark.");
+            return;
+        }
+        int index = remoteBookmarkSpinner.getSelectedItemPosition();
+        if (index < 0 || index >= profile.remoteBookmarks.size()) {
+            setStatus("No server bookmark selected.");
+            return;
+        }
+        List<String> nextBookmarks = new ArrayList<>(profile.remoteBookmarks);
+        nextBookmarks.remove(index);
+        SiteProfile next = new SiteProfile(profile.id, profile.name, profile.protocol, profile.host, profile.port,
+                profile.username, profile.localStartTreeUri, profile.remoteStartPath, profile.localBookmarks, nextBookmarks);
+        replaceProfile(next);
+        profileStore.save(profiles);
+        renderBookmarks();
+        setStatus("Server bookmark removed.");
+    }
+
     private void openRemoteBookmark() {
         SiteProfile profile = requireConnectedActiveProfile();
         if (profile == null) return;
@@ -698,7 +1107,6 @@ public final class MainActivity extends Activity {
             localEntries.addAll(next);
             selectedLocal = -1;
             renderLocal();
-            localPath.setText("Selected folder");
             return true;
         } catch (RuntimeException | IOException e) {
             clearLocalRoot();
@@ -719,9 +1127,13 @@ public final class MainActivity extends Activity {
         return treeUri != null && hasPersistedReadPermission(treeUri) ? treeUri.toString() : "";
     }
 
+    private String displayLocalPath() {
+        if (treeUri == null || currentDocumentId == null) return "No folder selected";
+        return currentDocumentId.equals(rootDocumentId) ? "Selected SAF folder" : currentDocumentId;
+    }
+
     private void refreshLocal() {
         if (treeUri == null || currentDocumentId == null) {
-            localPath.setText("No folder selected");
             renderLocal();
             return;
         }
@@ -730,12 +1142,10 @@ public final class MainActivity extends Activity {
             localEntries.clear();
             localEntries.addAll(next);
             selectedLocal = -1;
-            localPath.setText(currentDocumentId.equals(rootDocumentId) ? "Selected folder" : currentDocumentId);
             renderLocal();
         } catch (IOException e) {
             clearLocalRoot();
             renderLocal();
-            localPath.setText("No folder selected");
             setStatus("Local folder permission or provider is no longer available. Choose the folder again.");
         }
     }
@@ -771,7 +1181,6 @@ public final class MainActivity extends Activity {
                 localEntries.clear();
                 localEntries.addAll(next);
                 selectedLocal = -1;
-                localPath.setText(currentDocumentId);
                 renderLocal();
             } catch (IOException e) {
                 setStatus("Local directory is unavailable; current path was not changed: " + safeMessage(e));
@@ -792,7 +1201,6 @@ public final class MainActivity extends Activity {
             localEntries.clear();
             localEntries.addAll(next);
             selectedLocal = -1;
-            localPath.setText(currentDocumentId.equals(rootDocumentId) ? "Selected folder" : currentDocumentId);
             renderLocal();
         } catch (IOException e) {
             setStatus("Parent folder is unavailable; current path was not changed: " + safeMessage(e));
@@ -813,6 +1221,7 @@ public final class MainActivity extends Activity {
         SiteProfile next = profile.withLocalStartTreeUri(uri);
         replaceProfile(next);
         profileStore.save(profiles);
+        renderBookmarks();
         setStatus("Local site start folder saved as a SAF capability URI; no filesystem-wide permission was added.");
     }
 
@@ -832,6 +1241,27 @@ public final class MainActivity extends Activity {
         profileStore.save(profiles);
         renderBookmarks();
         setStatus("Local SAF bookmark added. It contains no credentials.");
+    }
+
+    private void removeLocalBookmark() {
+        SiteProfile profile = activeProfile();
+        if (profile == null) {
+            setStatus("Load a saved site before removing a local bookmark.");
+            return;
+        }
+        int index = localBookmarkSpinner.getSelectedItemPosition();
+        if (index < 0 || index >= profile.localBookmarks.size()) {
+            setStatus("No local bookmark selected.");
+            return;
+        }
+        List<String> nextBookmarks = new ArrayList<>(profile.localBookmarks);
+        nextBookmarks.remove(index);
+        SiteProfile next = new SiteProfile(profile.id, profile.name, profile.protocol, profile.host, profile.port,
+                profile.username, profile.localStartTreeUri, profile.remoteStartPath, nextBookmarks, profile.remoteBookmarks);
+        replaceProfile(next);
+        profileStore.save(profiles);
+        renderBookmarks();
+        setStatus("Local bookmark removed.");
     }
 
     private void openLocalBookmark() {
@@ -860,6 +1290,10 @@ public final class MainActivity extends Activity {
         FtpSession current = session;
         if (busy || current == null || selectedLocal < 0 || selectedLocal >= localEntries.size()) return;
         LocalEntry entry = localEntries.get(selectedLocal);
+        if (entry.directory) {
+            setStatus("Select a local file, not a directory, to upload.");
+            return;
+        }
         Uri document = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.documentId);
         String remoteBase = currentRemotePath;
         TransferAttempt attempt = beginTransfer("Uploading " + entry.name + "…");
@@ -896,6 +1330,10 @@ public final class MainActivity extends Activity {
         FtpSession current = session;
         if (busy || current == null || selectedRemote < 0 || selectedRemote >= remoteEntries.size() || treeUri == null) return;
         RemoteEntry entry = remoteEntries.get(selectedRemote);
+        if (entry.directory) {
+            setStatus("Select a server file, not a directory, to download.");
+            return;
+        }
         Uri selectedTree = treeUri;
         String selectedDocumentId = currentDocumentId;
         Uri parent = DocumentsContract.buildDocumentUriUsingTree(selectedTree, selectedDocumentId);
@@ -1069,20 +1507,32 @@ public final class MainActivity extends Activity {
     }
 
     private void renderLocal() {
+        if (localPath != null) localPath.setText(displayLocalPath());
+        if (bookmarkLocalCurrent != null) bookmarkLocalCurrent.setText(displayLocalPath());
         List<String> labels = new ArrayList<>();
         for (int i = 0; i < localEntries.size(); i++) {
             LocalEntry e = localEntries.get(i);
-            labels.add((i == selectedLocal ? "› " : "  ") + (e.directory ? "DIR   " : "FILE  ") + e.name + (e.directory ? "" : "  (" + e.size + " B)"));
+            String marker = i == selectedLocal ? "●  " : "   ";
+            String type = e.directory ? "DIR   " : "FILE  ";
+            String size = !e.directory && showFileSizes ? "   " + TransferProgress.formatBytes(e.size) : "";
+            labels.add(marker + type + e.name + size);
         }
-        localList.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, labels));
+        if (localList != null) localList.setAdapter(GhostTheme.listAdapter(this, labels));
         refreshButtons();
     }
 
     private void renderRemote() {
-        remotePath.setText(currentRemotePath);
+        if (remotePath != null) remotePath.setText(currentRemotePath);
+        if (bookmarkRemoteCurrent != null) bookmarkRemoteCurrent.setText(currentRemotePath);
         List<String> labels = new ArrayList<>();
-        for (int i = 0; i < remoteEntries.size(); i++) labels.add((i == selectedRemote ? "› " : "  ") + remoteEntries.get(i));
-        remoteList.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, labels));
+        for (int i = 0; i < remoteEntries.size(); i++) {
+            RemoteEntry e = remoteEntries.get(i);
+            String marker = i == selectedRemote ? "●  " : "   ";
+            String type = e.directory ? "DIR   " : "FILE  ";
+            String size = !e.directory && showFileSizes ? "   " + TransferProgress.formatBytes(e.size) : "";
+            labels.add(marker + type + e.name + size);
+        }
+        if (remoteList != null) remoteList.setAdapter(GhostTheme.listAdapter(this, labels));
         refreshButtons();
     }
 
@@ -1094,22 +1544,74 @@ public final class MainActivity extends Activity {
 
     private void refreshButtons() {
         boolean connected = session != null && session.isConnected();
+        boolean selectedLocalFile = selectedLocal >= 0 && selectedLocal < localEntries.size() && !localEntries.get(selectedLocal).directory;
+        boolean selectedRemoteFile = selectedRemote >= 0 && selectedRemote < remoteEntries.size() && !remoteEntries.get(selectedRemote).directory;
         SiteProfile profile = activeProfile();
         boolean activeSite = profile != null;
         boolean connectedSite = activeSite && connected && connectedIdentityKey != null && profile.identityKey().equals(connectedIdentityKey);
+
         connect.setEnabled(!busy && !connected);
         disconnect.setText(transferFinalizing ? "Finalizing…" : transferActive ? "Cancel transfer" : "Disconnect");
         disconnect.setEnabled((transferActive && !transferFinalizing) || (!busy && connected));
-        upload.setEnabled(!busy && connected && selectedLocal >= 0);
-        download.setEnabled(!busy && connected && selectedRemote >= 0 && treeUri != null);
+        upload.setEnabled(!busy && connected && selectedLocalFile);
+        download.setEnabled(!busy && connected && selectedRemoteFile && treeUri != null);
         saveSite.setEnabled(!busy && !connected);
         deleteSite.setEnabled(!busy && !connected && activeSite);
-        localSetStart.setEnabled(!busy && activeSite && persistedCurrentTreeUri().length() > 0);
-        localAddBookmark.setEnabled(!busy && activeSite && persistedCurrentTreeUri().length() > 0);
+        localSetStart.setEnabled(!busy && activeSite && !persistedCurrentTreeUri().isEmpty());
+        localAddBookmark.setEnabled(!busy && activeSite && !persistedCurrentTreeUri().isEmpty());
+        localRemoveBookmark.setEnabled(!busy && activeSite && !profile.localBookmarks.isEmpty());
         localOpenBookmark.setEnabled(!busy && activeSite && !profile.localBookmarks.isEmpty());
         remoteSetStart.setEnabled(!busy && connectedSite);
         remoteAddBookmark.setEnabled(!busy && connectedSite);
+        remoteRemoveBookmark.setEnabled(!busy && activeSite && !profile.remoteBookmarks.isEmpty());
         remoteOpenBookmark.setEnabled(!busy && connectedSite && !profile.remoteBookmarks.isEmpty());
+        transferCancel.setText(transferFinalizing ? "Finalizing…" : "Cancel active transfer");
+        transferCancel.setEnabled(transferActive && !transferFinalizing);
+        transferCancel.setAlpha(transferCancel.isEnabled() ? 1f : 0.45f);
+
+        updateConnectionBadge(connected);
+        updateTransferSurface();
+        updateEnabledAlpha(connect, disconnect, upload, download, saveSite, deleteSite,
+                localSetStart, localAddBookmark, localRemoveBookmark, localOpenBookmark,
+                remoteSetStart, remoteAddBookmark, remoteRemoveBookmark, remoteOpenBookmark);
+    }
+
+    private void updateConnectionBadge(boolean connected) {
+        if (connectionBadge == null) return;
+        String text;
+        int color;
+        if (transferFinalizing) {
+            text = "FINALIZING";
+            color = GhostTheme.WARN;
+        } else if (transferActive) {
+            text = "TRANSFER ACTIVE";
+            color = GhostTheme.WARN;
+        } else if (connected) {
+            boolean secure = protocol.getSelectedItem() != null && "FTPS".equals(protocol.getSelectedItem().toString());
+            text = secure ? "FTPS CONNECTED" : "FTP CONNECTED";
+            color = secure ? GhostTheme.SUCCESS : GhostTheme.WARN;
+        } else {
+            text = "DISCONNECTED";
+            color = GhostTheme.MUTED;
+        }
+        connectionBadge.setText(text);
+        GhostTheme.styleBadge(connectionBadge, color);
+    }
+
+    private void updateTransferSurface() {
+        if (transferStatus == null) return;
+        String value = status == null ? "Ready." : status.getText().toString();
+        if (!transferActive && !transferFinalizing && (value.isEmpty() || "Ready.".equals(value))) {
+            value = "No active transfer.";
+        }
+        transferStatus.setText(value);
+        transferStatus.setTextColor(GhostTheme.statusColor(value));
+    }
+
+    private void updateEnabledAlpha(Button... buttons) {
+        for (Button button : buttons) {
+            if (button != null) button.setAlpha(button.isEnabled() ? 1f : 0.45f);
+        }
     }
 
     private int parsePort() {
@@ -1144,7 +1646,10 @@ public final class MainActivity extends Activity {
     }
 
     private void setStatus(String value) {
-        status.setText(value == null ? "" : value.replace('\n', ' ').replace('\r', ' '));
+        String safe = value == null ? "" : value.replace('\n', ' ').replace('\r', ' ');
+        status.setText(safe);
+        status.setTextColor(GhostTheme.statusColor(safe));
+        updateTransferSurface();
     }
 
     private static String safeMessage(Exception e) {
@@ -1152,9 +1657,62 @@ public final class MainActivity extends Activity {
         return value == null || value.trim().isEmpty() ? e.getClass().getSimpleName() : value.replace('\n', ' ').replace('\r', ' ');
     }
 
-    private TextView section(String text) {
-        TextView view = label(text, 15, Color.rgb(94, 214, 200));
-        view.setPadding(0, dp(18), 0, dp(6));
+    private LinearLayout surfaceContent() {
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(12), dp(12), dp(12), dp(24));
+        content.setBackgroundColor(GhostTheme.WINDOW);
+        return content;
+    }
+
+    private View scrollSurface(LinearLayout content) {
+        ScrollView scroll = new ScrollView(this);
+        scroll.setFillViewport(true);
+        scroll.setBackgroundColor(GhostTheme.WINDOW);
+        scroll.addView(content, matchWrap());
+        return scroll;
+    }
+
+    private LinearLayout surfaceHeading(String title, String description) {
+        LinearLayout block = new LinearLayout(this);
+        block.setOrientation(LinearLayout.VERTICAL);
+        block.setPadding(dp(2), dp(2), dp(2), dp(12));
+        TextView heading = label(title, 24, GhostTheme.TEXT);
+        heading.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        TextView copy = label(description, 12, GhostTheme.MUTED);
+        copy.setPadding(0, dp(4), 0, 0);
+        block.addView(heading, matchWrap());
+        block.addView(copy, matchWrap());
+        return block;
+    }
+
+    private LinearLayout card(String title, String hint) {
+        LinearLayout card = new LinearLayout(this);
+        card.setOrientation(LinearLayout.VERTICAL);
+        card.setPadding(dp(14), dp(14), dp(14), dp(14));
+        card.setBackground(GhostTheme.rounded(this, GhostTheme.PANEL, GhostTheme.BORDER, 14));
+        TextView heading = label(title, 15, GhostTheme.TEXT);
+        heading.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        card.addView(heading, matchWrap());
+        if (hint != null && !hint.isEmpty()) {
+            TextView help = label(hint, 11, GhostTheme.MUTED);
+            help.setPadding(0, dp(4), 0, dp(10));
+            card.addView(help, matchWrap());
+        }
+        return card;
+    }
+
+    private TextView pathLabel(String value) {
+        TextView view = label(value, 13, GhostTheme.MUTED);
+        view.setPadding(dp(10), dp(9), dp(10), dp(9));
+        view.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 9));
+        return view;
+    }
+
+    private TextView infoLine(String name, String value) {
+        TextView view = label(name + "\n" + value, 12, GhostTheme.TEXT);
+        view.setPadding(dp(10), dp(9), dp(10), dp(9));
+        view.setBackground(GhostTheme.rounded(this, GhostTheme.LIST, GhostTheme.BORDER, 9));
         return view;
     }
 
@@ -1169,29 +1727,91 @@ public final class MainActivity extends Activity {
     private EditText field(String hint, boolean secret) {
         EditText edit = new EditText(this);
         edit.setHint(hint);
-        edit.setTextColor(Color.WHITE);
-        edit.setHintTextColor(Color.GRAY);
-        edit.setSingleLine(true);
+        GhostTheme.styleField(edit);
         if (secret) edit.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
         return edit;
     }
 
+    private CheckBox checkBox(String text) {
+        CheckBox check = new CheckBox(this);
+        check.setText(text);
+        check.setTextColor(GhostTheme.TEXT);
+        check.setTextSize(13f);
+        check.setButtonTintList(new ColorStateList(
+                new int[][]{new int[]{android.R.attr.state_checked}, new int[]{}},
+                new int[]{GhostTheme.ACCENT, GhostTheme.MUTED}));
+        check.setPadding(dp(4), dp(6), dp(4), dp(6));
+        return check;
+    }
+
     private Button button(String text) {
-        Button b = new Button(this);
-        b.setText(text);
-        b.setAllCaps(false);
-        return b;
+        Button button = new Button(this);
+        button.setText(text);
+        GhostTheme.styleSecondaryButton(button);
+        return button;
+    }
+
+    private Button primaryButton(String text) {
+        Button button = new Button(this);
+        button.setText(text);
+        GhostTheme.stylePrimaryButton(button);
+        return button;
+    }
+
+    private Button dangerButton(String text) {
+        Button button = new Button(this);
+        button.setText(text);
+        GhostTheme.styleDangerButton(button);
+        return button;
     }
 
     private LinearLayout row() {
-        LinearLayout r = new LinearLayout(this);
-        r.setOrientation(LinearLayout.HORIZONTAL);
-        return r;
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        return row;
     }
 
-    private LinearLayout.LayoutParams weighted() { return new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f); }
-    private LinearLayout.LayoutParams matchWrap() { return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT); }
-    private int dp(int value) { return Math.round(value * getResources().getDisplayMetrics().density); }
+    private LinearLayout.LayoutParams navParams() {
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, 0, 0, dp(5));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams weightedSpaced() {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        params.setMargins(dp(3), dp(3), dp(3), dp(3));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams fixedWidthSpaced(int widthDp) {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(dp(widthDp), ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setMargins(dp(3), dp(3), dp(3), dp(3));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams matchWrapSpaced() {
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, dp(4), 0, dp(4));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams cardParams() {
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, 0, 0, dp(10));
+        return params;
+    }
+
+    private LinearLayout.LayoutParams matchWrap() {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private LinearLayout.LayoutParams wrapWrap() {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private int dp(int value) {
+        return GhostTheme.dp(this, value);
+    }
 
     private static final class TransferAttempt {
         final long token;

--- a/android/app/src/main/res/drawable/ic_about.xml
+++ b/android/app/src/main/res/drawable/ic_about.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M11,17h2v-6h-2zM11,9h2V7h-2zM12,2a10,10 0,1 0,0 20,10 10,0 0,0 0,-20zM12,20a8,8 0,1 1,0 -16,8 8,0 0,1 0,16z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_bookmarks.xml
+++ b/android/app/src/main/res/drawable/ic_bookmarks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M5,3c-1.1,0 -2,0.9 -2,2v16l9,-4 9,4V5c0,-1.1 -0.9,-2 -2,-2zM19,18l-7,-3.1L5,18V5h14z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_files.xml
+++ b/android/app/src/main/res/drawable/ic_files.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M10,4H4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V8c0,-1.1 -0.9,-2 -2,-2h-8z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_menu.xml
+++ b/android/app/src/main/res/drawable/ic_menu.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M3,6h18v2H3zM3,11h18v2H3zM3,16h18v2H3z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_settings.xml
+++ b/android/app/src/main/res/drawable/ic_settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M19.4,13c0.04,-0.33 0.06,-0.66 0.06,-1s-0.02,-0.67 -0.07,-1l2.11,-1.65 -2,-3.46 -2.49,1a7.4,7.4 0,0 0,-1.73,-1L14.9,3h-4l-0.38,2.89c-0.62,0.25 -1.2,0.59 -1.73,1l-2.49,-1 -2,3.46L6.41,11c-0.05,0.33 -0.08,0.67 -0.08,1s0.03,0.67 0.08,1L4.3,14.65l2,3.46 2.49,-1c0.53,0.41 1.11,0.75 1.73,1L10.9,21h4l0.38,-2.89c0.62,-0.25 1.2,-0.59 1.73,-1l2.49,1 2,-3.46zM12.9,15.5a3.5,3.5 0,1 1,0 -7,3.5 3.5,0 0,1 0,7z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_sites.xml
+++ b/android/app/src/main/res/drawable/ic_sites.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M4,3h16c1.1,0 2,0.9 2,2v4c0,1.1 -0.9,2 -2,2H4c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2zM5,6h2v2H5zM4,13h16c1.1,0 2,0.9 2,2v4c0,1.1 -0.9,2 -2,2H4c-1.1,0 -2,-0.9 -2,-2v-4c0,-1.1 0.9,-2 2,-2zM5,16h2v2H5z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_transfers.xml
+++ b/android/app/src/main/res/drawable/ic_transfers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M7,7h10l-3,-3 1.4,-1.4L20.8,8l-5.4,5.4L14,12l3,-3H7zM17,17H7l3,3 -1.4,1.4L3.2,16l5.4,-5.4L10,12l-3,3h10z" />
+</vector>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ghost_window">#0B0F17</color>
+    <color name="ghost_panel">#121824</color>
+    <color name="ghost_list">#161D2A</color>
+    <color name="ghost_border">#2C3648</color>
+    <color name="ghost_text">#F2F5FA</color>
+    <color name="ghost_muted">#97A3B8</color>
+    <color name="ghost_accent">#5B7CFA</color>
+    <color name="ghost_accent_strong">#7A98FF</color>
+    <color name="ghost_success">#4AD79B</color>
+    <color name="ghost_warn">#F2BA55</color>
+    <color name="ghost_danger">#FF6878</color>
+    <color name="ghost_selection">#202F50</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ghost_window">#0B0F17</color>
-    <color name="ghost_panel">#121824</color>
-    <color name="ghost_list">#161D2A</color>
-    <color name="ghost_border">#2C3648</color>
     <color name="ghost_text">#F2F5FA</color>
     <color name="ghost_muted">#97A3B8</color>
     <color name="ghost_accent">#5B7CFA</color>
-    <color name="ghost_accent_strong">#7A98FF</color>
-    <color name="ghost_success">#4AD79B</color>
-    <color name="ghost_warn">#F2BA55</color>
-    <color name="ghost_danger">#FF6878</color>
-    <color name="ghost_selection">#202F50</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,7 +3,6 @@
     <style name="Theme.GhostFTP" parent="android:style/Theme.Material.NoActionBar">
         <item name="android:fontFamily">sans</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
         <item name="android:statusBarColor">@color/ghost_window</item>
         <item name="android:navigationBarColor">@color/ghost_window</item>
         <item name="android:windowBackground">@color/ghost_window</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,9 +3,13 @@
     <style name="Theme.GhostFTP" parent="android:style/Theme.Material.NoActionBar">
         <item name="android:fontFamily">sans</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:statusBarColor">#101317</item>
-        <item name="android:navigationBarColor">#101317</item>
-        <item name="android:windowBackground">#101317</item>
-        <item name="android:colorAccent">#5ED6C8</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:statusBarColor">@color/ghost_window</item>
+        <item name="android:navigationBarColor">@color/ghost_window</item>
+        <item name="android:windowBackground">@color/ghost_window</item>
+        <item name="android:colorAccent">@color/ghost_accent</item>
+        <item name="android:textColorPrimary">@color/ghost_text</item>
+        <item name="android:textColorSecondary">@color/ghost_muted</item>
+        <item name="android:windowNoTitle">true</item>
     </style>
 </resources>

--- a/scripts/test_android_contract.py
+++ b/scripts/test_android_contract.py
@@ -375,8 +375,18 @@ class AndroidContractTests(unittest.TestCase):
         readme = self.read("android/README.md")
         activity = self.read(f"{ANDROID_JAVA}/MainActivity.java")
         self.assertIn("SFTP is intentionally not exposed", readme)
-        self.assertIn('new String[]{"FTPS", "FTP"}', activity)
-        self.assertNotIn('"SFTP"', activity)
+        protocol_start = activity.index("protocol = new Spinner(this);")
+        protocol_end = activity.index('host = field("Server host"', protocol_start)
+        protocol_picker = activity[protocol_start:protocol_end]
+        self.assertIn('new String[]{"FTPS", "FTP"}', protocol_picker)
+        self.assertNotIn("SFTP", protocol_picker)
+        connect_start = activity.index("private void connect()")
+        connect_end = activity.index("private void disconnect()", connect_start)
+        connect = activity[connect_start:connect_end]
+        self.assertNotIn('"SFTP".equals', connect)
+        self.assertNotIn("JSch", connect)
+        self.assertIn("SFTP", activity)
+        self.assertIn("Hidden until strict Android host-key identity verification exists", activity)
 
     def test_android_has_no_telemetry_or_ad_sdk_dependency(self) -> None:
         build = self.read("android/app/build.gradle")

--- a/scripts/test_android_mobile_navigation_contract.py
+++ b/scripts/test_android_mobile_navigation_contract.py
@@ -4,6 +4,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 ACTIVITY = ROOT / "android/app/src/main/java/app/ghostftp/client/MainActivity.java"
+ANDROID_BUILD = ROOT / "android/app/build.gradle"
 ANDROID_README = ROOT / "android/README.md"
 UI_DOC = ROOT / "android/UI-UX.md"
 DRAWABLES = ROOT / "android/app/src/main/res/drawable"
@@ -117,6 +118,20 @@ class AndroidMobileNavigationContractTests(unittest.TestCase):
         self.assertIn("renderLocal();", settings)
         self.assertIn("renderRemote();", settings)
         self.assertIn("Runtime security policy is informational here and cannot be weakened from the UI.", settings)
+
+    def test_about_uses_generated_build_identity_not_hardcoded_version(self) -> None:
+        activity = self.read(ACTIVITY)
+        build = self.read(ANDROID_BUILD)
+        self.assertIn("buildFeatures {", build)
+        self.assertIn("buildConfig true", build)
+        self.assertIn("versionName \"${ghostFtpVersion}-dev\"", build)
+        self.assertIn('infoLine("Version", BuildConfig.VERSION_NAME)', activity)
+        self.assertIn('infoLine("Package", BuildConfig.APPLICATION_ID)', activity)
+        about_start = activity.index("private View buildAboutSurface()")
+        about_end = activity.index("private void addSurface(", about_start)
+        about = activity[about_start:about_end]
+        self.assertNotIn('infoLine("Version", "0.0.3', about)
+        self.assertIn("0.0.3 remains the published Windows/Linux release", about)
 
     def test_android_docs_describe_the_same_surface_contract(self) -> None:
         readme = self.read(ANDROID_README)

--- a/scripts/test_android_mobile_navigation_contract.py
+++ b/scripts/test_android_mobile_navigation_contract.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVITY = ROOT / "android/app/src/main/java/app/ghostftp/client/MainActivity.java"
+ANDROID_README = ROOT / "android/README.md"
+UI_DOC = ROOT / "android/UI-UX.md"
+DRAWABLES = ROOT / "android/app/src/main/res/drawable"
+
+
+class AndroidMobileNavigationContractTests(unittest.TestCase):
+    def read(self, path: Path) -> str:
+        return path.read_text(encoding="utf-8")
+
+    def test_phone_drawer_and_tablet_sidebar_are_real_runtime_navigation(self) -> None:
+        activity = self.read(ACTIVITY)
+        for marker in (
+            "private static final int TABLET_SIDEBAR_MIN_DP = 700;",
+            "FILES,",
+            "SITES,",
+            "BOOKMARKS,",
+            "TRANSFERS,",
+            "SETTINGS,",
+            "ABOUT",
+            'navButton("Files", R.drawable.ic_files, Section.FILES)',
+            'navButton("Sites", R.drawable.ic_sites, Section.SITES)',
+            'navButton("Bookmarks", R.drawable.ic_bookmarks, Section.BOOKMARKS)',
+            'navButton("Transfers", R.drawable.ic_transfers, Section.TRANSFERS)',
+            'navButton("Settings", R.drawable.ic_settings, Section.SETTINGS)',
+            'navButton("About", R.drawable.ic_about, Section.ABOUT)',
+            "tabletLayout = getResources().getConfiguration().screenWidthDp >= TABLET_SIDEBAR_MIN_DP;",
+            "menuToggle.setOnClickListener(v -> openNavigationDrawer());",
+            "navigationPanel.setVisibility(View.GONE);",
+            "private void showSection(Section section)",
+        ):
+            self.assertIn(marker, activity)
+
+        show = activity[activity.index("private void showSection(Section section)") : activity.index("private String sectionTitle(")]
+        for marker in (
+            "filesSurface.setVisibility(section == Section.FILES ? View.VISIBLE : View.GONE);",
+            "sitesSurface.setVisibility(section == Section.SITES ? View.VISIBLE : View.GONE);",
+            "bookmarksSurface.setVisibility(section == Section.BOOKMARKS ? View.VISIBLE : View.GONE);",
+            "transfersSurface.setVisibility(section == Section.TRANSFERS ? View.VISIBLE : View.GONE);",
+            "settingsSurface.setVisibility(section == Section.SETTINGS ? View.VISIBLE : View.GONE);",
+            "aboutSurface.setVisibility(section == Section.ABOUT ? View.VISIBLE : View.GONE);",
+        ):
+            self.assertIn(marker, show)
+
+    def test_navigation_uses_local_vector_assets_and_no_emoji_controls(self) -> None:
+        for name in (
+            "ic_menu.xml",
+            "ic_files.xml",
+            "ic_sites.xml",
+            "ic_bookmarks.xml",
+            "ic_transfers.xml",
+            "ic_settings.xml",
+            "ic_about.xml",
+        ):
+            content = self.read(DRAWABLES / name)
+            self.assertIn("<vector", content)
+            self.assertIn("<path", content)
+
+        activity = self.read(ACTIVITY)
+        for emoji in ("📁", "🔖", "⚙", "ℹ", "💻", "⬆", "⬇"):
+            self.assertNotIn(emoji, activity)
+
+    def test_android_sftp_and_rdp_are_fail_closed_in_navigation(self) -> None:
+        activity = self.read(ACTIVITY)
+        protocol_start = activity.index("protocol = new Spinner(this);")
+        protocol_end = activity.index('host = field("Server host"', protocol_start)
+        protocol_picker = activity[protocol_start:protocol_end]
+        self.assertIn('new String[]{"FTPS", "FTP"}', protocol_picker)
+        self.assertNotIn("SFTP", protocol_picker)
+
+        connect_start = activity.index("private void connect()")
+        connect_end = activity.index("private void disconnect()", connect_start)
+        connect = activity[connect_start:connect_end]
+        self.assertNotIn('"SFTP".equals', connect)
+        self.assertNotIn("JSch", connect)
+        self.assertNotIn("ssh", connect.lower())
+
+        navigation_start = activity.index("private LinearLayout buildNavigationPanel()")
+        navigation_end = activity.index("private Button navButton(", navigation_start)
+        navigation = activity[navigation_start:navigation_end]
+        self.assertNotIn("Remote Desktop", navigation)
+        self.assertNotIn("RDP", navigation)
+        self.assertNotIn("Coming Soon", navigation)
+
+    def test_transfers_surface_is_owned_by_real_transfer_lifecycle(self) -> None:
+        activity = self.read(ACTIVITY)
+        surface_start = activity.index("private View buildTransfersSurface()")
+        surface_end = activity.index("private View buildSettingsSurface()", surface_start)
+        surface = activity[surface_start:surface_end]
+        self.assertIn('transferCancel = dangerButton("Cancel active transfer")', surface)
+        self.assertIn("transferCancel.setOnClickListener(v -> cancelTransfer());", surface)
+        self.assertIn("No active transfer.", surface)
+        self.assertNotIn("Retry", surface)
+        self.assertNotIn("Resume", surface)
+        self.assertNotIn("Clear history", surface)
+        self.assertIn("No decorative queue or fake history is displayed.", surface)
+
+        buttons_start = activity.index("private void refreshButtons()")
+        buttons_end = activity.index("private void updateConnectionBadge(", buttons_start)
+        buttons = activity[buttons_start:buttons_end]
+        self.assertIn("transferCancel.setEnabled(transferActive && !transferFinalizing);", buttons)
+        self.assertIn('transferCancel.setText(transferFinalizing ? "Finalizing…" : "Cancel active transfer");', buttons)
+
+    def test_settings_controls_have_runtime_owners(self) -> None:
+        activity = self.read(ACTIVITY)
+        settings_start = activity.index("private View buildSettingsSurface()")
+        settings_end = activity.index("private View buildAboutSurface()", settings_start)
+        settings = activity[settings_start:settings_end]
+        self.assertIn("rememberEndpointToggle.setOnClickListener", settings)
+        self.assertIn("showFileSizesToggle.setOnClickListener", settings)
+        self.assertIn("savePreferences();", settings)
+        self.assertIn("renderLocal();", settings)
+        self.assertIn("renderRemote();", settings)
+        self.assertIn("Runtime security policy is informational here and cannot be weakened from the UI.", settings)
+
+    def test_android_docs_describe_the_same_surface_contract(self) -> None:
+        readme = self.read(ANDROID_README)
+        ui_doc = self.read(UI_DOC)
+        for marker in ("Files", "Sites", "Bookmarks", "Transfers", "Settings", "About"):
+            self.assertIn(marker, readme)
+            self.assertIn(marker, ui_doc)
+        self.assertIn("navigation drawer", readme.lower())
+        self.assertIn("persistent sidebar", readme.lower())
+        self.assertIn("Remote Desktop", ui_doc)
+        self.assertIn("not shown", ui_doc.lower())
+        self.assertIn("development", readme.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces the previous single long Android screen with a mobile-native Ghost FTP shell while preserving the existing FTP/FTPS, SAF, saved-site/bookmark and staged-transfer security contracts.

### Navigation

- Phone: real hamburger / left navigation drawer.
- Tablet: persistent left sidebar from the same destination model when width is sufficient.
- One active runtime surface at a time: Files, Sites, Bookmarks, Transfers, Settings and About.
- Uses local vector drawables; no emoji navigation icons or external visual dependency.
- Android Remote Desktop is intentionally not shown because there is no reviewed Android RDP runtime owner yet.

### Files

- Local SAF and active server views remain the only file workspace.
- Local and remote current paths, Up/Refresh, actual listings and upload/download remain connected to the existing runtime.
- Upload/download buttons now reject directory selections instead of implying unsupported directory transfer.
- Staged remote upload, staged SAF download, strict FTPS and transfer commit/cancellation gates are unchanged.

### Sites / Bookmarks

- Quick Connect remains transient and password remains memory-only.
- Saved sites remain explicit, non-secret profiles.
- Bookmarks/start directories remain account-bound and freshly revalidated.
- Adds explicit bookmark removal actions without changing the stored schema.

### Transfers

- Shows only real active transfer state and byte-backed progress.
- Cancel is available only before the irreversible final-name commit phase.
- No fake retry/resume/history/queue controls are exposed.

### Settings / About

- Settings expose only options with actual Android runtime ownership: remember non-secret Quick Connect metadata and show/hide file sizes.
- Security policy rows are informational and cannot weaken TLS/storage/transfer/privacy behavior.
- About distinguishes the already published Windows/Linux 0.0.3 release from the current post-release Android development/debug-signed APK.

### Security / privacy

- Android protocol picker remains FTP + strict explicit FTPS only.
- SFTP remains fail-closed until strict Android host-key verification/pinning exists; documentation may explain that status without exposing a runtime SFTP route.
- No telemetry, analytics, ads, fingerprinting, Ghost FTP cloud/backend, broad storage permission or new external dependency.

## Tests and documentation

- Adds `scripts/test_android_mobile_navigation_contract.py` for phone/tablet navigation, real surface ownership, vector assets, SFTP/RDP fail-closed behavior, Transfers ownership and Settings runtime ownership.
- Strengthens the existing SFTP regression to audit the actual protocol picker/connect path rather than forbidding informational text.
- Android APK workflow runs the navigation contract before lint/build.
- Updates `android/README.md` and adds `android/UI-UX.md` with the authoritative mobile UI contract and development-release status.

Merge only after all relevant workflows are `completed/success` on the exact final head SHA. After merge, verify actual `push` workflows on the resulting `main` SHA before considering this task complete.