### PR TITLE
Harden Windows modal lifecycle and profile duplication

### DIFF
--- a/internal/desktop/site_manager_duplicate.go
+++ b/internal/desktop/site_manager_duplicate.go
@@ -1,9 +1,14 @@
 package desktop
 
 import (
+	"strings"
+	"unicode/utf8"
+
 	"github.com/bren-wp/Ghost-FTP/internal/i18n"
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 )
+
+const siteManagerProfileNameLimit = 120
 
 var siteManagerDuplicateLabels = map[string]string{
 	"en": "Duplicate",
@@ -39,13 +44,29 @@ func siteManagerDuplicateLabel(language string) string {
 	return siteManagerDuplicateLabels[i18n.DefaultLanguage]
 }
 
+func duplicateProfileName(name string) string {
+	const suffix = " 2"
+
+	base := strings.TrimSpace(name)
+	budget := siteManagerProfileNameLimit - len(suffix)
+	for len(base) > budget {
+		_, size := utf8.DecodeLastRuneInString(base)
+		if size <= 0 {
+			break
+		}
+		base = base[:len(base)-size]
+	}
+	base = strings.TrimSpace(base)
+	return base + suffix
+}
+
 // duplicateProfileDraft copies only non-secret profile configuration into a
 // new profile draft. Stored credentials and the SFTP host-key pin deliberately
 // do not cross the new profile boundary: credentials must be entered again and
 // SFTP trust must be established for the duplicate before it can be persisted.
 func duplicateProfileDraft(profile model.PublicProfile) model.ProfileInput {
 	return model.ProfileInput{
-		Name:           profile.Name + " 2",
+		Name:           duplicateProfileName(profile.Name),
 		Protocol:       profile.Protocol,
 		Host:           profile.Host,
 		Port:           profile.Port,

--- a/internal/desktop/site_manager_duplicate_test.go
+++ b/internal/desktop/site_manager_duplicate_test.go
@@ -1,7 +1,9 @@
 package desktop
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/bren-wp/Ghost-FTP/internal/model"
 )
@@ -38,6 +40,35 @@ func TestDuplicateProfileDraftCopiesOnlyNonSecretConfiguration(t *testing.T) {
 	}
 	if got.PrivateKeyPath != source.PrivateKeyPath || got.RemotePath != source.RemotePath || got.LocalPath != source.LocalPath {
 		t.Fatalf("duplicate lost non-secret path configuration: %#v", got)
+	}
+}
+
+func TestDuplicateProfileNameStaysWithinSaveLimit(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "ASCII limit", source: strings.Repeat("a", siteManagerProfileNameLimit)},
+		{name: "UTF-8 limit", source: strings.Repeat("🙂", siteManagerProfileNameLimit/4)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := duplicateProfileName(test.source)
+			if !utf8.ValidString(got) {
+				t.Fatalf("duplicate name is invalid UTF-8: %q", got)
+			}
+			if len(got) > siteManagerProfileNameLimit {
+				t.Fatalf("duplicate name length = %d bytes, want <= %d", len(got), siteManagerProfileNameLimit)
+			}
+			if !strings.HasSuffix(got, " 2") {
+				t.Fatalf("duplicate name = %q, want duplicate suffix", got)
+			}
+		})
+	}
+}
+
+func TestDuplicateProfileNameKeepsShortNameUnchangedBeforeSuffix(t *testing.T) {
+	if got := duplicateProfileName(" Production "); got != "Production 2" {
+		t.Fatalf("duplicate name = %q, want %q", got, "Production 2")
 	}
 }
 

--- a/internal/platform/dialog_premium_windows.go
+++ b/internal/platform/dialog_premium_windows.go
@@ -20,6 +20,8 @@ var premiumAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
 var premiumAdjustWindowRectExForDpi = user32.NewProc("AdjustWindowRectExForDpi")
 var premiumEnableWindow = user32.NewProc("EnableWindow")
 var premiumSetActiveWindow = user32.NewProc("SetActiveWindow")
+var premiumShowWindow = user32.NewProc("ShowWindow")
+var premiumIsIconic = user32.NewProc("IsIconic")
 var premiumIsWindow = user32.NewProc("IsWindow")
 var premiumDwmapi = syscall.NewLazyDLL("dwmapi.dll")
 var premiumDwmSetAttribute = premiumDwmapi.NewProc("DwmSetWindowAttribute")
