### PR TITLE
Wire native macOS Quick Connect to shared engine

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -8,10 +8,16 @@ on:
       - 'VERSION'
       - 'build/icon.png'
       - 'macos/**'
+      - 'internal/api/**'
+      - 'internal/model/**'
+      - 'internal/platform/**'
+      - 'internal/remote/**'
+      - 'internal/security/**'
       - 'scripts/audit_platform_contract.py'
       - 'scripts/audit_desktop_surface.py'
       - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
+      - 'scripts/test_macos_engine_bridge_contract.py'
       - '.github/workflows/macos-app.yml'
   push:
     branches:
@@ -21,10 +27,16 @@ on:
       - 'VERSION'
       - 'build/icon.png'
       - 'macos/**'
+      - 'internal/api/**'
+      - 'internal/model/**'
+      - 'internal/platform/**'
+      - 'internal/remote/**'
+      - 'internal/security/**'
       - 'scripts/audit_platform_contract.py'
       - 'scripts/audit_desktop_surface.py'
       - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
+      - 'scripts/test_macos_engine_bridge_contract.py'
       - '.github/workflows/macos-app.yml'
 
 permissions:
@@ -38,7 +50,7 @@ jobs:
   macos:
     name: Universal native macOS development app
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Checkout exact source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,28 +67,43 @@ jobs:
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
           echo "MACOS_SOURCE_SHA=$SOURCE_SHA"
 
-      - name: Verify Apple toolchain
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.2.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+
+      - name: Verify toolchains and disable Go telemetry
         shell: bash
         run: |
           set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+          go version
           xcodebuild -version
           xcrun swiftc --version
           xcrun --sdk macosx --show-sdk-path
 
-      - name: Validate macOS parity contract
+      - name: Validate macOS engine and parity contracts
         shell: bash
         run: |
           set -euo pipefail
           python3 scripts/test_macos_windows_parity_contract.py
+          python3 scripts/test_macos_engine_bridge_contract.py
           python3 scripts/audit_platform_contract.py
           python3 scripts/audit_desktop_surface.py
           python3 scripts/audit_version.py
 
-      - name: Build universal native macOS app
+      - name: Build universal native macOS app and shared engine
         shell: bash
+        env:
+          GOTOOLCHAIN: local
+          GOPROXY: 'off'
+          GOSUMDB: 'off'
         run: bash macos/BUILD.sh
 
-      - name: Verify app bundle and universal executable
+      - name: Verify app, shared engine and AskPass helper
         shell: bash
         run: |
           set -euo pipefail
@@ -88,19 +115,24 @@ jobs:
           ditto -x -k "$archive" "$work"
           app="$work/Ghost FTP.app"
           executable="$app/Contents/MacOS/GhostFTP"
+          askpass="$app/Contents/MacOS/GhostFTPAskPass"
+          engine="$app/Contents/Frameworks/libGhostFTPEngine.dylib"
           plist="$app/Contents/Info.plist"
           icon="$app/Contents/Resources/GhostFTP.icns"
+          for file in "$executable" "$askpass" "$engine" "$plist" "$icon"; do test -s "$file"; done
           test -x "$executable"
-          test -s "$plist"
-          test -s "$icon"
+          test -x "$askpass"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = 'app.ghostftp.client'
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$plist")" = "$version"
-          archs="$(xcrun lipo -archs "$executable")"
-          [[ " $archs " == *" arm64 "* ]]
-          [[ " $archs " == *" x86_64 "* ]]
+          for binary in "$executable" "$askpass" "$engine"; do
+            archs="$(xcrun lipo -archs "$binary")"
+            [[ " $archs " == *" arm64 "* ]]
+            [[ " $archs " == *" x86_64 "* ]]
+          done
+          otool -D "$engine" | grep -F '@rpath/libGhostFTPEngine.dylib'
+          otool -L "$executable" | grep -F '@rpath/libGhostFTPEngine.dylib'
           codesign --verify --deep --strict "$app"
-          echo "MACOS_APP_BUNDLE=PASS"
-          echo "MACOS_APP_ARCHS=$archs"
+          echo "MACOS_APP_ENGINE_BRIDGE=PASS"
           echo "MACOS_APP_SIGNING=adhoc-development"
 
       - name: Store macOS development artifact

--- a/internal/config/profile_crypto_darwin.go
+++ b/internal/config/profile_crypto_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package config
+
+import "errors"
+
+var errDarwinPersistentProfilesUnavailable = errors.New("saved profiles are unavailable until macOS Keychain protection is enabled")
+
+// protectProfileData deliberately fails closed on macOS for now. The native
+// Quick Connect path does not persist connection secrets, and the in-memory
+// AskPass capability broker must never be reused as durable profile storage.
+// A later Site Manager parity change will replace this gate with Keychain-backed
+// profile protection before saved macOS profiles are enabled.
+func protectProfileData([]byte, string) (string, error) {
+	return "", errDarwinPersistentProfilesUnavailable
+}
+
+// Existing protected profile envelopes are not interpreted with a weaker or
+// platform-incompatible codec. Until Keychain-backed storage lands, macOS
+// refuses to unlock durable profile data rather than silently downgrading it.
+func unprotectProfileData(string, string) ([]byte, error) {
+	return nil, errDarwinPersistentProfilesUnavailable
+}
+
+func profileDataNeedsMigration(string) bool { return false }

