### PR TITLE
Add authentic Windows modal keyboard runtime test

### DIFF
--- a/.github/workflows/windows-modal-keyboard-runtime.yml
+++ b/.github/workflows/windows-modal-keyboard-runtime.yml
@@ -1,0 +1,83 @@
+name: Ghost FTP Windows Modal Keyboard Runtime
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'VERSION'
+      - 'BUILD-WINDOWS.ps1'
+      - 'BUILD-WINDOWS-ARCH-STAGE.ps1'
+      - 'cmd/ghostftp/**'
+      - 'internal/desktop/**'
+      - 'internal/platform/**'
+      - 'scripts/test_windows_modal_keyboard_runtime.ps1'
+      - 'scripts/test_windows_modal_keyboard_runtime_contract.py'
+      - '.github/workflows/windows-modal-keyboard-runtime.yml'
+  push:
+    branches:
+      - main
+      - 'hardening/**'
+      - 'release-prep/**'
+      - 'work/**'
+      - 'release/**'
+      - 'packaging/**'
+    paths:
+      - 'VERSION'
+      - 'BUILD-WINDOWS.ps1'
+      - 'BUILD-WINDOWS-ARCH-STAGE.ps1'
+      - 'cmd/ghostftp/**'
+      - 'internal/desktop/**'
+      - 'internal/platform/**'
+      - 'scripts/test_windows_modal_keyboard_runtime.ps1'
+      - 'scripts/test_windows_modal_keyboard_runtime_contract.py'
+      - '.github/workflows/windows-modal-keyboard-runtime.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-windows-modal-keyboard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime:
+    name: Authentic Site Manager and Bookmarks keyboard lifecycle
+    runs-on: windows-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+
+      - name: Disable Go telemetry
+        shell: pwsh
+        run: |
+          go telemetry off
+          if ($LASTEXITCODE -ne 0 -or (go telemetry).Trim() -ne 'off') {
+            throw 'Go telemetry is not disabled.'
+          }
+
+      - name: Build verified production Windows packages
+        shell: pwsh
+        run: .\BUILD-WINDOWS.ps1
+
+      - name: Verify native modal keyboard lifecycle
+        shell: pwsh
+        run: |
+          $version = (Get-Content VERSION -Raw).Trim()
+          $exe = "dist\internal\Ghost-FTP-$version-Portable-x64.exe"
+          if (-not (Test-Path $exe -PathType Leaf)) {
+            throw "Missing verified native production executable: $exe"
+          }
+          .\scripts\test_windows_modal_keyboard_runtime.ps1 -Executable $exe

--- a/scripts/test_windows_modal_keyboard_runtime.ps1
+++ b/scripts/test_windows_modal_keyboard_runtime.ps1
@@ -41,9 +41,6 @@ public static class GhostFtpKeyboardNative
     [DllImport("user32.dll")]
     public static extern bool EnumWindows(EnumWindowsProc callback, IntPtr extraData);
 
-    [DllImport("user32.dll")]
-    public static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc callback, IntPtr extraData);
-
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int maxCount);
 
@@ -52,6 +49,9 @@ public static class GhostFtpKeyboardNative
 
     [DllImport("user32.dll")]
     public static extern bool GetGUIThreadInfo(uint idThread, ref GUITHREADINFO info);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetDlgItem(IntPtr hDlg, int nIDDlgItem);
 
     [DllImport("user32.dll")]
     public static extern bool IsWindow(IntPtr hWnd);
@@ -82,6 +82,8 @@ $vkReturn = 0x0D
 $vkEscape = 0x1B
 $siteManagerCommand = 701
 $bookmarksCommand = 97
