### PR TITLE
Guard Windows file mutations against re-entry

### DIFF
--- a/internal/desktop/action_state_windows.go
+++ b/internal/desktop/action_state_windows.go
@@ -38,17 +38,19 @@ func (a *app) updateActionControls() {
 	localRecursiveActive := a.recursiveSearchPaneActive(false)
 	localSelected := validSelectionCount(a.localList, len(a.localItems))
 	localReady := !localRecursiveActive && !comparisonActive
-	setControlEnabled(a.localMkdir, localReady)
-	setControlEnabled(a.localRename, localReady && localSelected == 1)
-	setControlEnabled(a.localDelete, localReady && localSelected > 0)
+	localMutationReady := localReady && !a.localMutationBusy
+	setControlEnabled(a.localMkdir, localMutationReady)
+	setControlEnabled(a.localRename, localMutationReady && localSelected == 1)
+	setControlEnabled(a.localDelete, localMutationReady && localSelected > 0)
 	setControlEnabled(a.upload, localReady && a.connected && !a.connectionBusy && localSelected > 0)
 
 	remoteRecursiveActive := a.recursiveSearchPaneActive(true)
 	remoteSelected := validSelectionCount(a.remoteList, len(a.remoteItems))
 	remoteReady := a.connected && !a.connectionBusy && !remoteRecursiveActive && !comparisonActive
-	setControlEnabled(a.remoteMkdir, remoteReady)
-	setControlEnabled(a.remoteRename, remoteReady && remoteSelected == 1)
-	setControlEnabled(a.remoteDelete, remoteReady && remoteSelected > 0)
+	remoteMutationReady := remoteReady && !a.remoteMutationBusy
+	setControlEnabled(a.remoteMkdir, remoteMutationReady)
+	setControlEnabled(a.remoteRename, remoteMutationReady && remoteSelected == 1)
+	setControlEnabled(a.remoteDelete, remoteMutationReady && remoteSelected > 0)
 	setControlEnabled(a.download, remoteReady && remoteSelected > 0)
 	setControlEnabled(remoteEditButton(a), remoteReady && a.remoteEditSelectionReady())
 
@@ -60,7 +62,7 @@ func (a *app) updateActionControls() {
 			}
 		}
 	}
-	setControlEnabled(a.remoteChmod, remoteReady && chmodSelected > 0)
+	setControlEnabled(a.remoteChmod, remoteMutationReady && chmodSelected > 0)
 
 	selectedTransfers := selectedIndices(a.transferList)
 	transferState := deriveTransferActionState(a.transferJobs, selectedTransfers, a.connected && !a.connectionBusy, a.queuePaused)

--- a/internal/desktop/files_actions_windows.go
+++ b/internal/desktop/files_actions_windows.go
@@ -21,6 +21,56 @@ func (a *app) suppressExpectedDisconnectError(err error) bool {
 	return err != nil && errors.Is(err, context.Canceled) && (a.connectionBusy || !a.connected || a.closing)
 }
 
