### PR TITLE
Start native macOS client with Windows parity contract

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -10,6 +10,7 @@ on:
       - 'macos/**'
       - 'scripts/audit_platform_contract.py'
       - 'scripts/audit_desktop_surface.py'
+      - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
       - '.github/workflows/macos-app.yml'
   push:
@@ -22,6 +23,7 @@ on:
       - 'macos/**'
       - 'scripts/audit_platform_contract.py'
       - 'scripts/audit_desktop_surface.py'
+      - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
       - '.github/workflows/macos-app.yml'
 
@@ -68,6 +70,7 @@ jobs:
           python3 scripts/test_macos_windows_parity_contract.py
           python3 scripts/audit_platform_contract.py
           python3 scripts/audit_desktop_surface.py
+          python3 scripts/audit_version.py
 
       - name: Build universal native macOS app
         shell: bash
@@ -90,7 +93,7 @@ jobs:
           test -x "$executable"
           test -s "$plist"
           test -s "$icon"
-          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = 'com.brendigo.ghostftp'
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = 'app.ghostftp.client'
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$plist")" = "$version"
           archs="$(xcrun lipo -archs "$executable")"
           [[ " $archs " == *" arm64 "* ]]

--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -1,0 +1,109 @@
+name: Ghost FTP macOS Development App
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'VERSION'
+      - 'build/icon.png'
+      - 'macos/**'
+      - 'scripts/audit_platform_contract.py'
+      - 'scripts/audit_desktop_surface.py'
+      - 'scripts/test_macos_windows_parity_contract.py'
+      - '.github/workflows/macos-app.yml'
+  push:
+    branches:
+      - main
+      - 'feature/**'
+    paths:
+      - 'VERSION'
+      - 'build/icon.png'
+      - 'macos/**'
+      - 'scripts/audit_platform_contract.py'
+      - 'scripts/audit_desktop_surface.py'
+      - 'scripts/test_macos_windows_parity_contract.py'
+      - '.github/workflows/macos-app.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-macos-development-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: Universal native macOS development app
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Confirm exact tested SHA
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          echo "MACOS_SOURCE_SHA=$SOURCE_SHA"
+
+      - name: Verify Apple toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          xcrun swiftc --version
+          xcrun --sdk macosx --show-sdk-path
+
+      - name: Validate macOS parity contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/test_macos_windows_parity_contract.py
+          python3 scripts/audit_platform_contract.py
+          python3 scripts/audit_desktop_surface.py
+
+      - name: Build universal native macOS app
+        shell: bash
+        run: bash macos/BUILD.sh
+
+      - name: Verify app bundle and universal executable
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          archive="macos/dist/Ghost-FTP-${version}-macOS.app.zip"
+          test -s "$archive"
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          ditto -x -k "$archive" "$work"
+          app="$work/Ghost FTP.app"
+          executable="$app/Contents/MacOS/GhostFTP"
+          plist="$app/Contents/Info.plist"
+          icon="$app/Contents/Resources/GhostFTP.icns"
+          test -x "$executable"
+          test -s "$plist"
+          test -s "$icon"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = 'com.brendigo.ghostftp'
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$plist")" = "$version"
+          archs="$(xcrun lipo -archs "$executable")"
+          [[ " $archs " == *" arm64 "* ]]
+          [[ " $archs " == *" x86_64 "* ]]
+          codesign --verify --deep --strict "$app"
+          echo "MACOS_APP_BUNDLE=PASS"
+          echo "MACOS_APP_ARCHS=$archs"
+          echo "MACOS_APP_SIGNING=adhoc-development"
+
+      - name: Store macOS development artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-macos-development
+          if-no-files-found: error
+          retention-days: 14
+          path: macos/dist/Ghost-FTP-*-macOS.app.zip

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /cmd/installer/payload/payload.zip
 /ui-screenshots/
 /dev-signing/
