### PR TITLE
Guard Android connection lifecycle across Activity destruction

### DIFF
--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -39,6 +39,7 @@ final class FtpSession implements Closeable {
     private BufferedReader reader;
     private BufferedWriter writer;
     private volatile boolean connected;
+    private volatile boolean aborted;
 
     FtpSession(String host, int port, boolean secure) {
         this.host = requireHost(host);
@@ -47,20 +48,25 @@ final class FtpSession implements Closeable {
     }
 
     synchronized void connect(String username, String password) throws IOException {
+        requireNotAborted();
         if (connected) {
             throw new IOException("Session is already connected.");
         }
         Socket plain = new Socket();
+        controlSocket = plain;
+        requireNotAborted();
         plain.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
         plain.setSoTimeout(READ_TIMEOUT_MS);
-        controlSocket = plain;
+        requireNotAborted();
         bindStreams(plain);
         expect(readReply(), 220);
 
         if (secure) {
             expect(command("AUTH TLS"), 234, 334);
+            requireNotAborted();
             SSLSocket tls = wrapTls(plain);
             controlSocket = tls;
+            requireNotAborted();
             bindStreams(tls);
         }
 
@@ -76,6 +82,7 @@ final class FtpSession implements Closeable {
             expect(command("PBSZ 0"), 200);
             expect(command("PROT P"), 200);
         }
+        requireNotAborted();
         connected = true;
     }
 
@@ -294,6 +301,13 @@ final class FtpSession implements Closeable {
     }
 
     void cancelActiveTransfer() {
+        connected = false;
+        closeQuietly(activeDataSocket);
+        closeQuietly(controlSocket);
+    }
+
+    void abort() {
+        aborted = true;
         connected = false;
         closeQuietly(activeDataSocket);
         closeQuietly(controlSocket);
@@ -547,6 +561,13 @@ final class FtpSession implements Closeable {
         controlSocket = null;
         reader = null;
         writer = null;
+    }
+
+    private void requireNotAborted() throws IOException {
+        if (aborted) {
+            hardClose();
+            throw new IOException("Connection cancelled.");
+        }
     }
 
     private static String sanitizeArgument(String value) throws IOException {

--- a/android/app/src/main/java/app/ghostftp/client/MainActivity.java
+++ b/android/app/src/main/java/app/ghostftp/client/MainActivity.java
@@ -121,6 +121,8 @@ public final class MainActivity extends Activity {
     private int selectedLocal = -1;
     private int selectedRemote = -1;
     private FtpSession session;
+    private volatile FtpSession connectingSession;
+    private volatile boolean lifecycleDestroyed;
     private boolean busy;
     private boolean rememberEndpoint = true;
     private boolean showFileSizes = true;
@@ -147,6 +149,12 @@ public final class MainActivity extends Activity {
 
     @Override
     protected void onDestroy() {
+        lifecycleDestroyed = true;
+        FtpSession pending = connectingSession;
+        connectingSession = null;
+        if (pending != null) {
+            pending.abort();
+        }
         transferGeneration++;
         transferActive = false;
         transferFinalizing = false;
@@ -841,8 +849,12 @@ public final class MainActivity extends Activity {
         return null;
     }
 
+    private boolean connectionAttemptCurrent(FtpSession candidate) {
+        return !lifecycleDestroyed && connectingSession == candidate;
+    }
+
     private void connect() {
-        if (busy || session != null) return;
+        if (lifecycleDestroyed || busy || session != null || connectingSession != null) return;
         String hostValue = host.getText().toString().trim();
         String userValue = username.getText().toString().trim();
         String passwordValue = password.getText().toString();
@@ -865,17 +877,39 @@ public final class MainActivity extends Activity {
             return;
         }
         String requestedStart = profile == null ? null : profile.remoteStartPath;
+        final FtpSession next;
+        try {
+            next = new FtpSession(hostValue, portValue, secure);
+        } catch (IllegalArgumentException e) {
+            setStatus(e.getMessage());
+            return;
+        }
+        connectingSession = next;
         setBusy(true, secure ? "Connecting with strict FTPS TLS verification…" : "Connecting with unencrypted FTP…");
         io.execute(() -> {
-            FtpSession next = null;
             try {
-                next = new FtpSession(hostValue, portValue, secure);
+                if (!connectionAttemptCurrent(next)) {
+                    next.abort();
+                    return;
+                }
                 next.connect(userValue, passwordValue);
+                if (!connectionAttemptCurrent(next)) {
+                    next.abort();
+                    return;
+                }
                 String start = requestedStart == null ? next.pwd() : requestedStart;
                 List<RemoteEntry> entries = next.list(start);
-                FtpSession ready = next;
+                if (!connectionAttemptCurrent(next)) {
+                    next.abort();
+                    return;
+                }
                 runOnUiThread(() -> {
-                    session = ready;
+                    if (!connectionAttemptCurrent(next)) {
+                        next.abort();
+                        return;
+                    }
+                    connectingSession = null;
+                    session = next;
                     connectedIdentityKey = identity;
                     currentRemotePath = start;
                     remoteEntries.clear();
@@ -889,8 +923,13 @@ public final class MainActivity extends Activity {
                             : "FTP connected. Warning: transport is unencrypted; server start directory freshly listed.");
                 });
             } catch (Exception e) {
-                if (next != null) next.close();
-                postError(profile == null ? "Connection failed" : "Connection or saved server start directory failed", e);
+                next.abort();
+                runOnUiThread(() -> {
+                    if (!connectionAttemptCurrent(next)) return;
+                    connectingSession = null;
+                    setBusy(false, (profile == null ? "Connection failed" : "Connection or saved server start directory failed")
+                            + ": " + safeMessage(e));
+                });
             }
         });
     }
@@ -1649,7 +1688,9 @@ public final class MainActivity extends Activity {
     }
 
     private void postError(String prefix, Exception e) {
+        if (lifecycleDestroyed) return;
         runOnUiThread(() -> {
+            if (lifecycleDestroyed) return;
             FtpSession current = session;
             if (current != null && !current.isConnected()) {
                 session = null;

--- a/scripts/test_android_connection_lifecycle_contract.py
+++ b/scripts/test_android_connection_lifecycle_contract.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVITY = ROOT / "android/app/src/main/java/app/ghostftp/client/MainActivity.java"
+SESSION = ROOT / "android/app/src/main/java/app/ghostftp/client/FtpSession.java"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def method_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated method: {signature}")
+
+
+class AndroidConnectionLifecycleContractTests(unittest.TestCase):
+    def test_activity_owns_pending_connection_until_ui_commit(self) -> None:
+        source = read(ACTIVITY)
+        self.assertIn("private volatile FtpSession connectingSession;", source)
+        self.assertIn("private volatile boolean lifecycleDestroyed;", source)
+        self.assertIn("private boolean connectionAttemptCurrent(FtpSession candidate)", source)
+        helper = method_body(source, "private boolean connectionAttemptCurrent(FtpSession candidate)")
+        self.assertIn("!lifecycleDestroyed", helper)
+        self.assertIn("connectingSession == candidate", helper)
+
+    def test_destroy_aborts_pending_connection_before_executor_shutdown(self) -> None:
+        source = read(ACTIVITY)
+        body = method_body(source, "protected void onDestroy()")
+        for marker in (
+            "lifecycleDestroyed = true;",
+            "FtpSession pending = connectingSession;",
+            "connectingSession = null;",
+            "pending.abort();",
+            "io.shutdownNow();",
+        ):
+            self.assertIn(marker, body)
+        self.assertLess(body.index("lifecycleDestroyed = true;"), body.index("pending.abort();"))
+        self.assertLess(body.index("pending.abort();"), body.index("io.shutdownNow();"))
+
+    def test_connect_registers_attempt_before_background_work_and_rejects_stale_commit(self) -> None:
+        source = read(ACTIVITY)
+        body = method_body(source, "private void connect()")
+        for marker in (
+            "FtpSession next = new FtpSession(",
+            "connectingSession = next;",
+            "io.execute(() -> {",
+            "if (!connectionAttemptCurrent(next))",
+            "next.abort();",
+            "connectingSession = null;",
+            "session = next;",
+        ):
+            self.assertIn(marker, body)
+        self.assertLess(body.index("connectingSession = next;"), body.index("io.execute(() -> {"))
+        self.assertLess(body.index("if (!connectionAttemptCurrent(next))"), body.index("session = next;"))
+
+    def test_connect_failure_does_not_post_to_destroyed_activity(self) -> None:
+        source = read(ACTIVITY)
+        body = method_body(source, "private void connect()")
+        self.assertIn("if (!connectionAttemptCurrent(next)) return;", body)
+        post_error = method_body(source, "private void postError(")
+        self.assertIn("if (lifecycleDestroyed) return;", post_error)
+
+    def test_session_abort_is_nonblocking_and_cancels_connect_races(self) -> None:
+        source = read(SESSION)
+        self.assertIn("private volatile boolean aborted;", source)
+        abort = method_body(source, "void abort()")
+        self.assertIn("aborted = true;", abort)
+        self.assertIn("connected = false;", abort)
+        self.assertIn("closeQuietly(activeDataSocket);", abort)
+        self.assertIn("closeQuietly(controlSocket);", abort)
+        self.assertNotIn("synchronized void abort()", source)
+
+        connect = method_body(source, "synchronized void connect(")
+        self.assertGreaterEqual(connect.count("requireNotAborted();"), 2)
+        self.assertIn("controlSocket = plain;", connect)
+        self.assertLess(connect.index("controlSocket = plain;"), connect.index("requireNotAborted();", connect.index("controlSocket = plain;")))
+
+        guard = method_body(source, "private void requireNotAborted()")
+        self.assertIn("if (aborted)", guard)
+        self.assertIn("hardClose();", guard)
+        self.assertIn('throw new IOException("Connection cancelled.");', guard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_android_connection_lifecycle_contract.py
+++ b/scripts/test_android_connection_lifecycle_contract.py
@@ -54,7 +54,8 @@ class AndroidConnectionLifecycleContractTests(unittest.TestCase):
         source = read(ACTIVITY)
         body = method_body(source, "private void connect()")
         for marker in (
-            "FtpSession next = new FtpSession(",
+            "final FtpSession next;",
+            "next = new FtpSession(",
             "connectingSession = next;",
             "io.execute(() -> {",
             "if (!connectionAttemptCurrent(next))",


### PR DESCRIPTION
### Scope
- make an in-flight FTP/FTPS connection attempt explicitly owned by its Activity instance
- abort a pending connection when the Activity is destroyed or recreated
- prevent stale connection success/error callbacks from mutating a destroyed Activity
- make pending-connect abort non-blocking and able to cancel the socket-open race
- add a dedicated regression contract

### Guardrails
- no transfer protocol changes
- no saved-profile or credential persistence changes
- no permission changes
- no SFTP enablement
- no unrelated Android UI redesign

Draft until exact-head CI and authentic Android emulator evidence are green.