### PR TITLE
Fix Android authentic UI cleanup race

### DIFF
--- a/scripts/capture_android_screenshots.sh
+++ b/scripts/capture_android_screenshots.sh
@@ -66,10 +66,39 @@ printf 'ANDROID_AVD_READY=%s HOME=%s\n' "$AVD_NAME" "$AVD_HOME"
 
 "$EMULATOR_BIN" -avd "$AVD_NAME" -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect >"$EMULATOR_LOG" 2>&1 &
 emulator_pid=$!
+
+cleanup_avd_home() {
+  local attempt=''
+  for attempt in $(seq 1 5); do
+    if rm -rf "$AVD_HOME"; then
+      [[ ! -e "$AVD_HOME" ]] && return 0
+    fi
+    sleep 0.5
+  done
+  echo "Android AVD cleanup remained busy after bounded retries: $AVD_HOME" >&2
+  return 0
+}
+
 cleanup() {
+  local status=$?
+  set +e
+
+  # adb emu kill is graceful but asynchronous. Hosted runners can keep writing
+  # AVD lock/state files briefly after the command returns, so explicitly stop
+  # and reap the emulator process before removing its disposable AVD registry.
   timeout 10s adb emu kill >/dev/null 2>&1 || true
   kill "$emulator_pid" 2>/dev/null || true
-  rm -rf "$AVD_HOME"
+  for _ in $(seq 1 40); do
+    kill -0 "$emulator_pid" 2>/dev/null || break
+    sleep 0.25
+  done
+  if kill -0 "$emulator_pid" 2>/dev/null; then
+    kill -KILL "$emulator_pid" 2>/dev/null || true
+  fi
+  wait "$emulator_pid" 2>/dev/null || true
+  cleanup_avd_home
+
+  return "$status"
 }
 trap cleanup EXIT
 

--- a/scripts/test_authentic_ui_workflow_contract.py
+++ b/scripts/test_authentic_ui_workflow_contract.py
@@ -136,6 +136,15 @@ class AuthenticUIWorkflowContractTests(unittest.TestCase):
         self.assertIn("Sites Bookmarks Transfers Settings About", capture)
         self.assertIn("adb exec-out screencap -p", capture)
 
+    def test_android_capture_teardown_waits_before_bounded_avd_cleanup(self) -> None:
+        capture = read("scripts/capture_android_screenshots.sh")
+        self.assertIn("cleanup_avd_home()", capture)
+        self.assertIn("for attempt in $(seq 1 5); do", capture)
+        self.assertIn('if rm -rf "$AVD_HOME"; then', capture)
+        self.assertIn('wait "$emulator_pid" 2>/dev/null || true', capture)
+        cleanup = capture[capture.index("cleanup() {"):capture.index("trap cleanup EXIT")]
+        self.assertLess(cleanup.index('wait "$emulator_pid"'), cleanup.index("cleanup_avd_home"))
+
     def test_linux_capture_uses_packaged_native_runtime(self) -> None:
         workflow = read(".github/workflows/ui-screenshots.yml")
         capture = read("scripts/capture_linux_screenshots.sh")


### PR DESCRIPTION
### Scope
- preserve the verified Android UI capture result while fixing the post-capture AVD teardown race observed on the exact 0.0.5 post-merge main workflow
- stop and reap the emulator process before deleting its disposable AVD home
- use bounded AVD cleanup retries so asynchronous emulator file writes cannot create a false workflow failure
- add a regression contract for teardown ordering and bounded cleanup

### Evidence
Post-merge UI run 34676943777 reached `ANDROID_UI_SCREENSHOTS=PASS` and produced all seven verified Android screenshots, then failed only because `rm -rf` raced an emulator process still writing to the AVD directory.

### Guardrails
- no Android application/runtime behavior change
- no release content/version change
- original capture failure exit status remains authoritative
- cleanup remains bounded and local to the disposable runner AVD directory
- release 0.0.5 remains blocked until this PR passes exact-head gates, merges with exact SHA, and the new main passes post-merge gates