--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -1,0 +1,93 @@
+//go:build darwin
+
+package platform
+
+/*
+#cgo LDFLAGS: -lproc
+#include <libproc.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+func LocalAppData() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", errors.New("user home directory is unavailable")
+	}
+	return filepath.Join(home, "Library", "Application Support"), nil
+}
+
+func SystemDirectory() (string, error) {
+	return "", errors.New("Windows system directory is unavailable on macOS")
+}
+
+// HardenProcessPrivacy applies an owner-only creation mask before the shared
+// engine creates any state or credential-bearing temporary files.
+func HardenProcessPrivacy() {
+	syscall.Umask(0o077)
+}
+
+func darwinProcessPath(pid int) string {
+	buf := make([]byte, C.PROC_PIDPATHINFO_MAXSIZE)
+	if len(buf) == 0 {
+		return ""
+	}
+	n := C.proc_pidpath(C.int(pid), unsafe.Pointer(&buf[0]), C.uint32_t(len(buf)))
+	if n <= 0 || int(n) > len(buf) {
+		return ""
+	}
+	return strings.TrimRight(string(buf[:int(n)]), "\x00")
+}
+
+func trustedDarwinSystemTool(path string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path != "/usr/bin/ssh" && path != "/usr/bin/sftp" {
+		return false
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == 0
+}
+
+// TrustedAskPassParent permits only Apple's root-owned ssh/sftp executable as
+// the immediate parent of the bundled credential helper.
+func TrustedAskPassParent() bool {
+	return trustedDarwinSystemTool(darwinProcessPath(os.Getppid()))
+}
+
+func ChoosePrivateKey() (string, error) {
+	return "", errors.New("private-key selection is provided by the macOS AppKit UI")
+}
+
+func ChooseDirectory() (string, error) {
+	return "", errors.New("directory selection is provided by the macOS AppKit UI")
+}
+
+func MessageBox(title, text string, flags uintptr) int {
+	_, _ = os.Stderr.WriteString(title + ": " + text + "\n")
+	return 0
+}
+
+func ConfirmDialog(string, string, string) bool { return false }
+
+func InfoDialog(title, instruction, content string) {
+	_, _ = os.Stdout.WriteString(title + ": " + instruction + "\n" + content + "\n")
+}
+
+func ErrorDialog(title, instruction, content string) {
+	_, _ = os.Stderr.WriteString(title + ": " + instruction + "\n" + content + "\n")
+}
+
+func AcquireSingleInstance(string) (func(), bool) { return func() {}, true }

--- a/internal/platform/filemove_darwin.go
+++ b/internal/platform/filemove_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package platform
+
+import "os"
+
+// RenameNoReplace uses an atomic hard-link creation to reserve the destination
+// without replacing an existing entry, then removes the source name. The
+// staged source and final destination are required to reside on the same local
+// filesystem by the transfer activation path.
+func RenameNoReplace(src, dst string) error {
+	if err := os.Link(src, dst); err != nil {
+		return err
+	}
+	if err := os.Remove(src); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	return nil
+}

--- a/internal/platform/filemove_darwin.go
+++ b/internal/platform/filemove_darwin.go
@@ -18,3 +18,10 @@ func RenameNoReplace(src, dst string) error {
 	}
 	return nil
 }
+
+// ReplaceFile atomically activates a staged file in place. Callers create the
+// staged file in the destination directory, so os.Rename preserves the same
+// same-filesystem atomic replacement contract used by the Linux implementation.
+func ReplaceFile(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/internal/remote/transport_tools_darwin.go
+++ b/internal/remote/transport_tools_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package remote
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func findTrustedTransportExecutable(name string) (string, error) {
+	base := strings.ToLower(strings.TrimSpace(filepath.Base(name)))
+	base = strings.TrimSuffix(base, ".exe")
+	if base != "ssh" && base != "sftp" && base != "ssh-keyscan" {
+		return "", errors.New("unsupported macOS transport executable")
+	}
+	path := filepath.Join("/usr/bin", base)
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("trusted macOS transport executable is unavailable")
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return "", errors.New("macOS transport executable permissions are unsafe")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != 0 {
+		return "", errors.New("macOS transport executable owner is unsafe")
+	}
+	return path, nil
+}

--- a/internal/remote/transport_tools_other.go
+++ b/internal/remote/transport_tools_other.go
@@ -1,9 +1,9 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package remote
 
 import "errors"
 
 func findTrustedTransportExecutable(string) (string, error) {
-	return "", errors.New("trusted Linux transport resolution is unavailable")
+	return "", errors.New("trusted transport resolution is unavailable")
 }

--- a/internal/security/dpapi_darwin.go
+++ b/internal/security/dpapi_darwin.go
@@ -2,6 +2,22 @@
 
 package security
 
+/*
+#include <sys/types.h>
+#include <unistd.h>
+
+static int ghostftp_getpeereid(int fd, unsigned int *uid) {
+	uid_t euid;
+	gid_t egid;
+	if (getpeereid(fd, &euid, &egid) != 0) {
+		return -1;
+	}
+	*uid = (unsigned int)euid;
+	return 0;
+}
+*/
+import "C"
+
 import (
 	"crypto/rand"
 	"encoding/base64"
@@ -106,12 +122,12 @@ func darwinPeerUID(conn *net.UnixConn) (int, error) {
 	uid := -1
 	var peerErr error
 	if err := raw.Control(func(fd uintptr) {
-		euid, _, err := syscall.Getpeereid(int(fd))
-		if err != nil {
-			peerErr = err
+		var euid C.uint
+		if C.ghostftp_getpeereid(C.int(fd), &euid) != 0 {
+			peerErr = errors.New("macOS peer credential lookup failed")
 			return
 		}
-		uid = euid
+		uid = int(euid)
 	}); err != nil {
 		return -1, err
 	}

--- a/internal/security/dpapi_darwin.go
+++ b/internal/security/dpapi_darwin.go
@@ -1,0 +1,288 @@
+//go:build darwin
+
+package security
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	darwinSecretPrefix   = "darwin-secret-v1:"
+	darwinSecretMaxBytes = 64 << 10
+	darwinSecretTTL      = 2 * time.Hour
+	darwinSecretTokenLen = 32
+	darwinSecretLimit    = 256
+)
+
+type darwinSecretEntry struct {
+	value   []byte
+	expires time.Time
+}
+
+type darwinSecretBrokerState struct {
+	mu       sync.Mutex
+	listener *net.UnixListener
+	dir      string
+	socket   string
+	entries  map[string]*darwinSecretEntry
+}
+
+var darwinSecretBroker darwinSecretBrokerState
+
+func PersistentSecretStorageAvailable() bool { return false }
+
+func purgeExpiredDarwinSecretsLocked(now time.Time) {
+	for token, entry := range darwinSecretBroker.entries {
+		if entry == nil || now.After(entry.expires) {
+			if entry != nil {
+				WipeBytes(entry.value)
+			}
+			delete(darwinSecretBroker.entries, token)
+		}
+	}
+}
+
+func ensureDarwinSecretBroker() (string, error) {
+	darwinSecretBroker.mu.Lock()
+	defer darwinSecretBroker.mu.Unlock()
+	if darwinSecretBroker.listener != nil {
+		return darwinSecretBroker.socket, nil
+	}
+	dir, err := os.MkdirTemp("", "ghostftp-secret-")
+	if err != nil {
+		return "", err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	if err := os.Chmod(dir, 0o700); err != nil {
+		cleanup()
+		return "", err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 {
+		cleanup()
+		return "", errors.New("macOS secret broker directory is not private")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Geteuid() {
+		cleanup()
+		return "", errors.New("macOS secret broker directory has an invalid owner")
+	}
+	socket := filepath.Join(dir, "askpass.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socket, Net: "unix"})
+	if err != nil {
+		cleanup()
+		return "", err
+	}
+	if err := os.Chmod(socket, 0o600); err != nil {
+		_ = listener.Close()
+		cleanup()
+		return "", err
+	}
+	darwinSecretBroker.listener = listener
+	darwinSecretBroker.dir = dir
+	darwinSecretBroker.socket = socket
+	darwinSecretBroker.entries = make(map[string]*darwinSecretEntry)
+	go serveDarwinSecrets(listener)
+	return socket, nil
+}
+
+func darwinPeerUID(conn *net.UnixConn) (int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return -1, err
+	}
+	uid := -1
+	var peerErr error
+	if err := raw.Control(func(fd uintptr) {
+		euid, _, err := syscall.Getpeereid(int(fd))
+		if err != nil {
+			peerErr = err
+			return
+		}
+		uid = euid
+	}); err != nil {
+		return -1, err
+	}
+	if peerErr != nil {
+		return -1, peerErr
+	}
+	return uid, nil
+}
+
+func serveDarwinSecrets(listener *net.UnixListener) {
+	for {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			return
+		}
+		go handleDarwinSecretRequest(conn)
+	}
+}
+
+func handleDarwinSecretRequest(conn *net.UnixConn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(4 * time.Second))
+	uid, err := darwinPeerUID(conn)
+	if err != nil || uid != os.Geteuid() {
+		return
+	}
+	var rawToken [darwinSecretTokenLen]byte
+	if _, err := io.ReadFull(conn, rawToken[:]); err != nil {
+		return
+	}
+	token := hex.EncodeToString(rawToken[:])
+	darwinSecretBroker.mu.Lock()
+	purgeExpiredDarwinSecretsLocked(time.Now())
+	entry := darwinSecretBroker.entries[token]
+	var secret []byte
+	if entry != nil {
+		secret = append([]byte(nil), entry.value...)
+		entry.expires = time.Now().Add(darwinSecretTTL)
+	}
+	darwinSecretBroker.mu.Unlock()
+	if len(secret) == 0 {
+		return
+	}
+	defer WipeBytes(secret)
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(secret)))
+	if _, err := conn.Write(header[:]); err != nil {
+		return
+	}
+	_, _ = conn.Write(secret)
+}
+
+func ProtectBytes(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+	if len(data) > darwinSecretMaxBytes {
+		return "", errors.New("macOS runtime secret is too large")
+	}
+	socket, err := ensureDarwinSecretBroker()
+	if err != nil {
+		return "", err
+	}
+	raw := make([]byte, darwinSecretTokenLen)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	defer WipeBytes(raw)
+	token := hex.EncodeToString(raw)
+	darwinSecretBroker.mu.Lock()
+	defer darwinSecretBroker.mu.Unlock()
+	purgeExpiredDarwinSecretsLocked(time.Now())
+	if len(darwinSecretBroker.entries) >= darwinSecretLimit {
+		return "", errors.New("macOS runtime secret capacity reached")
+	}
+	darwinSecretBroker.entries[token] = &darwinSecretEntry{value: append([]byte(nil), data...), expires: time.Now().Add(darwinSecretTTL)}
+	encodedSocket := base64.RawURLEncoding.EncodeToString([]byte(socket))
+	return darwinSecretPrefix + encodedSocket + "." + token, nil
+}
+
+func ProtectString(value string) (string, error) { return ProtectBytes([]byte(value)) }
+
+func parseDarwinSecretBlob(encoded string) (string, []byte, string, error) {
+	if !strings.HasPrefix(encoded, darwinSecretPrefix) {
+		return "", nil, "", errors.New("persistent protected credentials are unavailable on macOS")
+	}
+	parts := strings.SplitN(strings.TrimPrefix(encoded, darwinSecretPrefix), ".", 2)
+	if len(parts) != 2 || len(parts[1]) != darwinSecretTokenLen*2 {
+		return "", nil, "", errors.New("macOS runtime secret token is malformed")
+	}
+	socketRaw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil || len(socketRaw) == 0 || len(socketRaw) > 4096 {
+		return "", nil, "", errors.New("macOS runtime secret socket is malformed")
+	}
+	socket := string(socketRaw)
+	if !filepath.IsAbs(socket) || strings.ContainsAny(socket, "\x00\r\n") {
+		return "", nil, "", errors.New("macOS runtime secret socket is invalid")
+	}
+	token, err := hex.DecodeString(parts[1])
+	if err != nil || len(token) != darwinSecretTokenLen {
+		return "", nil, "", errors.New("macOS runtime secret token is invalid")
+	}
+	return socket, token, parts[1], nil
+}
+
+func UnprotectBytes(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	socket, token, _, err := parseDarwinSecretBlob(encoded)
+	if err != nil {
+		return nil, err
+	}
+	defer WipeBytes(token)
+	conn, err := net.DialTimeout("unix", socket, 3*time.Second)
+	if err != nil {
+		return nil, errors.New("macOS runtime secret broker is unavailable")
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(4 * time.Second))
+	if _, err := conn.Write(token); err != nil {
+		return nil, err
+	}
+	var header [4]byte
+	if _, err := io.ReadFull(conn, header[:]); err != nil {
+		return nil, errors.New("macOS runtime secret broker rejected the request")
+	}
+	n := int(binary.BigEndian.Uint32(header[:]))
+	if n < 1 || n > darwinSecretMaxBytes {
+		return nil, errors.New("macOS runtime secret broker returned an invalid length")
+	}
+	secret := make([]byte, n)
+	if _, err := io.ReadFull(conn, secret); err != nil {
+		WipeBytes(secret)
+		return nil, err
+	}
+	return secret, nil
+}
+
+func UnprotectString(encoded string) (string, error) {
+	secret, err := UnprotectBytes(encoded)
+	if err != nil {
+		return "", err
+	}
+	defer WipeBytes(secret)
+	return string(secret), nil
+}
+
+func ForgetProtectedSecret(encoded string) {
+	if encoded == "" {
+		return
+	}
+	socket, token, tokenHex, err := parseDarwinSecretBlob(encoded)
+	if err != nil {
+		return
+	}
+	WipeBytes(token)
+	darwinSecretBroker.mu.Lock()
+	defer darwinSecretBroker.mu.Unlock()
+	if socket != darwinSecretBroker.socket {
+		return
+	}
+	entry := darwinSecretBroker.entries[tokenHex]
+	delete(darwinSecretBroker.entries, tokenHex)
+	if entry != nil {
+		WipeBytes(entry.value)
+	}
+}
+
+func WipeBytes(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
+}

--- a/macos/AskPass/main.go
+++ b/macos/AskPass/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+const askpassTokenLength = 32
+
+var askpassEnvironmentKeys = [...]string{
+	"GhostFTP_ASKPASS_TOKEN",
+	"GhostFTP_PASSWORD_BLOB",
+	"GhostFTP_PASSPHRASE_BLOB",
+	"SSH_ASKPASS",
+	"SSH_ASKPASS_REQUIRE",
+}
+
+func validToken(token string) bool {
+	if len(token) != askpassTokenLength {
+		return false
+	}
+	_, err := hex.DecodeString(token)
+	return err == nil
+}
+
+func sameExecutable(a, b string) bool {
+	a = filepath.Clean(strings.TrimSpace(a))
+	b = filepath.Clean(strings.TrimSpace(b))
+	if a == "" || b == "" || !filepath.IsAbs(a) || !filepath.IsAbs(b) {
+		return false
+	}
+	ai, err := os.Stat(a)
+	if err != nil || !ai.Mode().IsRegular() {
+		return false
+	}
+	bi, err := os.Stat(b)
+	return err == nil && bi.Mode().IsRegular() && os.SameFile(ai, bi)
+}
+
+func normalizePrompt(prompt string) string {
+	return strings.ToLower(strings.Join(strings.Fields(prompt), " "))
+}
+
+func selectSecret(prompt string, password, passphrase []byte) ([]byte, bool) {
+	prompt = normalizePrompt(prompt)
+	if prompt == "" {
+		return nil, false
+	}
+	for _, blocked := range []string{"verification code", "one-time", "one time", "otp", "security key", "touch your", "challenge", "response code", "authentication code", "token"} {
+		if strings.Contains(prompt, blocked) {
+			return nil, false
+		}
+	}
+	if strings.Contains(prompt, "passphrase") && len(passphrase) > 0 {
+		return passphrase, true
+	}
+	if strings.Contains(prompt, "password") && len(password) > 0 {
+		return password, true
+	}
+	return nil, false
+}
+
+func clearEnvironment() {
+	for _, key := range askpassEnvironmentKeys {
+		_ = os.Unsetenv(key)
+	}
+}
+
+func writeSecret(secret []byte) error {
+	if len(secret) == 0 {
+		return errors.New("credential is not available")
+	}
+	if _, err := os.Stdout.Write(secret); err != nil {
+		return err
+	}
+	_, err := io.WriteString(os.Stdout, "\n")
+	return err
+}
+
+func run() error {
+	platform.HardenProcessPrivacy()
+	token := os.Getenv("GhostFTP_ASKPASS_TOKEN")
+	passwordBlob := os.Getenv("GhostFTP_PASSWORD_BLOB")
+	passphraseBlob := os.Getenv("GhostFTP_PASSPHRASE_BLOB")
+	askpassExe := os.Getenv("SSH_ASKPASS")
+	require := os.Getenv("SSH_ASKPASS_REQUIRE")
+	clearEnvironment()
+	if !validToken(token) || !strings.EqualFold(strings.TrimSpace(require), "force") {
+		return errors.New("invalid authentication request")
+	}
+	exe, err := os.Executable()
+	if err != nil || !sameExecutable(exe, askpassExe) {
+		return errors.New("invalid authentication helper identity")
+	}
+	if !platform.TrustedAskPassParent() {
+		return errors.New("untrusted parent process")
+	}
+	if passwordBlob == "" && passphraseBlob == "" {
+		return errors.New("credential is not available")
+	}
+	var password, passphrase []byte
+	if passwordBlob != "" {
+		password, err = security.UnprotectBytes(passwordBlob)
+		if err != nil {
+			return err
+		}
+		defer security.WipeBytes(password)
+	}
+	if passphraseBlob != "" {
+		passphrase, err = security.UnprotectBytes(passphraseBlob)
+		if err != nil {
+			return err
+		}
+		defer security.WipeBytes(passphrase)
+	}
+	secret, ok := selectSecret(strings.Join(os.Args[1:], " "), password, passphrase)
+	if !ok {
+		return errors.New("unknown or unsupported credential request")
+	}
+	return writeSecret(secret)
+}
+
+func main() {
+	if run() != nil {
+		os.Exit(1)
+	}
+}

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-VERSION="$(tr -d '\r\n' < "$REPO_ROOT/VERSION")"
+VERSION="$(tr -d '\r\n' < "$SCRIPT_DIR/../VERSION")"
 
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Invalid root VERSION: $VERSION" >&2

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-VERSION="$(tr -d '\r\n' < "$SCRIPT_DIR/../VERSION")"
+VERSION="$(tr -d '\r\n' < "$REPO_ROOT/VERSION")"
 
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Invalid root VERSION: $VERSION" >&2
@@ -11,19 +11,23 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/main.swift"
+BRIDGE_SOURCE="$SCRIPT_DIR/Bridge/main.go"
+ASKPASS_SOURCE="$SCRIPT_DIR/AskPass/main.go"
 ICON_SOURCE="$REPO_ROOT/build/icon.png"
 OUT="$SCRIPT_DIR/out"
 DIST="$SCRIPT_DIR/dist"
 APP="$OUT/Ghost FTP.app"
 CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
+FRAMEWORKS="$CONTENTS/Frameworks"
 RESOURCES="$CONTENTS/Resources"
+MODULE_DIR="$OUT/GhostFTPEngineModule"
 ZIP="$DIST/Ghost-FTP-${VERSION}-macOS.app.zip"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
 DEPLOYMENT_TARGET="13.0"
 BUNDLE_ID="app.ghostftp.client"
 
-for required in "$SOURCE" "$ICON_SOURCE"; do
+for required in "$SOURCE" "$BRIDGE_SOURCE" "$ASKPASS_SOURCE" "$ICON_SOURCE"; do
   if [[ ! -s "$required" ]]; then
     echo "Missing required macOS build input: $required" >&2
     exit 1
@@ -31,58 +35,94 @@ for required in "$SOURCE" "$ICON_SOURCE"; do
 done
 
 rm -rf "$OUT" "$DIST"
-mkdir -p "$MACOS" "$RESOURCES" "$DIST"
+mkdir -p "$MACOS" "$FRAMEWORKS" "$RESOURCES" "$DIST" "$MODULE_DIR"
 
-build_arch() {
+build_go_arch() {
+  local arch="$1"
+  local clang_arch="$2"
+  mkdir -p "$OUT/go-$arch"
+  (
+    cd "$REPO_ROOT"
+    CGO_ENABLED=1 GOOS=darwin GOARCH="$arch" \
+      CGO_CFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET} -arch ${clang_arch}" \
+      CGO_LDFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET} -arch ${clang_arch}" \
+      go build -trimpath -buildmode=c-shared \
+        -o "$OUT/go-$arch/libGhostFTPEngine.dylib" ./macos/Bridge
+    CGO_ENABLED=1 GOOS=darwin GOARCH="$arch" \
+      CGO_CFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET} -arch ${clang_arch}" \
+      CGO_LDFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET} -arch ${clang_arch}" \
+      go build -trimpath -o "$OUT/go-$arch/GhostFTPAskPass" ./macos/AskPass
+  )
+}
+
+build_go_arch arm64 arm64
+build_go_arch amd64 x86_64
+
+xcrun lipo -create \
+  "$OUT/go-arm64/libGhostFTPEngine.dylib" \
+  "$OUT/go-amd64/libGhostFTPEngine.dylib" \
+  -output "$FRAMEWORKS/libGhostFTPEngine.dylib"
+xcrun install_name_tool -id '@rpath/libGhostFTPEngine.dylib' "$FRAMEWORKS/libGhostFTPEngine.dylib"
+
+xcrun lipo -create \
+  "$OUT/go-arm64/GhostFTPAskPass" \
+  "$OUT/go-amd64/GhostFTPAskPass" \
+  -output "$MACOS/GhostFTPAskPass"
+chmod 0755 "$MACOS/GhostFTPAskPass"
+
+cp "$OUT/go-arm64/libGhostFTPEngine.h" "$MODULE_DIR/GhostFTPEngine.h"
+cat > "$MODULE_DIR/module.modulemap" <<'MODULEMAP'
+module GhostFTPEngine [system] {
+  header "GhostFTPEngine.h"
+  export *
+}
+MODULEMAP
+
+build_swift_arch() {
   local arch="$1"
   local target="$arch-apple-macosx${DEPLOYMENT_TARGET}"
   xcrun --sdk macosx swiftc \
     -sdk "$SDK" \
     -target "$target" \
     -O \
+    -I "$MODULE_DIR" \
+    -L "$FRAMEWORKS" \
+    -lGhostFTPEngine \
+    -Xlinker -rpath \
+    -Xlinker '@executable_path/../Frameworks' \
     -framework AppKit \
     "$SOURCE" \
     -o "$OUT/GhostFTP-$arch"
 }
 