+/macos/out/
+/macos/dist/
 
 # Generated release/package artifacts
 *.exe

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION="$(tr -d '\r\n' < "$SCRIPT_DIR/../VERSION")"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid root VERSION: $VERSION" >&2
+  exit 1
+fi
+
+SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/main.swift"
+ICON_SOURCE="$REPO_ROOT/build/icon.png"
+OUT="$SCRIPT_DIR/out"
+DIST="$SCRIPT_DIR/dist"
+APP="$OUT/Ghost FTP.app"
+CONTENTS="$APP/Contents"
+MACOS="$CONTENTS/MacOS"
+RESOURCES="$CONTENTS/Resources"
+ZIP="$DIST/Ghost-FTP-${VERSION}-macOS.app.zip"
+SDK="$(xcrun --sdk macosx --show-sdk-path)"
+DEPLOYMENT_TARGET="13.0"
+
+for required in "$SOURCE" "$ICON_SOURCE"; do
+  if [[ ! -s "$required" ]]; then
+    echo "Missing required macOS build input: $required" >&2
+    exit 1
+  fi
+done
+
+rm -rf "$OUT" "$DIST"
+mkdir -p "$MACOS" "$RESOURCES" "$DIST"
+
+build_arch() {
+  local arch="$1"
+  local target="$arch-apple-macosx${DEPLOYMENT_TARGET}"
+  xcrun --sdk macosx swiftc \
+    -sdk "$SDK" \
+    -target "$target" \
+    -O \
+    -framework AppKit \
+    "$SOURCE" \
+    -o "$OUT/GhostFTP-$arch"
+}
+
+build_arch arm64
+build_arch x86_64
+xcrun lipo -create "$OUT/GhostFTP-arm64" "$OUT/GhostFTP-x86_64" -output "$MACOS/GhostFTP"
+chmod 0755 "$MACOS/GhostFTP"
+
+ARCHS="$(xcrun lipo -archs "$MACOS/GhostFTP")"
+[[ " $ARCHS " == *" arm64 "* ]] || { echo "Universal app is missing arm64" >&2; exit 1; }
+[[ " $ARCHS " == *" x86_64 "* ]] || { echo "Universal app is missing x86_64" >&2; exit 1; }
+
+cat > "$CONTENTS/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Ghost FTP</string>
+  <key>CFBundleExecutable</key>
+  <string>GhostFTP</string>
+  <key>CFBundleIconFile</key>
+  <string>GhostFTP</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.brendigo.ghostftp</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Ghost FTP</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${VERSION}</string>
+  <key>CFBundleVersion</key>
+  <string>${VERSION}</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>${DEPLOYMENT_TARGET}</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+ICONSET="$OUT/GhostFTP.iconset"
+mkdir -p "$ICONSET"
+make_icon() {
+  local pixels="$1"
+  local name="$2"
+  sips -s format png -z "$pixels" "$pixels" "$ICON_SOURCE" --out "$ICONSET/$name" >/dev/null
+}
+make_icon 16 icon_16x16.png
+make_icon 32 icon_16x16@2x.png
+make_icon 32 icon_32x32.png
+make_icon 64 icon_32x32@2x.png
+make_icon 128 icon_128x128.png
+make_icon 256 icon_128x128@2x.png
+make_icon 256 icon_256x256.png
+make_icon 512 icon_256x256@2x.png
+make_icon 512 icon_512x512.png
+make_icon 1024 icon_512x512@2x.png
+iconutil -c icns "$ICONSET" -o "$RESOURCES/GhostFTP.icns"
+
+/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$CONTENTS/Info.plist" | grep -Fx 'com.brendigo.ghostftp' >/dev/null
+/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
+/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
+
+# Development CI uses ad-hoc signing only. A future public Mac release must use
+# an explicitly configured Apple Developer identity plus hardened runtime and
+# notarization; this build never fabricates a production identity.
+codesign --force --deep --sign - "$APP"
+codesign --verify --deep --strict "$APP"
+
+ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
+test -s "$ZIP"
+
+printf 'MACOS_APP=%s\n' "$APP"
+printf 'MACOS_DEVELOPMENT_ARTIFACT=%s\n' "$ZIP"
+printf 'MACOS_VERSION=%s\n' "$VERSION"
+printf 'MACOS_ARCHS=%s\n' "$ARCHS"
+printf 'MACOS_SIGNING=adhoc-development\n'

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -21,6 +21,7 @@ RESOURCES="$CONTENTS/Resources"
 ZIP="$DIST/Ghost-FTP-${VERSION}-macOS.app.zip"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
 DEPLOYMENT_TARGET="13.0"
+BUNDLE_ID="app.ghostftp.client"
 
 for required in "$SOURCE" "$ICON_SOURCE"; do
   if [[ ! -s "$required" ]]; then
@@ -67,7 +68,7 @@ cat > "$CONTENTS/Info.plist" <<EOF
   <key>CFBundleIconFile</key>
   <string>GhostFTP</string>
   <key>CFBundleIdentifier</key>
-  <string>com.brendigo.ghostftp</string>
+  <string>${BUNDLE_ID}</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
@@ -105,7 +106,7 @@ make_icon 512 icon_512x512.png
 make_icon 1024 icon_512x512@2x.png
 iconutil -c icns "$ICONSET" -o "$RESOURCES/GhostFTP.icns"
 
-/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$CONTENTS/Info.plist" | grep -Fx 'com.brendigo.ghostftp' >/dev/null
+/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$CONTENTS/Info.plist" | grep -Fx "$BUNDLE_ID" >/dev/null
 /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
 /usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
 

