### PR TITLE
Add guarded macOS remote permissions

### DIFF
--- a/macos/Bridge/permissions.go
+++ b/macos/Bridge/permissions.go
@@ -1,0 +1,55 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+func requireVisibleRemotePermissionItem(name string) error {
+	name = strings.TrimSpace(name)
+	if err := security.ValidateRemoteName(name); err != nil {
+		return err
+	}
+	item, ok := snapshotItem(bridgeState.remoteItems, name)
+	if !ok {
+		return errors.New("selected item is no longer in the visible remote folder")
+	}
+	if item.IsSymlink {
+		return errors.New("symbolic-link permissions are not changed")
+	}
+	return nil
+}
+
+//export GhostFTPRemoteChmod
+func GhostFTPRemoteChmod(baseValue, nameValue, modeValue *C.char) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	base, err := requireRemoteSnapshot(goString(baseValue))
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not change remote permissions.")
+		return 0
+	}
+	name := strings.TrimSpace(goString(nameValue))
+	if err := requireVisibleRemotePermissionItem(name); err != nil {
+		setBridgeError(err, "Ghost FTP could not change remote permissions.")
+		return 0
+	}
+	mode := strings.TrimSpace(goString(modeValue))
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	if err := bridgeState.engine.RemoteChmod(ctx, base, name, mode); err != nil {
+		setBridgeError(err, "Ghost FTP could not change remote permissions.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	return 1
+}

--- a/macos/PARITY.md
+++ b/macos/PARITY.md
@@ -46,7 +46,7 @@ A checkbox moves to `[x]` only when the visible Mac action is wired to real shar
 - [x] Remote New Folder
 - [x] Remote Rename
 - [x] Remote Delete
-- [ ] Remote Permissions
+- [x] Remote Permissions
 - [ ] Remote Edit
 - [ ] Remote Filter
 - [ ] Remote Recursive Search
@@ -70,9 +70,11 @@ A checkbox moves to `[x]` only when the visible Mac action is wired to real shar
 
 The native AppKit workspace exposes real Local and Remote file tables backed by `internal/api.Engine.LocalList` and `internal/api.Engine.RemoteList`. Local folder selection uses the native macOS folder panel. Local/remote Up and Refresh actions operate on the active engine paths, and directory double-click navigation follows the same intent as Windows. Upload and Download queue real shared-engine transfers; regular files use `AddTransfer`, directories use bounded `AddTreeTransfer`, and symbolic links are rejected rather than silently followed.
 
-Local and Remote New Folder, Rename and Delete are now wired to the same `Engine.LocalMkdir` / `LocalRename` / `LocalDelete` and `Engine.RemoteMkdir` / `RemoteRename` / `RemoteDelete` APIs used by the desktop model. Mutation bridge calls require the directory shown in AppKit to match the engine snapshot, and rename/delete require the selected name to still exist in that snapshot. A stale folder or stale selection therefore fails closed rather than mutating an unseen target. Destructive delete always requires an explicit native confirmation in the current Mac development surface.
+Local and Remote New Folder, Rename and Delete are wired to the same `Engine.LocalMkdir` / `LocalRename` / `LocalDelete` and `Engine.RemoteMkdir` / `RemoteRename` / `RemoteDelete` APIs used by the desktop model. Mutation bridge calls require the directory shown in AppKit to match the engine snapshot, and rename/delete require the selected name to still exist in that snapshot. A stale folder or stale selection therefore fails closed rather than mutating an unseen target. Destructive delete always requires an explicit native confirmation in the current Mac development surface.
 
-Mutation completion is generation-bound: if the user navigates away while an operation is queued or running, the old operation cannot refresh the newly selected directory. Remote mutations also require the active connection and use bounded engine contexts. Permissions/chmod remains a separate unfinished parity item rather than being represented by a dead control.
+Remote Permissions is wired to `Engine.RemoteChmod` for both FTP/FTPS and SFTP. The Mac action mirrors the Windows safety boundary: at most 1000 selected items, symbolic links are skipped, the prompt defaults to `644`, and only 3- or 4-digit octal modes are accepted by the UI before the shared transport layer validates the mode again. Each target must still exist in the active remote snapshot, and mutation completion remains navigation-generation-bound before the pane is refreshed.
+
+Mutation completion is generation-bound: if the user navigates away while an operation is queued or running, the old operation cannot refresh the newly selected directory. Remote mutations also require the active connection and use bounded engine contexts.
 
 The macOS bridge keeps each transfer action bound to the currently visible engine snapshot so stale UI names cannot be used after navigation. Download targets are derived with the shared safe-local-child validation and remote names are validated before transfer. The bridge remains typed C ABI only: no JSON dispatcher, localhost server, browser IPC or credential-bearing generic payload was added.
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -20,6 +20,7 @@ The native AppKit application currently includes:
 - stale-folder and stale-selection rejection before mutations can reach the engine;
 - navigation-generation ownership so an old mutation cannot refresh a newly selected folder;
 - remote file metadata including size, modification time and permissions when provided by the protocol;
+- Remote Permissions/CHMOD through `Engine.RemoteChmod`, with the same 1000-item safety bound as Windows, 3/4-digit octal modes, symbolic-link skipping and success/failure/skipped reporting;
 - real Upload and Download queue entry points; regular files use `Engine.AddTransfer` and directories use the bounded `Engine.AddTreeTransfer` path;
 - symbolic-link rejection for transfer actions rather than silent traversal;
 - visible-snapshot binding for transfer actions so stale names cannot be submitted after navigation.
@@ -45,7 +46,7 @@ Persistent saved-profile secrets remain fail-closed on macOS until the dedicated
 
 ## Remaining parity work
 
-The development surface is not yet a complete Mac release. Site Manager, saved-profile Keychain support, Bookmarks, Settings/About/Diagnostics, permissions, filtering/search, Directory Compare, Remote Edit, full transfer queue controls, localization and the remaining Windows behavior inventory are still tracked in `PARITY.md` and remain intentionally absent until their real engine-backed implementations are ready.
+The development surface is not yet a complete Mac release. Site Manager, saved-profile Keychain support, Bookmarks, Settings/About/Diagnostics, filtering/search, Directory Compare, Remote Edit, full transfer queue controls, localization and the remaining Windows behavior inventory are still tracked in `PARITY.md` and remain intentionally absent until their real engine-backed implementations are ready.
 
 The Mac development artifact is **not part of the current 0.0.5 public release allow-list**. The existing verified Windows/Linux 14-platform-artifact / 17-public-file release contract remains unchanged until macOS reaches full functionality, runtime evidence and distribution/signing/notarization gates.
 

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -110,6 +110,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     private let remoteNewFolderButton = NSButton(title: "New Folder", target: nil, action: nil)
     private let remoteRenameButton = NSButton(title: "Rename", target: nil, action: nil)
     private let remoteDeleteButton = NSButton(title: "Delete", target: nil, action: nil)
+    private let remotePermissionsButton = NSButton(title: "Permissions", target: nil, action: nil)
     private let downloadButton = NSButton(title: "Download", target: nil, action: nil)
 
     private var localCurrent = NSHomeDirectory()
@@ -270,7 +271,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             title: "Remote",
             table: remoteTable,
             pathLabel: remotePathLabel,
-            buttons: [remoteUpButton, remoteRefreshButton, remoteNewFolderButton, remoteRenameButton, remoteDeleteButton, downloadButton]
+            buttons: [remoteUpButton, remoteRefreshButton, remoteNewFolderButton, remoteRenameButton, remoteDeleteButton, remotePermissionsButton, downloadButton]
         ))
 
         let container = NSView()
