### PR TITLE
Guard Windows profile mutations against re-entry

### DIFF
--- a/internal/desktop/action_state_windows.go
+++ b/internal/desktop/action_state_windows.go
@@ -28,11 +28,11 @@ func (a *app) updateActionControls() {
 		return
 	}
 
-	profileEditable := !a.connected && !a.connectionBusy
+	profileEditable := !a.connected && !a.connectionBusy && !a.profileMutationBusy
 	setControlEnabled(a.siteManagerBtn, profileEditable)
 	setControlEnabled(a.saveProfile, profileEditable)
 	setControlEnabled(a.removeProfile, profileEditable && a.selectedProfileID != "")
-	setControlEnabled(a.settingsBtn, !a.connectionBusy)
+	setControlEnabled(a.settingsBtn, !a.connectionBusy && !a.profileMutationBusy)
 
 	comparisonActive := a.directoryComparisonActive()
 	localRecursiveActive := a.recursiveSearchPaneActive(false)

--- a/internal/desktop/connection_profiles_windows.go
+++ b/internal/desktop/connection_profiles_windows.go
@@ -61,6 +61,28 @@ func (a *app) setProtocolValue(protocol string) {
 	a.updateProtocolControls()
 }
 
+func (a *app) setProfileMutationBusy(busy bool) {
+	if a == nil {
+		return
+	}
+	a.profileMutationBusy = busy
+	if a.closing {
+		return
+	}
+
+	editable := !busy && !a.connected && !a.connectionBusy
+	for _, h := range []uintptr{
+		a.connect, a.profilesCombo, a.protocol, a.host, a.port, a.user, a.pass,
+		a.keyPath, a.chooseKey, a.passphrase,
+	} {
+		setControlEnabled(h, editable)
+	}
+	if editable {
+		a.updateProtocolControls()
+	}
+	a.updateActionControls()
+}
+
 func (a *app) setConnectionBusy(busy bool) {
 	a.connectionBusy = busy
 	if !busy {
@@ -105,7 +127,7 @@ func (a *app) setConnectionUI(connected bool) {
 }
 
 func (a *app) connectNow() {
-	if a.connectionBusy || a.connected {
+	if a.connectionBusy || a.connected || a.profileMutationBusy {
 		return
 	}
 	host := getText(a.host)
@@ -303,6 +325,9 @@ func (a *app) disconnectNow() {
 }
 
 func (a *app) choosePrivateKey() {
+	if a.profileMutationBusy {
+		return
+	}
 	p, err := a.engine.ChoosePrivateKey()
 	if err != nil {
 		platform.ErrorDialog("Ghost FTP", a.tr("key.choose_failed"), a.userMessage(err, "key.choose_failed_body"))
@@ -387,7 +412,7 @@ func (a *app) currentProfile() (model.PublicProfile, bool) {
 }
 
 func (a *app) selectProfile() {
-	if a.connectionBusy || a.connected {
+	if a.connectionBusy || a.connected || a.profileMutationBusy {
 		return
 	}
 	idx, _, _ := sendMessageW.Call(a.profilesCombo, cbGetCurSel, 0, 0)
@@ -421,6 +446,9 @@ func (a *app) selectProfile() {
 func (a *app) saveCurrentProfile() {
 	language := a.languageCode()
 	profileTitle := "Ghost FTP — " + a.tr("profile.save")
+	if a.profileMutationBusy {
+		return
+	}
 	if a.connected || a.connectionBusy {
 		platform.InfoDialog("Ghost FTP", profileBusyHeading(language), profileBusyBody(language))
 		return
@@ -517,6 +545,9 @@ func (a *app) saveCurrentProfile() {
 		}
 	}
 
+	if a.profileMutationBusy || a.connected || a.connectionBusy {
+		return
+	}
 	payload := model.ProfileInput{
 		ID:              a.selectedProfileID,
 		Name:            name,
@@ -536,12 +567,14 @@ func (a *app) saveCurrentProfile() {
 	setText(a.passphrase, "")
 	password = ""
 	passphrase = ""
+	a.setProfileMutationBusy(true)
 	a.goSafe(func() {
 		saved, err := a.engine.SaveProfile(payload)
 		payload.Password = ""
 		payload.Passphrase = ""
 		a.dispatch(func() {
 			if err != nil {
+				a.setProfileMutationBusy(false)
 				platform.ErrorDialog(profileTitle, a.tr("settings.save_failed"), a.userMessage(err, "settings.save_failed_body"))
 				return
 			}
@@ -549,6 +582,7 @@ func (a *app) saveCurrentProfile() {
 			setText(a.pass, "")
 			setText(a.passphrase, "")
 			a.setProfileCredentialCues(saved)
+			a.setProfileMutationBusy(false)
 			a.setStatus(a.tr("profile.save") + ": " + saved.Name)
 			a.loadProfiles()
 		})
@@ -556,7 +590,7 @@ func (a *app) saveCurrentProfile() {
 }
 
 func (a *app) removeCurrentProfile() {
-	if a.connectionBusy {
+	if a.profileMutationBusy || a.connectionBusy {
 		return
 	}
 	p, ok := a.currentProfile()
@@ -571,16 +605,22 @@ func (a *app) removeCurrentProfile() {
 	if !platform.ConfirmDialog("Ghost FTP — "+a.tr("profile.delete"), a.tr("profile.delete"), p.Name) {
 		return
 	}
+	if a.profileMutationBusy || a.connected || a.connectionBusy {
+		return
+	}
 	id := p.ID
+	a.setProfileMutationBusy(true)
 	a.goSafe(func() {
 		err := a.engine.RemoveProfile(id)
 		a.dispatch(func() {
 			if err != nil {
+				a.setProfileMutationBusy(false)
 				platform.ErrorDialog("Ghost FTP — "+a.tr("profile.delete"), a.tr("profile.delete"), a.userMessage(err, "error.generic"))
 				return
 			}
 			a.selectedProfileID = ""
 			a.resetProfileCredentialCues()
+			a.setProfileMutationBusy(false)
 			a.loadProfiles()
 			a.setStatus(a.tr("profile.delete"))
 			a.updateActionControls()

--- a/internal/desktop/windows.go
+++ b/internal/desktop/windows.go
@@ -354,6 +354,12 @@ func wndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
 		a.runDispatch()
 		return 0
 	case wmClose:
+		// Profile persistence is intentionally short and cannot be cancelled safely.
+		// Keep the process alive until the in-flight save/delete has committed so a
+		// close click cannot leave the encrypted profile store partially updated.
+		if a.profileMutationBusy {
+			return 0
+		}
 		if a.connected || a.connectionBusy || a.hasActiveTransfers() {
 			if !platform.ConfirmDialog("Ghost FTP", closeQuestion(a.languageCode()), closeBody(a.languageCode())) {
 				return 0

--- a/internal/desktop/windows.go
+++ b/internal/desktop/windows.go
@@ -53,6 +53,7 @@ type app struct {
 	selectedProfileID    string
 	connected            bool
 	connectionBusy       bool
+	profileMutationBusy  bool
 	connectionGeneration uint64
 	healthCheckRunning   bool
 	connectionCancel     context.CancelFunc

--- a/scripts/test_windows_profile_mutation_contract.py
+++ b/scripts/test_windows_profile_mutation_contract.py
@@ -46,6 +46,19 @@ class WindowsProfileMutationContractTests(unittest.TestCase):
         ):
             self.assertIn(control, helper)
 
+    def test_shutdown_waits_for_profile_persistence(self):
+        close_case = re.search(
+            r"case wmClose:\s*(.*?)\s*case wmDestroy:",
+            WINDOWS,
+            re.S,
+        )
+        self.assertIsNotNone(close_case, "missing WM_CLOSE lifecycle")
+        self.assertIn("if a.profileMutationBusy", close_case.group(1))
+        self.assertLess(
+            close_case.group(1).find("if a.profileMutationBusy"),
+            close_case.group(1).find("destroyWindow.Call(hwnd)"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_windows_profile_mutation_contract.py
+++ b/scripts/test_windows_profile_mutation_contract.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS = (ROOT / "internal" / "desktop" / "windows.go").read_text(encoding="utf-8")
+ACTIONS = (ROOT / "internal" / "desktop" / "action_state_windows.go").read_text(encoding="utf-8")
+PROFILES = (ROOT / "internal" / "desktop" / "connection_profiles_windows.go").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(rf"func \(a \*app\) {re.escape(name)}\([^)]*\).*?\n\}}", source, re.S)
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    return match.group(0)
+
+
+class WindowsProfileMutationContractTests(unittest.TestCase):
+    def test_app_tracks_profile_mutation_state(self):
+        self.assertIn("profileMutationBusy", WINDOWS)
+
+    def test_profile_actions_are_disabled_while_mutation_is_active(self):
+        self.assertIn("!a.profileMutationBusy", ACTIONS)
+
+    def test_save_and_delete_use_mutation_guard(self):
+        save = function_body(PROFILES, "saveCurrentProfile")
+        delete = function_body(PROFILES, "removeCurrentProfile")
+        for body in (save, delete):
+            self.assertIn("profileMutationBusy", body)
+            self.assertIn("setProfileMutationBusy(true)", body)
+            self.assertIn("setProfileMutationBusy(false)", body)
+
+    def test_conflicting_profile_inputs_are_locked(self):
+        helper = function_body(PROFILES, "setProfileMutationBusy")
+        for control in (
+            "a.connect",
+            "a.profilesCombo",
+            "a.protocol",
+            "a.host",
+            "a.port",
+            "a.user",
+            "a.pass",
+            "a.keyPath",
+            "a.chooseKey",
+            "a.passphrase",
+        ):
+            self.assertIn(control, helper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft Windows stability fix for profile persistence re-entrancy and shutdown lifecycle. Serializes profile Save/Delete, locks conflicting connection/profile controls while persistence is in flight, and blocks WM_CLOSE until the short non-cancellable profile-store mutation commits. Includes a static regression contract. No release/version changes.