@@ -35,6 +37,7 @@ const (
 	premiumWMCtlColorListBox = 0x0134
 	premiumWMCtlColorBtn     = 0x0135
 	premiumWMCtlColorStatic  = 0x0138
+	premiumSWRestore         = 9
 )
 
 type premiumRect struct {
@@ -265,11 +268,14 @@ func premiumDialogPosition(owner uintptr, width, height int) (int, int) {
 }
 
 // premiumModalOwner makes the custom top-level window actually modal. Without
-// this, the nested message loop still dispatches input to the main window.
+// this, the nested message loop still dispatches input to the main window. Keep
+// the owner's pre-dialog iconic state so a dialog can repair an unexpected
+// minimize without overriding a window the user had already minimized.
 func premiumModalOwner(owner uintptr) func() {
 	if owner == 0 {
 		return func() {}
 	}
+	wasIconic, _, _ := premiumIsIconic.Call(owner)
 	premiumEnableWindow.Call(owner, 0)
 	var once sync.Once
 	return func() {
@@ -279,6 +285,12 @@ func premiumModalOwner(owner uintptr) func() {
 				return
 			}
 			premiumEnableWindow.Call(owner, 1)
+			if wasIconic == 0 {
+				isIconic, _, _ := premiumIsIconic.Call(owner)
+				if isIconic != 0 {
+					premiumShowWindow.Call(owner, premiumSWRestore)
+				}
+			}
 			premiumSetActiveWindow.Call(owner)
 		})
 	}

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -49,6 +49,24 @@ class WindowsModalSharedContractTests(unittest.TestCase):
             self.assertIn("premiumRunDialogLoop(hwnd", source, relative)
             self.assertNotIn('NewProc("IsDialogMessageW")', source, relative)
 
+    def test_modal_owner_restores_only_unexpected_iconic_state(self) -> None:
+        source = read("internal/platform/dialog_premium_windows.go")
+        for marker in (
+            'premiumIsIconic = user32.NewProc("IsIconic")',
+            'premiumShowWindow = user32.NewProc("ShowWindow")',
+            "premiumSWRestore         = 9",
+            "wasIconic, _, _ := premiumIsIconic.Call(owner)",
+            "if wasIconic == 0",
+            "isIconic, _, _ := premiumIsIconic.Call(owner)",
+            "premiumShowWindow.Call(owner, premiumSWRestore)",
+            "premiumSetActiveWindow.Call(owner)",
+        ):
+            self.assertIn(marker, source)
+        self.assertLess(
+            source.index("premiumEnableWindow.Call(owner, 1)"),
+            source.index("premiumShowWindow.Call(owner, premiumSWRestore)"),
+        )
+
     def test_option_selector_uses_native_enter_and_escape_commands(self) -> None:
         source = read("internal/platform/language_windows.go")
         self.assertIn("languageIDInstall = 1 // IDOK", source)


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Summary

- Keep duplicated Site Manager profile names within the existing 120-byte persistence contract.
- Truncate only the source-name base before appending ` 2`, preserving UTF-8 rune boundaries.
- Harden the shared Windows modal-owner lifecycle so button-triggered dialogs cannot leave an application window unexpectedly minimized.
- Preserve a window that was already minimized before the modal opened; only repair a new iconic/minimized state introduced during the modal lifecycle.

## Defects fixed

### Unsavable duplicated profiles
A valid saved profile may already use the full 120-byte name limit. The duplicate flow previously appended ` 2` unconditionally, producing a draft that the profile persistence layer rejects as too long.

### Button-triggered application minimization
Several Windows actions share the same native modal layer (Settings, About/info cards, prompts, confirmation dialogs, file filters and related actions). The modal cleanup previously re-enabled and activated the owner without checking whether it had become iconic/minimized. The shared cleanup now records the pre-dialog iconic state and uses `SW_RESTORE` only when a previously visible owner unexpectedly becomes iconic.

## Branding and compatibility

- [x] No public branding or installed-application identity changes.
- [x] Existing short-name behavior remains unchanged (`Production` -> `Production 2`).
- [x] No protocol or transfer behavior changes.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [x] SFTP host-key verification and pinning remain active and unchanged.
- [x] Local path-traversal, symlink, junction and reparse-point protections remain active and unchanged.
- [x] No external Go module was added.
- [x] Tests contain no credentials, production servers or customer data.

## Regression coverage

- Maximum-length ASCII profile names remain <= 120 bytes after duplication.
- Maximum-length multibyte UTF-8 profile names remain valid UTF-8 and fit the persistence contract.
- Existing duplicate secret/trust isolation remains tested.
- Windows shared-modal contract requires `IsIconic`, `SW_RESTORE`, pre-dialog iconic-state preservation and owner reactivation in the safe order.
- Authentic Windows runtime evidence must still build and capture the main window, Site Manager, Bookmarks, Settings and About surfaces from the exact PR head.

## Validation gate

Keep this PR in draft until the exact-head required workflows are green and the branch is confirmed `behind_by=0` against current `main`.