-build_arch arm64
-build_arch x86_64
+build_swift_arch arm64
+build_swift_arch x86_64
 xcrun lipo -create "$OUT/GhostFTP-arm64" "$OUT/GhostFTP-x86_64" -output "$MACOS/GhostFTP"
 chmod 0755 "$MACOS/GhostFTP"
 
-ARCHS="$(xcrun lipo -archs "$MACOS/GhostFTP")"
-[[ " $ARCHS " == *" arm64 "* ]] || { echo "Universal app is missing arm64" >&2; exit 1; }
-[[ " $ARCHS " == *" x86_64 "* ]] || { echo "Universal app is missing x86_64" >&2; exit 1; }
+for binary in "$MACOS/GhostFTP" "$MACOS/GhostFTPAskPass" "$FRAMEWORKS/libGhostFTPEngine.dylib"; do
+  archs="$(xcrun lipo -archs "$binary")"
+  [[ " $archs " == *" arm64 "* ]] || { echo "$binary is missing arm64" >&2; exit 1; }
+  [[ " $archs " == *" x86_64 "* ]] || { echo "$binary is missing x86_64" >&2; exit 1; }
+done
 
 cat > "$CONTENTS/Info.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleDisplayName</key>
-  <string>Ghost FTP</string>
-  <key>CFBundleExecutable</key>
-  <string>GhostFTP</string>
-  <key>CFBundleIconFile</key>
-  <string>GhostFTP</string>
-  <key>CFBundleIdentifier</key>
-  <string>${BUNDLE_ID}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>Ghost FTP</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>${VERSION}</string>
-  <key>CFBundleVersion</key>
-  <string>${VERSION}</string>
-  <key>LSMinimumSystemVersion</key>
-  <string>${DEPLOYMENT_TARGET}</string>
-  <key>NSHighResolutionCapable</key>
-  <true/>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleDisplayName</key><string>Ghost FTP</string>
+  <key>CFBundleExecutable</key><string>GhostFTP</string>
+  <key>CFBundleIconFile</key><string>GhostFTP</string>
+  <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>Ghost FTP</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+  <key>CFBundleVersion</key><string>${VERSION}</string>
+  <key>LSMinimumSystemVersion</key><string>${DEPLOYMENT_TARGET}</string>
+  <key>NSHighResolutionCapable</key><true/>
 </dict>
 </plist>
 EOF