@@ -368,6 +369,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         remoteRenameButton.action = #selector(remoteRenameTapped)
         remoteDeleteButton.target = self
         remoteDeleteButton.action = #selector(remoteDeleteTapped)
+        remotePermissionsButton.target = self
+        remotePermissionsButton.action = #selector(remotePermissionsTapped)
         downloadButton.target = self
         downloadButton.action = #selector(downloadTapped)
     }
@@ -674,6 +677,67 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             if failed > 0 { status += " • Failed: \(failed)" }
             return MutationResult(changed: deleted > 0, status: status, error: firstError)
         }
+    }
+
+    @objc private func remotePermissionsTapped() {
+        let selected = selectedItems(table: remoteTable, items: remoteItems)
+        guard !remoteMutationBusy, GhostFTPIsConnected() == 1, !selected.isEmpty else { return }
+        if selected.count > 1000 {
+            statusLabel.stringValue = "Permissions: too many selected items."
+            return
+        }
+        guard let mode = promptPermissionMode() else { return }
+        guard isValidPermissionMode(mode) else {
+            showError("Permissions must contain exactly 3 or 4 octal digits (0–7).")
+            return
+        }
+        let base = remoteCurrent
+        runRemoteMutation(status: "Changing remote permissions…") {
+            var changed = 0
+            var failed = 0
+            var skipped = 0
+            var firstError = ""
+            for item in selected {
+                if item.isSymlink {
+                    skipped += 1
+                    continue
+                }
+                let baseValue = CStringBox(base)
+                let nameValue = CStringBox(item.name)
+                let modeValue = CStringBox(mode)
+                if GhostFTPRemoteChmod(baseValue.pointer, nameValue.pointer, modeValue.pointer) == 1 {
+                    changed += 1
+                } else {
+                    failed += 1
+                    if firstError.isEmpty {
+                        firstError = bridgeString(GhostFTPLastError())
+                    }
+                }
+            }
+            var status = "Changed: \(changed)"
+            if failed > 0 { status += " • Failed: \(failed)" }
+            if skipped > 0 { status += " • Skipped links: \(skipped)" }
+            return MutationResult(changed: changed > 0, status: status, error: firstError)
+        }
+    }
+
+    private func promptPermissionMode() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "Remote permissions"
+        alert.informativeText = "Permissions (644 / 755):"
+        alert.addButton(withTitle: "Apply")
+        alert.addButton(withTitle: "Cancel")
+        let input = NSTextField(string: "644")
+        input.frame = NSRect(x: 0, y: 0, width: 180, height: 24)
+        alert.accessoryView = input
+        window.makeFirstResponder(input)
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        return input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func isValidPermissionMode(_ value: String) -> Bool {
+        guard value.count == 3 || value.count == 4 else { return false }
+        return value.allSatisfy { $0 >= "0" && $0 <= "7" }
     }
 
     private func promptName(title: String, initial: String) -> String? {
@@ -1001,6 +1065,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         remoteNewFolderButton.isEnabled = connected && !remoteMutationBusy
         remoteRenameButton.isEnabled = connected && !remoteMutationBusy && remoteSelectionCount == 1
         remoteDeleteButton.isEnabled = connected && !remoteMutationBusy && remoteSelectionCount > 0
+        remotePermissionsButton.isEnabled = connected && !remoteMutationBusy && remoteSelectionCount > 0
         downloadButton.isEnabled = connected && !remoteMutationBusy && remoteSelectionCount > 0
         remoteTable.isEnabled = connected
     }

