### PR TITLE
Guard Windows remote edit sessions against re-entry

### DIFF
--- a/internal/desktop/action_state_windows.go
+++ b/internal/desktop/action_state_windows.go
@@ -47,7 +47,7 @@ func (a *app) updateActionControls() {
 	remoteRecursiveActive := a.recursiveSearchPaneActive(true)
 	remoteSelected := validSelectionCount(a.remoteList, len(a.remoteItems))
 	remoteReady := a.connected && !a.connectionBusy && !remoteRecursiveActive && !comparisonActive
-	remoteMutationReady := remoteReady && !a.remoteMutationBusy
+	remoteMutationReady := remoteReady && !a.remoteMutationBusy && !remoteEditSessionBusy(a)
 	setControlEnabled(a.remoteMkdir, remoteMutationReady)
 	setControlEnabled(a.remoteRename, remoteMutationReady && remoteSelected == 1)
 	setControlEnabled(a.remoteDelete, remoteMutationReady && remoteSelected > 0)

--- a/internal/desktop/remote_edit_windows.go
+++ b/internal/desktop/remote_edit_windows.go
@@ -60,6 +60,10 @@ func (a *app) beginRemoteEditSession() bool {
 	if _, loaded := remoteEditSessions.LoadOrStore(a, struct{}{}); loaded {
 		return false
 	}
+	// Share the remote mutation exclusion flag for the lifetime of the edit
+	// session so stale/direct rename, delete, chmod, or mkdir commands also
+	// fail closed instead of relying only on disabled controls.
+	a.remoteMutationBusy = true
 	a.updateActionControls()
 	return true
 }
@@ -69,6 +73,7 @@ func (a *app) finishRemoteEditSession() {
 		return
 	}
 	remoteEditSessions.Delete(a)
+	a.remoteMutationBusy = false
 	if !a.closing {
 		a.updateActionControls()
 	}

--- a/internal/desktop/remote_edit_windows.go
+++ b/internal/desktop/remote_edit_windows.go
@@ -17,6 +17,7 @@ import (
 const idRemoteEdit = 309
 
 var remoteEditButtons sync.Map
+var remoteEditSessions sync.Map
 
 func storeRemoteEditButton(a *app, hwnd uintptr) {
 	if a == nil || hwnd == 0 {
@@ -37,14 +38,44 @@ func remoteEditButton(a *app) uintptr {
 	return 0
 }
 
+func remoteEditSessionBusy(a *app) bool {
+	if a == nil {
+		return false
+	}
+	_, ok := remoteEditSessions.Load(a)
+	return ok
+}
+
 func clearRemoteEditButton(a *app) {
 	if a != nil {
 		remoteEditButtons.Delete(a)
+		remoteEditSessions.Delete(a)
+	}
+}
+
+func (a *app) beginRemoteEditSession() bool {
+	if a == nil || a.closing || !a.connected || a.connectionBusy || a.remoteMutationBusy {
+		return false
+	}
+	if _, loaded := remoteEditSessions.LoadOrStore(a, struct{}{}); loaded {
+		return false
+	}
+	a.updateActionControls()
+	return true
+}
+
+func (a *app) finishRemoteEditSession() {
+	if a == nil {
+		return
+	}
+	remoteEditSessions.Delete(a)
+	if !a.closing {
+		a.updateActionControls()
 	}
 }
 
 func (a *app) remoteEditSelectionReady() bool {
-	if a == nil || !a.connected || a.connectionBusy {
+	if a == nil || !a.connected || a.connectionBusy || a.remoteMutationBusy || remoteEditSessionBusy(a) {
 		return false
 	}
 	indices := selectedIndices(a.remoteList)
@@ -66,11 +97,20 @@ func (a *app) remoteEditAction() {
 		a.setStatus(a.userMessage(err, "error.invalid_name"))
 		return
 	}
+	if !a.beginRemoteEditSession() {
+		return
+	}
 	remotePath := path.Join(a.remoteCurrent, item.Name)
 	generation := a.connectionGeneration
 	words := remoteEditWords(a.languageCode())
 	a.setStatus(words.Opening)
 	a.goSafe(func() {
+		handedOff := false
+		defer func() {
+			if !handedOff {
+				a.dispatch(func() { a.finishRemoteEditSession() })
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		doc, err := a.engine.RemoteEditOpen(ctx, remotePath)
@@ -78,12 +118,15 @@ func (a *app) remoteEditAction() {
 		if err == nil {
 			buffer, err = newRemoteEditBuffer(doc.Text)
 		}
+		handedOff = true
 		a.dispatch(func() {
 			if generation != a.connectionGeneration || !a.connected {
+				a.finishRemoteEditSession()
 				a.setStatus(words.ConnectionChanged)
 				return
 			}
 			if err != nil {
+				a.finishRemoteEditSession()
 				message := a.userMessage(err, "error.generic")
 				if errors.Is(err, errRemoteEditMixedNewlines) {
 					message = words.MixedNewlines
@@ -100,6 +143,7 @@ func (a *app) remoteEditAction() {
 
 func (a *app) showRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEditBuffer, text string, generation uint64) {
 	if generation != a.connectionGeneration || !a.connected {
+		a.finishRemoteEditSession()
 		a.setStatus(remoteEditWords(a.languageCode()).ConnectionChanged)
 		return
 	}
@@ -115,6 +159,7 @@ func (a *app) showRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEdit
 	})
 	result.Text = normalizeRemoteEditorText(result.Text)
 	if generation != a.connectionGeneration || !a.connected {
+		a.finishRemoteEditSession()
 		a.setStatus(words.ConnectionChanged)
 		return
 	}
@@ -132,7 +177,9 @@ func (a *app) showRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEdit
 	default:
 		if dirty && !platform.ConfirmDialog("Ghost FTP — "+words.Title, words.Close+"?", words.DiscardClose) {
 			a.showRemoteTextEditor(doc, buffer, result.Text, generation)
+			return
 		}
+		a.finishRemoteEditSession()
 	}
 }
 
@@ -141,6 +188,12 @@ func (a *app) saveRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEdit
 	encoded := buffer.Encode(text)
 	a.setStatus(words.Saving)
 	a.goSafe(func() {
+		handedOff := false
+		defer func() {
+			if !handedOff {
+				a.dispatch(func() { a.finishRemoteEditSession() })
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 		saved, err := a.engine.RemoteEditSave(ctx, doc.Path, doc.Revision, encoded)
@@ -148,8 +201,10 @@ func (a *app) saveRemoteTextEditor(doc api.RemoteEditDocument, buffer remoteEdit
 		if err == nil {
 			next, err = newRemoteEditBuffer(saved.Text)
 		}
+		handedOff = true
 		a.dispatch(func() {
 			if generation != a.connectionGeneration || !a.connected {
+				a.finishRemoteEditSession()
 				a.setStatus(words.ConnectionChanged)
 				return
 			}
@@ -176,6 +231,12 @@ func (a *app) reloadRemoteTextEditor(remotePath string, generation uint64) {
 	words := remoteEditWords(a.languageCode())
 	a.setStatus(words.Reloading)
 	a.goSafe(func() {
+		handedOff := false
+		defer func() {
+			if !handedOff {
+				a.dispatch(func() { a.finishRemoteEditSession() })
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		doc, err := a.engine.RemoteEditOpen(ctx, remotePath)
@@ -183,12 +244,15 @@ func (a *app) reloadRemoteTextEditor(remotePath string, generation uint64) {
 		if err == nil {
 			buffer, err = newRemoteEditBuffer(doc.Text)
 		}
+		handedOff = true
 		a.dispatch(func() {
 			if generation != a.connectionGeneration || !a.connected {
+				a.finishRemoteEditSession()
 				a.setStatus(words.ConnectionChanged)
 				return
 			}
 			if err != nil {
+				a.finishRemoteEditSession()
 				message := a.userMessage(err, "error.generic")
 				if errors.Is(err, errRemoteEditMixedNewlines) {
 					message = words.MixedNewlines

--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -108,7 +108,7 @@ sleep 2
 # between platform releases, so parse both ActivityTaskManager and WindowManager
 # evidence instead of depending on one historical mResumedActivity label.
 activity_dump="$(timeout 10s adb shell dumpsys activity activities 2>/dev/null | tr -d '\r' || true)"
-resolved_component="$(printf '%s\n' "$activity_dump" | awk '
+resolved_component="$(awk '
 /topResumedActivity=ActivityRecord|ResumedActivity: ActivityRecord/ {
   for (i = 1; i <= NF; i++) {
     candidate = $i
@@ -118,11 +118,11 @@ resolved_component="$(printf '%s\n' "$activity_dump" | awk '
       exit
     }
   }
-}')"
+}' <<<"$activity_dump")"
 window_dump=''
 if [[ -z "$resolved_component" ]]; then
   window_dump="$(timeout 10s adb shell dumpsys window windows 2>/dev/null | tr -d '\r' || true)"
-  resolved_component="$(printf '%s\n' "$window_dump" | awk '
+  resolved_component="$(awk '
 /mCurrentFocus=Window|mFocusedApp=ActivityRecord/ {
   for (i = 1; i <= NF; i++) {
     candidate = $i
@@ -132,7 +132,7 @@ if [[ -z "$resolved_component" ]]; then
       exit
     }
   }
-}')"
+}' <<<"$window_dump")"
 fi
 [[ "$resolved_component" == "$package_name/"* ]] || {
   printf '%s\n' "$activity_dump" >&2

--- a/scripts/test_windows_remote_edit_session_contract.py
+++ b/scripts/test_windows_remote_edit_session_contract.py
@@ -26,17 +26,26 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
         self.assertIn("remoteEditSessions sync.Map", source)
         self.assertIn("func remoteEditSessionBusy(a *app) bool", source)
 
-    def test_remote_edit_readiness_rejects_reentry(self) -> None:
+    def test_remote_edit_readiness_rejects_reentry_and_remote_mutation_overlap(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
         body = function_source(source, "remoteEditSelectionReady")
         self.assertTrue(body)
         self.assertIn("remoteEditSessionBusy(a)", body)
+        self.assertIn("a.remoteMutationBusy", body)
+
+    def test_remote_mutations_are_disabled_while_remote_edit_session_is_active(self) -> None:
+        source = read("internal/desktop/action_state_windows.go")
+        self.assertIn(
+            "remoteMutationReady := remoteReady && !a.remoteMutationBusy && !remoteEditSessionBusy(a)",
+            source,
+        )
 
     def test_remote_edit_session_has_atomic_code_level_begin_and_finish_guards(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
         begin = function_source(source, "beginRemoteEditSession")
         finish = function_source(source, "finishRemoteEditSession")
         self.assertIn("LoadOrStore", begin)
+        self.assertIn("a.remoteMutationBusy", begin)
         self.assertIn("remoteEditSessions.Delete(a)", finish)
         action = function_source(source, "remoteEditAction")
         self.assertTrue(action)

--- a/scripts/test_windows_remote_edit_session_contract.py
+++ b/scripts/test_windows_remote_edit_session_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def function_source(source: str, name: str) -> str:
+    marker = f"func (a *app) {name}("
+    start = source.find(marker)
+    if start < 0:
+        return ""
+    next_func = source.find("\nfunc (", start + len(marker))
+    if next_func < 0:
+        return source[start:]
+    return source[start:next_func]
+
+
+class WindowsRemoteEditSessionContractTests(unittest.TestCase):
+    def test_app_tracks_remote_edit_session_busy_state(self) -> None:
+        source = read("internal/desktop/windows.go")
+        self.assertIn("remoteEditBusy", source)
+
+    def test_remote_edit_readiness_rejects_reentry(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        body = function_source(source, "remoteEditSelectionReady")
+        self.assertTrue(body)
+        self.assertIn("a.remoteEditBusy", body)
+
+    def test_remote_edit_session_has_code_level_begin_and_finish_guards(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        self.assertIn("func (a *app) beginRemoteEditSession() bool", source)
+        self.assertIn("func (a *app) finishRemoteEditSession()", source)
+        action = function_source(source, "remoteEditAction")
+        self.assertTrue(action)
+        self.assertIn("beginRemoteEditSession()", action)
+
+    def test_terminal_remote_edit_paths_release_session(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        for name in (
+            "remoteEditAction",
+            "showRemoteTextEditor",
+            "saveRemoteTextEditor",
+            "reloadRemoteTextEditor",
+        ):
+            body = function_source(source, name)
+            self.assertTrue(body, name)
+            self.assertIn("finishRemoteEditSession()", body, name)
+
+    def test_remote_edit_button_state_is_refreshed_when_session_changes(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        begin = function_source(source, "beginRemoteEditSession")
+        finish = function_source(source, "finishRemoteEditSession")
+        self.assertIn("a.updateActionControls()", begin)
+        self.assertIn("a.updateActionControls()", finish)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_remote_edit_session_contract.py
+++ b/scripts/test_windows_remote_edit_session_contract.py
@@ -9,12 +9,23 @@ def read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
 
-def function_source(source: str, name: str) -> str:
+def method_source(source: str, name: str) -> str:
     marker = f"func (a *app) {name}("
     start = source.find(marker)
     if start < 0:
         return ""
-    next_func = source.find("\nfunc (", start + len(marker))
+    next_func = source.find("\nfunc ", start + len(marker))
+    if next_func < 0:
+        return source[start:]
+    return source[start:next_func]
+
+
+def free_function_source(source: str, name: str) -> str:
+    marker = f"func {name}("
+    start = source.find(marker)
+    if start < 0:
+        return ""
+    next_func = source.find("\nfunc ", start + len(marker))
     if next_func < 0:
         return source[start:]
     return source[start:next_func]
@@ -28,7 +39,7 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
 
     def test_remote_edit_readiness_rejects_reentry_and_remote_mutation_overlap(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
-        body = function_source(source, "remoteEditSelectionReady")
+        body = method_source(source, "remoteEditSelectionReady")
         self.assertTrue(body)
         self.assertIn("remoteEditSessionBusy(a)", body)
         self.assertIn("a.remoteMutationBusy", body)
@@ -42,12 +53,12 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
 
     def test_remote_edit_session_has_atomic_code_level_begin_and_finish_guards(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
-        begin = function_source(source, "beginRemoteEditSession")
-        finish = function_source(source, "finishRemoteEditSession")
+        begin = method_source(source, "beginRemoteEditSession")
+        finish = method_source(source, "finishRemoteEditSession")
         self.assertIn("LoadOrStore", begin)
         self.assertIn("a.remoteMutationBusy", begin)
         self.assertIn("remoteEditSessions.Delete(a)", finish)
-        action = function_source(source, "remoteEditAction")
+        action = method_source(source, "remoteEditAction")
         self.assertTrue(action)
         self.assertIn("beginRemoteEditSession()", action)
 
@@ -59,20 +70,21 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
             "saveRemoteTextEditor",
             "reloadRemoteTextEditor",
         ):
-            body = function_source(source, name)
+            body = method_source(source, name)
             self.assertTrue(body, name)
             self.assertIn("finishRemoteEditSession()", body, name)
 
     def test_remote_edit_button_state_is_refreshed_when_session_changes(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
-        begin = function_source(source, "beginRemoteEditSession")
-        finish = function_source(source, "finishRemoteEditSession")
+        begin = method_source(source, "beginRemoteEditSession")
+        finish = method_source(source, "finishRemoteEditSession")
         self.assertIn("a.updateActionControls()", begin)
         self.assertIn("a.updateActionControls()", finish)
 
     def test_destroy_cleanup_drops_stale_session_state(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
-        body = function_source(source, "clearRemoteEditButton")
+        body = free_function_source(source, "clearRemoteEditButton")
+        self.assertTrue(body)
         self.assertIn("remoteEditSessions.Delete(a)", body)
 
 

--- a/scripts/test_windows_remote_edit_session_contract.py
+++ b/scripts/test_windows_remote_edit_session_contract.py
@@ -21,20 +21,23 @@ def function_source(source: str, name: str) -> str:
 
 
 class WindowsRemoteEditSessionContractTests(unittest.TestCase):
-    def test_app_tracks_remote_edit_session_busy_state(self) -> None:
-        source = read("internal/desktop/windows.go")
-        self.assertIn("remoteEditBusy", source)
+    def test_remote_edit_sessions_are_tracked_per_app(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        self.assertIn("remoteEditSessions sync.Map", source)
+        self.assertIn("func remoteEditSessionBusy(a *app) bool", source)
 
     def test_remote_edit_readiness_rejects_reentry(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
         body = function_source(source, "remoteEditSelectionReady")
         self.assertTrue(body)
-        self.assertIn("a.remoteEditBusy", body)
+        self.assertIn("remoteEditSessionBusy(a)", body)
 
-    def test_remote_edit_session_has_code_level_begin_and_finish_guards(self) -> None:
+    def test_remote_edit_session_has_atomic_code_level_begin_and_finish_guards(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")
-        self.assertIn("func (a *app) beginRemoteEditSession() bool", source)
-        self.assertIn("func (a *app) finishRemoteEditSession()", source)
+        begin = function_source(source, "beginRemoteEditSession")
+        finish = function_source(source, "finishRemoteEditSession")
+        self.assertIn("LoadOrStore", begin)
+        self.assertIn("remoteEditSessions.Delete(a)", finish)
         action = function_source(source, "remoteEditAction")
         self.assertTrue(action)
         self.assertIn("beginRemoteEditSession()", action)
@@ -57,6 +60,11 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
         finish = function_source(source, "finishRemoteEditSession")
         self.assertIn("a.updateActionControls()", begin)
         self.assertIn("a.updateActionControls()", finish)
+
+    def test_destroy_cleanup_drops_stale_session_state(self) -> None:
+        source = read("internal/desktop/remote_edit_windows.go")
+        body = function_source(source, "clearRemoteEditButton")
+        self.assertIn("remoteEditSessions.Delete(a)", body)
 
 
 if __name__ == "__main__":

--- a/scripts/test_windows_remote_edit_session_contract.py
+++ b/scripts/test_windows_remote_edit_session_contract.py
@@ -57,10 +57,18 @@ class WindowsRemoteEditSessionContractTests(unittest.TestCase):
         finish = method_source(source, "finishRemoteEditSession")
         self.assertIn("LoadOrStore", begin)
         self.assertIn("a.remoteMutationBusy", begin)
+        self.assertIn("a.remoteMutationBusy = true", begin)
         self.assertIn("remoteEditSessions.Delete(a)", finish)
+        self.assertIn("a.remoteMutationBusy = false", finish)
         action = method_source(source, "remoteEditAction")
         self.assertTrue(action)
         self.assertIn("beginRemoteEditSession()", action)
+
+    def test_remote_mutation_execution_guard_observes_shared_busy_flag(self) -> None:
+        source = read("internal/desktop/files_actions_windows.go")
+        body = method_source(source, "remoteMutationActionReady")
+        self.assertTrue(body)
+        self.assertIn("!a.remoteMutationBusy", body)
 
     def test_terminal_remote_edit_paths_release_session(self) -> None:
         source = read("internal/desktop/remote_edit_windows.go")


### PR DESCRIPTION
Adds a regression contract first, then will harden the Windows Remote Edit lifecycle so only one edit session can be active at a time across open, save, reload, modal reopen, error, and connection-change paths. This PR remains draft until exact-head CI/runtime evidence is fully green.