--- a/macos/PARITY.md
+++ b/macos/PARITY.md
@@ -1,0 +1,87 @@
+# macOS ↔ Windows parity contract
+
+The Windows desktop is the canonical visual and behavior reference for the macOS client. macOS may use native AppKit windowing, accessibility, file panels and menu conventions, but capability/state/security parity is mandatory. The Mac frontend must use the same typed `internal/api.Engine`; no decorative or dead controls are allowed.
+
+## Appearance and product identity
+
+- Classic Light uses workspace `#EEF1F5`, panel `#F6F8FB`, list `#FAFBFD`.
+- Dark uses workspace `#0B0F17`, panel `#121824`, list `#161D2A`.
+- English remains the default/fallback and the product exposes the same 24 languages.
+- FTP, explicit FTPS and SFTP remain the desktop protocol set.
+- Product telemetry remains disabled: no telemetry, analytics, advertising, tracking or hidden Ghost FTP backend.
+- Root `VERSION` is the only product version source of truth.
+
+## Windows action inventory
+
+A checkbox moves to `[x]` only when the visible Mac action is wired to real shared-engine/platform behavior and covered by tests. Merely drawing the matching control does not satisfy parity.
+
+### Connection, profiles and application
+
+- [ ] Connect
+- [ ] Disconnect
+- [ ] Site Manager
+- [ ] Bookmarks
+- [ ] Private Key
+- [ ] Save Profile
+- [ ] Remove Profile
+- [ ] Settings
+- [ ] About
+- [ ] Diagnostics
+
+### Local file pane
+
+- [ ] Local Refresh
+- [ ] Local Choose Folder
+- [ ] Local Up
+- [ ] Local New Folder
+- [ ] Local Rename
+- [ ] Local Delete
+- [ ] Local Filter
+- [ ] Local Recursive Search
+
+### Remote file pane
+
+- [ ] Remote Refresh
+- [ ] Remote Up
+- [ ] Remote New Folder
+- [ ] Remote Rename
+- [ ] Remote Delete
+- [ ] Remote Permissions
+- [ ] Remote Edit
+- [ ] Remote Filter
+- [ ] Remote Recursive Search
+- [ ] Directory Compare
+
+### Transfer actions and queue
+
+- [ ] Upload
+- [ ] Download
+- [ ] Pause Queue
+- [ ] Resume Queue
+- [ ] Cancel Transfer
+- [ ] Retry Transfer
+- [ ] Clear Finished
+- [ ] Move Top
+- [ ] Move Up
+- [ ] Move Down
+- [ ] Move Bottom
+
+## Behavior that must remain identical
+
+The completed Mac surface must preserve the Windows/shared contracts for protocol defaults and explicit secure-protocol selection, FTPS certificate/hostname validation, strict SFTP host-key trust, saved-profile credential consent, account-identity rebinding, connection cancellation/generation ownership, sorting, filtering, bounded recursive search, conservative directory comparison, Remote Edit conflict/read-back semantics, transfer pause/resume/cancel/retry, four-way queued reordering, progress/speed/ETA truthfulness, conflict policy, parallelism, retry behavior, timeout, delete confirmation and independent aggregate upload/download bandwidth ceilings.
+
+## macOS-native boundaries
+
+The following are allowed to be macOS-native without weakening parity:
+
+- application/window lifecycle and menu integration;
+- `NSOpenPanel` / `NSSavePanel` style file and folder selection;
+- Keychain-backed saved-secret protection after explicit user consent;
+- native keyboard focus, VoiceOver/accessibility and Retina scaling;
+- Apple signing, hardened runtime and notarization for a future public release.
+
+Native behavior does not permit removing Windows functionality, silently changing protocol/security behavior or exposing controls that are not connected to real state.
+
+## Promotion gate
+
+macOS remains a development source platform until all action boxes above are complete, universal Intel/Apple-Silicon builds pass from exact source, native runtime screenshots are captured from the tested SHA, privacy/security audits pass, signing/notarization policy is truthful and the public release workflow is explicitly expanded in a separate reviewed change.

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,38 @@
+# Ghost FTP macOS development app
+
+The `macos/` tree is the dedicated native macOS development surface for Ghost FTP. It is deliberately separate from the Windows and Linux packaging trees, but it is not a separate product or a reduced feature edition.
+
+**Windows desktop is the canonical visual and behavior reference.** The target is 1:1 feature parity in the sense that every supported Windows desktop action has an equivalent, real macOS action backed by the same product state and security rules. Native platform primitives may differ where macOS requires them, but capability, labels, ordering, validation, enabled/disabled state and workflow semantics must remain aligned.
+
+The completed macOS client will use the same typed `internal/api.Engine` as the maintained Windows/Linux desktop clients. UI work must therefore follow one non-negotiable rule: **no decorative or dead controls**. A control is added to the visible Mac UI only when the corresponding engine-backed operation is functional and testable.
+
+## Visual contract
+
+The macOS frontend follows the maintained Windows layout hierarchy: branded header, profile/application actions, Quick Connect, Local and Remote panes, transfer actions, transfer queue, status and version surfaces. The native AppKit window may use macOS window chrome, focus behavior and accessibility APIs, while the Ghost FTP workspace remains visually aligned with Windows.
+
+The local source palettes are identical to the desktop reference:
+
+- Classic Light: workspace `#EEF1F5`, panel `#F6F8FB`, list `#FAFBFD`.
+- Dark: workspace `#0B0F17`, panel `#121824`, list `#161D2A`.
+
+The finished Mac client must expose the same **24 languages**, with English as canonical default/fallback, and the same FTP, explicit FTPS and SFTP protocol semantics as the maintained desktop product.
+
+## Privacy and dependency boundary
+
+The Mac app has no telemetry, analytics, advertising, tracking pixels, remote fonts, remote styles or mandatory Ghost FTP account. The build is source-local and must not download runtime UI or application code. macOS credential/keychain integration will be added only behind the same explicit credential-persistence consent and account-identity binding used by the shared desktop model.
+
+## Current stage
+
+This is an active **development surface**. The first maintained stage establishes a native AppKit application bundle, universal Intel/Apple-Silicon build verification, the Windows parity inventory and fail-closed platform audits. Feature controls are intentionally introduced only as their `internal/api.Engine` bridge is implemented; placeholders are not accepted as parity.
+
+The Mac development artifact is **not part of the current 0.0.5 public release allow-list**. The existing verified Windows/Linux 14-platform-artifact / 17-public-file release contract remains unchanged until macOS reaches full functionality, runtime evidence and distribution/signing/notarization gates.
+
+Build on macOS with:
+
+```bash
+bash macos/BUILD.sh
+```
+
+The development output is `macos/dist/Ghost-FTP-<VERSION>-macOS.app.zip` and contains `Ghost FTP.app`.
+
+See `PARITY.md` for the exact Windows action inventory that must be completed before macOS can be promoted from development source to a public desktop release platform.

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -162,6 +162,6 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 }
 
 let application = NSApplication.shared
