### PR TITLE
Own Windows native fallback dialogs

### DIFF
--- a/internal/platform/windows.go
+++ b/internal/platform/windows.go
@@ -209,6 +209,7 @@ func ChoosePrivateKey() (string, error) {
 	filter := multiString(privateKeyFilter + "|id_*;*.pem;*.key|" + allFilesLabel + "|*.*")
 	title, _ := syscall.UTF16PtrFromString(privateKeyTitle)
 	ofn := openFileName{
+		Owner:       premiumDialogOwner(),
 		File:        &buf[0],
 		MaxFile:     uint32(len(buf)),
 		Filter:      &filter[0],
@@ -228,7 +229,12 @@ func ChooseDirectory() (string, error) {
 	display := make([]uint16, 260)
 	_, _, _, directoryTitle := resolvedPickerLabels()
 	title, _ := syscall.UTF16PtrFromString(directoryTitle)
-	bi := browseInfo{DisplayName: &display[0], Title: title, Flags: bifReturnOnlyFS | bifNewDialogStyle}
+	bi := browseInfo{
+		Owner:       premiumDialogOwner(),
+		DisplayName: &display[0],
+		Title:       title,
+		Flags:       bifReturnOnlyFS | bifNewDialogStyle,
+	}
 	pidl, _, _ := browseFolder.Call(uintptr(unsafe.Pointer(&bi)))
 	if pidl == 0 {
 		return "", nil // cancel
@@ -249,9 +255,10 @@ func taskDialogCall(title, instruction, content string, buttons uintptr) (int, b
 	t, _ := syscall.UTF16PtrFromString(title)
 	i, _ := syscall.UTF16PtrFromString(instruction)
 	c, _ := syscall.UTF16PtrFromString(content)
+	owner := premiumDialogOwner()
 	var pressed int32
 	hr, _, _ := taskDialog.Call(
-		0, 0,
+		owner, 0,
 		uintptr(unsafe.Pointer(t)),
 		uintptr(unsafe.Pointer(i)),
 		uintptr(unsafe.Pointer(c)),
@@ -301,7 +308,7 @@ func ErrorDialog(title, instruction, content string) {
 func MessageBox(title, text string, flags uintptr) int {
 	t, _ := syscall.UTF16PtrFromString(text)
 	c, _ := syscall.UTF16PtrFromString(title)
-	r, _, _ := messageBox.Call(0, uintptr(unsafe.Pointer(t)), uintptr(unsafe.Pointer(c)), flags)
+	r, _, _ := messageBox.Call(premiumDialogOwner(), uintptr(unsafe.Pointer(t)), uintptr(unsafe.Pointer(c)), flags)
 	return int(r)
 }
 

--- a/scripts/test_windows_native_dialog_owner_contract.py
+++ b/scripts/test_windows_native_dialog_owner_contract.py
@@ -28,12 +28,12 @@ class WindowsNativeDialogOwnerContractTests(unittest.TestCase):
     def test_private_key_picker_uses_validated_active_owner(self) -> None:
         source = read("internal/platform/windows.go")
         body = function_body(source, "func ChoosePrivateKey()")
-        self.assertIn("Owner:       premiumDialogOwner(),", body)
+        self.assertRegex(body, r"Owner:\s+premiumDialogOwner\(\),")
 
     def test_directory_picker_uses_validated_active_owner(self) -> None:
         source = read("internal/platform/windows.go")
         body = function_body(source, "func ChooseDirectory()")
-        self.assertIn("Owner: premiumDialogOwner(),", body)
+        self.assertRegex(body, r"Owner:\s+premiumDialogOwner\(\),")
 
     def test_task_dialog_fallback_uses_validated_active_owner(self) -> None:
         source = read("internal/platform/windows.go")

--- a/scripts/test_windows_native_dialog_owner_contract.py
+++ b/scripts/test_windows_native_dialog_owner_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+class WindowsNativeDialogOwnerContractTests(unittest.TestCase):
+    def test_private_key_picker_uses_validated_active_owner(self) -> None:
+        source = read("internal/platform/windows.go")
+        body = function_body(source, "func ChoosePrivateKey()")
+        self.assertIn("Owner:       premiumDialogOwner(),", body)
+
+    def test_directory_picker_uses_validated_active_owner(self) -> None:
+        source = read("internal/platform/windows.go")
+        body = function_body(source, "func ChooseDirectory()")
+        self.assertIn("Owner: premiumDialogOwner(),", body)
+
+    def test_task_dialog_fallback_uses_validated_active_owner(self) -> None:
+        source = read("internal/platform/windows.go")
+        body = function_body(source, "func taskDialogCall(")
+        self.assertIn("owner := premiumDialogOwner()", body)
+        self.assertIn("taskDialog.Call(\n\t\towner, 0,", body)
+        self.assertNotIn("taskDialog.Call(\n\t\t0, 0,", body)
+
+    def test_message_box_fallback_uses_validated_active_owner(self) -> None:
+        source = read("internal/platform/windows.go")
+        body = function_body(source, "func MessageBox(")
+        self.assertIn("messageBox.Call(premiumDialogOwner(),", body)
+        self.assertNotIn("messageBox.Call(0,", body)
+
+    def test_owner_resolution_is_fail_closed_for_non_window_contexts(self) -> None:
+        source = read("internal/platform/dialog_premium_windows.go")
+        body = function_body(source, "func premiumDialogOwner()")
+        self.assertIn("premiumGetActiveWindow.Call()", body)
+        self.assertIn("if owner == 0", body)
+        self.assertIn("premiumIsWindow.Call(owner)", body)
+        self.assertIn("if valid == 0", body)
+        self.assertGreaterEqual(body.count("return 0"), 2)
+        self.assertIn("return owner", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Scope
- bind the private-key picker, folder picker, TaskDialog fallback and MessageBox fallback to the validated active Ghost FTP window
- preserve owner `0` when there is no valid active window, so installer/uninstaller and non-window contexts remain safe
- add a source-level regression contract for owner propagation

### Guardrails
- no desktop-global HWND coupling
- no installer/uninstaller behavior change when no active owner exists
- no unrelated UI or packaging changes

Draft until exact-head CI/runtime and cross-platform evidence are fully green.