@@ -90,8 +130,7 @@ EOF
 ICONSET="$OUT/GhostFTP.iconset"
 mkdir -p "$ICONSET"
 make_icon() {
-  local pixels="$1"
-  local name="$2"
+  local pixels="$1" name="$2"
   sips -s format png -z "$pixels" "$pixels" "$ICON_SOURCE" --out "$ICONSET/$name" >/dev/null
 }
 make_icon 16 icon_16x16.png
@@ -108,12 +147,12 @@ iconutil -c icns "$ICONSET" -o "$RESOURCES/GhostFTP.icns"
 
 /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$CONTENTS/Info.plist" | grep -Fx "$BUNDLE_ID" >/dev/null
 /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
-/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$CONTENTS/Info.plist" | grep -Fx "$VERSION" >/dev/null
 
-# Development CI uses ad-hoc signing only. A future public Mac release must use
-# an explicitly configured Apple Developer identity plus hardened runtime and
-# notarization; this build never fabricates a production identity.
-codesign --force --deep --sign - "$APP"
+# Sign nested executable code before the outer development bundle.
+codesign --force --sign - "$FRAMEWORKS/libGhostFTPEngine.dylib"
+codesign --force --sign - "$MACOS/GhostFTPAskPass"
+codesign --force --sign - "$MACOS/GhostFTP"
+codesign --force --sign - "$APP"
 codesign --verify --deep --strict "$APP"
 
 ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
@@ -122,5 +161,7 @@ test -s "$ZIP"
 printf 'MACOS_APP=%s\n' "$APP"
 printf 'MACOS_DEVELOPMENT_ARTIFACT=%s\n' "$ZIP"
 printf 'MACOS_VERSION=%s\n' "$VERSION"
-printf 'MACOS_ARCHS=%s\n' "$ARCHS"
+printf 'MACOS_ARCHS=%s\n' "$(xcrun lipo -archs "$MACOS/GhostFTP")"
+printf 'MACOS_ENGINE_ARCHS=%s\n' "$(xcrun lipo -archs "$FRAMEWORKS/libGhostFTPEngine.dylib")"
+printf 'MACOS_ASKPASS_ARCHS=%s\n' "$(xcrun lipo -archs "$MACOS/GhostFTPAskPass")"
 printf 'MACOS_SIGNING=adhoc-development\n'