-let delegate = AppDelegate()
+private let delegate = AppDelegate()
 application.delegate = delegate
 application.run()

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -1,0 +1,167 @@
+import AppKit
+import Foundation
+
+private extension NSColor {
+    convenience init(rgb: UInt32) {
+        let red = CGFloat((rgb >> 16) & 0xff) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xff) / 255.0
+        let blue = CGFloat(rgb & 0xff) / 255.0
+        self.init(srgbRed: red, green: green, blue: blue, alpha: 1.0)
+    }
+}
+
+private enum GhostPalette {
+    static let workspace = NSColor(rgb: 0xEEF1F5)
+    static let panel = NSColor(rgb: 0xF6F8FB)
+    static let list = NSColor(rgb: 0xFAFBFD)
+    static let text = NSColor(rgb: 0x111827)
+    static let muted = NSColor(rgb: 0x667085)
+    static let accent = NSColor(rgb: 0x2563EB)
+    static let border = NSColor(rgb: 0xD7DDE6)
+}
+
+private final class PanelView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = GhostPalette.panel.cgColor
+        layer?.borderColor = GhostPalette.border.cgColor
+        layer?.borderWidth = 1
+        layer?.cornerRadius = 12
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    private var window: NSWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.appearance = NSAppearance(named: .aqua)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1500, height: 960),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Ghost FTP \(productVersion()) — Brendigo"
+        window.minSize = NSSize(width: 1100, height: 720)
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.center()
+
+        let root = NSView(frame: window.contentView?.bounds ?? .zero)
+        root.autoresizingMask = [.width, .height]
+        root.wantsLayer = true
+        root.layer?.backgroundColor = GhostPalette.workspace.cgColor
+        window.contentView = root
+
+        let title = label("Ghost FTP", size: 28, weight: .bold, color: GhostPalette.text)
+        let subtitle = label(
+            "macOS parity development surface",
+            size: 14,
+            weight: .regular,
+            color: GhostPalette.muted
+        )
+        let badge = label("ENGINE BRIDGE IN PROGRESS", size: 12, weight: .semibold, color: GhostPalette.accent)
+
+        let foundation = PanelView(frame: .zero)
+        let foundationTitle = label("Native AppKit foundation", size: 18, weight: .semibold, color: GhostPalette.text)
+        let foundationBody = wrappingLabel(
+            "This bundle proves the dedicated native macOS build, universal Intel + Apple Silicon executable, product identity and Ghost FTP desktop palette. Windows remains the canonical visual and behavior reference.",
+            size: 14
+        )
+
+        let parity = PanelView(frame: .zero)
+        let parityTitle = label("Fail-closed parity rule", size: 18, weight: .semibold, color: GhostPalette.text)
+        let parityBody = wrappingLabel(
+            "FTP controls are intentionally not drawn until each action is connected to the same internal/api.Engine behavior used by Windows/Linux. Ghost FTP does not count placeholder or dead controls as parity.",
+            size: 14
+        )
+
+        [title, subtitle, badge, foundation, parity].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            root.addSubview($0)
+        }
+        [foundationTitle, foundationBody].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            foundation.addSubview($0)
+        }
+        [parityTitle, parityBody].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            parity.addSubview($0)
+        }
+
+        NSLayoutConstraint.activate([
+            title.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 30),
+            title.topAnchor.constraint(equalTo: root.topAnchor, constant: 26),
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 3),
+            badge.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -30),
+            badge.centerYAnchor.constraint(equalTo: title.centerYAnchor),
+
+            foundation.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 30),
+            foundation.trailingAnchor.constraint(equalTo: root.centerXAnchor, constant: -8),
+            foundation.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 28),
+            foundation.heightAnchor.constraint(greaterThanOrEqualToConstant: 210),
+
+            parity.leadingAnchor.constraint(equalTo: root.centerXAnchor, constant: 8),
+            parity.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -30),
+            parity.topAnchor.constraint(equalTo: foundation.topAnchor),
+            parity.heightAnchor.constraint(equalTo: foundation.heightAnchor),
+
+            foundationTitle.leadingAnchor.constraint(equalTo: foundation.leadingAnchor, constant: 22),
+            foundationTitle.trailingAnchor.constraint(equalTo: foundation.trailingAnchor, constant: -22),
+            foundationTitle.topAnchor.constraint(equalTo: foundation.topAnchor, constant: 22),
+            foundationBody.leadingAnchor.constraint(equalTo: foundationTitle.leadingAnchor),
+            foundationBody.trailingAnchor.constraint(equalTo: foundationTitle.trailingAnchor),
+            foundationBody.topAnchor.constraint(equalTo: foundationTitle.bottomAnchor, constant: 14),
+            foundationBody.bottomAnchor.constraint(lessThanOrEqualTo: foundation.bottomAnchor, constant: -22),
+
+            parityTitle.leadingAnchor.constraint(equalTo: parity.leadingAnchor, constant: 22),
+            parityTitle.trailingAnchor.constraint(equalTo: parity.trailingAnchor, constant: -22),
+            parityTitle.topAnchor.constraint(equalTo: parity.topAnchor, constant: 22),
+            parityBody.leadingAnchor.constraint(equalTo: parityTitle.leadingAnchor),
+            parityBody.trailingAnchor.constraint(equalTo: parityTitle.trailingAnchor),
+            parityBody.topAnchor.constraint(equalTo: parityTitle.bottomAnchor, constant: 14),
+            parityBody.bottomAnchor.constraint(lessThanOrEqualTo: parity.bottomAnchor, constant: -22),
+        ])
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window = window
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
+    private func productVersion() -> String {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "dev"
+    }
+
+    private func label(_ text: String, size: CGFloat, weight: NSFont.Weight, color: NSColor) -> NSTextField {
+        let field = NSTextField(labelWithString: text)
+        field.font = NSFont.systemFont(ofSize: size, weight: weight)
+        field.textColor = color
+        field.backgroundColor = .clear
+        return field
+    }
+
+    private func wrappingLabel(_ text: String, size: CGFloat) -> NSTextField {
+        let field = label(text, size: size, weight: .regular, color: GhostPalette.muted)
+        field.maximumNumberOfLines = 0
+        field.lineBreakMode = .byWordWrapping
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return field
+    }
+}
+
+let application = NSApplication.shared
+let delegate = AppDelegate()
+application.delegate = delegate
+application.run()

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -48,7 +48,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             backing: .buffered,
             defer: false
         )
