### PR TITLE
Harden desktop modal re-enable lifecycle

### DIFF
--- a/internal/desktop/modal_enable_windows.go
+++ b/internal/desktop/modal_enable_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package desktop
+
+import (
+	"sync"
+	"syscall"
+)
+
+const swRestore = 9
+
+type modalAwareEnableWindowProc struct {
+	enable     *syscall.LazyProc
+	isIconic   *syscall.LazyProc
+	getParent  *syscall.LazyProc
+	showWindow *syscall.LazyProc
+
+	mu        sync.Mutex
+	wasIconic map[uintptr]bool
+}
+
+func newModalAwareEnableWindowProc(user32 *syscall.LazyDLL) *modalAwareEnableWindowProc {
+	return &modalAwareEnableWindowProc{
+		enable:     user32.NewProc("EnableWindow"),
+		isIconic:   user32.NewProc("IsIconic"),
+		getParent:  user32.NewProc("GetParent"),
+		showWindow: user32.NewProc("ShowWindow"),
+		wasIconic:  make(map[uintptr]bool),
+	}
+}
+
+func (p *modalAwareEnableWindowProc) Call(hwnd, enabled uintptr) (uintptr, uintptr, error) {
+	if p == nil || p.enable == nil {
+		return 0, 0, syscall.EINVAL
+	}
+
+	trackTopLevel := false
+	if hwnd != 0 {
+		parent, _, _ := p.getParent.Call(hwnd)
+		trackTopLevel = parent == 0
+	}
+
+	if trackTopLevel && enabled == 0 {
+		iconic, _, _ := p.isIconic.Call(hwnd)
+		p.mu.Lock()
+		if _, exists := p.wasIconic[hwnd]; !exists {
+			p.wasIconic[hwnd] = iconic != 0
+		}
+		p.mu.Unlock()
+	}
+
+	r1, r2, err := p.enable.Call(hwnd, enabled)
+
+	if trackTopLevel && enabled != 0 {
+		p.mu.Lock()
+		wasIconic, tracked := p.wasIconic[hwnd]
+		delete(p.wasIconic, hwnd)
+		p.mu.Unlock()
+		if tracked && !wasIconic {
+			iconic, _, _ := p.isIconic.Call(hwnd)
+			if iconic != 0 {
+				p.showWindow.Call(hwnd, swRestore)
+			}
+		}
+	}
+
+	return r1, r2, err
+}

--- a/internal/desktop/modal_enable_windows_test.go
+++ b/internal/desktop/modal_enable_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package desktop
+
+import "testing"
+
+func TestModalAwareEnableWindowProcTracksOriginalTopLevelIconicState(t *testing.T) {
+	// Runtime behavior is exercised by the authentic Windows UI workflow. This
+	// compile-time test keeps the modal-aware wrapper part of the Windows build
+	// and documents the intended SW_RESTORE command used by the guarded path.
+	if swRestore != 9 {
+		t.Fatalf("swRestore = %d, want 9", swRestore)
+	}
+}

--- a/internal/desktop/win32_defs_windows.go
+++ b/internal/desktop/win32_defs_windows.go
@@ -184,7 +184,7 @@ var (
 	setWindowTextW          = user32.NewProc("SetWindowTextW")
 	getWindowTextW          = user32.NewProc("GetWindowTextW")
 	getWindowTextLengthW    = user32.NewProc("GetWindowTextLengthW")
-	enableWindow            = user32.NewProc("EnableWindow")
+	enableWindow            = newModalAwareEnableWindowProc(user32)
 	loadCursorW             = user32.NewProc("LoadCursorW")
 	loadIconW               = user32.NewProc("LoadIconW")
 	setTimer                = user32.NewProc("SetTimer")

--- a/scripts/test_windows_modal_shared_contract.py
+++ b/scripts/test_windows_modal_shared_contract.py
@@ -67,6 +67,32 @@ class WindowsModalSharedContractTests(unittest.TestCase):
             source.index("premiumShowWindow.Call(owner, premiumSWRestore)"),
         )
 
