### PR TITLE
CI: authentic cross-platform UI screenshot pipeline

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -4,7 +4,8 @@ name: Ghost FTP Authentic Cross-Platform UI Screenshots
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches:
+      - main
     paths:
       - 'VERSION'
       - 'BUILD-WINDOWS.ps1'
@@ -17,9 +18,16 @@ on:
       - 'linux/**'
       - 'android/**'
       - 'scripts/capture_windows_screenshots.ps1'
+      - 'docs/UI-SCREENSHOT-REQUEST'
       - '.github/workflows/ui-screenshots.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'hardening/**'
+      - 'release-prep/**'
+      - 'work/**'
+      - 'release/**'
+      - 'packaging/**'
     paths:
       - 'VERSION'
       - 'BUILD-WINDOWS.ps1'
@@ -32,6 +40,7 @@ on:
       - 'linux/**'
       - 'android/**'
       - 'scripts/capture_windows_screenshots.ps1'
+      - 'docs/UI-SCREENSHOT-REQUEST'
       - '.github/workflows/ui-screenshots.yml'
 
 permissions:
@@ -56,12 +65,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27.1'
           check-latest: false
           cache: false
+
       - name: Disable Go telemetry
         shell: pwsh
         run: |
@@ -69,10 +80,12 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or (go telemetry).Trim() -ne 'off') {
             throw 'Go telemetry is not disabled.'
           }
+
       - name: Build production Windows packages
         shell: pwsh
         run: .\BUILD-WINDOWS.ps1
-      - name: Capture real Windows UI
+
+      - name: Capture authentic main, Site Manager, Bookmarks, Settings and About windows
         shell: pwsh
         run: |
           $version = (Get-Content VERSION -Raw).Trim()
@@ -81,7 +94,8 @@ jobs:
             throw "Missing verified native production executable: $exe"
           }
           .\scripts\capture_windows_screenshots.ps1 -Executable $exe -OutputDirectory "ui-screenshots\windows"
-      - name: Verify Windows PNG evidence
+
+      - name: Verify screenshot outputs
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -114,7 +128,8 @@ jobs:
             }
             finally { $bitmap.Dispose() }
           }
-      - name: Upload Windows UI evidence
+
+      - name: Publish authentic UI screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ghostftp-authentic-ui-windows
@@ -131,18 +146,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27.1'
           check-latest: false
           cache: false
+
       - name: Install native capture tools
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends xvfb xdotool imagemagick
+
       - name: Build production Linux portable packages
         shell: bash
         run: |
@@ -150,6 +168,7 @@ jobs:
           go telemetry off
           test "$(go telemetry)" = 'off'
           bash linux/BUILD.sh
+
       - name: Capture real Linux X11 UI
         shell: bash
         run: |
@@ -218,7 +237,8 @@ jobs:
             }
             printf 'LINUX_UI=%s SHA256=%s\n' "$(basename "$png")" "$(sha256sum "$png" | awk '{print $1}')"
           done
-      - name: Upload Linux UI evidence
+
+      - name: Publish authentic Linux UI screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ghostftp-authentic-ui-linux
@@ -233,17 +253,21 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Set up Java 17
         uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: '17'
+
       - name: Set up Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
       - name: Set up Gradle 8.9
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-version: '8.9'
+
       - name: Install Android capture dependencies
         shell: bash
         run: |
@@ -251,6 +275,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends imagemagick
           sdkmanager 'platforms;android-35' 'build-tools;35.0.0' 'emulator' 'system-images;android-35;google_apis;x86_64'
+
       - name: Build exact-source Android APK
         working-directory: android
         shell: bash
@@ -258,6 +283,7 @@ jobs:
           set -euo pipefail
           gradle :app:lintDebug :app:packageGhostFtpApk --no-daemon --stacktrace
           test -s dist/Ghost-FTP-Android.apk
+
       - name: Boot emulator and capture real Android UI
         shell: bash
         run: |
@@ -344,7 +370,8 @@ PY
             }
             printf 'ANDROID_UI=%s SHA256=%s\n' "$(basename "$png")" "$(sha256sum "$png" | awk '{print $1}')"
           done
-      - name: Upload Android UI evidence
+
+      - name: Publish authentic Android UI screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ghostftp-authentic-ui-android
@@ -366,22 +393,26 @@ PY
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+
       - name: Download Windows evidence
         uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
         with:
           name: ghostftp-authentic-ui-windows
           path: staging/windows
+
       - name: Download Linux evidence
         uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
         with:
           name: ghostftp-authentic-ui-linux
           path: staging/linux
+
       - name: Download Android evidence
         uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
         with:
           name: ghostftp-authentic-ui-android
           path: staging/android
-      - name: Persist images and cryptographic provenance
+
+      - name: Persist authentic screenshots in repository
         shell: bash
         env:
           SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
@@ -392,7 +423,7 @@ PY
           git fetch origin "$HEAD_BRANCH"
           remote_sha="$(git rev-parse "origin/$HEAD_BRANCH")"
           test "$remote_sha" = "$SOURCE_SHA" || {
-            echo "PR branch moved from capture source $SOURCE_SHA to $remote_sha; refusing stale screenshot persistence." >&2
+            echo "PR branch moved from the capture commit ($SOURCE_SHA) to $remote_sha; refusing a stale screenshot commit." >&2
             exit 1
           }
 

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -1,46 +1,44 @@
-# Current-head reproducible evidence workflow for authentic production Windows UI captures.
-name: Ghost FTP Authentic UI Screenshots
+# Authentic cross-platform runtime screenshot evidence for Ghost FTP.
+name: Ghost FTP Authentic Cross-Platform UI Screenshots
 
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - 'VERSION'
       - 'BUILD-WINDOWS.ps1'
       - 'BUILD-WINDOWS-ARCH-STAGE.ps1'
-      - 'cmd/windowsbootstrap/**'
+      - 'cmd/ghostftp/**'
       - 'internal/desktop/**'
       - 'internal/i18n/**'
       - 'internal/platform/**'
+      - 'linux/BUILD.sh'
+      - 'linux/**'
+      - 'android/**'
       - 'scripts/capture_windows_screenshots.ps1'
-      - 'scripts/verify_release.py'
       - '.github/workflows/ui-screenshots.yml'
   push:
-    branches:
-      - 'hardening/**'
-      - 'release-prep/**'
-      - 'work/**'
-      - 'release/**'
-      - 'packaging/**'
+    branches: [main]
     paths:
       - 'VERSION'
       - 'BUILD-WINDOWS.ps1'
       - 'BUILD-WINDOWS-ARCH-STAGE.ps1'
-      - 'cmd/windowsbootstrap/**'
+      - 'cmd/ghostftp/**'
       - 'internal/desktop/**'
       - 'internal/i18n/**'
       - 'internal/platform/**'
+      - 'linux/BUILD.sh'
+      - 'linux/**'
+      - 'android/**'
       - 'scripts/capture_windows_screenshots.ps1'
-      - 'scripts/verify_release.py'
       - '.github/workflows/ui-screenshots.yml'
 
 permissions:
   contents: write
 
 concurrency:
-  group: ghostftp-ui-screenshots-${{ github.ref }}
+  group: ghostftp-authentic-ui-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -49,23 +47,21 @@ env:
   GOSUMDB: off
 
 jobs:
-  capture:
-    name: Build and capture real Ghost FTP windows
+  windows:
+    name: Authentic Windows runtime surfaces
     runs-on: windows-latest
-    timeout-minutes: 35
+    timeout-minutes: 40
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27.1'
           check-latest: false
           cache: false
-
       - name: Disable Go telemetry
         shell: pwsh
         run: |
@@ -73,147 +69,386 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or (go telemetry).Trim() -ne 'off') {
             throw 'Go telemetry is not disabled.'
           }
-
       - name: Build production Windows packages
         shell: pwsh
         run: .\BUILD-WINDOWS.ps1
-
-      - name: Capture authentic main, Site Manager, Bookmarks, Settings and About windows
+      - name: Capture real Windows UI
         shell: pwsh
         run: |
           $version = (Get-Content VERSION -Raw).Trim()
-          # Public Windows output is architecture-neutral. Authentic UI evidence
-          # intentionally captures the verified native x64 client retained only
-          # in the internal staging directory by BUILD-WINDOWS.ps1.
           $exe = "dist\internal\Ghost-FTP-$version-Portable-x64.exe"
           if (-not (Test-Path $exe -PathType Leaf)) {
             throw "Missing verified native production executable: $exe"
           }
-          .\scripts\capture_windows_screenshots.ps1 -Executable $exe -OutputDirectory "ui-screenshots"
-
-      - name: Verify screenshot outputs
+          .\scripts\capture_windows_screenshots.ps1 -Executable $exe -OutputDirectory "ui-screenshots\windows"
+      - name: Verify Windows PNG evidence
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           Add-Type -AssemblyName System.Drawing
           $expected = @(
-            'ui-screenshots\Ghost-FTP-main-workspace.png',
-            'ui-screenshots\Ghost-FTP-site-manager.png',
-            'ui-screenshots\Ghost-FTP-bookmarks.png',
-            'ui-screenshots\Ghost-FTP-settings.png',
-            'ui-screenshots\Ghost-FTP-about.png'
+            'Ghost-FTP-main-workspace.png',
+            'Ghost-FTP-site-manager.png',
+            'Ghost-FTP-bookmarks.png',
+            'Ghost-FTP-settings.png',
+            'Ghost-FTP-about.png'
           )
-          $pngSignature = [byte[]](137, 80, 78, 71, 13, 10, 26, 10)
-
-          foreach ($path in $expected) {
-            if (-not (Test-Path $path -PathType Leaf)) {
-              throw "Missing authentic UI screenshot: $path"
-            }
-
+          foreach ($name in $expected) {
+            $path = Join-Path 'ui-screenshots\windows' $name
+            if (-not (Test-Path $path -PathType Leaf)) { throw "Missing Windows screenshot: $path" }
             $file = Get-Item -LiteralPath $path
-            if ($file.Length -lt 2048) {
-              throw "Authentic UI screenshot is implausibly small: $path ($($file.Length) bytes)"
-            }
-
-            $bytes = [IO.File]::ReadAllBytes($file.FullName)
-            if ($bytes.Length -lt $pngSignature.Length) {
-              throw "Authentic UI screenshot has an invalid PNG header: $path"
-            }
-            for ($i = 0; $i -lt $pngSignature.Length; $i++) {
-              if ($bytes[$i] -ne $pngSignature[$i]) {
-                throw "Authentic UI screenshot has an invalid PNG signature: $path"
-              }
-            }
-
+            if ($file.Length -lt 2048) { throw "Windows screenshot is implausibly small: $path" }
             $bitmap = New-Object System.Drawing.Bitmap $file.FullName
             try {
-              if ($bitmap.Width -lt 320 -or $bitmap.Height -lt 200 -or $bitmap.Width -gt 8000 -or $bitmap.Height -gt 8000) {
-                throw "Authentic UI screenshot has implausible dimensions: $path ($($bitmap.Width)x$($bitmap.Height))"
-              }
-
-              # File size is not a quality metric for a compact native dialog.
-              # Sample a deterministic grid and require enough distinct colors
-              # to reject blank/solid PrintWindow captures while permitting
-              # efficiently compressed real Settings/About surfaces.
+              if ($bitmap.Width -lt 320 -or $bitmap.Height -lt 200) { throw "Invalid Windows screenshot dimensions: $path" }
               $colors = New-Object 'System.Collections.Generic.HashSet[int]'
-              $sampleColumns = 32
-              $sampleRows = 24
-              for ($sx = 0; $sx -lt $sampleColumns; $sx++) {
-                $x = [Math]::Min($bitmap.Width - 1, [int](($sx + 0.5) * $bitmap.Width / $sampleColumns))
-                for ($sy = 0; $sy -lt $sampleRows; $sy++) {
-                  $y = [Math]::Min($bitmap.Height - 1, [int](($sy + 0.5) * $bitmap.Height / $sampleRows))
+              for ($sx = 0; $sx -lt 32; $sx++) {
+                $x = [Math]::Min($bitmap.Width - 1, [int](($sx + 0.5) * $bitmap.Width / 32))
+                for ($sy = 0; $sy -lt 24; $sy++) {
+                  $y = [Math]::Min($bitmap.Height - 1, [int](($sy + 0.5) * $bitmap.Height / 24))
                   [void]$colors.Add($bitmap.GetPixel($x, $y).ToArgb())
                 }
               }
-              if ($colors.Count -lt 8) {
-                throw "Authentic UI screenshot appears blank or visually degenerate: $path (sampled colors=$($colors.Count))"
-              }
-
-              Write-Host "SCREENSHOT_VERIFIED=$($file.Name) DIMENSIONS=$($bitmap.Width)x$($bitmap.Height) BYTES=$($file.Length) SAMPLED_COLORS=$($colors.Count) SHA256=$((Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant())"
+              if ($colors.Count -lt 8) { throw "Windows screenshot appears blank: $path" }
+              Write-Host "WINDOWS_UI=$name SHA256=$((Get-FileHash $path -Algorithm SHA256).Hash.ToLowerInvariant())"
             }
-            finally {
-              $bitmap.Dispose()
-            }
+            finally { $bitmap.Dispose() }
           }
+      - name: Upload Windows UI evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-authentic-ui-windows
+          if-no-files-found: error
+          retention-days: 30
+          path: ui-screenshots/windows/*.png
 
-      - name: Persist authentic screenshots in repository
-        # Release-prep branches are evidence-only: publishing an artifact is safe,
-        # while self-committing screenshots would move the exact head being gated.
-        if: github.event_name == 'push' && !startsWith(github.ref_name, 'release-prep/') && !contains(github.ref_name, '-prep-')
-        shell: pwsh
+  linux:
+    name: Authentic Linux runtime surfaces
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Install native capture tools
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          $branch = '${{ github.ref_name }}'
-          if ([string]::IsNullOrWhiteSpace($branch)) {
-            throw 'Unable to resolve branch for screenshot persistence.'
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends xvfb xdotool imagemagick
+      - name: Build production Linux portable packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+          bash linux/BUILD.sh
+      - name: Capture real Linux X11 UI
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          mkdir -p ui-screenshots/linux linux-ui
+          tar -xzf "dist/Ghost-FTP-${version}-Linux-amd64.tar.gz" -C linux-ui
+          exe="linux-ui/Ghost-FTP-${version}-Linux-amd64/ghostftp"
+          test -x "$exe"
+
+          export DISPLAY=:99
+          export HOME="$RUNNER_TEMP/ghostftp-linux-home"
+          mkdir -p "$HOME"
+          Xvfb "$DISPLAY" -screen 0 1440x1000x24 -nolisten tcp >"$RUNNER_TEMP/xvfb.log" 2>&1 &
+          xvfb_pid=$!
+          "$exe" >"$RUNNER_TEMP/ghostftp-linux.log" 2>&1 &
+          app_pid=$!
+          cleanup() {
+            kill "$app_pid" 2>/dev/null || true
+            kill "$xvfb_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          win=''
+          for _ in $(seq 1 100); do
+            win="$(xdotool search --onlyvisible --pid "$app_pid" --name '.*' 2>/dev/null | head -n1 || true)"
+            if [[ -n "$win" ]]; then break; fi
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              cat "$RUNNER_TEMP/ghostftp-linux.log" >&2 || true
+              exit 1
+            fi
+            sleep 0.2
+          done
+          [[ -n "$win" ]] || { echo 'Unable to locate Ghost FTP Linux window.' >&2; exit 1; }
+          xdotool windowsize "$win" 1280 900
+          sleep 0.8
+
+          capture() {
+            local output="$1"
+            import -window "$win" "ui-screenshots/linux/$output"
+            test -s "ui-screenshots/linux/$output"
           }
 
-          New-Item -ItemType Directory -Force -Path 'docs\images' | Out-Null
-          $visuals = @(
-            'docs/images/ghost-ftp-main-workspace.png',
-            'docs/images/ghost-ftp-site-manager.png',
-            'docs/images/ghost-ftp-bookmarks.png',
-            'docs/images/ghost-ftp-settings.png',
-            'docs/images/ghost-ftp-about.png'
-          )
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-main-workspace.png' -Destination $visuals[0] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-site-manager.png' -Destination $visuals[1] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-bookmarks.png' -Destination $visuals[2] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-settings.png' -Destination $visuals[3] -Force
-          Copy-Item -LiteralPath 'ui-screenshots\Ghost-FTP-about.png' -Destination $visuals[4] -Force
+          capture 'ghost-ftp-linux-main-workspace.png'
 
-          git add -- $visuals
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Unable to stage authentic screenshots.'
+          # Linux uses one native X11 window with modal overlays. Coordinates
+          # follow the maintained buildLinuxDesktopLayout geometry at 1280x900.
+          xdotool mousemove --window "$win" 1080 35 click 1
+          sleep 0.5
+          capture 'ghost-ftp-linux-bookmarks.png'
+          xdotool key --window "$win" Escape
+          sleep 0.3
+
+          xdotool mousemove --window "$win" 1210 35 click 1
+          sleep 0.5
+          capture 'ghost-ftp-linux-settings.png'
+          xdotool key --window "$win" Escape
+          sleep 0.3
+
+          for png in ui-screenshots/linux/*.png; do
+            dims="$(identify -format '%w %h %k' "$png")"
+            read -r width height colors <<<"$dims"
+            (( width >= 320 && height >= 200 && colors >= 8 )) || {
+              echo "Implausible Linux screenshot: $png ($dims)" >&2
+              exit 1
+            }
+            printf 'LINUX_UI=%s SHA256=%s\n' "$(basename "$png")" "$(sha256sum "$png" | awk '{print $1}')"
+          done
+      - name: Upload Linux UI evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-authentic-ui-linux
+          if-no-files-found: error
+          retention-days: 30
+          path: ui-screenshots/linux/*.png
+
+  android:
+    name: Authentic Android emulator surfaces
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Java 17
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      - name: Set up Gradle 8.9
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        with:
+          gradle-version: '8.9'
+      - name: Install Android capture dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends imagemagick
+          sdkmanager 'platforms;android-35' 'build-tools;35.0.0' 'emulator' 'system-images;android-35;google_apis;x86_64'
+      - name: Build exact-source Android APK
+        working-directory: android
+        shell: bash
+        run: |
+          set -euo pipefail
+          gradle :app:lintDebug :app:packageGhostFtpApk --no-daemon --stacktrace
+          test -s dist/Ghost-FTP-Android.apk
+      - name: Boot emulator and capture real Android UI
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ui-screenshots/android
+          if [[ -e /dev/kvm ]]; then sudo chmod 666 /dev/kvm; fi
+          printf 'no\n' | avdmanager create avd --force --name ghostftp-ui --package 'system-images;android-35;google_apis;x86_64' --device 'pixel_6'
+          emulator -avd ghostftp-ui -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect >"$RUNNER_TEMP/android-emulator.log" 2>&1 &
+          emulator_pid=$!
+          cleanup() {
+            adb emu kill >/dev/null 2>&1 || true
+            kill "$emulator_pid" 2>/dev/null || true
           }
-          git diff --cached --quiet
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host 'AUTHENTIC_UI_SCREENSHOTS=UNCHANGED'
+          trap cleanup EXIT
+
+          adb wait-for-device
+          booted=''
+          for _ in $(seq 1 180); do
+            booted="$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')"
+            [[ "$booted" == '1' ]] && break
+            sleep 1
+          done
+          [[ "$booted" == '1' ]] || { cat "$RUNNER_TEMP/android-emulator.log" >&2 || true; exit 1; }
+
+          adb shell settings put global window_animation_scale 0
+          adb shell settings put global transition_animation_scale 0
+          adb shell settings put global animator_duration_scale 0
+          adb install -r android/dist/Ghost-FTP-Android.apk
+          adb shell am force-stop app.ghostftp.client
+          adb shell am start -n app.ghostftp.client/.MainActivity
+          sleep 2
+
+          tap_ui() {
+            local query="$1"
+            adb shell uiautomator dump /sdcard/ghostftp-window.xml >/dev/null
+            adb pull /sdcard/ghostftp-window.xml "$RUNNER_TEMP/ghostftp-window.xml" >/dev/null
+            local coords
+            coords="$(python - "$RUNNER_TEMP/ghostftp-window.xml" "$query" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+path, query = sys.argv[1], sys.argv[2]
+root = ET.parse(path).getroot()
+for node in root.iter('node'):
+    if node.attrib.get('text') == query or node.attrib.get('content-desc') == query:
+        m = re.fullmatch(r'\[(\d+),(\d+)\]\[(\d+),(\d+)\]', node.attrib.get('bounds', ''))
+        if m:
+            x1, y1, x2, y2 = map(int, m.groups())
+            print(f'{(x1+x2)//2} {(y1+y2)//2}')
+            raise SystemExit(0)
+raise SystemExit(f'UI node not found: {query}')
+PY
+)"
+            read -r x y <<<"$coords"
+            adb shell input tap "$x" "$y"
+            sleep 0.7
+          }
+
+          capture() {
+            local name="$1"
+            adb exec-out screencap -p >"ui-screenshots/android/$name"
+            test -s "ui-screenshots/android/$name"
+          }
+
+          capture 'ghost-ftp-android-files.png'
+          tap_ui 'Open navigation'
+          capture 'ghost-ftp-android-navigation.png'
+          adb shell input keyevent KEYCODE_BACK
+          sleep 0.4
+
+          for section in Sites Bookmarks Transfers Settings About; do
+            tap_ui 'Open navigation'
+            tap_ui "$section"
+            lower="$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')"
+            capture "ghost-ftp-android-${lower}.png"
+          done
+
+          for png in ui-screenshots/android/*.png; do
+            dims="$(identify -format '%w %h %k' "$png")"
+            read -r width height colors <<<"$dims"
+            (( width >= 320 && height >= 480 && colors >= 8 )) || {
+              echo "Implausible Android screenshot: $png ($dims)" >&2
+              exit 1
+            }
+            printf 'ANDROID_UI=%s SHA256=%s\n' "$(basename "$png")" "$(sha256sum "$png" | awk '{print $1}')"
+          done
+      - name: Upload Android UI evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-authentic-ui-android
+          if-no-files-found: error
+          retention-days: 30
+          path: ui-screenshots/android/*.png
+
+  persist:
+    name: Persist verified cross-platform evidence on same-repository PR
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [windows, linux, android]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout exact PR head branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Download Windows evidence
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
+        with:
+          name: ghostftp-authentic-ui-windows
+          path: staging/windows
+      - name: Download Linux evidence
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
+        with:
+          name: ghostftp-authentic-ui-linux
+          path: staging/linux
+      - name: Download Android evidence
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
+        with:
+          name: ghostftp-authentic-ui-android
+          path: staging/android
+      - name: Persist images and cryptographic provenance
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$HEAD_BRANCH"
+          remote_sha="$(git rev-parse "origin/$HEAD_BRANCH")"
+          test "$remote_sha" = "$SOURCE_SHA" || {
+            echo "PR branch moved from capture source $SOURCE_SHA to $remote_sha; refusing stale screenshot persistence." >&2
+            exit 1
+          }
+
+          mkdir -p docs/images
+          cp staging/windows/Ghost-FTP-main-workspace.png docs/images/ghost-ftp-main-workspace.png
+          cp staging/windows/Ghost-FTP-site-manager.png docs/images/ghost-ftp-site-manager.png
+          cp staging/windows/Ghost-FTP-bookmarks.png docs/images/ghost-ftp-bookmarks.png
+          cp staging/windows/Ghost-FTP-settings.png docs/images/ghost-ftp-settings.png
+          cp staging/windows/Ghost-FTP-about.png docs/images/ghost-ftp-about.png
+          cp staging/linux/ghost-ftp-linux-main-workspace.png docs/images/ghost-ftp-linux-main-workspace.png
+          cp staging/linux/ghost-ftp-linux-bookmarks.png docs/images/ghost-ftp-linux-bookmarks.png
+          cp staging/linux/ghost-ftp-linux-settings.png docs/images/ghost-ftp-linux-settings.png
+          cp staging/android/ghost-ftp-android-files.png docs/images/ghost-ftp-android-files.png
+          cp staging/android/ghost-ftp-android-navigation.png docs/images/ghost-ftp-android-navigation.png
+          cp staging/android/ghost-ftp-android-sites.png docs/images/ghost-ftp-android-sites.png
+          cp staging/android/ghost-ftp-android-bookmarks.png docs/images/ghost-ftp-android-bookmarks.png
+          cp staging/android/ghost-ftp-android-transfers.png docs/images/ghost-ftp-android-transfers.png
+          cp staging/android/ghost-ftp-android-settings.png docs/images/ghost-ftp-android-settings.png
+          cp staging/android/ghost-ftp-android-about.png docs/images/ghost-ftp-android-about.png
+
+          python - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+images = sorted(Path('docs/images').glob('ghost-ftp-*.png'))
+manifest = {
+    'schema': 1,
+    'evidence': 'authentic-runtime-capture',
+    'capture_source_sha': os.environ['SOURCE_SHA'],
+    'workflow_run_id': int(os.environ['WORKFLOW_RUN_ID']),
+    'workflow': 'Ghost FTP Authentic Cross-Platform UI Screenshots',
+    'images': [],
+}
+for path in images:
+    data = path.read_bytes()
+    manifest['images'].append({
+        'path': path.as_posix(),
+        'bytes': len(data),
+        'sha256': hashlib.sha256(data).hexdigest(),
+    })
+Path('docs/UI-SCREENSHOT-PROVENANCE.json').write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+)
+PY
+
+          git add docs/images docs/UI-SCREENSHOT-PROVENANCE.json
+          git diff --cached --check
+          if git diff --cached --quiet; then
+            echo 'AUTHENTIC_UI_EVIDENCE=UNCHANGED'
             exit 0
-          }
-          if ($LASTEXITCODE -ne 1) {
-            throw 'Unable to determine whether authentic screenshots changed.'
-          }
-
-          git fetch origin $branch
-          if ($LASTEXITCODE -ne 0) { throw 'Unable to refresh screenshot target branch.' }
-          $remote = (git rev-parse "origin/$branch").Trim()
-          if ($remote -ne '${{ github.sha }}') {
-            throw "Branch moved from the capture commit (${{ github.sha }}) to $remote; refusing a stale screenshot commit."
-          }
+          fi
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m 'Update authentic Ghost FTP UI screenshots [skip ci]'
-          if ($LASTEXITCODE -ne 0) { throw 'Unable to commit authentic screenshots.' }
-          git push origin "HEAD:$branch"
-          if ($LASTEXITCODE -ne 0) { throw 'Unable to push authentic screenshots.' }
-          Write-Host 'AUTHENTIC_UI_SCREENSHOTS=PERSISTED'
-
-      - name: Publish authentic UI screenshots
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ghostftp-authentic-ui-screenshots
-          if-no-files-found: error
-          retention-days: 30
-          path: ui-screenshots/*.png
+          git commit -m 'docs: refresh authentic cross-platform UI evidence'
+          git push origin "HEAD:$HEAD_BRANCH"
+          echo "AUTHENTIC_UI_EVIDENCE=PERSISTED SOURCE_SHA=$SOURCE_SHA COMMIT_SHA=$(git rev-parse HEAD)"

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -452,3 +452,4 @@ PY
           git commit -m 'docs: refresh authentic cross-platform UI evidence'
           git push origin "HEAD:$HEAD_BRANCH"
           echo "AUTHENTIC_UI_EVIDENCE=PERSISTED SOURCE_SHA=$SOURCE_SHA COMMIT_SHA=$(git rev-parse HEAD)"
+          echo 'AUTHENTIC_UI_SCREENSHOTS=PERSISTED'

--- a/scripts/test_authentic_ui_workflow_contract.py
+++ b/scripts/test_authentic_ui_workflow_contract.py
@@ -9,13 +9,14 @@ WORKFLOW = ROOT / ".github" / "workflows" / "ui-screenshots.yml"
 class AuthenticUIWorkflowContractTests(unittest.TestCase):
     def test_release_prep_capture_is_evidence_only(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        persist = workflow.split("- name: Persist authentic screenshots in repository", 1)[1].split(
-            "- name: Publish authentic UI screenshots", 1
-        )[0]
-        self.assertIn("github.event_name == 'push'", persist)
-        self.assertIn("!startsWith(github.ref_name, 'release-prep/')", persist)
-        self.assertIn("!contains(github.ref_name, '-prep-')", persist)
+        trigger = workflow.split("permissions:", 1)[0]
+        persist = workflow.split("  persist:", 1)[1]
+
+        self.assertIn("- 'release-prep/**'", trigger)
+        self.assertIn("github.event_name == 'pull_request'", persist)
+        self.assertNotIn("github.event_name == 'push'", persist)
         self.assertIn("refusing a stale screenshot commit", persist)
+        self.assertNotIn("[skip ci]", workflow)
 
     def test_pull_request_ui_changes_always_request_authentic_capture(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -27,24 +28,71 @@ class AuthenticUIWorkflowContractTests(unittest.TestCase):
             "'internal/desktop/**'",
             "'internal/i18n/**'",
             "'internal/platform/**'",
+            "'android/**'",
+            "'linux/**'",
             "'scripts/capture_windows_screenshots.ps1'",
+            "'docs/UI-SCREENSHOT-REQUEST'",
             "'.github/workflows/ui-screenshots.yml'",
         ):
             self.assertIn(path, trigger)
 
-    def test_verified_captures_are_always_published_as_artifact(self) -> None:
+    def test_verified_captures_are_always_published_as_artifacts(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        publish = workflow.split("- name: Publish authentic UI screenshots", 1)[1]
-        self.assertNotIn("if:", publish.split("with:", 1)[0])
-        self.assertIn("ghostftp-authentic-ui-screenshots", publish)
+        for artifact in (
+            "ghostftp-authentic-ui-windows",
+            "ghostftp-authentic-ui-linux",
+            "ghostftp-authentic-ui-android",
+        ):
+            self.assertIn(artifact, workflow)
+        self.assertEqual(workflow.count("actions/upload-artifact@"), 3)
+
         for name in (
             "Ghost-FTP-main-workspace.png",
             "Ghost-FTP-site-manager.png",
             "Ghost-FTP-bookmarks.png",
             "Ghost-FTP-settings.png",
             "Ghost-FTP-about.png",
+            "ghost-ftp-linux-main-workspace.png",
+            "ghost-ftp-linux-bookmarks.png",
+            "ghost-ftp-linux-settings.png",
+            "ghost-ftp-android-files.png",
+            "ghost-ftp-android-navigation.png",
+            "ghost-ftp-android-sites.png",
+            "ghost-ftp-android-bookmarks.png",
+            "ghost-ftp-android-transfers.png",
+            "ghost-ftp-android-settings.png",
+            "ghost-ftp-android-about.png",
         ):
             self.assertIn(name, workflow)
+
+    def test_persistence_is_sha_bound_and_records_provenance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        persist = workflow.split("  persist:", 1)[1]
+        self.assertIn("SOURCE_SHA", persist)
+        self.assertIn("remote_sha", persist)
+        self.assertIn("capture_source_sha", persist)
+        self.assertIn("UI-SCREENSHOT-PROVENANCE.json", persist)
+        self.assertIn("sha256", persist)
+        self.assertIn("AUTHENTIC_UI_SCREENSHOTS=PERSISTED", persist)
+        self.assertIn("AUTHENTIC_UI_EVIDENCE=PERSISTED", persist)
+
+    def test_android_capture_drives_real_runtime_navigation(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        android = workflow.split("  android:", 1)[1].split("  persist:", 1)[0]
+        self.assertIn("adb install -r android/dist/Ghost-FTP-Android.apk", android)
+        self.assertIn("uiautomator dump", android)
+        self.assertIn("tap_ui 'Open navigation'", android)
+        self.assertIn("Sites Bookmarks Transfers Settings About", android)
+        self.assertIn("adb exec-out screencap -p", android)
+
+    def test_linux_capture_uses_packaged_native_runtime(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        linux = workflow.split("  linux:", 1)[1].split("  android:", 1)[0]
+        self.assertIn("bash linux/BUILD.sh", linux)
+        self.assertIn("Linux-amd64.tar.gz", linux)
+        self.assertIn("Xvfb", linux)
+        self.assertIn("xdotool", linux)
+        self.assertIn("import -window", linux)
 
     def test_bookmarks_manager_is_captured_through_real_runtime_command(self) -> None:
         capture = (ROOT / "scripts" / "capture_windows_screenshots.ps1").read_text(encoding="utf-8")

--- a/scripts/test_windows_visual_regressions.py
+++ b/scripts/test_windows_visual_regressions.py
@@ -101,7 +101,10 @@ class WindowsVisualRegressionTests(unittest.TestCase):
         self.assertIn("- 'internal/i18n/**'", workflow)
         self.assertIn("Capture authentic main, Site Manager, Bookmarks, Settings and About windows", workflow)
         self.assertIn("Ghost-FTP-$version-Portable-x64.exe", workflow)
-        self.assertIn("!startsWith(github.ref_name, 'release-prep/')", workflow)
+        persist = workflow.split("  persist:", 1)[1]
+        self.assertIn("github.event_name == 'pull_request'", persist)
+        self.assertNotIn("github.event_name == 'push'", persist)
+        self.assertNotIn("[skip ci]", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Bootstraps the cross-platform authentic UI evidence pipeline on the default branch.

### What changes

- Replaces the previous Windows-only screenshot workflow with independent Windows, Linux and Android runtime-capture jobs.
- Windows captures the verified native x64 payload produced by the production universal Windows build.
- Linux captures the exact amd64 executable extracted from the production Portable package under Xvfb; Bookmarks and Settings are real X11 overlays.
- Android builds the exact-source APK, installs it in an Android 35 emulator and captures Files, navigation drawer, Sites, Bookmarks, Transfers, Settings and About through real UI interaction.
- Every image is checked for dimensions and visual non-degeneracy and published as a workflow artifact.
- Same-repository PRs persist only verified images plus a SHA-256 provenance manifest.
- Removes the old `[skip ci]` screenshot-commit loophole: persisted evidence is a normal commit and therefore gets its own CI head.

This PR is intentionally the default-branch bootstrap. GitHub evaluates `pull_request` workflow definitions from the base branch, so the new cross-platform workflow itself becomes runnable for PR evidence only after this workflow definition is merged to `main`.

Merge only after the regular exact-head Ghost FTP CI is green. After merge, verify the new workflow on the resulting `main` SHA before opening the separate README/evidence PR.