--- a/macos/Bridge/main.go
+++ b/macos/Bridge/main.go
@@ -1,0 +1,214 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/api"
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+	"github.com/bren-wp/Ghost-FTP/internal/platform"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+	"github.com/bren-wp/Ghost-FTP/internal/usererror"
+)
+
+var bridgeState struct {
+	mu                 sync.Mutex
+	engine             *api.Engine
+	lastError          string
+	pendingFingerprint string
+}
+
+func setBridgeError(err error, fallback string) {
+	if err == nil {
+		bridgeState.lastError = ""
+		return
+	}
+	bridgeState.lastError = usererror.Message(err, fallback)
+}
+
+func goString(value *C.char) string {
+	if value == nil {
+		return ""
+	}
+	return C.GoString(value)
+}
+
+func askPassHelperPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(filepath.Dir(exe), "GhostFTPAskPass")
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 {
+		return "", errors.New("bundled macOS authentication helper is unavailable")
+	}
+	return path, nil
+}
+
+//export GhostFTPCreateEngine
+func GhostFTPCreateEngine() C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine != nil {
+		return 1
+	}
+	platform.HardenProcessPrivacy()
+	dataDir, err := api.DataDir()
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not access its application data folder.")
+		return 0
+	}
+	localAppData, err := platform.LocalAppData()
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not access the macOS Application Support folder.")
+		return 0
+	}
+	if err := security.EnsureNoRedirectDirectory(localAppData, dataDir); err != nil {
+		setBridgeError(err, "The Ghost FTP data folder is not safe to use.")
+		return 0
+	}
+	helper, err := askPassHelperPath()
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not initialize secure SFTP authentication.")
+		return 0
+	}
+	engine, err := api.New(dataDir, helper)
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not start its connection engine.")
+		return 0
+	}
+	bridgeState.engine = engine
+	bridgeState.lastError = ""
+	bridgeState.pendingFingerprint = ""
+	return 1
+}
+
+// GhostFTPConnect returns 1 for connected, 2 when SFTP host-key trust is
+// required, and 0 for a user-safe failure exposed through GhostFTPLastError.
+//export GhostFTPConnect
+func GhostFTPConnect(protocol, host *C.char, port C.int, username, password, privateKeyPath, passphrase, trustFingerprint *C.char, rememberFingerprint C.int) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		setBridgeError(errors.New("engine is not initialized"), "Ghost FTP is not ready.")
+		return 0
+	}
+	cfg := model.ConnectionConfig{
+		Protocol:       strings.ToLower(strings.TrimSpace(goString(protocol))),
+		Host:           strings.TrimSpace(goString(host)),
+		Port:           int(port),
+		Username:       goString(username),
+		Password:       goString(password),
+		PrivateKeyPath: strings.TrimSpace(goString(privateKeyPath)),
+		Passphrase:     goString(passphrase),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	result, err := bridgeState.engine.Connect(ctx, "", cfg, strings.TrimSpace(goString(trustFingerprint)), rememberFingerprint != 0)
+	if err != nil {
+		bridgeState.pendingFingerprint = ""
+		setBridgeError(err, "Connection failed. Check the connection details and try again.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	if result.RequiresTrust {
+		bridgeState.pendingFingerprint = result.Fingerprint
+		return 2
+	}
+	bridgeState.pendingFingerprint = ""
+	if result.Connected {
+		return 1
+	}
+	setBridgeError(errors.New("connection was not established"), "Connection failed. Please try again.")
+	return 0
+}
+
+//export GhostFTPDisconnect
+func GhostFTPDisconnect() C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	if err := bridgeState.engine.Disconnect(ctx); err != nil {
+		setBridgeError(err, "Ghost FTP could not disconnect cleanly.")
+		return 0
+	}
+	bridgeState.pendingFingerprint = ""
+	bridgeState.lastError = ""
+	return 1
+}
+
+//export GhostFTPCancelPendingTrust
+func GhostFTPCancelPendingTrust() {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine != nil {
+		bridgeState.engine.CancelPendingTrust()
+	}
+	bridgeState.pendingFingerprint = ""
+}
+
+//export GhostFTPIsConnected
+func GhostFTPIsConnected() C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		return 0
+	}
+	_, ok := bridgeState.engine.ActiveConnection()
+	if ok {
+		return 1
+	}
+	return 0
+}
+
+//export GhostFTPLastError
+func GhostFTPLastError() *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	return C.CString(bridgeState.lastError)
+}
+
+//export GhostFTPPendingFingerprint
+func GhostFTPPendingFingerprint() *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	return C.CString(bridgeState.pendingFingerprint)
+}
+
+//export GhostFTPShutdown
+func GhostFTPShutdown() {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine != nil {
+		bridgeState.engine.CancelPendingTrust()
+		bridgeState.engine.Close()
+		bridgeState.engine = nil
+	}
+	bridgeState.pendingFingerprint = ""
+	bridgeState.lastError = ""
+}
+
+//export GhostFTPFreeCString
+func GhostFTPFreeCString(value *C.char) {
+	if value != nil {
+		C.free(unsafe.Pointer(value))
+	}
+}
+
+func main() {}

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -1,167 +1,371 @@
 import AppKit
+import Darwin
 import Foundation
+import GhostFTPEngine
 
-private extension NSColor {
-    convenience init(rgb: UInt32) {
-        let red = CGFloat((rgb >> 16) & 0xff) / 255.0
-        let green = CGFloat((rgb >> 8) & 0xff) / 255.0
-        let blue = CGFloat(rgb & 0xff) / 255.0
-        self.init(srgbRed: red, green: green, blue: blue, alpha: 1.0)
-    }
-}
-
-private enum GhostPalette {
+private enum Palette {
     static let workspace = NSColor(rgb: 0xEEF1F5)
     static let panel = NSColor(rgb: 0xF6F8FB)
-    static let list = NSColor(rgb: 0xFAFBFD)
     static let text = NSColor(rgb: 0x111827)
     static let muted = NSColor(rgb: 0x667085)
     static let accent = NSColor(rgb: 0x2563EB)
     static let border = NSColor(rgb: 0xD7DDE6)
 }
 
-private final class PanelView: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.backgroundColor = GhostPalette.panel.cgColor
-        layer?.borderColor = GhostPalette.border.cgColor
-        layer?.borderWidth = 1
-        layer?.cornerRadius = 12
-    }
-
-    required init?(coder: NSCoder) {
-        nil
+private extension NSColor {
+    convenience init(rgb: Int) {
+        self.init(
+            calibratedRed: CGFloat((rgb >> 16) & 0xff) / 255.0,
+            green: CGFloat((rgb >> 8) & 0xff) / 255.0,
+            blue: CGFloat(rgb & 0xff) / 255.0,
+            alpha: 1
+        )
     }
 }
 
+private final class CStringBox {
+    let pointer: UnsafeMutablePointer<CChar>?
+    init(_ value: String) { pointer = strdup(value) }
+    deinit { free(pointer) }
+}
+
+private struct ConnectionInput {
+    var protocolName: String
+    var host: String
+    var port: Int32
+    var username: String
+    var password: String
+    var privateKeyPath: String
+    var passphrase: String
+    var rememberFingerprint: Bool
+
+    mutating func clearSecrets() {
+        password.removeAll(keepingCapacity: false)
+        passphrase.removeAll(keepingCapacity: false)
+    }
+}
+
+private func bridgeString(_ pointer: UnsafeMutablePointer<CChar>?) -> String {
+    guard let pointer else { return "" }
+    defer { GhostFTPFreeCString(pointer) }
+    return String(cString: pointer)
+}
+
 private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    private var window: NSWindow?
+    private var window: NSWindow!
+    private let engineQueue = DispatchQueue(label: "app.ghostftp.engine", qos: .userInitiated)
+
+    private let protocolPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let hostField = NSTextField(string: "")
+    private let portField = NSTextField(string: "21")
+    private let usernameField = NSTextField(string: "")
+    private let passwordField = NSSecureTextField(string: "")
+    private let privateKeyField = NSTextField(string: "")
+    private let passphraseField = NSSecureTextField(string: "")
+    private let privateKeyLabel = NSTextField(labelWithString: "Private key")
+    private let passphraseLabel = NSTextField(labelWithString: "Passphrase")
+    private let chooseKeyButton = NSButton(title: "Browse…", target: nil, action: nil)
+    private let rememberFingerprint = NSButton(checkboxWithTitle: "Remember trusted SFTP host key", target: nil, action: nil)
+    private let connectButton = NSButton(title: "Connect", target: nil, action: nil)
+    private let disconnectButton = NSButton(title: "Disconnect", target: nil, action: nil)
+    private let statusLabel = NSTextField(labelWithString: "Not connected")
+    private let workspaceLabel = NSTextField(labelWithString: "Connect to a server to open the local and remote file workspace.")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
-        NSApp.appearance = NSAppearance(named: .aqua)
+        buildWindow()
+        if GhostFTPCreateEngine() != 1 {
+            statusLabel.stringValue = bridgeString(GhostFTPLastError())
+            connectButton.isEnabled = false
+        }
+        refreshConnectionState()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
 
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1500, height: 960),
+    func applicationWillTerminate(_ notification: Notification) {
+        GhostFTPCancelPendingTrust()
+        GhostFTPShutdown()
+    }
+
+    private func buildWindow() {
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1320, height: 820),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.title = "Ghost FTP \(productVersion())"
-        window.minSize = NSSize(width: 1100, height: 720)
-        window.isReleasedWhenClosed = false
-        window.delegate = self
+        window.title = "Ghost FTP"
+        window.minSize = NSSize(width: 1040, height: 680)
         window.center()