--- a/scripts/test_macos_file_mutations_contract.py
+++ b/scripts/test_macos_file_mutations_contract.py
@@ -108,7 +108,7 @@ class MacOSFileMutationsContract(unittest.TestCase):
         self.assertIn("GhostFTPIsConnected() == 1", remote)
         self.assertIn("self.refreshRemote(base)", remote)
 
-    def test_parity_marks_only_newly_wired_mutations_complete(self):
+    def test_wired_file_mutations_remain_complete(self):
         for item in (
             "Local New Folder",
             "Local Rename",
@@ -118,7 +118,6 @@ class MacOSFileMutationsContract(unittest.TestCase):
             "Remote Delete",
         ):
             self.assertIn(f"- [x] {item}", self.parity)
-        self.assertIn("- [ ] Remote Permissions", self.parity)
 
 
 if __name__ == "__main__":

--- a/scripts/test_macos_remote_permissions_contract.py
+++ b/scripts/test_macos_remote_permissions_contract.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_bridge_package() -> str:
+    sources = sorted((ROOT / "macos/Bridge").glob("*.go"))
+    if not sources:
+        raise AssertionError("missing macOS bridge Go sources")
+    return "\n".join(path.read_text(encoding="utf-8") for path in sources)
+
+
+def function_body(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        raise AssertionError(f"missing function signature: {signature}")
+    open_brace = source.find("{", start)
+    if open_brace < 0:
+        raise AssertionError(f"missing function body: {signature}")
+    depth = 0
+    for index in range(open_brace, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace : index + 1]
+    raise AssertionError(f"unterminated function body: {signature}")
+
+
+class MacOSRemotePermissionsContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bridge = read_bridge_package()
+        cls.swift = (ROOT / "macos/Sources/GhostFTPApp/main.swift").read_text(encoding="utf-8")
+        cls.parity = (ROOT / "macos/PARITY.md").read_text(encoding="utf-8")
+        cls.windows = (ROOT / "internal/desktop/files_actions_windows.go").read_text(encoding="utf-8")
+
+    def test_bridge_exposes_snapshot_bound_remote_chmod(self):
+        body = function_body(self.bridge, "func GhostFTPRemoteChmod(")
+        self.assertIn("requireRemoteSnapshot", body)
+        self.assertIn("requireVisibleRemotePermissionItem", body)
+        self.assertIn("engine.RemoteChmod", body)
+        self.assertIn("context.WithTimeout", body)
+
+        guard = function_body(self.bridge, "func requireVisibleRemotePermissionItem(")
+        self.assertIn("snapshotItem(bridgeState.remoteItems", guard)
+        self.assertIn("ValidateRemoteName", guard)
+        self.assertIn("IsSymlink", guard)
+
+    def test_app_exposes_real_permissions_action_with_windows_batch_bound(self):
+        for marker in (
+            'NSButton(title: "Permissions"',
+            "remotePermissionsTapped",
+            'messageText = "Remote permissions"',
+            'informativeText = "Permissions (644 / 755):"',
+            'NSTextField(string: "644")',
+            "selected.count > 1000",
+            "item.isSymlink",
+            "GhostFTPRemoteChmod",
+        ):
+            self.assertIn(marker, self.swift)
+
+    def test_permissions_mode_is_prevalidated_but_engine_remains_authoritative(self):
+        action = function_body(self.swift, "private func remotePermissionsTapped(")
+        self.assertIn("isValidPermissionMode", action)
+        validator = function_body(self.swift, "private func isValidPermissionMode(")
+        self.assertIn("value.count == 3 || value.count == 4", validator)
+        self.assertIn("$0 >= \"0\" && $0 <= \"7\"", validator)
+
+        bridge = function_body(self.bridge, "func GhostFTPRemoteChmod(")
+        self.assertIn("engine.RemoteChmod", bridge)
+
+    def test_permissions_batch_reports_success_failure_and_skipped_links(self):
+        action = function_body(self.swift, "private func remotePermissionsTapped(")
+        for marker in (
+            "var changed = 0",
+            "var failed = 0",
+            "var skipped = 0",
+            '"Changed: \\(changed)"',
+            '"Failed: \\(failed)"',
+            '"Skipped links: \\(skipped)"',
+        ):
+            self.assertIn(marker, action)
+        self.assertIn("runRemoteMutation", action)
+
+    def test_permissions_reuses_remote_mutation_generation_refresh_guard(self):
+        runner = function_body(self.swift, "private func runRemoteMutation(")
+        self.assertIn("let generation = remoteNavigationGeneration", runner)
+        self.assertIn("result.changed && generation == self.remoteNavigationGeneration", runner)
+        self.assertIn("GhostFTPIsConnected() == 1", runner)
+        self.assertIn("self.refreshRemote(base)", runner)
+
+    def test_windows_contract_and_macos_parity_are_aligned(self):
+        windows = function_body(self.windows, "func (a *app) remoteChmodAction(")
+        self.assertIn("len(indices) > 1000", windows)
+        self.assertIn("item.IsSymlink", windows)
+        self.assertIn('"644"', windows)
+        self.assertIn("engine.RemoteChmod", windows)
+        self.assertIn("- [x] Remote Permissions", self.parity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_macos_remote_permissions_contract.py
+++ b/scripts/test_macos_remote_permissions_contract.py
@@ -80,8 +80,8 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
             "var failed = 0",
             "var skipped = 0",
             '"Changed: \\(changed)"',
-            '"Failed: \\(failed)"',
-            '"Skipped links: \\(skipped)"',
+            'Failed: \\(failed)',
+            'Skipped links: \\(skipped)',
         ):
             self.assertIn(marker, action)
         self.assertIn("runRemoteMutation", action)

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -73,6 +73,7 @@ IMPLEMENTED_MACOS_ACTIONS = {
     "Remote New Folder",
     "Remote Rename",
     "Remote Delete",
+    "Remote Permissions",
     "Upload",
     "Download",
 }


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] Repository license and contribution constraints remain unchanged.

