### PR TITLE
Restore native keyboard navigation in desktop modals

### DIFF
--- a/internal/desktop/modal_message_windows.go
+++ b/internal/desktop/modal_message_windows.go
@@ -1,0 +1,143 @@
+//go:build windows
+
+package desktop
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	desktopGARoot     = 2
+	desktopWMKeyDown  = 0x0100
+	desktopVKEscape   = 0x1B
+	desktopVKReturn   = 0x0D
+	desktopBMClick    = 0x00F5
+)
+
+type modalAwareGetMessageProc struct {
+	getMessage      *syscall.LazyProc
+	getAncestor     *syscall.LazyProc
+	getFocus        *syscall.LazyProc
+	isWindowEnabled *syscall.LazyProc
+	isDialogMessage *syscall.LazyProc
+	sendMessage     *syscall.LazyProc
+}
+
+func newModalAwareGetMessageProc(user32 *syscall.LazyDLL) *modalAwareGetMessageProc {
+	return &modalAwareGetMessageProc{
+		getMessage:      user32.NewProc("GetMessageW"),
+		getAncestor:     user32.NewProc("GetAncestor"),
+		getFocus:        user32.NewProc("GetFocus"),
+		isWindowEnabled: user32.NewProc("IsWindowEnabled"),
+		isDialogMessage: user32.NewProc("IsDialogMessageW"),
+		sendMessage:     user32.NewProc("SendMessageW"),
+	}
+}
+
+func (p *modalAwareGetMessageProc) Call(messagePtr, hwndFilter, messageMin, messageMax uintptr) (uintptr, uintptr, error) {
+	if p == nil || p.getMessage == nil {
+		return 0, 0, syscall.EINVAL
+	}
+
+	result, aux, err := p.getMessage.Call(messagePtr, hwndFilter, messageMin, messageMax)
+	if int32(result) <= 0 || messagePtr == 0 {
+		return result, aux, err
+	}
+
+	message := (*msg)(unsafe.Pointer(messagePtr))
+	root := p.modalRoot(message.Hwnd)
+	if root == 0 {
+		return result, aux, err
+	}
+
+	if p.handleModalShortcut(root, message) {
+		*message = msg{}
+		return result, aux, err
+	}
+
+	handled, _, _ := p.isDialogMessage.Call(root, messagePtr)
+	if handled != 0 {
+		// The nested caller must regain control after every consumed dialog
+		// message so its closed flag is observed immediately. Returning a
+		// harmless WM_NULL-style thread message avoids dispatching the same
+		// keyboard input twice without hiding WM_QUIT/GetMessage errors.
+		*message = msg{}
+	}
+	return result, aux, err
+}
+
+func (p *modalAwareGetMessageProc) modalRoot(hwnd uintptr) uintptr {
+	if hwnd == 0 || p.getAncestor == nil {
+		return 0
+	}
+	root, _, _ := p.getAncestor.Call(hwnd, desktopGARoot)
+	if root == 0 {
+		return 0
+	}
+	if _, ok := siteManagerStates.Load(root); ok {
+		return root
+	}
+	if _, ok := bookmarkManagerStates.Load(root); ok {
+		return root
+	}
+	return 0
+}
+
+func (p *modalAwareGetMessageProc) handleModalShortcut(root uintptr, message *msg) bool {
+	if message == nil || message.Message != desktopWMKeyDown {
+		return false
+	}
+
+	switch message.WParam {
+	case desktopVKEscape:
+		p.sendMessage.Call(root, wmClose, 0, 0)
+		return true
+	case desktopVKReturn:
+		button := p.modalEnterButton(root)
+		if button != 0 && p.windowEnabled(button) {
+			p.sendMessage.Call(button, desktopBMClick, 0, 0)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *modalAwareGetMessageProc) modalEnterButton(root uintptr) uintptr {
+	focus := uintptr(0)
+	if p.getFocus != nil {
+		focus, _, _ = p.getFocus.Call()
+	}
+
+	if value, ok := siteManagerStates.Load(root); ok {
+		state := value.(*siteManagerState)
+		buttons := []uintptr{state.duplicate, state.save, state.delete, state.connect, state.close}
+		for _, button := range buttons {
+			if focus != 0 && focus == button {
+				return button
+			}
+		}
+		return state.connect
+	}
+
+	if value, ok := bookmarkManagerStates.Load(root); ok {
+		state := value.(*bookmarkManagerState)
+		buttons := []uintptr{state.open, state.addLocal, state.addRemote, state.delete, state.close}
+		for _, button := range buttons {
+			if focus != 0 && focus == button {
+				return button
+			}
+		}
+		return state.open
+	}
+	return 0
+}
+
+func (p *modalAwareGetMessageProc) windowEnabled(hwnd uintptr) bool {
+	if hwnd == 0 || p.isWindowEnabled == nil {
+		return false
+	}
+	enabled, _, _ := p.isWindowEnabled.Call(hwnd)
+	return enabled != 0
+}

--- a/internal/desktop/modal_message_windows.go
+++ b/internal/desktop/modal_message_windows.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	desktopGARoot     = 2
-	desktopWMKeyDown  = 0x0100
-	desktopVKEscape   = 0x1B
-	desktopVKReturn   = 0x0D
-	desktopBMClick    = 0x00F5
+	desktopGARoot    = 2
+	desktopWMKeyDown = 0x0100
+	desktopVKEscape  = 0x1B
+	desktopVKReturn  = 0x0D
+	desktopBMClick   = 0x00F5
 )
 
 type modalAwareGetMessageProc struct {

--- a/internal/desktop/modal_message_windows.go
+++ b/internal/desktop/modal_message_windows.go
@@ -35,6 +35,22 @@ func newModalAwareGetMessageProc(user32 *syscall.LazyDLL) *modalAwareGetMessageP
 	}
 }
 