+        window.delegate = self
+        window.contentView?.wantsLayer = true
+        window.contentView?.layer?.backgroundColor = Palette.workspace.cgColor
 
-        let root = NSView(frame: window.contentView?.bounds ?? .zero)
-        root.autoresizingMask = [.width, .height]
-        root.wantsLayer = true
-        root.layer?.backgroundColor = GhostPalette.workspace.cgColor
-        window.contentView = root
+        protocolPopup.addItems(withTitles: ["FTP", "FTPS", "SFTP"])
+        protocolPopup.target = self
+        protocolPopup.action = #selector(protocolChanged)
+        chooseKeyButton.target = self
+        chooseKeyButton.action = #selector(choosePrivateKey)
+        connectButton.target = self
+        connectButton.action = #selector(connectTapped)
+        connectButton.bezelStyle = .rounded
+        connectButton.keyEquivalent = "\r"
+        disconnectButton.target = self
+        disconnectButton.action = #selector(disconnectTapped)
 
-        let title = label("Ghost FTP", size: 28, weight: .bold, color: GhostPalette.text)
-        let subtitle = label(
-            "macOS parity development surface",
-            size: 14,
-            weight: .regular,
-            color: GhostPalette.muted
-        )
-        let badge = label("ENGINE BRIDGE IN PROGRESS", size: 12, weight: .semibold, color: GhostPalette.accent)
+        let title = NSTextField(labelWithString: "Ghost FTP")
+        title.font = .systemFont(ofSize: 25, weight: .bold)
+        title.textColor = Palette.text
+        let subtitle = NSTextField(labelWithString: "Quick Connect")
+        subtitle.font = .systemFont(ofSize: 13, weight: .medium)
+        subtitle.textColor = Palette.muted
 
-        let foundation = PanelView(frame: .zero)
-        let foundationTitle = label("Native AppKit foundation", size: 18, weight: .semibold, color: GhostPalette.text)
-        let foundationBody = wrappingLabel(
-            "This bundle proves the dedicated native macOS build, universal Intel + Apple Silicon executable, product identity and Ghost FTP desktop palette. Windows remains the canonical visual and behavior reference.",
-            size: 14
-        )
+        let heading = NSStackView(views: [title, subtitle])
+        heading.orientation = .vertical
+        heading.alignment = .leading
+        heading.spacing = 3
 
-        let parity = PanelView(frame: .zero)
-        let parityTitle = label("Fail-closed parity rule", size: 18, weight: .semibold, color: GhostPalette.text)
-        let parityBody = wrappingLabel(
-            "FTP controls are intentionally not drawn until each action is connected to the same internal/api.Engine behavior used by Windows/Linux. Ghost FTP does not count placeholder or dead controls as parity.",
-            size: 14
-        )
+        let form = makeConnectionForm()
+        let buttonRow = NSStackView(views: [connectButton, disconnectButton, statusLabel])
+        buttonRow.orientation = .horizontal
+        buttonRow.alignment = .centerY
+        buttonRow.spacing = 10
+        statusLabel.textColor = Palette.muted
+        statusLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        [title, subtitle, badge, foundation, parity].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            root.addSubview($0)
-        }
-        [foundationTitle, foundationBody].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            foundation.addSubview($0)
-        }
-        [parityTitle, parityBody].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            parity.addSubview($0)
-        }
+        let connectionStack = NSStackView(views: [heading, form, rememberFingerprint, buttonRow])
+        connectionStack.orientation = .vertical
+        connectionStack.alignment = .leading
+        connectionStack.spacing = 14
+        connectionStack.edgeInsets = NSEdgeInsets(top: 18, left: 20, bottom: 18, right: 20)
+        connectionStack.wantsLayer = true
+        connectionStack.layer?.backgroundColor = Palette.panel.cgColor
+        connectionStack.layer?.cornerRadius = 10
+        connectionStack.layer?.borderWidth = 1
+        connectionStack.layer?.borderColor = Palette.border.cgColor
 
+        workspaceLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        workspaceLabel.textColor = Palette.muted
+        workspaceLabel.alignment = .center
+        let workspace = NSView()
+        workspace.wantsLayer = true
+        workspace.layer?.backgroundColor = NSColor.white.cgColor
+        workspace.layer?.cornerRadius = 10
+        workspace.layer?.borderWidth = 1
+        workspace.layer?.borderColor = Palette.border.cgColor
+        workspace.addSubview(workspaceLabel)
+        workspaceLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            title.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 30),
-            title.topAnchor.constraint(equalTo: root.topAnchor, constant: 26),
-            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 3),
-            badge.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -30),
-            badge.centerYAnchor.constraint(equalTo: title.centerYAnchor),
-
-            foundation.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 30),
-            foundation.trailingAnchor.constraint(equalTo: root.centerXAnchor, constant: -8),
-            foundation.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 28),
-            foundation.heightAnchor.constraint(greaterThanOrEqualToConstant: 210),
-
-            parity.leadingAnchor.constraint(equalTo: root.centerXAnchor, constant: 8),
-            parity.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -30),
-            parity.topAnchor.constraint(equalTo: foundation.topAnchor),
-            parity.heightAnchor.constraint(equalTo: foundation.heightAnchor),
-
-            foundationTitle.leadingAnchor.constraint(equalTo: foundation.leadingAnchor, constant: 22),
-            foundationTitle.trailingAnchor.constraint(equalTo: foundation.trailingAnchor, constant: -22),
-            foundationTitle.topAnchor.constraint(equalTo: foundation.topAnchor, constant: 22),
-            foundationBody.leadingAnchor.constraint(equalTo: foundationTitle.leadingAnchor),
-            foundationBody.trailingAnchor.constraint(equalTo: foundationTitle.trailingAnchor),
-            foundationBody.topAnchor.constraint(equalTo: foundationTitle.bottomAnchor, constant: 14),
-            foundationBody.bottomAnchor.constraint(lessThanOrEqualTo: foundation.bottomAnchor, constant: -22),
-
-            parityTitle.leadingAnchor.constraint(equalTo: parity.leadingAnchor, constant: 22),
-            parityTitle.trailingAnchor.constraint(equalTo: parity.trailingAnchor, constant: -22),
-            parityTitle.topAnchor.constraint(equalTo: parity.topAnchor, constant: 22),
-            parityBody.leadingAnchor.constraint(equalTo: parityTitle.leadingAnchor),
-            parityBody.trailingAnchor.constraint(equalTo: parityTitle.trailingAnchor),
-            parityBody.topAnchor.constraint(equalTo: parityTitle.bottomAnchor, constant: 14),
-            parityBody.bottomAnchor.constraint(lessThanOrEqualTo: parity.bottomAnchor, constant: -22),
+            workspaceLabel.centerXAnchor.constraint(equalTo: workspace.centerXAnchor),
+            workspaceLabel.centerYAnchor.constraint(equalTo: workspace.centerYAnchor)
         ])
 
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
-        self.window = window
+        let root = NSStackView(views: [connectionStack, workspace])
+        root.orientation = .vertical
+        root.spacing = 14
+        root.edgeInsets = NSEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
+        root.translatesAutoresizingMaskIntoConstraints = false
+        window.contentView?.addSubview(root)
+        guard let content = window.contentView else { return }
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            root.topAnchor.constraint(equalTo: content.topAnchor),
+            root.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            workspace.heightAnchor.constraint(greaterThanOrEqualToConstant: 360),
+            connectionStack.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -36)
+        ])
+        protocolChanged()
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+    private func makeConnectionForm() -> NSGridView {
+        let keyRow = NSStackView(views: [privateKeyField, chooseKeyButton])
+        keyRow.orientation = .horizontal
+        keyRow.spacing = 8
+        privateKeyField.widthAnchor.constraint(greaterThanOrEqualToConstant: 280).isActive = true
+
+        let grid = NSGridView(views: [
+            [fieldLabel("Protocol"), protocolPopup, fieldLabel("Host"), hostField],
+            [fieldLabel("Port"), portField, fieldLabel("Username"), usernameField],
+            [fieldLabel("Password"), passwordField, privateKeyLabel, keyRow],
+            [passphraseLabel, passphraseField, NSView(), NSView()]
+        ])
+        grid.rowSpacing = 10
+        grid.columnSpacing = 10
+        grid.column(at: 0).xPlacement = .trailing
+        grid.column(at: 2).xPlacement = .trailing
+        hostField.widthAnchor.constraint(greaterThanOrEqualToConstant: 300).isActive = true
+        usernameField.widthAnchor.constraint(greaterThanOrEqualToConstant: 300).isActive = true
+        passwordField.widthAnchor.constraint(greaterThanOrEqualToConstant: 220).isActive = true
+        passphraseField.widthAnchor.constraint(greaterThanOrEqualToConstant: 220).isActive = true
+        return grid
     }
 