+$siteManagerCloseControlId = 8114
+$bookmarksCloseControlId = 8206
 
 function Wait-ForMainWindow {
     param(
@@ -145,41 +147,24 @@ function Find-ProcessWindow {
     throw "Timed out waiting for Ghost FTP window containing '$TitleContains'."
 }
 
-function Find-ChildWindowByText {
+function Wait-ForControlById {
     param(
-        [Parameter(Mandatory = $true)]
-        [IntPtr]$Parent,
-        [Parameter(Mandatory = $true)]
-        [string]$Text,
+        [Parameter(Mandatory = $true)][IntPtr]$Parent,
+        [Parameter(Mandatory = $true)][int]$ControlId,
+        [Parameter(Mandatory = $true)][string]$Name,
         [int]$TimeoutSeconds = 10
     )
 
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     do {
-        $script:ghostFtpKeyboardFoundChild = [IntPtr]::Zero
-        $script:ghostFtpKeyboardChildText = $Text
-        $callback = [GhostFtpKeyboardNative+EnumWindowsProc]{
-            param([IntPtr]$hWnd, [IntPtr]$lParam)
-
-            if (-not [GhostFtpKeyboardNative]::IsWindowVisible($hWnd)) {
-                return $true
-            }
-            $buffer = New-Object System.Text.StringBuilder 512
-            [GhostFtpKeyboardNative]::GetWindowText($hWnd, $buffer, $buffer.Capacity) | Out-Null
-            if ($buffer.ToString() -eq $script:ghostFtpKeyboardChildText) {
-                $script:ghostFtpKeyboardFoundChild = $hWnd
-                return $false
-            }
-            return $true
-        }
-        [GhostFtpKeyboardNative]::EnumChildWindows($Parent, $callback, [IntPtr]::Zero) | Out-Null
-        if ($script:ghostFtpKeyboardFoundChild -ne [IntPtr]::Zero) {
-            return $script:ghostFtpKeyboardFoundChild
+        $control = [GhostFtpKeyboardNative]::GetDlgItem($Parent, $ControlId)
+        if ($control -ne [IntPtr]::Zero -and [GhostFtpKeyboardNative]::IsWindow($control)) {
+            return $control
         }
         Start-Sleep -Milliseconds 100
     } while ([DateTime]::UtcNow -lt $deadline)
 
-    throw "Timed out waiting for child control '$Text'."
+    throw "Timed out waiting for $Name control ID $ControlId."
 }
 
 function Get-FocusedWindow {
@@ -256,10 +241,11 @@ function Open-ModalWindow {
 function Focus-CloseWithTab {
     param(
         [Parameter(Mandatory = $true)][IntPtr]$Window,
+        [Parameter(Mandatory = $true)][int]$CloseControlId,
         [Parameter(Mandatory = $true)][string]$Name
     )
 
-    $closeButton = Find-ChildWindowByText -Parent $Window -Text 'Close'
+    $closeButton = Wait-ForControlById -Parent $Window -ControlId $CloseControlId -Name "$Name dismiss"
     for ($index = 0; $index -lt 40; $index++) {
         $focus = Get-FocusedWindow -Window $Window
         if ($focus -eq $closeButton) {
@@ -272,7 +258,7 @@ function Focus-CloseWithTab {
         [GhostFtpKeyboardNative]::PostMessage($target, $wmKeyUp, [IntPtr]$vkTab, [IntPtr]::Zero) | Out-Null
         Start-Sleep -Milliseconds 100
     }
-    throw "Tab traversal did not reach the Close button in $Name."
+    throw "Tab traversal did not reach the dismiss button in $Name."
 }
 
 function Verify-ModalKeyboardContract {
@@ -280,6 +266,7 @@ function Verify-ModalKeyboardContract {
         [Parameter(Mandatory = $true)][IntPtr]$Main,
         [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
         [Parameter(Mandatory = $true)][int]$Command,
+        [Parameter(Mandatory = $true)][int]$CloseControlId,
         [Parameter(Mandatory = $true)][string]$Title
     )
 
@@ -287,13 +274,13 @@ function Verify-ModalKeyboardContract {
     if ([GhostFtpKeyboardNative]::IsWindowEnabled($Main)) {
         throw "Main window remained enabled while $Title was open."
     }
-    $closeButton = Focus-CloseWithTab -Window $modal -Name $Title
+    $closeButton = Focus-CloseWithTab -Window $modal -CloseControlId $CloseControlId -Name $Title
     $focus = Get-FocusedWindow -Window $modal
     if ($focus -ne $closeButton) {
-        throw "Close button did not retain keyboard focus in $Title."
+        throw "Dismiss button did not retain keyboard focus in $Title."
     }
     if (-not [GhostFtpKeyboardNative]::PostMessage($closeButton, $wmKeyDown, [IntPtr]$vkReturn, [IntPtr]::Zero)) {
-        throw "Could not post Enter to the focused Close button in $Title."
+        throw "Could not post Enter to the focused dismiss button in $Title."
     }
     Wait-ForWindowClosed -Window $modal -Name $Title
     Assert-MainRestored -Main $Main -Process $Process -Context "$Title Enter close"
@@ -315,8 +302,8 @@ try {
     [GhostFtpKeyboardNative]::SetForegroundWindow($main) | Out-Null
     Start-Sleep -Milliseconds 500
 
-    Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -Title 'Site Manager'
-    Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -Title 'Bookmarks'
+    Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -CloseControlId $siteManagerCloseControlId -Title 'Site Manager'
+    Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -CloseControlId $bookmarksCloseControlId -Title 'Bookmarks'
 
     if (-not [GhostFtpKeyboardNative]::PostMessage($main, $wmClose, [IntPtr]::Zero, [IntPtr]::Zero)) {
         throw 'Could not close the Ghost FTP main window.'

--- a/scripts/test_windows_modal_keyboard_runtime.ps1
+++ b/scripts/test_windows_modal_keyboard_runtime.ps1
@@ -1,0 +1,335 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Add-Type @"
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+public static class GhostFtpKeyboardNative
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GUITHREADINFO
+    {
+        public int cbSize;
+        public uint flags;
+        public IntPtr hwndActive;
+        public IntPtr hwndFocus;
+        public IntPtr hwndCapture;
+        public IntPtr hwndMenuOwner;
+        public IntPtr hwndMoveSize;
+        public IntPtr hwndCaret;
+        public RECT rcCaret;
+    }
+
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc callback, IntPtr extraData);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc callback, IntPtr extraData);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll")]
+    public static extern bool GetGUIThreadInfo(uint idThread, ref GUITHREADINFO info);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowEnabled(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool PostMessage(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+}
+"@
+
+$wmCommand = 0x0111
+$wmKeyDown = 0x0100
+$wmKeyUp = 0x0101
+$wmClose = 0x0010
+$vkTab = 0x09
+$vkReturn = 0x0D
+$vkEscape = 0x1B
+$siteManagerCommand = 701
+$bookmarksCommand = 97
+
+function Wait-ForMainWindow {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process,
+        [int]$TimeoutSeconds = 20
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if ($Process.HasExited) {
+            throw "Ghost FTP exited before its main window became available. Exit code: $($Process.ExitCode)"
+        }
+        $Process.Refresh()
+        if ($Process.MainWindowHandle -ne [IntPtr]::Zero) {
+            return $Process.MainWindowHandle
+        }
+        Start-Sleep -Milliseconds 200
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    throw 'Timed out waiting for the Ghost FTP main window.'
+}
+
+function Find-ProcessWindow {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$ProcessId,
+        [Parameter(Mandatory = $true)]
+        [string]$TitleContains,
+        [int]$TimeoutSeconds = 15
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $script:ghostFtpKeyboardFoundWindow = [IntPtr]::Zero
+        $script:ghostFtpKeyboardTargetPid = [uint32]$ProcessId
+        $script:ghostFtpKeyboardTitle = $TitleContains
+        $callback = [GhostFtpKeyboardNative+EnumWindowsProc]{
+            param([IntPtr]$hWnd, [IntPtr]$lParam)
+
+            [uint32]$windowProcessId = 0
+            [GhostFtpKeyboardNative]::GetWindowThreadProcessId($hWnd, [ref]$windowProcessId) | Out-Null
+            if ($windowProcessId -ne $script:ghostFtpKeyboardTargetPid -or -not [GhostFtpKeyboardNative]::IsWindowVisible($hWnd)) {
+                return $true
+            }
+            $buffer = New-Object System.Text.StringBuilder 512
+            [GhostFtpKeyboardNative]::GetWindowText($hWnd, $buffer, $buffer.Capacity) | Out-Null
+            if ($buffer.ToString() -like "*$($script:ghostFtpKeyboardTitle)*") {
+                $script:ghostFtpKeyboardFoundWindow = $hWnd
+                return $false
+            }
+            return $true
+        }
+        [GhostFtpKeyboardNative]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
+        if ($script:ghostFtpKeyboardFoundWindow -ne [IntPtr]::Zero) {
+            return $script:ghostFtpKeyboardFoundWindow
+        }
+        Start-Sleep -Milliseconds 150
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    throw "Timed out waiting for Ghost FTP window containing '$TitleContains'."
+}
+
+function Find-ChildWindowByText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IntPtr]$Parent,
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+        [int]$TimeoutSeconds = 10
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $script:ghostFtpKeyboardFoundChild = [IntPtr]::Zero
+        $script:ghostFtpKeyboardChildText = $Text
+        $callback = [GhostFtpKeyboardNative+EnumWindowsProc]{
+            param([IntPtr]$hWnd, [IntPtr]$lParam)
+
+            if (-not [GhostFtpKeyboardNative]::IsWindowVisible($hWnd)) {
+                return $true
+            }
+            $buffer = New-Object System.Text.StringBuilder 512
+            [GhostFtpKeyboardNative]::GetWindowText($hWnd, $buffer, $buffer.Capacity) | Out-Null
+            if ($buffer.ToString() -eq $script:ghostFtpKeyboardChildText) {
+                $script:ghostFtpKeyboardFoundChild = $hWnd
+                return $false
+            }
+            return $true
+        }
+        [GhostFtpKeyboardNative]::EnumChildWindows($Parent, $callback, [IntPtr]::Zero) | Out-Null
+        if ($script:ghostFtpKeyboardFoundChild -ne [IntPtr]::Zero) {
+            return $script:ghostFtpKeyboardFoundChild
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    throw "Timed out waiting for child control '$Text'."
+}
+
+function Get-FocusedWindow {
+    param([Parameter(Mandatory = $true)][IntPtr]$Window)
+
+    [uint32]$processId = 0
+    $threadId = [GhostFtpKeyboardNative]::GetWindowThreadProcessId($Window, [ref]$processId)
+    if ($threadId -eq 0) {
+        throw 'Unable to determine the Ghost FTP UI thread.'
+    }
+    $info = New-Object GhostFtpKeyboardNative+GUITHREADINFO
+    $info.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($info)
+    if (-not [GhostFtpKeyboardNative]::GetGUIThreadInfo($threadId, [ref]$info)) {
+        throw 'GetGUIThreadInfo failed for the Ghost FTP UI thread.'
+    }
+    return $info.hwndFocus
+}
+
+function Wait-ForWindowClosed {
+    param(
+        [Parameter(Mandatory = $true)][IntPtr]$Window,
+        [string]$Name,
+        [int]$TimeoutSeconds = 5
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if (-not [GhostFtpKeyboardNative]::IsWindow($Window)) {
+            return
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw "$Name did not close after the keyboard action."
+}
+
+function Assert-MainRestored {
+    param(
+        [Parameter(Mandatory = $true)][IntPtr]$Main,
+        [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
+        [string]$Context,
+        [int]$TimeoutSeconds = 5
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if ($Process.HasExited) {
+            throw "Ghost FTP exited unexpectedly after $Context."
+        }
+        if ([GhostFtpKeyboardNative]::IsWindowEnabled($Main) -and -not [GhostFtpKeyboardNative]::IsIconic($Main)) {
+            return
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw "Main window was not restored and enabled after $Context."
+}
+
+function Open-ModalWindow {
+    param(
+        [Parameter(Mandatory = $true)][IntPtr]$Main,
+        [Parameter(Mandatory = $true)][int]$Command,
+        [Parameter(Mandatory = $true)][int]$ProcessId,
+        [Parameter(Mandatory = $true)][string]$Title
+    )
+
+    if (-not [GhostFtpKeyboardNative]::PostMessage($Main, $wmCommand, [IntPtr]$Command, [IntPtr]::Zero)) {
+        throw "Could not request $Title."
+    }
+    $window = Find-ProcessWindow -ProcessId $ProcessId -TitleContains $Title
+    [GhostFtpKeyboardNative]::SetForegroundWindow($window) | Out-Null
+    Start-Sleep -Milliseconds 250
+    return $window
+}
+
+function Focus-CloseWithTab {
+    param(
+        [Parameter(Mandatory = $true)][IntPtr]$Window,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $closeButton = Find-ChildWindowByText -Parent $Window -Text 'Close'
+    for ($index = 0; $index -lt 40; $index++) {
+        $focus = Get-FocusedWindow -Window $Window
+        if ($focus -eq $closeButton) {
+            return $closeButton
+        }
+        $target = if ($focus -ne [IntPtr]::Zero) { $focus } else { $Window }
+        if (-not [GhostFtpKeyboardNative]::PostMessage($target, $wmKeyDown, [IntPtr]$vkTab, [IntPtr]::Zero)) {
+            throw "Could not post Tab to $Name."
+        }
+        [GhostFtpKeyboardNative]::PostMessage($target, $wmKeyUp, [IntPtr]$vkTab, [IntPtr]::Zero) | Out-Null
+        Start-Sleep -Milliseconds 100
+    }
+    throw "Tab traversal did not reach the Close button in $Name."
+}
+
+function Verify-ModalKeyboardContract {
+    param(
+        [Parameter(Mandatory = $true)][IntPtr]$Main,
+        [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory = $true)][int]$Command,
+        [Parameter(Mandatory = $true)][string]$Title
+    )
+
+    $modal = Open-ModalWindow -Main $Main -Command $Command -ProcessId $Process.Id -Title $Title
+    if ([GhostFtpKeyboardNative]::IsWindowEnabled($Main)) {
+        throw "Main window remained enabled while $Title was open."
+    }
+    $closeButton = Focus-CloseWithTab -Window $modal -Name $Title
+    $focus = Get-FocusedWindow -Window $modal
+    if ($focus -ne $closeButton) {
+        throw "Close button did not retain keyboard focus in $Title."
+    }
+    if (-not [GhostFtpKeyboardNative]::PostMessage($closeButton, $wmKeyDown, [IntPtr]$vkReturn, [IntPtr]::Zero)) {
+        throw "Could not post Enter to the focused Close button in $Title."
+    }
+    Wait-ForWindowClosed -Window $modal -Name $Title
+    Assert-MainRestored -Main $Main -Process $Process -Context "$Title Enter close"
+
+    $modal = Open-ModalWindow -Main $Main -Command $Command -ProcessId $Process.Id -Title $Title
+    if (-not [GhostFtpKeyboardNative]::PostMessage($modal, $wmKeyDown, [IntPtr]$vkEscape, [IntPtr]::Zero)) {
+        throw "Could not post Escape to $Title."
+    }
+    Wait-ForWindowClosed -Window $modal -Name $Title
+    Assert-MainRestored -Main $Main -Process $Process -Context "$Title Escape close"
+
+    Write-Host "MODAL_KEYBOARD_OK=$Title"
+}
+
+$exe = (Resolve-Path -LiteralPath $Executable).Path
+$process = Start-Process -FilePath $exe -PassThru
+try {
+    $main = Wait-ForMainWindow -Process $process
+    [GhostFtpKeyboardNative]::SetForegroundWindow($main) | Out-Null
+    Start-Sleep -Milliseconds 500
+
+    Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -Title 'Site Manager'
+    Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -Title 'Bookmarks'
+
+    if (-not [GhostFtpKeyboardNative]::PostMessage($main, $wmClose, [IntPtr]::Zero, [IntPtr]::Zero)) {
+        throw 'Could not close the Ghost FTP main window.'
+    }
+    if (-not $process.WaitForExit(5000)) {
+        throw 'Ghost FTP did not exit after the runtime keyboard test.'
+    }
+}
+finally {
+    if (-not $process.HasExited) {
+        $process.Kill()
+        $process.WaitForExit()
+    }
+}
+
+Write-Host 'WINDOWS_MODAL_KEYBOARD_RUNTIME=PASS'

--- a/scripts/test_windows_modal_keyboard_runtime_contract.py
+++ b/scripts/test_windows_modal_keyboard_runtime_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class WindowsModalKeyboardRuntimeContractTests(unittest.TestCase):
+    def test_runtime_probe_uses_real_windows_focus_and_message_apis(self) -> None:
+        source = read("scripts/test_windows_modal_keyboard_runtime.ps1")
+
+        for marker in (
+            'GetGUIThreadInfo',
+            'GetWindowThreadProcessId',
+            'IsWindowEnabled',
+            'IsIconic',
+            'PostMessage',
+            'SetForegroundWindow',
+        ):
+            self.assertIn(marker, source)
+        self.assertIn("$vkTab = 0x09", source)
+        self.assertIn("$vkReturn = 0x0D", source)
+        self.assertIn("$vkEscape = 0x1B", source)
+
+    def test_site_manager_and_bookmarks_run_tab_enter_escape_cycles(self) -> None:
+        source = read("scripts/test_windows_modal_keyboard_runtime.ps1")
+
+        self.assertIn("$siteManagerCommand = 701", source)
+        self.assertIn("$bookmarksCommand = 97", source)
+        self.assertIn("Focus-CloseWithTab", source)
+        self.assertIn("Close button did not retain keyboard focus", source)
+        self.assertIn("Could not post Enter", source)
+        self.assertIn("Could not post Escape", source)
+        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -Title 'Site Manager'", source)
+        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -Title 'Bookmarks'", source)
+
+    def test_owner_restore_regression_is_runtime_verified(self) -> None:
+        source = read("scripts/test_windows_modal_keyboard_runtime.ps1")
+
+        self.assertIn("Main window remained enabled while $Title was open.", source)
+        self.assertIn("IsWindowEnabled($Main)", source)
+        self.assertIn("IsIconic($Main)", source)
+        self.assertIn("Main window was not restored and enabled after $Context.", source)
+        self.assertIn("WINDOWS_MODAL_KEYBOARD_RUNTIME=PASS", source)
+
+    def test_workflow_builds_verified_production_binary_and_runs_probe(self) -> None:
+        workflow = read(".github/workflows/windows-modal-keyboard-runtime.yml")
+
+        self.assertIn("Build verified production Windows packages", workflow)
+        self.assertIn(".\\BUILD-WINDOWS.ps1", workflow)
+        self.assertIn("dist\\internal\\Ghost-FTP-$version-Portable-x64.exe", workflow)
+        self.assertIn(".\\scripts\\test_windows_modal_keyboard_runtime.ps1 -Executable $exe", workflow)
+        self.assertIn("ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}", workflow)
+        self.assertIn("contents: read", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_modal_keyboard_runtime_contract.py
+++ b/scripts/test_windows_modal_keyboard_runtime_contract.py
@@ -16,6 +16,7 @@ class WindowsModalKeyboardRuntimeContractTests(unittest.TestCase):
         for marker in (
             'GetGUIThreadInfo',
             'GetWindowThreadProcessId',
+            'GetDlgItem',
             'IsWindowEnabled',
             'IsIconic',
             'PostMessage',
@@ -31,12 +32,17 @@ class WindowsModalKeyboardRuntimeContractTests(unittest.TestCase):
 
         self.assertIn("$siteManagerCommand = 701", source)
         self.assertIn("$bookmarksCommand = 97", source)
+        self.assertIn("$siteManagerCloseControlId = 8114", source)
+        self.assertIn("$bookmarksCloseControlId = 8206", source)
+        self.assertIn("Wait-ForControlById", source)
         self.assertIn("Focus-CloseWithTab", source)
-        self.assertIn("Close button did not retain keyboard focus", source)
+        self.assertIn("Dismiss button did not retain keyboard focus", source)
         self.assertIn("Could not post Enter", source)
         self.assertIn("Could not post Escape", source)
-        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -Title 'Site Manager'", source)
-        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -Title 'Bookmarks'", source)
+        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $siteManagerCommand -CloseControlId $siteManagerCloseControlId -Title 'Site Manager'", source)
+        self.assertIn("Verify-ModalKeyboardContract -Main $main -Process $process -Command $bookmarksCommand -CloseControlId $bookmarksCloseControlId -Title 'Bookmarks'", source)
+        self.assertNotIn("Find-ChildWindowByText", source)
+        self.assertNotIn("-Text 'Close'", source)
 
     def test_owner_restore_regression_is_runtime_verified(self) -> None:
         source = read("scripts/test_windows_modal_keyboard_runtime.ps1")


### PR DESCRIPTION
## Summary
- add a dedicated GitHub-hosted Windows runtime regression gate for Site Manager and Bookmarks
- build the verified production x64 executable before probing behavior
- exercise real Win32 focus/message behavior: Tab traversal, Enter on the focused dismiss button, Escape close, owner re-enable and non-minimized restore
- use stable native control IDs instead of localized button text so the probe is language-independent
- keep the workflow read-only and bound to the exact PR/main SHA

## Scope and safety
- test/workflow changes only; no application behavior changes
- no version or release changes
- no signing/AuthentiCode policy changes
- no network/protocol changes
- no telemetry or external dependencies

## Validation required before merge
- exact-head Ghost FTP CI
- exact-head Windows Modal Keyboard Runtime = success on GitHub-hosted Windows
- branch behind_by=0
- no unresolved review threads