-        window.title = "Ghost FTP \(productVersion()) — Brendigo"
+        window.title = "Ghost FTP \(productVersion())"
         window.minSize = NSSize(width: 1100, height: 720)
         window.isReleasedWhenClosed = false
         window.delegate = self

--- a/scripts/audit_desktop_surface.py
+++ b/scripts/audit_desktop_surface.py
@@ -10,7 +10,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 RETIRED_ROOTS = (
     "ios/",
-    "macos/",
     "GhostFTP WEB/",
     "web/",
     "pwa/",
@@ -39,6 +38,7 @@ def tracked_paths() -> list[str]:
 
 def main() -> int:
     paths = tracked_paths()
+    path_set = set(paths)
     retired: list[str] = []
     suspicious: list[str] = []
     for path in paths:
@@ -63,15 +63,27 @@ def main() -> int:
         "android/app/src/main/java/app/ghostftp/client/MainActivity.java",
         ".github/workflows/android-apk.yml",
     }
-    missing_android = sorted(android_required - set(paths))
+    missing_android = sorted(android_required - path_set)
     if missing_android:
         fail("active Android source contract is incomplete: " + ", ".join(missing_android))
 
+    macos_required = {
+        "macos/README.md",
+        "macos/PARITY.md",
+        "macos/BUILD.sh",
+        "macos/Sources/GhostFTPApp/main.swift",
+        ".github/workflows/macos-app.yml",
+    }
+    missing_macos = sorted(macos_required - path_set)
+    if missing_macos:
+        fail("active macOS source contract is incomplete: " + ", ".join(missing_macos))
+
     print("DESKTOP_SURFACE_AUDIT=PASS")
     print("PUBLIC_RELEASE_PLATFORMS=WINDOWS,LINUX")
-    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID")
+    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID,MACOS")
     print("ANDROID_APK_DEVELOPMENT_SURFACE=ACTIVE")
-    print("RETIRED_APPLICATION_PLATFORMS=IOS,MACOS")
+    print("MACOS_APP_DEVELOPMENT_SURFACE=ACTIVE")
+    print("RETIRED_APPLICATION_PLATFORMS=IOS")
     print("RETIRED_APPLICATION_SURFACES=WEB,PWA")
     return 0
 

--- a/scripts/audit_platform_contract.py
+++ b/scripts/audit_platform_contract.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
-RETIRED_ROOTS = ("ios/", "macos/", "GhostFTP WEB/")
+RETIRED_ROOTS = ("ios/", "GhostFTP WEB/")
 RETIRED_SCRIPTS = {
     "scripts/audit_android.py",
     "scripts/audit_android_localization.py",
@@ -33,6 +33,14 @@ ANDROID_REQUIRED = {
     "android/app/src/main/java/app/ghostftp/client/FtpSession.java",
     ".github/workflows/android-apk.yml",
     "scripts/test_android_contract.py",
+}
+MACOS_REQUIRED = {
+    "macos/README.md",
+    "macos/PARITY.md",
+    "macos/BUILD.sh",
+    "macos/Sources/GhostFTPApp/main.swift",
+    ".github/workflows/macos-app.yml",
+    "scripts/test_macos_windows_parity_contract.py",
 }
 
 
@@ -57,17 +65,18 @@ def main() -> int:
     path_set = set(paths)
     for path in paths:
         normalized = path.replace("\\", "/")
-        lowered = normalized.lower()
         if normalized.startswith(RETIRED_ROOTS):
             fail(f"retired application platform/surface is tracked: {path}")
         if normalized in RETIRED_SCRIPTS:
             fail(f"retired platform tooling is tracked: {path}")
-        if lowered.endswith("_darwin.go"):
-            fail(f"retired macOS/Darwin platform source is tracked: {path}")
 
     missing_android = sorted(ANDROID_REQUIRED - path_set)
     if missing_android:
         fail("active Android source contract is incomplete: " + ", ".join(missing_android))
+
+    missing_macos = sorted(MACOS_REQUIRED - path_set)
+    if missing_macos:
+        fail("active macOS source contract is incomplete: " + ", ".join(missing_macos))
 
     if "internal/platform/filemove_other.go" in path_set:
         fail("generic unsupported-OS filemove fallback must not be restored")
@@ -85,7 +94,7 @@ def main() -> int:
         lowered = text.lower()
         for marker in ("runs-on: macos", "ios/", "macos/", "ghostftp web/"):
             if marker in lowered:
-                fail(f"{rel} still references retired application platform marker: {marker}")
+                fail(f"{rel} public Windows/Linux workflow contract unexpectedly references: {marker}")
         for marker in ("windows:", "linux:"):
             if marker not in text:
                 fail(f"Windows/Linux public workflow contract is incomplete in {rel}: missing {marker}")
@@ -101,6 +110,16 @@ def main() -> int:
         if marker not in android_workflow:
             fail(f"Android development workflow is missing contract marker: {marker}")
 
+    macos_workflow = read(".github/workflows/macos-app.yml")
+    for marker in (
+        "Ghost FTP macOS Development App",
+        "runs-on: macos-",
+        "bash macos/BUILD.sh",
+        "ghostftp-macos-development",
+    ):
+        if marker not in macos_workflow:
+            fail(f"macOS development workflow is missing contract marker: {marker}")
+
     version = read("VERSION").strip()
     if not VERSION_RE.fullmatch(version):
         fail(f"VERSION is not semantic: {version!r}")
@@ -110,12 +129,13 @@ def main() -> int:
 
     print(f"PLATFORM_CONTRACT_AUDIT=PASS ({version})")
     print("PUBLIC_RELEASE_PLATFORMS=WINDOWS,LINUX")
-    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID")
+    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID,MACOS")
     print("ANDROID_APK_DEVELOPMENT_SURFACE=ACTIVE")
-    print("RETIRED_APPLICATION_PLATFORMS=IOS,MACOS")
+    print("MACOS_APP_DEVELOPMENT_SURFACE=ACTIVE")
+    print("RETIRED_APPLICATION_PLATFORMS=IOS")
     print("RETIRED_APPLICATION_SURFACES=WEB,PWA")
     print("LINUX_PLATFORM_STUBS=EXPLICIT")
-    print("DARWIN_SOURCE=BLOCKED")
+    print("DARWIN_SOURCE=ALLOWED_FOR_MACOS_DEVELOPMENT")
     print("MINIMUM_PUBLIC_VERSION=0.0.1")
     print("VERSIONING_PLATFORM_INDEPENDENT=YES")
     return 0

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -270,7 +270,19 @@ def main() -> int:
         "latest",
     )
 