-    private func productVersion() -> String {
-        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "dev"
+    private func fieldLabel(_ title: String) -> NSTextField {
+        let label = NSTextField(labelWithString: title)
+        label.textColor = Palette.text
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        return label
     }
 
-    private func label(_ text: String, size: CGFloat, weight: NSFont.Weight, color: NSColor) -> NSTextField {
-        let field = NSTextField(labelWithString: text)
-        field.font = NSFont.systemFont(ofSize: size, weight: weight)
-        field.textColor = color
-        field.backgroundColor = .clear
-        return field
+    @objc private func protocolChanged() {
+        let sftp = protocolPopup.titleOfSelectedItem == "SFTP"
+        privateKeyLabel.isHidden = !sftp
+        privateKeyField.isHidden = !sftp
+        chooseKeyButton.isHidden = !sftp
+        passphraseLabel.isHidden = !sftp
+        passphraseField.isHidden = !sftp
+        rememberFingerprint.isHidden = !sftp
+        if sftp && portField.stringValue == "21" { portField.stringValue = "22" }
+        if !sftp && portField.stringValue == "22" { portField.stringValue = "21" }
     }
 
-    private func wrappingLabel(_ text: String, size: CGFloat) -> NSTextField {
-        let field = label(text, size: size, weight: .regular, color: GhostPalette.muted)
-        field.maximumNumberOfLines = 0
-        field.lineBreakMode = .byWordWrapping
-        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        return field
+    @objc private func choosePrivateKey() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.title = "Choose private key"
+        if panel.runModal() == .OK, let url = panel.url {
+            privateKeyField.stringValue = url.path
+        }
+    }
+
+    private func currentInput() -> ConnectionInput? {
+        let host = hostField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = usernameField.stringValue
+        guard !host.isEmpty else {
+            showError("Host is required.")
+            return nil
+        }
+        guard let port = Int32(portField.stringValue), port > 0, port <= 65535 else {
+            showError("Port must be between 1 and 65535.")
+            return nil
+        }
+        return ConnectionInput(
+            protocolName: (protocolPopup.titleOfSelectedItem ?? "FTP").lowercased(),
+            host: host,
+            port: port,
+            username: username,
+            password: passwordField.stringValue,
+            privateKeyPath: privateKeyField.stringValue,
+            passphrase: passphraseField.stringValue,
+            rememberFingerprint: rememberFingerprint.state == .on
+        )
+    }
+
+    @objc private func connectTapped() {
+        guard var input = currentInput() else { return }
+        passwordField.stringValue = ""
+        passphraseField.stringValue = ""
+        setBusy(true, status: "Connecting…")
+        engineQueue.async { [weak self] in
+            let result = self?.bridgeConnect(input: input, trustFingerprint: "") ?? 0
+            input.clearSecrets()
+            DispatchQueue.main.async {
+                self?.handleConnectResult(result, original: input)
+            }
+        }
+    }
+
+    private func bridgeConnect(input: ConnectionInput, trustFingerprint: String) -> Int32 {
+        let p = CStringBox(input.protocolName)
+        let h = CStringBox(input.host)
+        let u = CStringBox(input.username)
+        let pw = CStringBox(input.password)
+        let key = CStringBox(input.privateKeyPath)
+        let pass = CStringBox(input.passphrase)
+        let trust = CStringBox(trustFingerprint)
+        return Int32(GhostFTPConnect(p.pointer, h.pointer, CInt(input.port), u.pointer, pw.pointer, key.pointer, pass.pointer, trust.pointer, input.rememberFingerprint ? 1 : 0))
+    }
+
+    private func handleConnectResult(_ result: Int32, original: ConnectionInput) {
+        if result == 1 {
+            setBusy(false, status: "Connected")
+            workspaceLabel.stringValue = "Connected. File workspace parity is the next implementation layer."
+            refreshConnectionState()
+            return
+        }
+        if result == 2 {
+            let fingerprint = bridgeString(GhostFTPPendingFingerprint())
+            guard !fingerprint.isEmpty else {
+                setBusy(false, status: "Connection failed")
+                showError("Ghost FTP did not receive a valid SFTP host fingerprint.")
+                return
+            }
+            let alert = NSAlert()
+            alert.messageText = "Trust this SFTP host key?"
+            alert.informativeText = fingerprint
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Trust and connect")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                var trusted = original
+                trusted.password = ""
+                trusted.passphrase = ""
+                setBusy(true, status: "Verifying host key…")
+                engineQueue.async { [weak self] in
+                    let second = self?.bridgeConnect(input: trusted, trustFingerprint: fingerprint) ?? 0
+                    trusted.clearSecrets()
+                    DispatchQueue.main.async { self?.handleConnectResult(second, original: trusted) }
+                }
+            } else {
+                GhostFTPCancelPendingTrust()
+                setBusy(false, status: "Not connected")
+            }
+            return
+        }
+        setBusy(false, status: "Connection failed")
+        showError(bridgeString(GhostFTPLastError()))
+        refreshConnectionState()
+    }
+
+    @objc private func disconnectTapped() {
+        setBusy(true, status: "Disconnecting…")
+        engineQueue.async { [weak self] in
+            let ok = GhostFTPDisconnect() == 1
+            let message = ok ? "" : bridgeString(GhostFTPLastError())
+            DispatchQueue.main.async {
+                self?.setBusy(false, status: ok ? "Not connected" : "Disconnect failed")
+                if !ok { self?.showError(message) }
+                self?.workspaceLabel.stringValue = "Connect to a server to open the local and remote file workspace."
+                self?.refreshConnectionState()
+            }
+        }
+    }
+
+    private func setBusy(_ busy: Bool, status: String) {
+        connectButton.isEnabled = !busy && GhostFTPIsConnected() == 0
+        disconnectButton.isEnabled = !busy && GhostFTPIsConnected() == 1
+        protocolPopup.isEnabled = !busy
+        hostField.isEnabled = !busy
+        portField.isEnabled = !busy
+        usernameField.isEnabled = !busy
+        passwordField.isEnabled = !busy
+        privateKeyField.isEnabled = !busy
+        passphraseField.isEnabled = !busy
+        chooseKeyButton.isEnabled = !busy
+        statusLabel.stringValue = status
+    }
+
+    private func refreshConnectionState() {
+        let connected = GhostFTPIsConnected() == 1
+        connectButton.isEnabled = !connected
+        disconnectButton.isEnabled = connected
+        statusLabel.stringValue = connected ? "Connected" : "Not connected"
+    }
+
+    private func showError(_ text: String) {
+        let alert = NSAlert()
+        alert.messageText = "Ghost FTP"
+        alert.informativeText = text.isEmpty ? "The operation could not be completed." : text
+        alert.alertStyle = .critical
+        alert.runModal()
     }
 }
 