## Scope

Implement the next narrow Windows-parity vertical in the native macOS client: Remote Permissions/CHMOD.

- add a real native AppKit Permissions action to the Remote file pane;
- route permission changes through the existing typed `internal/api.Engine.RemoteChmod` path;
- preserve FTP/FTPS `SITE CHMOD` and SFTP `chmod` shared transport semantics;
- accept only 3- or 4-digit octal modes, with the UI defaulting to `644` and the shared engine validating again;
- support multi-selection with the same 1000-item safety boundary as Windows;
- skip symbolic links rather than changing the link target's permissions;
- require each target to still exist in the current remote engine snapshot;
- reuse the existing remote mutation generation/disconnect guard before refreshing the pane;
- report changed, failed and skipped-link counts;
- mark only Remote Permissions complete in the macOS parity inventory;
- keep macOS development-only and leave the current public 0.0.5 Windows/Linux release contract unchanged.

## Security and privacy

- [x] No JSON dispatcher, localhost server, browser IPC or external runtime service was added.
- [x] No telemetry, analytics, tracking or credential persistence was added.
- [x] Stale remote-folder and stale-target attempts fail closed.
- [x] Symbolic links are rejected in the bridge and skipped by the UI batch.
- [x] Remote names and chmod modes remain validated by the shared transport layer.
- [x] Existing connection-generation and navigation-generation ownership remains in force.

## Regression coverage

`scripts/test_macos_remote_permissions_contract.py` requires the snapshot-bound chmod bridge, symlink rejection, 1000-item Windows batch bound, native `644` prompt, octal prevalidation, result counts and reuse of the remote mutation refresh guard. The canonical parity test now includes Remote Permissions only after the real implementation exists.

## Validation

Keep this PR draft until the exact head passes the universal native macOS build plus the repository CI/security/packaging gates. Fix only evidence-backed failures.