### PR TITLE
Fix Android authentic foreground validation

### DIFF
--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -214,7 +214,8 @@ wait_ui() {
     dump_ui
     coords="$(find_ui_coords "$query" 2>/dev/null || true)"
     if [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]]; then
-      printf 'ANDROID_UI_VISIBLE=%s X=%s Y=%s\n' "$query" ${coords/ / Y=}
+      read -r x y <<<"$coords"
+      printf 'ANDROID_UI_VISIBLE=%s X=%s Y=%s\n' "$query" "$x" "$y"
       return 0
     fi
     sleep 0.4

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -185,6 +185,25 @@ raise SystemExit(1)
 PY
 }
 
+find_ui_bounds() {
+  local query="$1"
+  python3 - "$UI_XML_LOCAL" "$query" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+path, query = sys.argv[1], sys.argv[2]
+root = ET.parse(path).getroot()
+for node in root.iter("node"):
+    if node.attrib.get("text") == query or node.attrib.get("content-desc") == query:
+        match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", node.attrib.get("bounds", ""))
+        if match:
+            print(" ".join(match.groups()))
+            raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 tap_ui() {
   local query="$1"
   local coords=''
@@ -222,40 +241,47 @@ wait_ui() {
   return 1
 }
 
-# Android 35 can omit the programmatically created drawer buttons from the
-# uiautomator hierarchy even though they are visibly rendered and clickable.
-# In that case, anchor the fallback to the *rendered* active Files selection
-# (#202F50) in the already captured navigation screenshot. The search is
-# deliberately restricted to MainActivity's 286dp drawer width so similarly
-# colored status badges in the app bar can never become the anchor. This
-# measures the real row center after Android has applied font metrics, density
-# and layout; only the fixed 48dp row height + 5dp margin from MainActivity is
-# then used as the pitch. The post-tap section title remains authoritative.
+# Android 35 can omit the programmatically created drawer Button nodes from the
+# uiautomator hierarchy even though the drawer's stable text labels remain
+# exposed. Anchor the coordinate fallback to the bottom edge of the actual
+# "Android development client" TextView. MainActivity adds Files immediately
+# after that TextView, then six navigation rows with a 48dp minimum height and
+# 5dp bottom margin. This keeps font metrics and top padding runtime-derived
+# instead of guessed. Every coordinate tap is still followed by the requested
+# section-title assertion, so a wrong fallback cannot produce PASS.
 calibrate_navigation_geometry() {
   local screenshot="$OUTPUT_DIR/ghost-ftp-android-navigation.png"
   local dims=''
-  local geometry=''
   local screen_width=''
   local screen_height=''
-  local crop_width=''
-  local crop_height=''
-  local box_width=''
-  local box_height=''
-  local box_x=''
-  local box_y=''
+  local platform_bounds=''
+  local platform_x1=''
+  local platform_y1=''
+  local platform_x2=''
+  local platform_y2=''
   local density=''
   local button_height=''
   local row_margin=''
+  local drawer_width=''
 
   [[ -s "$screenshot" ]] || {
-    echo "Navigation screenshot is unavailable for rendered-row calibration: $screenshot" >&2
+    echo "Navigation screenshot is unavailable for geometry validation: $screenshot" >&2
     return 1
   }
-
   dims="$(identify -format '%w %h' "$screenshot" 2>/dev/null || true)"
   read -r screen_width screen_height <<<"$dims"
   [[ "$screen_width" =~ ^[0-9]+$ && "$screen_height" =~ ^[0-9]+$ ]] || {
     echo "Unable to read navigation screenshot dimensions: ${dims:-<none>}" >&2
+    return 1
+  }
+
+  dump_ui
+  platform_bounds="$(find_ui_bounds 'Android development client' 2>/dev/null || true)"
+  read -r platform_x1 platform_y1 platform_x2 platform_y2 <<<"$platform_bounds"
+  [[ "$platform_x1" =~ ^[0-9]+$ && "$platform_y1" =~ ^[0-9]+$ \
+      && "$platform_x2" =~ ^[0-9]+$ && "$platform_y2" =~ ^[0-9]+$ ]] || {
+    echo "Unable to resolve runtime drawer header bounds: ${platform_bounds:-<none>}" >&2
+    [[ -s "$UI_XML_LOCAL" ]] && cat "$UI_XML_LOCAL" >&2 || true
     return 1
   }
 
@@ -266,40 +292,26 @@ calibrate_navigation_geometry() {
   }
   button_height=$(((48 * density + 80) / 160))
   row_margin=$(((5 * density + 80) / 160))
-  crop_width=$(((286 * density + 80) / 160))
-  (( crop_width > screen_width )) && crop_width="$screen_width"
-  crop_height=$((screen_height * 3 / 5))
+  drawer_width=$(((286 * density + 80) / 160))
+  (( drawer_width > screen_width )) && drawer_width="$screen_width"
 
-  geometry="$(convert "$screenshot" \
-    -crop "${crop_width}x${crop_height}+0+0" +repage -alpha off \
-    -fx '(abs(r-0.125490196)<0.008&&abs(g-0.184313725)<0.008&&abs(b-0.313725490)<0.008)?1:0' \
-    -trim -format '%w %h %X %Y' info: 2>/dev/null || true)"
-  read -r box_width box_height box_x box_y <<<"$geometry"
-  box_x="${box_x#+}"
-  box_y="${box_y#+}"
-  [[ "$box_width" =~ ^[0-9]+$ && "$box_height" =~ ^[0-9]+$ \
-      && "$box_x" =~ ^-?[0-9]+$ && "$box_y" =~ ^-?[0-9]+$ ]] || {
-    echo "Unable to resolve the active Files selection bounds: ${geometry:-<none>}" >&2
-    return 1
-  }
-  if (( box_x < 0 || box_y < 0 || box_width < crop_width / 2 \
-        || box_height < button_height / 2 || box_height > button_height * 2 )); then
-    echo "Implausible active Files selection bounds: $geometry in ${crop_width}x${crop_height} drawer crop" >&2
+  if (( platform_x1 < 0 || platform_x2 <= platform_x1 || platform_x2 > drawer_width \
+        || platform_y1 < 0 || platform_y2 <= platform_y1 || platform_y2 >= screen_height / 2 )); then
+    echo "Implausible runtime drawer header bounds: $platform_bounds drawer_width=$drawer_width screen=${screen_width}x${screen_height}" >&2
     return 1
   fi
 
-  NAV_ANCHOR_X=$((box_x + box_width / 2))
-  NAV_FILES_Y=$((box_y + box_height / 2))
+  NAV_ANCHOR_X=$((drawer_width / 2))
+  NAV_FILES_Y=$((platform_y2 + button_height / 2))
   NAV_ROW_PITCH=$((button_height + row_margin))
-  if (( NAV_ANCHOR_X <= 0 || NAV_ANCHOR_X >= crop_width || NAV_FILES_Y <= 0 || NAV_ROW_PITCH <= 0 \
+  if (( NAV_ANCHOR_X <= 0 || NAV_FILES_Y <= platform_y2 || NAV_ROW_PITCH <= 0 \
         || NAV_FILES_Y + 5 * NAV_ROW_PITCH >= screen_height )); then
     echo "Implausible navigation calibration: X=$NAV_ANCHOR_X FILES_Y=$NAV_FILES_Y PITCH=$NAV_ROW_PITCH" >&2
     return 1
   fi
 
-  printf 'ANDROID_NAV_CALIBRATION=PASS X=%s FILES_Y=%s ROW_PITCH=%s SELECTION_BOUNDS=%sx%s+%s+%s DRAWER_WIDTH=%s DENSITY=%s\n' \
-    "$NAV_ANCHOR_X" "$NAV_FILES_Y" "$NAV_ROW_PITCH" \
-    "$box_width" "$box_height" "$box_x" "$box_y" "$crop_width" "$density"
+  printf 'ANDROID_NAV_CALIBRATION=PASS X=%s FILES_Y=%s ROW_PITCH=%s PLATFORM_BOUNDS=%s DRAWER_WIDTH=%s DENSITY=%s\n' \
+    "$NAV_ANCHOR_X" "$NAV_FILES_Y" "$NAV_ROW_PITCH" "$platform_bounds" "$drawer_width" "$density"
 }
 
 tap_nav_section() {
@@ -323,7 +335,7 @@ tap_nav_section() {
     x="$NAV_ANCHOR_X"
     y=$((NAV_FILES_Y + NAV_ROW_PITCH * ordinal))
     timeout 10s adb shell input tap "$x" "$y"
-    printf 'ANDROID_NAV_TAP=%s MODE=rendered-selection-anchor X=%s Y=%s FILES_Y=%s ROW_PITCH=%s\n' \
+    printf 'ANDROID_NAV_TAP=%s MODE=runtime-header-anchor X=%s Y=%s FILES_Y=%s ROW_PITCH=%s\n' \
       "$section" "$x" "$y" "$NAV_FILES_Y" "$NAV_ROW_PITCH"
   fi
   sleep 0.7

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -73,9 +73,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Never let a dead or unreachable emulator block this evidence workflow
-# indefinitely. Poll both the adb transport and Android boot property while also
-# proving that the emulator process is still alive.
 timeout 10s adb start-server >/dev/null 2>&1 || true
 booted=''
 for _ in $(seq 1 180); do
@@ -84,7 +81,6 @@ for _ in $(seq 1 180); do
     echo 'Android emulator terminated before becoming ready.' >&2
     exit 1
   fi
-
   state="$(timeout 5s adb get-state 2>/dev/null || true)"
   if [[ "$state" == 'device' ]]; then
     booted="$(timeout 5s adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
@@ -154,8 +150,6 @@ dump_ui() {
       echo 'Android emulator terminated during UI capture.' >&2
       return 1
     fi
-    # uiautomator dump is real runtime accessibility evidence, but on a busy
-    # emulator it can occasionally stall. Bound each attempt and retry.
     if timeout 10s adb shell uiautomator dump "$UI_XML_DEVICE" >/dev/null 2>&1 &&
        timeout 10s adb pull "$UI_XML_DEVICE" "$UI_XML_LOCAL" >/dev/null 2>&1 &&
        [[ -s "$UI_XML_LOCAL" ]]; then
@@ -185,47 +179,6 @@ for node in root.iter("node"):
             print(f"{(x1 + x2) // 2} {(y1 + y2) // 2}")
             raise SystemExit(0)
 raise SystemExit(1)
-PY
-}
-
-# The Android 35 accessibility hierarchy can omit Button text for this
-# programmatic drawer. In that case identify the six app-owned navigation rows
-# from their real runtime bounds instead of guessing a vertical dp position.
-# The drawer is 286dp wide; each navigation row spans most of that width.
-find_nav_coords() {
-  local ordinal="$1"
-  local density="$2"
-  python3 - "$UI_XML_LOCAL" "$ordinal" "$density" <<'PY'
-import re
-import sys
-import xml.etree.ElementTree as ET
-
-path, ordinal, density = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-root = ET.parse(path).getroot()
-drawer_right = round(286 * density / 160)
-slack = round(6 * density / 160)
-min_width = round(220 * density / 160)
-candidates = []
-for node in root.iter("node"):
-    if node.attrib.get("class") != "android.widget.Button" or node.attrib.get("clickable") != "true":
-        continue
-    match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", node.attrib.get("bounds", ""))
-    if not match:
-        continue
-    x1, y1, x2, y2 = map(int, match.groups())
-    if x1 >= drawer_right or x2 > drawer_right + slack or (x2 - x1) < min_width:
-        continue
-    candidates.append((y1, y2, x1, x2))
-
-candidates.sort()
-if len(candidates) != 6:
-    print(f"Expected exactly 6 drawer navigation buttons, found {len(candidates)}: {candidates}", file=sys.stderr)
-    raise SystemExit(1)
-if ordinal < 0 or ordinal >= len(candidates):
-    print(f"Navigation ordinal out of range: {ordinal}", file=sys.stderr)
-    raise SystemExit(1)
-y1, y2, x1, x2 = candidates[ordinal]
-print(f"{(x1 + x2) // 2} {(y1 + y2) // 2}")
 PY
 }
 
@@ -266,9 +219,12 @@ wait_ui() {
   return 1
 }
 
-# Prefer semantic text when Android exposes it. Otherwise select the exact
-# runtime Button bounds from the open drawer. A tap is accepted only after the
-# independently rendered section title proves that the requested transition ran.
+# Android 35 does not expose the programmatic drawer rows to uiautomator. The
+# exact runner proved that 152dp vertically lands inside the Files row. All six
+# navigation rows are created by the same Button factory with 48dp minimum
+# height and a 5dp bottom margin, so preserving that in-row offset and adding
+# the 53dp row pitch reaches the requested row. The separately rendered title
+# below remains authoritative: a coordinate tap alone can never produce PASS.
 tap_nav_section() {
   local section="$1"
   local ordinal="$2"
@@ -283,17 +239,14 @@ tap_nav_section() {
   else
     density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
     [[ "$density" =~ ^[0-9]+$ ]] || {
-      echo "Unable to resolve emulator density for drawer hierarchy fallback: ${density:-<none>}" >&2
+      echo "Unable to resolve emulator density for drawer row calibration: ${density:-<none>}" >&2
       return 1
     }
-    coords="$(find_nav_coords "$ordinal" "$density")" || return 1
-    [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]] || {
-      echo "Unable to resolve runtime drawer button bounds for $section." >&2
-      return 1
-    }
-    read -r x y <<<"$coords"
+    x=$((143 * density / 160))
+    y_dp=$((152 + 53 * ordinal))
+    y=$((y_dp * density / 160))
     timeout 10s adb shell input tap "$x" "$y"
-    printf 'ANDROID_NAV_TAP=%s MODE=verified-hierarchy-fallback DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
+    printf 'ANDROID_NAV_TAP=%s MODE=verified-row-calibration DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
   fi
   sleep 0.7
   wait_ui "$expected_title"
@@ -315,9 +268,6 @@ capture 'ghost-ftp-android-files.png'
 tap_ui 'Open navigation'
 capture 'ghost-ftp-android-navigation.png'
 
-# The drawer is already open for Sites. Each verified section transition closes
-# it, then the next iteration reopens the real drawer before selecting the next
-# destination. Ordinal zero is Files, so Sites begins at one.
 first_section=1
 ordinal=1
 for section in Sites Bookmarks Transfers Settings About; do

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -222,12 +222,18 @@ capture() {
 capture 'ghost-ftp-android-files.png'
 tap_ui 'Open navigation'
 capture 'ghost-ftp-android-navigation.png'
-timeout 10s adb shell input keyevent KEYCODE_BACK
-sleep 0.4
 
+# The drawer is already open after the navigation evidence capture. Select the
+# first destination directly instead of closing it with BACK and racing the
+# accessibility hierarchy while trying to reopen it. Each navigation button
+# transitions sections and closes the drawer, so subsequent sections reopen it.
+first_section=1
 for section in Sites Bookmarks Transfers Settings About; do
-  tap_ui 'Open navigation'
+  if (( first_section == 0 )); then
+    tap_ui 'Open navigation'
+  fi
   tap_ui "$section"
+  first_section=0
   lower="$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')"
   capture "ghost-ftp-android-${lower}.png"
 done

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -188,6 +188,47 @@ raise SystemExit(1)
 PY
 }
 
+# The Android 35 accessibility hierarchy can omit Button text for this
+# programmatic drawer. In that case identify the six app-owned navigation rows
+# from their real runtime bounds instead of guessing a vertical dp position.
+# The drawer is 286dp wide; each navigation row spans most of that width.
+find_nav_coords() {
+  local ordinal="$1"
+  local density="$2"
+  python3 - "$UI_XML_LOCAL" "$ordinal" "$density" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+path, ordinal, density = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+root = ET.parse(path).getroot()
+drawer_right = round(286 * density / 160)
+slack = round(6 * density / 160)
+min_width = round(220 * density / 160)
+candidates = []
+for node in root.iter("node"):
+    if node.attrib.get("class") != "android.widget.Button" or node.attrib.get("clickable") != "true":
+        continue
+    match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", node.attrib.get("bounds", ""))
+    if not match:
+        continue
+    x1, y1, x2, y2 = map(int, match.groups())
+    if x1 >= drawer_right or x2 > drawer_right + slack or (x2 - x1) < min_width:
+        continue
+    candidates.append((y1, y2, x1, x2))
+
+candidates.sort()
+if len(candidates) != 6:
+    print(f"Expected exactly 6 drawer navigation buttons, found {len(candidates)}: {candidates}", file=sys.stderr)
+    raise SystemExit(1)
+if ordinal < 0 or ordinal >= len(candidates):
+    print(f"Navigation ordinal out of range: {ordinal}", file=sys.stderr)
+    raise SystemExit(1)
+y1, y2, x1, x2 = candidates[ordinal]
+print(f"{(x1 + x2) // 2} {(y1 + y2) // 2}")
+PY
+}
+
 tap_ui() {
   local query="$1"
   local coords=''
@@ -225,10 +266,9 @@ wait_ui() {
   return 1
 }
 
-# Android 35's uiautomator can omit text for the programmatic native drawer
-# buttons even while the drawer is visibly rendered. Prefer semantic lookup; if
-# unavailable, use the fixed app-owned drawer geometry in dp, then prove the
-# section transition through a separately rendered title before accepting it.
+# Prefer semantic text when Android exposes it. Otherwise select the exact
+# runtime Button bounds from the open drawer. A tap is accepted only after the
+# independently rendered section title proves that the requested transition ran.
 tap_nav_section() {
   local section="$1"
   local ordinal="$2"
@@ -243,16 +283,17 @@ tap_nav_section() {
   else
     density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
     [[ "$density" =~ ^[0-9]+$ ]] || {
-      echo "Unable to resolve emulator density for drawer fallback: ${density:-<none>}" >&2
+      echo "Unable to resolve emulator density for drawer hierarchy fallback: ${density:-<none>}" >&2
       return 1
     }
-    # Drawer width is 286dp. Native navigation rows are 48dp high with 5dp
-    # spacing; their measured centers on this app-owned layout start at ~99dp.
-    x=$((143 * density / 160))
-    y_dp=$((99 + 53 * ordinal))
-    y=$((y_dp * density / 160))
+    coords="$(find_nav_coords "$ordinal" "$density")" || return 1
+    [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]] || {
+      echo "Unable to resolve runtime drawer button bounds for $section." >&2
+      return 1
+    }
+    read -r x y <<<"$coords"
     timeout 10s adb shell input tap "$x" "$y"
-    printf 'ANDROID_NAV_TAP=%s MODE=verified-dp-fallback DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
+    printf 'ANDROID_NAV_TAP=%s MODE=verified-hierarchy-fallback DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
   fi
   sleep 0.7
   wait_ui "$expected_title"
@@ -276,7 +317,7 @@ capture 'ghost-ftp-android-navigation.png'
 
 # The drawer is already open for Sites. Each verified section transition closes
 # it, then the next iteration reopens the real drawer before selecting the next
-# destination. Every coordinate fallback is accepted only after title evidence.
+# destination. Ordinal zero is Files, so Sites begins at one.
 first_section=1
 ordinal=1
 for section in Sites Bookmarks Transfers Settings About; do

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -13,6 +13,9 @@ SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
 EMULATOR_BIN="${SDK_ROOT:+$SDK_ROOT/emulator/emulator}"
 AAPT_BIN="${SDK_ROOT:+$SDK_ROOT/build-tools/35.0.0/aapt}"
 AVD_HOME="${GHOSTFTP_UI_AVD_HOME:-${RUNNER_TEMP:-/tmp}/ghostftp-avd}"
+NAV_ANCHOR_X=''
+NAV_FILES_Y=''
+NAV_ROW_PITCH=''
 
 [[ -s "$APK_PATH" ]] || {
   echo "Missing Android APK: $APK_PATH" >&2
@@ -219,17 +222,91 @@ wait_ui() {
   return 1
 }
 
-# Android 35 does not expose the programmatic drawer rows to uiautomator. The
-# exact runner proved that 152dp vertically lands inside the Files row. All six
-# navigation rows are created by the same Button factory with 48dp minimum
-# height and a 5dp bottom margin, so preserving that in-row offset and adding
-# the 53dp row pitch reaches the requested row. The separately rendered title
-# below remains authoritative: a coordinate tap alone can never produce PASS.
+# Android 35 can omit the programmatically created drawer buttons from the
+# uiautomator hierarchy even though they are visibly rendered and clickable.
+# In that case, anchor the fallback to the *rendered* active Files selection
+# (#202F50) in the already captured navigation screenshot. This measures the
+# real row center after Android has applied font metrics, density and layout;
+# only the fixed 48dp row height + 5dp margin from MainActivity is then used as
+# the pitch. The post-tap section title remains authoritative, so a coordinate
+# fallback can never produce PASS unless the requested section actually opened.
+calibrate_navigation_geometry() {
+  local screenshot="$OUTPUT_DIR/ghost-ftp-android-navigation.png"
+  local dims=''
+  local geometry=''
+  local screen_width=''
+  local screen_height=''
+  local crop_width=''
+  local crop_height=''
+  local box_width=''
+  local box_height=''
+  local box_x=''
+  local box_y=''
+  local density=''
+  local button_height=''
+  local row_margin=''
+
+  [[ -s "$screenshot" ]] || {
+    echo "Navigation screenshot is unavailable for rendered-row calibration: $screenshot" >&2
+    return 1
+  }
+
+  dims="$(identify -format '%w %h' "$screenshot" 2>/dev/null || true)"
+  read -r screen_width screen_height <<<"$dims"
+  [[ "$screen_width" =~ ^[0-9]+$ && "$screen_height" =~ ^[0-9]+$ ]] || {
+    echo "Unable to read navigation screenshot dimensions: ${dims:-<none>}" >&2
+    return 1
+  }
+  crop_width=$((screen_width * 4 / 5))
+  crop_height=$((screen_height * 3 / 5))
+
+  geometry="$(convert "$screenshot" \
+    -crop "${crop_width}x${crop_height}+0+0" +repage -alpha off \
+    -fx '(abs(r-0.125490196)<0.008&&abs(g-0.184313725)<0.008&&abs(b-0.313725490)<0.008)?1:0' \
+    -trim -format '%w %h %X %Y' info: 2>/dev/null || true)"
+  read -r box_width box_height box_x box_y <<<"$geometry"
+  box_x="${box_x#+}"
+  box_y="${box_y#+}"
+  [[ "$box_width" =~ ^[0-9]+$ && "$box_height" =~ ^[0-9]+$ \
+      && "$box_x" =~ ^-?[0-9]+$ && "$box_y" =~ ^-?[0-9]+$ ]] || {
+    echo "Unable to resolve the active Files selection bounds: ${geometry:-<none>}" >&2
+    return 1
+  }
+  if (( box_x < 0 || box_y < 0 || box_width < screen_width / 4 || box_height < 20 || box_height > screen_height / 8 )); then
+    echo "Implausible active Files selection bounds: $geometry on ${screen_width}x${screen_height}" >&2
+    return 1
+  fi
+
+  density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
+  [[ "$density" =~ ^[0-9]+$ ]] || {
+    echo "Unable to resolve emulator density for navigation row pitch: ${density:-<none>}" >&2
+    return 1
+  }
+  button_height=$(((48 * density + 80) / 160))
+  row_margin=$(((5 * density + 80) / 160))
+
+  NAV_ANCHOR_X=$((box_x + box_width / 2))
+  NAV_FILES_Y=$((box_y + box_height / 2))
+  NAV_ROW_PITCH=$((button_height + row_margin))
+  if (( NAV_ANCHOR_X <= 0 || NAV_FILES_Y <= 0 || NAV_ROW_PITCH <= 0 \
+        || NAV_FILES_Y + 5 * NAV_ROW_PITCH >= screen_height )); then
+    echo "Implausible navigation calibration: X=$NAV_ANCHOR_X FILES_Y=$NAV_FILES_Y PITCH=$NAV_ROW_PITCH" >&2
+    return 1
+  fi
+
+  printf 'ANDROID_NAV_CALIBRATION=PASS X=%s FILES_Y=%s ROW_PITCH=%s SELECTION_BOUNDS=%sx%s+%s+%s DENSITY=%s\n' \
+    "$NAV_ANCHOR_X" "$NAV_FILES_Y" "$NAV_ROW_PITCH" \
+    "$box_width" "$box_height" "$box_x" "$box_y" "$density"
+}
+
 tap_nav_section() {
   local section="$1"
   local ordinal="$2"
   local expected_title="$3"
   local coords=''
+  local x=''
+  local y=''
+
   dump_ui
   coords="$(find_ui_coords "$section" 2>/dev/null || true)"
   if [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]]; then
@@ -237,16 +314,14 @@ tap_nav_section() {
     timeout 10s adb shell input tap "$x" "$y"
     printf 'ANDROID_NAV_TAP=%s MODE=semantic X=%s Y=%s\n' "$section" "$x" "$y"
   else
-    density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
-    [[ "$density" =~ ^[0-9]+$ ]] || {
-      echo "Unable to resolve emulator density for drawer row calibration: ${density:-<none>}" >&2
-      return 1
-    }
-    x=$((143 * density / 160))
-    y_dp=$((152 + 53 * ordinal))
-    y=$((y_dp * density / 160))
+    if [[ ! "$NAV_ANCHOR_X" =~ ^[0-9]+$ || ! "$NAV_FILES_Y" =~ ^[0-9]+$ || ! "$NAV_ROW_PITCH" =~ ^[0-9]+$ ]]; then
+      calibrate_navigation_geometry
+    fi
+    x="$NAV_ANCHOR_X"
+    y=$((NAV_FILES_Y + NAV_ROW_PITCH * ordinal))
     timeout 10s adb shell input tap "$x" "$y"
-    printf 'ANDROID_NAV_TAP=%s MODE=verified-row-calibration DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
+    printf 'ANDROID_NAV_TAP=%s MODE=rendered-selection-anchor X=%s Y=%s FILES_Y=%s ROW_PITCH=%s\n' \
+      "$section" "$x" "$y" "$NAV_FILES_Y" "$NAV_ROW_PITCH"
   fi
   sleep 0.7
   wait_ui "$expected_title"

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -207,6 +207,56 @@ tap_ui() {
   return 1
 }
 
+wait_ui() {
+  local query="$1"
+  local coords=''
+  for _ in $(seq 1 20); do
+    dump_ui
+    coords="$(find_ui_coords "$query" 2>/dev/null || true)"
+    if [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]]; then
+      printf 'ANDROID_UI_VISIBLE=%s X=%s Y=%s\n' "$query" ${coords/ / Y=}
+      return 0
+    fi
+    sleep 0.4
+  done
+  echo "Expected UI node did not become visible: $query" >&2
+  [[ -s "$UI_XML_LOCAL" ]] && cat "$UI_XML_LOCAL" >&2 || true
+  return 1
+}
+
+# Android 35's uiautomator can omit text for the programmatic native drawer
+# buttons even while the drawer is visibly rendered. Prefer semantic lookup; if
+# unavailable, use the fixed app-owned drawer geometry in dp, then prove the
+# section transition through a separately rendered title before accepting it.
+tap_nav_section() {
+  local section="$1"
+  local ordinal="$2"
+  local expected_title="$3"
+  local coords=''
+  dump_ui
+  coords="$(find_ui_coords "$section" 2>/dev/null || true)"
+  if [[ "$coords" =~ ^[0-9]+\ [0-9]+$ ]]; then
+    read -r x y <<<"$coords"
+    timeout 10s adb shell input tap "$x" "$y"
+    printf 'ANDROID_NAV_TAP=%s MODE=semantic X=%s Y=%s\n' "$section" "$x" "$y"
+  else
+    density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
+    [[ "$density" =~ ^[0-9]+$ ]] || {
+      echo "Unable to resolve emulator density for drawer fallback: ${density:-<none>}" >&2
+      return 1
+    }
+    # Drawer width is 286dp. Native navigation rows are 48dp high with 5dp
+    # spacing; their measured centers on this app-owned layout start at ~99dp.
+    x=$((143 * density / 160))
+    y_dp=$((99 + 53 * ordinal))
+    y=$((y_dp * density / 160))
+    timeout 10s adb shell input tap "$x" "$y"
+    printf 'ANDROID_NAV_TAP=%s MODE=verified-dp-fallback DENSITY=%s X=%s Y=%s\n' "$section" "$density" "$x" "$y"
+  fi
+  sleep 0.7
+  wait_ui "$expected_title"
+}
+
 capture() {
   local name="$1"
   if ! timeout 15s adb exec-out screencap -p >"$OUTPUT_DIR/$name"; then
@@ -223,17 +273,20 @@ capture 'ghost-ftp-android-files.png'
 tap_ui 'Open navigation'
 capture 'ghost-ftp-android-navigation.png'
 
-# The drawer is already open after the navigation evidence capture. Select the
-# first destination directly instead of closing it with BACK and racing the
-# accessibility hierarchy while trying to reopen it. Each navigation button
-# transitions sections and closes the drawer, so subsequent sections reopen it.
+# The drawer is already open for Sites. Each verified section transition closes
+# it, then the next iteration reopens the real drawer before selecting the next
+# destination. Every coordinate fallback is accepted only after title evidence.
 first_section=1
+ordinal=1
 for section in Sites Bookmarks Transfers Settings About; do
   if (( first_section == 0 )); then
     tap_ui 'Open navigation'
   fi
-  tap_ui "$section"
+  expected_title="$section"
+  [[ "$section" == 'Sites' ]] && expected_title='Sites / Connections'
+  tap_nav_section "$section" "$ordinal" "$expected_title"
   first_section=0
+  ordinal=$((ordinal + 1))
   lower="$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')"
   capture "ghost-ftp-android-${lower}.png"
 done

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -225,11 +225,12 @@ wait_ui() {
 # Android 35 can omit the programmatically created drawer buttons from the
 # uiautomator hierarchy even though they are visibly rendered and clickable.
 # In that case, anchor the fallback to the *rendered* active Files selection
-# (#202F50) in the already captured navigation screenshot. This measures the
-# real row center after Android has applied font metrics, density and layout;
-# only the fixed 48dp row height + 5dp margin from MainActivity is then used as
-# the pitch. The post-tap section title remains authoritative, so a coordinate
-# fallback can never produce PASS unless the requested section actually opened.
+# (#202F50) in the already captured navigation screenshot. The search is
+# deliberately restricted to MainActivity's 286dp drawer width so similarly
+# colored status badges in the app bar can never become the anchor. This
+# measures the real row center after Android has applied font metrics, density
+# and layout; only the fixed 48dp row height + 5dp margin from MainActivity is
+# then used as the pitch. The post-tap section title remains authoritative.
 calibrate_navigation_geometry() {
   local screenshot="$OUTPUT_DIR/ghost-ftp-android-navigation.png"
   local dims=''
@@ -257,7 +258,16 @@ calibrate_navigation_geometry() {
     echo "Unable to read navigation screenshot dimensions: ${dims:-<none>}" >&2
     return 1
   }
-  crop_width=$((screen_width * 4 / 5))
+
+  density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
+  [[ "$density" =~ ^[0-9]+$ ]] || {
+    echo "Unable to resolve emulator density for navigation calibration: ${density:-<none>}" >&2
+    return 1
+  }
+  button_height=$(((48 * density + 80) / 160))
+  row_margin=$(((5 * density + 80) / 160))
+  crop_width=$(((286 * density + 80) / 160))
+  (( crop_width > screen_width )) && crop_width="$screen_width"
   crop_height=$((screen_height * 3 / 5))
 
   geometry="$(convert "$screenshot" \
@@ -272,31 +282,24 @@ calibrate_navigation_geometry() {
     echo "Unable to resolve the active Files selection bounds: ${geometry:-<none>}" >&2
     return 1
   }
-  if (( box_x < 0 || box_y < 0 || box_width < screen_width / 4 || box_height < 20 || box_height > screen_height / 8 )); then
-    echo "Implausible active Files selection bounds: $geometry on ${screen_width}x${screen_height}" >&2
+  if (( box_x < 0 || box_y < 0 || box_width < crop_width / 2 \
+        || box_height < button_height / 2 || box_height > button_height * 2 )); then
+    echo "Implausible active Files selection bounds: $geometry in ${crop_width}x${crop_height} drawer crop" >&2
     return 1
   fi
-
-  density="$(timeout 10s adb shell wm density | tr -d '\r' | awk -F': ' '/Physical density/{v=$2} /Override density/{v=$2} END{print v}')"
-  [[ "$density" =~ ^[0-9]+$ ]] || {
-    echo "Unable to resolve emulator density for navigation row pitch: ${density:-<none>}" >&2
-    return 1
-  }
-  button_height=$(((48 * density + 80) / 160))
-  row_margin=$(((5 * density + 80) / 160))
 
   NAV_ANCHOR_X=$((box_x + box_width / 2))
   NAV_FILES_Y=$((box_y + box_height / 2))
   NAV_ROW_PITCH=$((button_height + row_margin))
-  if (( NAV_ANCHOR_X <= 0 || NAV_FILES_Y <= 0 || NAV_ROW_PITCH <= 0 \
+  if (( NAV_ANCHOR_X <= 0 || NAV_ANCHOR_X >= crop_width || NAV_FILES_Y <= 0 || NAV_ROW_PITCH <= 0 \
         || NAV_FILES_Y + 5 * NAV_ROW_PITCH >= screen_height )); then
     echo "Implausible navigation calibration: X=$NAV_ANCHOR_X FILES_Y=$NAV_FILES_Y PITCH=$NAV_ROW_PITCH" >&2
     return 1
   fi
 
-  printf 'ANDROID_NAV_CALIBRATION=PASS X=%s FILES_Y=%s ROW_PITCH=%s SELECTION_BOUNDS=%sx%s+%s+%s DENSITY=%s\n' \
+  printf 'ANDROID_NAV_CALIBRATION=PASS X=%s FILES_Y=%s ROW_PITCH=%s SELECTION_BOUNDS=%sx%s+%s+%s DRAWER_WIDTH=%s DENSITY=%s\n' \
     "$NAV_ANCHOR_X" "$NAV_FILES_Y" "$NAV_ROW_PITCH" \
-    "$box_width" "$box_height" "$box_x" "$box_y" "$density"
+    "$box_width" "$box_height" "$box_x" "$box_y" "$crop_width" "$density"
 }
 
 tap_nav_section() {

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -108,10 +108,39 @@ timeout 10s adb shell am start -W -n "$launcher_component"
 sleep 2
 
 # Fail closed if the exact APK package was installed but its launcher did not
-# actually become the foreground activity.
-resolved_component="$(timeout 10s adb shell dumpsys activity activities 2>/dev/null | sed -n 's/.*mResumedActivity:.* \([^ ]*\/[^ ]*\).*/\1/p' | head -n1 | tr -d '\r' || true)"
+# actually become the foreground activity. Android dumpsys field names differ
+# between platform releases, so parse both ActivityTaskManager and WindowManager
+# evidence instead of depending on one historical mResumedActivity label.
+activity_dump="$(timeout 10s adb shell dumpsys activity activities 2>/dev/null | tr -d '\r' || true)"
+resolved_component="$(printf '%s\n' "$activity_dump" | awk '
+/topResumedActivity=ActivityRecord|ResumedActivity: ActivityRecord/ {
+  for (i = 1; i <= NF; i++) {
+    candidate = $i
+    gsub(/[{}]/, "", candidate)
+    if (candidate ~ /^[[:alnum:]_.]+\/[[:alnum:]_.$]+$/) {
+      print candidate
+      exit
+    }
+  }
+}')"
+window_dump=''
+if [[ -z "$resolved_component" ]]; then
+  window_dump="$(timeout 10s adb shell dumpsys window windows 2>/dev/null | tr -d '\r' || true)"
+  resolved_component="$(printf '%s\n' "$window_dump" | awk '
+/mCurrentFocus=Window|mFocusedApp=ActivityRecord/ {
+  for (i = 1; i <= NF; i++) {
+    candidate = $i
+    gsub(/[{}]/, "", candidate)
+    if (candidate ~ /^[[:alnum:]_.]+\/[[:alnum:]_.$]+$/) {
+      print candidate
+      exit
+    }
+  }
+}')"
+fi
 [[ "$resolved_component" == "$package_name/"* ]] || {
-  timeout 10s adb shell dumpsys activity activities >&2 || true
+  printf '%s\n' "$activity_dump" >&2
+  [[ -z "$window_dump" ]] || printf '%s\n' "$window_dump" >&2
   echo "Android launcher did not become foreground: expected package $package_name, got ${resolved_component:-<none>}." >&2
   exit 1
 }


### PR DESCRIPTION
## Summary

Final hotfix for the Android authentic UI evidence workflow after #243.

- keeps APK identity derived from the exact built artifact;
- replaces the obsolete single-field `mResumedActivity` parser with bounded parsing of current ActivityTaskManager foreground fields;
- falls back to WindowManager focus evidence when Android output format differs;
- remains fail-closed if the exact APK package is not actually foreground;
- preserves the existing bounded emulator, UI hierarchy, screenshot and provenance checks.

Merge only after exact-head CI, distro workflows, Windows/Linux authentic capture, Android emulator capture, and evidence persistence all pass.