-let application = NSApplication.shared
+private let app = NSApplication.shared
 private let delegate = AppDelegate()
-application.delegate = delegate
-application.run()
+app.delegate = delegate
+app.run()

--- a/scripts/test_macos_engine_bridge_contract.py
+++ b/scripts/test_macos_engine_bridge_contract.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    path = ROOT / relative
+    if not path.is_file():
+        raise AssertionError(f"missing required macOS engine bridge file: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+class MacOSEngineBridgeContractTests(unittest.TestCase):
+    def test_bridge_is_typed_in_process_and_uses_shared_engine(self) -> None:
+        bridge = read("macos/Bridge/main.go")
+        for marker in (
+            '"github.com/bren-wp/Ghost-FTP/internal/api"',
+            '"github.com/bren-wp/Ghost-FTP/internal/model"',
+            "//export GhostFTPCreateEngine",
+            "//export GhostFTPConnect",
+            "//export GhostFTPDisconnect",
+            "//export GhostFTPCancelPendingTrust",
+            "//export GhostFTPIsConnected",
+            "//export GhostFTPLastError",
+            "//export GhostFTPPendingFingerprint",
+            "//export GhostFTPShutdown",
+            "//export GhostFTPFreeCString",
+            "api.DataDir()",
+            "api.New(",
+            "engine.Connect(",
+            "engine.Disconnect(",
+            "engine.CancelPendingTrust()",
+            "engine.ActiveConnection()",
+        ):
+            self.assertIn(marker, bridge)
+        self.assertNotIn("encoding/json", bridge)
+        self.assertNotIn("net/http", bridge)
+        self.assertNotIn("http.ListenAndServe", bridge)
+
+    def test_bridge_does_not_persist_plaintext_secrets(self) -> None:
+        bridge = read("macos/Bridge/main.go")
+        self.assertIn("model.ConnectionConfig{", bridge)
+        self.assertIn("Password:", bridge)
+        self.assertIn("Passphrase:", bridge)
+        self.assertNotIn("WriteFile", bridge)
+        self.assertNotIn("os.Setenv", bridge)
+        self.assertNotIn("password =", bridge.lower())
+        self.assertNotIn("passphrase =", bridge.lower())
+
+    def test_darwin_platform_boundary_is_explicit_and_private(self) -> None:
+        darwin = read("internal/platform/darwin.go")
+        for marker in (
+            "//go:build darwin",
+            'filepath.Join(home, "Library", "Application Support")',
+            "syscall.Umask(0o077)",
+            "func LocalAppData()",
+            "func HardenProcessPrivacy()",
+            "func ChoosePrivateKey()",
+            "func ChooseDirectory()",
+        ):
+            self.assertIn(marker, darwin)
+        self.assertNotIn("XDG_DATA_HOME", darwin)
+
+    def test_macos_build_links_universal_go_engine_dylib(self) -> None:
+        build = read("macos/BUILD.sh")
+        for marker in (
+            "macos/Bridge/main.go",
+            "-buildmode=c-shared",
+            "GOOS=darwin",
+            "GOARCH=arm64",
+            "GOARCH=amd64",
+            "libGhostFTPEngine.dylib",
+            "GhostFTPEngine.h",
+            "module.modulemap",
+            "lipo -create",
+            "@rpath/libGhostFTPEngine.dylib",
+            "@executable_path/../Frameworks",
+            "Contents/Frameworks",
+        ):
+            self.assertIn(marker, build)
+
+    def test_appkit_quick_connect_is_wired_to_the_bridge(self) -> None:
+        swift = read("macos/Sources/GhostFTPApp/main.swift")
+        for marker in (
+            "import GhostFTPEngine",
+            "NSSecureTextField",
+            "GhostFTPCreateEngine()",
+            "GhostFTPConnect(",
+            "GhostFTPDisconnect()",
+            "GhostFTPCancelPendingTrust()",
+            "GhostFTPIsConnected()",
+            "GhostFTPPendingFingerprint()",
+            "GhostFTPLastError()",
+            "GhostFTPFreeCString(",
+            "DispatchQueue",
+            'passwordField.stringValue = ""',
+            'passphraseField.stringValue = ""',
+        ):
+            self.assertIn(marker, swift)
+        self.assertNotIn("URLSession", swift)
+        self.assertNotIn("UserDefaults", swift)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_macos_engine_bridge_contract.py
+++ b/scripts/test_macos_engine_bridge_contract.py
@@ -66,7 +66,7 @@ class MacOSEngineBridgeContractTests(unittest.TestCase):
     def test_macos_build_links_universal_go_engine_dylib(self) -> None:
         build = read("macos/BUILD.sh")
         for marker in (
-            "macos/Bridge/main.go",
+            "./macos/Bridge",
             "-buildmode=c-shared",
             "GOOS=darwin",
             "GOARCH=arm64",

--- a/scripts/test_macos_engine_bridge_contract.py
+++ b/scripts/test_macos_engine_bridge_contract.py
@@ -63,6 +63,21 @@ class MacOSEngineBridgeContractTests(unittest.TestCase):
             self.assertIn(marker, darwin)
         self.assertNotIn("XDG_DATA_HOME", darwin)
 
+    def test_persistent_macos_profiles_fail_closed_until_keychain(self) -> None:
+        profile_crypto = read("internal/config/profile_crypto_darwin.go")
+        for marker in (
+            "//go:build darwin",
+            "saved profiles are unavailable until macOS Keychain protection is enabled",
+            "func protectProfileData([]byte, string) (string, error)",
+            "func unprotectProfileData(string, string) ([]byte, error)",
+            "return \"\", errDarwinPersistentProfilesUnavailable",
+            "return nil, errDarwinPersistentProfilesUnavailable",
+        ):
+            self.assertIn(marker, profile_crypto)
+        self.assertNotIn("base64", profile_crypto)
+        self.assertNotIn("WriteFile", profile_crypto)
+        self.assertNotIn("ProtectString", profile_crypto)
+
     def test_macos_build_links_universal_go_engine_dylib(self) -> None:
         build = read("macos/BUILD.sh")
         for marker in (

--- a/scripts/test_macos_engine_bridge_contract.py
+++ b/scripts/test_macos_engine_bridge_contract.py
@@ -69,15 +69,16 @@ class MacOSEngineBridgeContractTests(unittest.TestCase):
             "./macos/Bridge",
             "-buildmode=c-shared",
             "GOOS=darwin",
-            "GOARCH=arm64",
-            "GOARCH=amd64",
+            'GOARCH="$arch"',
+            "build_go_arch arm64 arm64",
+            "build_go_arch amd64 x86_64",
             "libGhostFTPEngine.dylib",
             "GhostFTPEngine.h",
             "module.modulemap",
             "lipo -create",
             "@rpath/libGhostFTPEngine.dylib",
             "@executable_path/../Frameworks",
-            "Contents/Frameworks",
+            'FRAMEWORKS="$CONTENTS/Frameworks"',
         ):
             self.assertIn(marker, build)
 


### PR DESCRIPTION
## Scope

Implement the first real Windows-parity vertical in the dedicated native macOS app.

- link AppKit to the same typed `internal/api.Engine` through an in-process C ABI bridge;
- add real FTP / FTPS / SFTP Quick Connect and Disconnect controls;
- preserve the existing SFTP pending-host-key trust flow without retaining plaintext credentials in UI fields;
- add a dedicated bundled Go AskPass helper for SFTP password/private-key passphrase prompts;
- add an owner-only Darwin runtime secret broker for cross-process AskPass capabilities;
- resolve only Apple system `ssh`, `sftp`, and `ssh-keyscan` executables with root-owner / non-writable checks;
- add explicit Darwin platform support required by the shared engine;
- build and verify universal arm64 + x86_64 AppKit executable, shared Go engine dylib, and AskPass helper;
- keep macOS a development surface only; public release configuration is unchanged.

## Security / privacy boundary

No JSON dispatcher, localhost server, browser IPC, telemetry, analytics, credential file, command-line password, or remote hosted code is introduced. Password/passphrase fields are cleared immediately after dispatching a connection attempt. SFTP host-key trust remains fail-closed and uses the existing engine pending-trust model.

## Validation

This remains draft until the exact PR head passes the native macOS runner plus the repository's existing CI/security/regression gates. Any failures will be fixed only from exact-head evidence.