-    for retired in ("ios", "macos", "GhostFTP WEB"):
+    # macOS is an active development source platform but is deliberately not
+    # part of this Windows/Linux public release contract yet. The workflow
+    # checks above fail closed on any macOS path, runner or artifact leakage.
+    for required_macos in (
+        "macos/README.md",
+        "macos/PARITY.md",
+        "macos/BUILD.sh",
+        ".github/workflows/macos-app.yml",
+    ):
+        if not (ROOT / required_macos).is_file():
+            fail(f"active macOS development source is incomplete: {required_macos}")
+
+    for retired in ("ios", "GhostFTP WEB"):
         if (ROOT / retired).exists():
             fail(f"retired application directory exists: {retired}/")
     for retired_file in (
@@ -284,8 +296,9 @@ def main() -> int:
     print("TECHNICAL_IDENTITY=GhostFTP")
     print("RELEASE_TAG_NAMESPACE=ghostftp-vX.Y.Z")
     print("PUBLIC_RELEASE_PLATFORMS=WINDOWS,LINUX")
-    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID")
+    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID,MACOS")
     print("ANDROID_PUBLIC_RELEASE_ARTIFACT=NO")
+    print("MACOS_PUBLIC_RELEASE_ARTIFACT=NO")
     print("PUBLIC_RELEASE_CHANNEL=CURRENT")
     print("CURRENT_RELEASE_PRERELEASE_FLAG=FALSE")
     print("MINIMUM_PUBLIC_VERSION=0.0.1")

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 GO_TOOLCHAIN = "1.27.1"
-RETIRED_ROOTS = ("ios", "macos", "GhostFTP WEB")
+RETIRED_ROOTS = ("ios", "GhostFTP WEB")
 CURRENT_LINE_DOCS = (
     "README.md",
     "CHANGELOG.md",
@@ -174,6 +174,29 @@ def main() -> int:
         ".github/workflows/android-apk.yml",
     )
 
+    macos_build = read("macos/BUILD.sh")
+    require(
+        macos_build,
+        (
+            'VERSION="$(tr -d \'\\r\\n\' < "$SCRIPT_DIR/../VERSION")"',
+            "CFBundleShortVersionString",
+            "CFBundleVersion",
+            "app.ghostftp.client",
+            'Ghost-FTP-${VERSION}-macOS.app.zip',
+        ),
+        "macos/BUILD.sh",
+    )
+    macos_workflow = read(".github/workflows/macos-app.yml")
+    require(
+        macos_workflow,
+        (
+            "Ghost FTP macOS Development App",
+            "bash macos/BUILD.sh",
+            "name: ghostftp-macos-development",
+        ),
+        ".github/workflows/macos-app.yml",
+    )
+
     for retired in RETIRED_ROOTS:
         if (ROOT / retired).exists():
             fail(f"retired application surface must be removed: {retired}/")
@@ -190,11 +213,11 @@ def main() -> int:
         lowered = workflow.lower()
         for marker in ("ios/", "macos/", "ghostftp web/", "runs-on: macos"):
             if marker in lowered:
-                fail(f"{workflow_rel} references retired application marker: {marker}")
+                fail(f"{workflow_rel} references non-public application marker: {marker}")
 
     release_workflow = read(".github/workflows/release.yml")
-    if "android/" in release_workflow.lower():
-        fail("published Windows/Linux release workflow must not retroactively include Android development artifacts")
+    if "android/" in release_workflow.lower() or "macos/" in release_workflow.lower():
+        fail("published Windows/Linux release workflow must not retroactively include development-platform artifacts")
     if re.search(r"(?m)^\s*default:\s*['\"]?\d+\.\d+\.\d+", release_workflow):
         fail("release workflow contains a hard-coded production version")
     require(
@@ -274,8 +297,9 @@ def main() -> int:
     print("PUBLIC_BRAND=Ghost FTP")
     print("RELEASE_TAG_NAMESPACE=ghostftp-vX.Y.Z")
     print("PUBLIC_RELEASE_PLATFORMS=WINDOWS,LINUX")
-    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID")
+    print("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID,MACOS")
     print("ANDROID_VERSION_BOUND_TO_ROOT_VERSION=YES")
+    print("MACOS_VERSION_BOUND_TO_ROOT_VERSION=YES")
     print("PUBLIC_RELEASE_CHANNEL=CURRENT")
     print("CURRENT_RELEASE_PRERELEASE_FLAG=FALSE")
     print("MINIMUM_PUBLIC_VERSION=0.0.1")

--- a/scripts/test_filesystem_hardening.py
+++ b/scripts/test_filesystem_hardening.py
@@ -69,10 +69,12 @@ def run_checks() -> None:
         "os.Rename(src, dst)",
     ))
 