+func readModalMessage(messagePtr uintptr) msg {
+	var message msg
+	if messagePtr != 0 {
+		rtlMoveMemory.Call(uintptr(unsafe.Pointer(&message)), messagePtr, unsafe.Sizeof(message))
+	}
+	return message
+}
+
+func clearModalMessage(messagePtr uintptr) {
+	if messagePtr == 0 {
+		return
+	}
+	var message msg
+	rtlMoveMemory.Call(messagePtr, uintptr(unsafe.Pointer(&message)), unsafe.Sizeof(message))
+}
+
 func (p *modalAwareGetMessageProc) Call(messagePtr, hwndFilter, messageMin, messageMax uintptr) (uintptr, uintptr, error) {
 	if p == nil || p.getMessage == nil {
 		return 0, 0, syscall.EINVAL
@@ -45,14 +61,14 @@ func (p *modalAwareGetMessageProc) Call(messagePtr, hwndFilter, messageMin, mess
 		return result, aux, err
 	}
 
-	message := (*msg)(unsafe.Pointer(messagePtr))
+	message := readModalMessage(messagePtr)
 	root := p.modalRoot(message.Hwnd)
 	if root == 0 {
 		return result, aux, err
 	}
 
 	if p.handleModalShortcut(root, message) {
-		*message = msg{}
+		clearModalMessage(messagePtr)
 		return result, aux, err
 	}
 
@@ -62,7 +78,7 @@ func (p *modalAwareGetMessageProc) Call(messagePtr, hwndFilter, messageMin, mess
 		// message so its closed flag is observed immediately. Returning a
 		// harmless WM_NULL-style thread message avoids dispatching the same
 		// keyboard input twice without hiding WM_QUIT/GetMessage errors.
-		*message = msg{}
+		clearModalMessage(messagePtr)
 	}
 	return result, aux, err
 }
@@ -84,8 +100,8 @@ func (p *modalAwareGetMessageProc) modalRoot(hwnd uintptr) uintptr {
 	return 0
 }
 
-func (p *modalAwareGetMessageProc) handleModalShortcut(root uintptr, message *msg) bool {
-	if message == nil || message.Message != desktopWMKeyDown {
+func (p *modalAwareGetMessageProc) handleModalShortcut(root uintptr, message msg) bool {
+	if message.Message != desktopWMKeyDown {
 		return false
 	}
 

--- a/internal/desktop/win32_defs_windows.go
+++ b/internal/desktop/win32_defs_windows.go
@@ -172,7 +172,7 @@ var (
 	defWindowProcW          = user32.NewProc("DefWindowProcW")
 	showWindow              = user32.NewProc("ShowWindow")
 	updateWindow            = user32.NewProc("UpdateWindow")
-	getMessageW             = user32.NewProc("GetMessageW")
+	getMessageW             = newModalAwareGetMessageProc(user32)
 	getClientRect           = user32.NewProc("GetClientRect")
 	getSystemMetrics        = user32.NewProc("GetSystemMetrics")
 	translateMessage        = user32.NewProc("TranslateMessage")

--- a/scripts/test_windows_desktop_modal_keyboard_contract.py
+++ b/scripts/test_windows_desktop_modal_keyboard_contract.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
+    def test_getmessage_is_modal_aware(self) -> None:
+        defs = read("internal/desktop/win32_defs_windows.go")
+        helper = read("internal/desktop/modal_message_windows.go")
+
+        self.assertIn("getMessageW             = newModalAwareGetMessageProc(user32)", defs)
+        self.assertIn('user32.NewProc("GetMessageW")', helper)
+        self.assertIn('user32.NewProc("IsDialogMessageW")', helper)
+        self.assertIn('user32.NewProc("GetAncestor")', helper)
+        self.assertIn("desktopGARoot     = 2", helper)
+
+    def test_only_desktop_owned_modal_windows_are_intercepted(self) -> None:
+        helper = read("internal/desktop/modal_message_windows.go")
+
+        self.assertIn("siteManagerStates.Load(root)", helper)
+        self.assertIn("bookmarkManagerStates.Load(root)", helper)
+        self.assertNotIn("apps.Load(root)", helper)
+        self.assertIn("if root == 0", helper)
+
+    def test_native_tab_traversal_is_consumed_once(self) -> None:
+        helper = read("internal/desktop/modal_message_windows.go")
+        site = read("internal/desktop/site_manager_windows.go")
+        bookmarks = read("internal/desktop/bookmark_manager_windows.go")
+
+        self.assertIn("isDialogMessage.Call(root, messagePtr)", helper)
+        self.assertIn("*message = msg{}", helper)
+        self.assertIn("wsTabStop", site)
+        self.assertIn("wsTabStop", bookmarks)
+        self.assertIn("getMessageW.Call", site)
+        self.assertIn("getMessageW.Call", bookmarks)
+
+    def test_enter_and_escape_have_bounded_modal_semantics(self) -> None:
+        helper = read("internal/desktop/modal_message_windows.go")
+
+        self.assertIn("desktopVKEscape   = 0x1B", helper)
+        self.assertIn("desktopVKReturn   = 0x0D", helper)
+        self.assertIn("desktopBMClick    = 0x00F5", helper)
+        self.assertIn("p.sendMessage.Call(root, wmClose, 0, 0)", helper)
+        self.assertIn("p.sendMessage.Call(button, desktopBMClick, 0, 0)", helper)
+        self.assertIn("return state.connect", helper)
+        self.assertIn("return state.open", helper)
+        self.assertIn("p.windowEnabled(button)", helper)
+
+    def test_consumed_message_returns_control_to_nested_loop(self) -> None:
+        helper = read("internal/desktop/modal_message_windows.go")
+
+        self.assertIn("if p.handleModalShortcut(root, message)", helper)
+        self.assertGreaterEqual(helper.count("*message = msg{}"), 2)
+        self.assertIn("int32(result) <= 0", helper)
+        self.assertIn("WM_QUIT/GetMessage errors", helper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_desktop_modal_keyboard_contract.py
+++ b/scripts/test_windows_desktop_modal_keyboard_contract.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import re
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,7 +19,7 @@ class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
         self.assertIn('user32.NewProc("GetMessageW")', helper)
         self.assertIn('user32.NewProc("IsDialogMessageW")', helper)
         self.assertIn('user32.NewProc("GetAncestor")', helper)
-        self.assertIn("desktopGARoot     = 2", helper)
+        self.assertRegex(helper, r"desktopGARoot\s*=\s*2")
 
     def test_only_desktop_owned_modal_windows_are_intercepted(self) -> None:
         helper = read("internal/desktop/modal_message_windows.go")
@@ -43,9 +44,9 @@ class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
     def test_enter_and_escape_have_bounded_modal_semantics(self) -> None:
         helper = read("internal/desktop/modal_message_windows.go")
 
-        self.assertIn("desktopVKEscape   = 0x1B", helper)
-        self.assertIn("desktopVKReturn   = 0x0D", helper)
-        self.assertIn("desktopBMClick    = 0x00F5", helper)
+        self.assertRegex(helper, r"desktopVKEscape\s*=\s*0x1B")
+        self.assertRegex(helper, r"desktopVKReturn\s*=\s*0x0D")
+        self.assertRegex(helper, r"desktopBMClick\s*=\s*0x00F5")
         self.assertIn("p.sendMessage.Call(root, wmClose, 0, 0)", helper)
         self.assertIn("p.sendMessage.Call(button, desktopBMClick, 0, 0)", helper)
         self.assertIn("return state.connect", helper)

--- a/scripts/test_windows_desktop_modal_keyboard_contract.py
+++ b/scripts/test_windows_desktop_modal_keyboard_contract.py
@@ -21,6 +21,14 @@ class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
         self.assertIn('user32.NewProc("GetAncestor")', helper)
         self.assertRegex(helper, r"desktopGARoot\s*=\s*2")
 
+    def test_message_memory_uses_vet_safe_win32_copy(self) -> None:
+        helper = read("internal/desktop/modal_message_windows.go")
+
+        self.assertIn("func readModalMessage(messagePtr uintptr) msg", helper)
+        self.assertIn("func clearModalMessage(messagePtr uintptr)", helper)
+        self.assertIn("rtlMoveMemory.Call", helper)
+        self.assertNotIn("unsafe.Pointer(messagePtr)", helper)
+
     def test_only_desktop_owned_modal_windows_are_intercepted(self) -> None:
         helper = read("internal/desktop/modal_message_windows.go")
 
@@ -35,7 +43,7 @@ class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
         bookmarks = read("internal/desktop/bookmark_manager_windows.go")
 
         self.assertIn("isDialogMessage.Call(root, messagePtr)", helper)
-        self.assertIn("*message = msg{}", helper)
+        self.assertIn("clearModalMessage(messagePtr)", helper)
         self.assertIn("wsTabStop", site)
         self.assertIn("wsTabStop", bookmarks)
         self.assertIn("getMessageW.Call", site)
@@ -57,7 +65,7 @@ class WindowsDesktopModalKeyboardContractTests(unittest.TestCase):
         helper = read("internal/desktop/modal_message_windows.go")
 
         self.assertIn("if p.handleModalShortcut(root, message)", helper)
-        self.assertGreaterEqual(helper.count("*message = msg{}"), 2)
+        self.assertGreaterEqual(helper.count("clearModalMessage(messagePtr)"), 2)
         self.assertIn("int32(result) <= 0", helper)
         self.assertIn("WM_QUIT/GetMessage errors", helper)
 


### PR DESCRIPTION
## Summary
- route desktop `GetMessageW` through a modal-aware wrapper only for Ghost FTP Site Manager and Bookmarks
- use `IsDialogMessageW` for native Tab/Shift+Tab traversal
- make Enter activate the focused modal button, otherwise the modal default action (Connect/Open)
- make Escape follow the existing WM_CLOSE path
- zero consumed messages so nested loops regain control immediately and never dispatch the same key twice
- preserve WM_QUIT/GetMessage error semantics
- add a regression contract covering routing, scope, Tab, Enter, Escape, and single-consumption behavior

## Scope and safety
- no release/version changes
- no signing/AuthentiCode changes
- no network/protocol changes
- no changes to Site Manager or Bookmarks implementation files themselves
- wrapper only recognizes windows registered in `siteManagerStates` or `bookmarkManagerStates`

## Validation required before merge
- exact-head Ghost FTP CI
- Windows production build/artifact verification
- authentic Windows runtime capture including Site Manager and Bookmarks
- branch must remain `behind_by=0`