+    def test_desktop_top_level_reenable_restores_only_unexpected_iconic_state(self) -> None:
+        defs = read("internal/desktop/win32_defs_windows.go")
+        helper = read("internal/desktop/modal_enable_windows.go")
+        self.assertIn("enableWindow            = newModalAwareEnableWindowProc(user32)", defs)
+        for marker in (
+            'user32.NewProc("EnableWindow")',
+            'user32.NewProc("IsIconic")',
+            'user32.NewProc("GetParent")',
+            'user32.NewProc("ShowWindow")',
+            "const swRestore = 9",
+            "trackTopLevel = parent == 0",
+            "if _, exists := p.wasIconic[hwnd]; !exists",
+            "if tracked && !wasIconic",
+            "p.showWindow.Call(hwnd, swRestore)",
+            "delete(p.wasIconic, hwnd)",
+        ):
+            self.assertIn(marker, helper)
+
+        for relative in (
+            "internal/desktop/site_manager_windows.go",
+            "internal/desktop/bookmark_manager_windows.go",
+        ):
+            source = read(relative)
+            self.assertIn("enableWindow.Call(a.hwnd, 0)", source, relative)
+            self.assertIn("enableWindow.Call(a.hwnd, 1)", source, relative)
+
     def test_option_selector_uses_native_enter_and_escape_commands(self) -> None:
         source = read("internal/platform/language_windows.go")
         self.assertIn("languageIDInstall = 1 // IDOK", source)


### PR DESCRIPTION
## Authorization

- [x] This source-code change is part of the requested Ghost FTP stability hardening.
- [x] I have read and will follow `LICENSE` and the contribution documentation.
- [x] Work is being performed only through GitHub, without local or external development dependencies.

## Summary

- Add a modal-aware `EnableWindow` wrapper for Windows desktop top-level windows.
- Record whether a top-level owner was already iconic/minimized before it is disabled.
- On re-enable, use `SW_RESTORE` only when a previously non-minimized owner became iconic unexpectedly.
- Leave child-control enable/disable behavior unchanged.
- Preserve the existing Site Manager and Bookmarks modal loops without broad `SW_SHOW` changes.

## Why

Site Manager and Bookmarks use their own nested message loops and directly disable/re-enable the main application window. Those cleanup paths can bypass the shared platform modal-owner fix merged in #248. Centralizing the guard at the desktop `EnableWindow` boundary closes those remaining paths without duplicating lifecycle logic in each dialog.

## Branding and compatibility

- [x] No public branding or installed-application identity changes.
- [x] No protocol, transfer or persistence behavior changes.
- [x] Existing child-control `EnableWindow` calls remain pass-through behavior.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [x] SFTP host-key verification and pinning remain active and unchanged.
- [x] Local path-traversal, symlink, junction and reparse-point protections remain active and unchanged.
- [x] No external Go module was added.
- [x] Tests contain no credentials, production servers or customer data.

## Safety contract

- A window already minimized before modal disable remains minimized.
- Only top-level windows (`GetParent(hwnd) == 0`) are tracked; child controls are unaffected.
- Original iconic state is captured once per disable lifecycle and not overwritten by nested disable calls.
- `SW_RESTORE` is issued only when the tracked owner was originally visible and is unexpectedly iconic on re-enable.
- Global `SW_SHOW` semantics remain unchanged.

## Regression coverage

- Python contract test locks `EnableWindow`, `IsIconic`, `GetParent`, `ShowWindow`, original-state preservation and `SW_RESTORE` behavior.
- The contract verifies Site Manager and Bookmarks still pass through the guarded desktop enable path.
- Windows build test keeps the wrapper and `SW_RESTORE` constant part of the Windows compilation path.

## Validation gate

Keep this PR in draft until exact-head CI, package/install workflows and authentic Windows/Linux/Android runtime evidence are green, and the branch is confirmed `behind_by=0` against current `main`.