-    # Windows/Linux desktop and Android source are active. Retired native
-    # targets and Darwin-specific desktop source must not silently return.
-    for retired in ("ios", "macos", "internal/platform/filemove_darwin.go"):
-        require_absent(retired)
+    # Windows/Linux desktop, Android and macOS source are active. iOS remains
+    # retired; macOS-specific filesystem implementations may now be added, but
+    # they must receive their own no-replace/root-capability regression tests.
+    require_absent("ios")
+    if not (ROOT / "macos").is_dir():
+        raise AssertionError("active macOS development source is missing")
 
     # Recursive delete must keep traversal anchored to held os.Root
     # capabilities. Path-based ReadDir/recursive descent would reopen the

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -12,6 +12,10 @@ def read(relative: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def retired_roots_declaration(source: str) -> str:
+    return source.split("RETIRED_ROOTS =", 1)[1].split(")", 1)[0]
+
+
 WINDOWS_PARITY_ACTIONS = (
     "Connect",
     "Disconnect",
@@ -61,7 +65,7 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
         desktop_audit = read("scripts/audit_desktop_surface.py")
         for source in (platform_audit, desktop_audit):
             self.assertIn("WINDOWS,LINUX,ANDROID,MACOS", source)
-            self.assertNotIn('"macos/",', source)
+            self.assertNotIn("macos", retired_roots_declaration(source).lower())
             self.assertNotIn("IOS,MACOS", source)
         self.assertNotIn("DARWIN_SOURCE=BLOCKED", platform_audit)
 
@@ -124,7 +128,7 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
         self.assertIn("Ghost FTP.app", build)
         self.assertIn("CFBundleShortVersionString", build)
         self.assertIn("CFBundleVersion", build)
-        self.assertIn("com.brendigo.ghostftp", build)
+        self.assertIn("app.ghostftp.client", build)
         self.assertIn("Ghost-FTP-${VERSION}-macOS.app.zip", build)
         self.assertNotIn("curl ", build)
         self.assertNotIn("wget ", build)

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    path = ROOT / relative
+    if not path.is_file():
+        raise AssertionError(f"missing required macOS parity file: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+WINDOWS_PARITY_ACTIONS = (
+    "Connect",
+    "Disconnect",
+    "Site Manager",
+    "Bookmarks",
+    "Private Key",
+    "Save Profile",
+    "Remove Profile",
+    "Settings",
+    "About",
+    "Diagnostics",
+    "Local Refresh",
+    "Local Choose Folder",
+    "Local Up",
+    "Local New Folder",
+    "Local Rename",
+    "Local Delete",
+    "Local Filter",
+    "Local Recursive Search",
+    "Remote Refresh",
+    "Remote Up",
+    "Remote New Folder",
+    "Remote Rename",
+    "Remote Delete",
+    "Remote Permissions",
+    "Remote Edit",
+    "Remote Filter",
+    "Remote Recursive Search",
+    "Directory Compare",
+    "Upload",
+    "Download",
+    "Pause Queue",
+    "Resume Queue",
+    "Cancel Transfer",
+    "Retry Transfer",
+    "Clear Finished",
+    "Move Top",
+    "Move Up",
+    "Move Down",
+    "Move Bottom",
+)
+
+
+class MacOSWindowsParityContractTests(unittest.TestCase):
+    def test_macos_is_an_active_separate_development_surface(self) -> None:
+        platform_audit = read("scripts/audit_platform_contract.py")
+        desktop_audit = read("scripts/audit_desktop_surface.py")
+        for source in (platform_audit, desktop_audit):
+            self.assertIn("WINDOWS,LINUX,ANDROID,MACOS", source)
+            self.assertNotIn('"macos/",', source)
+            self.assertNotIn("IOS,MACOS", source)
+        self.assertNotIn("DARWIN_SOURCE=BLOCKED", platform_audit)
+
+    def test_macos_has_its_own_source_build_and_ci_surface(self) -> None:
+        for relative in (
+            "macos/README.md",
+            "macos/PARITY.md",
+            "macos/BUILD.sh",
+            ".github/workflows/macos-app.yml",
+        ):
+            self.assertTrue((ROOT / relative).is_file(), relative)
+
+        workflow = read(".github/workflows/macos-app.yml")
+        self.assertIn("runs-on: macos-", workflow)
+        self.assertIn("bash macos/BUILD.sh", workflow)
+        self.assertIn("ghostftp-macos-development", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+
+    def test_windows_is_the_visual_and_behavior_reference(self) -> None:
+        readme = read("macos/README.md")
+        parity = read("macos/PARITY.md")
+        combined = readme + "\n" + parity
+        for marker in (
+            "Windows desktop is the canonical visual and behavior reference",
+            "same typed `internal/api.Engine`",
+            "no decorative or dead controls",
+            "Classic Light",
+            "#EEF1F5",
+            "#F6F8FB",
+            "#FAFBFD",
+            "Dark",
+            "#0B0F17",
+            "#121824",
+            "#161D2A",
+            "24 languages",
+            "FTP",
+            "FTPS",
+            "SFTP",
+            "no telemetry",
+        ):
+            self.assertIn(marker, combined)
+
+    def test_complete_windows_action_inventory_is_recorded(self) -> None:
+        parity = read("macos/PARITY.md")
+        for action in WINDOWS_PARITY_ACTIONS:
+            self.assertIn(f"- [ ] {action}", parity)
+
+    def test_macos_does_not_silently_expand_current_public_release(self) -> None:
+        readme = read("macos/README.md")
+        self.assertIn("development surface", readme)
+        self.assertIn("not part of the current 0.0.5 public release allow-list", readme)
+
+        release = read(".github/workflows/release.yml")
+        self.assertNotIn("Ghost-FTP-${VERSION}-macOS", release)
+        self.assertNotIn("macos/BUILD.sh", release)
+
+    def test_build_contract_binds_to_root_version_and_app_bundle(self) -> None:
+        build = read("macos/BUILD.sh")
+        self.assertIn("../VERSION", build)
+        self.assertIn("Ghost FTP.app", build)
+        self.assertIn("CFBundleShortVersionString", build)
+        self.assertIn("CFBundleVersion", build)
+        self.assertIn("com.brendigo.ghostftp", build)
+        self.assertIn("Ghost-FTP-${VERSION}-macOS.app.zip", build)
+        self.assertNotIn("curl ", build)
+        self.assertNotIn("wget ", build)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_maintenance.py
+++ b/scripts/test_maintenance.py
@@ -40,12 +40,13 @@ class MaintenanceRegressionTests(unittest.TestCase):
         self.assertIn("cfg.Password = password", src)
         self.assertIn("cfg.Passphrase = passphrase", src)
 
-    def test_active_android_and_retired_release_surfaces(self) -> None:
+    def test_active_android_macos_and_retired_release_surfaces(self) -> None:
         self.assertTrue((ROOT / "android").is_dir(), "active Android source surface is missing")
         self.assertTrue((ROOT / ".github/workflows/android-apk.yml").is_file(), "Android APK workflow is missing")
+        self.assertTrue((ROOT / "macos").is_dir(), "active macOS source surface is missing")
+        self.assertTrue((ROOT / ".github/workflows/macos-app.yml").is_file(), "macOS app workflow is missing")
         for rel in (
             "ios",
-            "macos",
             "GhostFTP WEB",
             "scripts/package_web.py",
             "scripts/test_package_web.py",
@@ -54,15 +55,23 @@ class MaintenanceRegressionTests(unittest.TestCase):
         ):
             self.assertFalse((ROOT / rel).exists(), f"retired application/release surface exists: {rel}")
 
+        release = read(".github/workflows/release.yml").lower()
+        self.assertNotIn("macos/", release)
+        self.assertNotIn("runs-on: macos", release)
+        self.assertNotIn("android/", release)
+
     def test_platform_contract_rejects_only_retired_target_reintroduction(self) -> None:
         audit = read("scripts/audit_platform_contract.py")
-        self.assertIn('RETIRED_ROOTS = ("ios/", "macos/", "GhostFTP WEB/")', audit)
+        self.assertIn('RETIRED_ROOTS = ("ios/", "GhostFTP WEB/")', audit)
         self.assertIn("ANDROID_REQUIRED", audit)
+        self.assertIn("MACOS_REQUIRED", audit)
         self.assertIn("active Android source contract is incomplete", audit)
+        self.assertIn("active macOS source contract is incomplete", audit)
         self.assertIn("retired application platform/surface is tracked", audit)
         self.assertIn("PUBLIC_RELEASE_PLATFORMS=WINDOWS,LINUX", audit)
-        self.assertIn("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID", audit)
-        self.assertIn("RETIRED_APPLICATION_PLATFORMS=IOS,MACOS", audit)
+        self.assertIn("ACTIVE_SOURCE_PLATFORMS=WINDOWS,LINUX,ANDROID,MACOS", audit)
+        self.assertIn("RETIRED_APPLICATION_PLATFORMS=IOS", audit)
+        self.assertIn("MACOS_APP_DEVELOPMENT_SURFACE=ACTIVE", audit)
 
     def test_release_workflow_refuses_stale_main_or_tag_rewrite(self) -> None:
         workflow = read(".github/workflows/release.yml")


### PR DESCRIPTION
## Scope

Start a dedicated native macOS development surface without changing the current Ghost FTP 0.0.5 Windows/Linux public release.

- reactivate macOS as an active source platform in fail-closed repository/platform audits;
- add a dedicated `macos/` source/build tree;
- define the complete Windows desktop action inventory as the macOS parity contract;
- make Windows the canonical visual/behavior reference, including the exact Classic Light/Dark palettes and 24-language target;
- add a native AppKit development bundle with the Ghost FTP identity/palette and no fake FTP controls;
- build one universal Intel + Apple Silicon executable from exact source;
- add read-only macOS CI and a retained development artifact;
- keep the current 14-platform-artifact / 17-public-file 0.0.5 release allow-list unchanged.

## Safety / honesty boundary

This PR does **not** claim completed macOS feature parity yet. The visible development shell deliberately omits FTP controls until each control is wired to the same typed `internal/api.Engine`; placeholder/dead controls are forbidden by the parity contract. Public Mac distribution, Developer ID signing and notarization remain gated behind full engine/UI/runtime parity.

## Next phase after foundation is green

Wire the shared engine/platform bridge, then implement the Windows action inventory incrementally with exact-head macOS build/runtime evidence.