+func (a *app) beginLocalMutation() bool {
+	if a == nil || a.localMutationBusy {
+		return false
+	}
+	a.localMutationBusy = true
+	a.updateActionControls()
+	return true
+}
+
+func (a *app) finishLocalMutation() {
+	if a == nil || !a.localMutationBusy {
+		return
+	}
+	a.localMutationBusy = false
+	a.updateActionControls()
+}
+
+func (a *app) remoteMutationActionReady() bool {
+	return a != nil && a.connected && !a.connectionBusy && !a.remoteMutationBusy
+}
+
+func (a *app) beginRemoteMutation() bool {
+	if !a.remoteMutationActionReady() {
+		return false
+	}
+	a.remoteMutationBusy = true
+	a.updateActionControls()
+	return true
+}
+
+func (a *app) finishRemoteMutation() {
+	if a == nil || !a.remoteMutationBusy {
+		return
+	}
+	a.remoteMutationBusy = false
+	a.updateActionControls()
+}
+
+func (a *app) runLocalMutation(operation func() error, complete func(error)) {
+	a.goSafe(func() {
+		defer a.dispatch(func() {
+			a.finishLocalMutation()
+		})
+		err := operation()
+		a.dispatch(func() {
+			complete(err)
+		})
+	})
+}
+
 func (a *app) chooseLocalDirectory() {
 	p, err := a.engine.ChooseDirectory()
 	if err != nil {
@@ -164,53 +214,64 @@ func (a *app) openSelectedRemote() {
 }
 
 func (a *app) localMkdirAction() {
+	if !a.beginLocalMutation() {
+		return
+	}
 	name, ok := platform.PromptDialog("Ghost FTP — "+a.tr("common.new_folder"), a.tr("column.name")+":", a.tr("common.new_folder"))
 	if !ok {
+		a.finishLocalMutation()
 		return
 	}
 	name = strings.TrimSpace(name)
 	base := a.localCurrent
-	a.goSafe(func() {
-		err := a.engine.LocalMkdir(base, name)
-		a.dispatch(func() {
-			if err != nil {
-				platform.ErrorDialog("Ghost FTP", a.tr("common.new_folder"), a.userMessage(err, "error.generic"))
-				return
-			}
-			a.refreshLocal(a.localCurrent)
-			a.setStatus(a.tr("common.new_folder") + ": " + name)
-		})
+	a.runLocalMutation(func() error {
+		return a.engine.LocalMkdir(base, name)
+	}, func(err error) {
+		if err != nil {
+			platform.ErrorDialog("Ghost FTP", a.tr("common.new_folder"), a.userMessage(err, "error.generic"))
+			return
+		}
+		a.refreshLocal(a.localCurrent)
+		a.setStatus(a.tr("common.new_folder") + ": " + name)
 	})
 }
 
 func (a *app) localRenameAction() {
+	if !a.beginLocalMutation() {
+		return
+	}
 	indices := selectedIndices(a.localList)
 	if len(indices) != 1 || indices[0] < 0 || indices[0] >= len(a.localItems) {
+		a.finishLocalMutation()
 		a.setStatus(a.tr("common.rename") + ": " + a.tr("error.invalid_name"))
 		return
 	}
 	item := a.localItems[indices[0]]
 	name, ok := platform.PromptDialog("Ghost FTP — "+a.tr("common.rename"), a.tr("column.name")+":", item.Name)
 	if !ok || strings.TrimSpace(name) == item.Name {
+		a.finishLocalMutation()
 		return
 	}
 	base := a.localCurrent
-	a.goSafe(func() {
-		err := a.engine.LocalRename(base, item.Name, strings.TrimSpace(name))
-		a.dispatch(func() {
-			if err != nil {
-				platform.ErrorDialog("Ghost FTP", a.tr("common.rename"), a.userMessage(err, "error.generic"))
-				return
-			}
-			a.refreshLocal(a.localCurrent)
-			a.setStatus(a.tr("common.rename") + ": " + item.Name)
-		})
+	a.runLocalMutation(func() error {
+		return a.engine.LocalRename(base, item.Name, strings.TrimSpace(name))
+	}, func(err error) {
+		if err != nil {
+			platform.ErrorDialog("Ghost FTP", a.tr("common.rename"), a.userMessage(err, "error.generic"))
+			return
+		}
+		a.refreshLocal(a.localCurrent)
+		a.setStatus(a.tr("common.rename") + ": " + item.Name)
 	})
 }
 
 func (a *app) localDeleteAction() {
+	if !a.beginLocalMutation() {
+		return
+	}
 	indices := selectedIndices(a.localList)
 	if len(indices) == 0 {
+		a.finishLocalMutation()
 		a.setStatus(a.tr("common.delete") + ": " + a.tr("error.invalid_name"))
 		return
 	}
@@ -221,6 +282,7 @@ func (a *app) localDeleteAction() {
 		}
 	}
 	if len(items) == 0 {
+		a.finishLocalMutation()
 		return
 	}
 	if a.settings.ConfirmDelete {
@@ -229,11 +291,12 @@ func (a *app) localDeleteAction() {
 			detail = strconv.Itoa(len(items)) + " × " + a.tr("column.name")
 		}
 		if !platform.ConfirmDialog("Ghost FTP — "+a.tr("common.delete"), a.tr("common.delete")+"?", detail) {
+			a.finishLocalMutation()
 			return
 		}
 	}
 	base := a.localCurrent
-	a.goSafe(func() {
+	a.runLocalMutation(func() error {
 		deleted := 0
 		var errs []error
 		for _, item := range items {
@@ -243,19 +306,46 @@ func (a *app) localDeleteAction() {
 			}
 			deleted++
 		}
-		err := errors.Join(errs...)
-		a.dispatch(func() {
-			if err != nil {
-				platform.ErrorDialog("Ghost FTP", a.tr("common.delete"), a.userMessage(err, "error.generic"))
-			}
-			a.refreshLocal(a.localCurrent)
-			a.setStatus(a.tr("common.delete") + ": " + strconv.Itoa(deleted) + " • " + a.tr("status.failed") + ": " + strconv.Itoa(len(items)-deleted))
-		})
+		if err := errors.Join(errs...); err != nil {
+			return &localDeleteResultError{err: err, deleted: deleted}
+		}
+		return &localDeleteResultError{deleted: deleted}
+	}, func(err error) {
+		deleted := len(items)
+		var result *localDeleteResultError
+		if errors.As(err, &result) {
+			deleted = result.deleted
+			err = result.err
+		}
+		if err != nil {
+			platform.ErrorDialog("Ghost FTP", a.tr("common.delete"), a.userMessage(err, "error.generic"))
+		}
+		a.refreshLocal(a.localCurrent)
+		a.setStatus(a.tr("common.delete") + ": " + strconv.Itoa(deleted) + " • " + a.tr("status.failed") + ": " + strconv.Itoa(len(items)-deleted))
 	})
 }
 
+type localDeleteResultError struct {
+	err     error
+	deleted int
+}
+
+func (e *localDeleteResultError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *localDeleteResultError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
 func (a *app) remoteMkdirAction() {
-	if !a.connected || a.connectionBusy {
+	if !a.remoteMutationActionReady() {
 		return
 	}
 	name, ok := platform.PromptDialog("Ghost FTP — "+a.tr("common.new_folder"), a.tr("column.name")+":", a.tr("common.new_folder"))
@@ -271,8 +361,11 @@ func (a *app) remoteMkdirAction() {
 }
 
 func (a *app) remoteRenameAction() {
+	if !a.remoteMutationActionReady() {
+		return
+	}
 	indices := selectedIndices(a.remoteList)
-	if len(indices) != 1 || indices[0] < 0 || indices[0] >= len(a.remoteItems) || a.connectionBusy {
+	if len(indices) != 1 || indices[0] < 0 || indices[0] >= len(a.remoteItems) {
 		a.setStatus(a.tr("common.rename") + ": " + a.tr("error.invalid_name"))
 		return
 	}
@@ -295,8 +388,11 @@ func (a *app) remoteRenameAction() {
 }
 
 func (a *app) remoteDeleteAction() {
+	if !a.remoteMutationActionReady() {
+		return
+	}
 	indices := selectedIndices(a.remoteList)
-	if len(indices) == 0 || a.connectionBusy {
+	if len(indices) == 0 {
 		a.setStatus(a.tr("common.delete") + ": " + a.tr("error.invalid_name"))
 		return
 	}
@@ -326,8 +422,11 @@ func (a *app) remoteDeleteAction() {
 }
 
 func (a *app) remoteChmodAction() {
+	if !a.remoteMutationActionReady() {
+		return
+	}
 	indices := selectedIndices(a.remoteList)
-	if len(indices) == 0 || a.connectionBusy {
+	if len(indices) == 0 {
 		a.setStatus(a.tr("common.permissions") + ": " + a.tr("error.invalid_name"))
 		return
 	}
@@ -379,13 +478,16 @@ func (a *app) runRemoteMutation(label string, operation func(context.Context) er
 }
 
 func (a *app) runRemoteMutationWithTimeout(label string, timeout time.Duration, operation func(context.Context) error, success string) {
-	if !a.connected || a.connectionBusy {
+	if !a.beginRemoteMutation() {
 		return
 	}
 	baseNavGeneration := a.remoteNavSeq
 	connectionGeneration := a.connectionGeneration
 	a.setStatus(label + "…")
 	a.goSafe(func() {
+		defer a.dispatch(func() {
+			a.finishRemoteMutation()
+		})
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		err := operation(ctx)
@@ -411,13 +513,16 @@ func (a *app) runRemoteMutationWithTimeout(label string, timeout time.Duration, 
 }
 
 func (a *app) runRemoteBatchMutationWithTimeout(label string, timeout time.Duration, count int, operation func(context.Context, int) error, successPrefix string, skipped int) {
-	if !a.connected || a.connectionBusy || count <= 0 {
+	if count <= 0 || !a.beginRemoteMutation() {
 		return
 	}
 	baseNavGeneration := a.remoteNavSeq
 	connectionGeneration := a.connectionGeneration
 	a.setStatus(label + "…")
 	a.goSafe(func() {
+		defer a.dispatch(func() {
+			a.finishRemoteMutation()
+		})
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		result := executeBatchMutation(ctx, count, operation)

--- a/internal/desktop/windows.go
+++ b/internal/desktop/windows.go
@@ -54,6 +54,8 @@ type app struct {
 	connected            bool
 	connectionBusy       bool
 	profileMutationBusy  bool
+	localMutationBusy    bool
+	remoteMutationBusy   bool
 	connectionGeneration uint64
 	healthCheckRunning   bool
 	connectionCancel     context.CancelFunc

--- a/scripts/test_windows_file_mutation_contract.py
+++ b/scripts/test_windows_file_mutation_contract.py
@@ -64,7 +64,7 @@ class WindowsFileMutationContractTests(unittest.TestCase):
     def test_async_mutation_guards_are_released_from_dispatch(self) -> None:
         source = read("internal/desktop/files_actions_windows.go")
         self.assertGreaterEqual(source.count("a.finishLocalMutation()"), 4)
-        self.assertGreaterEqual(source.count("a.finishRemoteMutation()"), 3)
+        self.assertEqual(source.count("a.finishRemoteMutation()"), 2)
         self.assertIn("a.updateActionControls()", source)
 
 

--- a/scripts/test_windows_file_mutation_contract.py
+++ b/scripts/test_windows_file_mutation_contract.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def function_source(source: str, name: str) -> str:
+    marker = f"func (a *app) {name}("
+    start = source.find(marker)
+    if start < 0:
+        return ""
+    next_func = source.find("\nfunc (", start + len(marker))
+    if next_func < 0:
+        return source[start:]
+    return source[start:next_func]
+
+
+class WindowsFileMutationContractTests(unittest.TestCase):
+    def test_app_tracks_local_and_remote_mutations_independently(self) -> None:
+        source = read("internal/desktop/windows.go")
+        self.assertIn("localMutationBusy", source)
+        self.assertIn("remoteMutationBusy", source)
+
+    def test_mutation_buttons_follow_side_specific_busy_state(self) -> None:
+        source = read("internal/desktop/action_state_windows.go")
+        self.assertIn("localMutationReady := localReady && !a.localMutationBusy", source)
+        self.assertIn("remoteMutationReady := remoteReady && !a.remoteMutationBusy", source)
+        self.assertIn("setControlEnabled(a.localMkdir, localMutationReady)", source)
+        self.assertIn("setControlEnabled(a.remoteMkdir, remoteMutationReady)", source)
+
+    def test_local_mutations_take_a_code_level_guard(self) -> None:
+        source = read("internal/desktop/files_actions_windows.go")
+        self.assertIn("func (a *app) beginLocalMutation() bool", source)
+        self.assertIn("func (a *app) finishLocalMutation()", source)
+        for name in ("localMkdirAction", "localRenameAction", "localDeleteAction"):
+            body = function_source(source, name)
+            self.assertTrue(body, name)
+            self.assertIn("beginLocalMutation()", body, name)
+
+    def test_remote_mutations_guard_before_prompt_and_before_async_start(self) -> None:
+        source = read("internal/desktop/files_actions_windows.go")
+        self.assertIn("func (a *app) remoteMutationActionReady() bool", source)
+        self.assertIn("func (a *app) beginRemoteMutation() bool", source)
+        self.assertIn("func (a *app) finishRemoteMutation()", source)
+        for name in (
+            "remoteMkdirAction",
+            "remoteRenameAction",
+            "remoteDeleteAction",
+            "remoteChmodAction",
+        ):
+            body = function_source(source, name)
+            self.assertTrue(body, name)
+            self.assertIn("remoteMutationActionReady()", body, name)
+        for name in ("runRemoteMutationWithTimeout", "runRemoteBatchMutationWithTimeout"):
+            body = function_source(source, name)
+            self.assertTrue(body, name)
+            self.assertIn("beginRemoteMutation()", body, name)
+
+    def test_async_mutation_guards_are_released_from_dispatch(self) -> None:
+        source = read("internal/desktop/files_actions_windows.go")
+        self.assertGreaterEqual(source.count("a.finishLocalMutation()"), 4)
+        self.assertGreaterEqual(source.count("a.finishRemoteMutation()"), 3)
+        self.assertIn("a.updateActionControls()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft Windows stability fix for asynchronous local and remote file mutations that can be re-entered by duplicate or stale commands while the previous mutation is still running. The first commit adds a regression contract. Scope is intentionally narrow: serialize local mutations independently from remote mutations, disable only conflicting mutation controls, retain unrelated transfer/navigation behavior, and add code-level guards rather than relying only on disabled buttons. No release/version metadata changes.