### PR TITLE
Fix/macos remote permissions batch cancel 2

### DIFF
--- a/macos/Bridge/permissions.go
+++ b/macos/Bridge/permissions.go
@@ -9,10 +9,19 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bren-wp/Ghost-FTP/internal/security"
 )
+
+var remoteChmodBatch struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	base   string
+	mode   string
+}
 
 func requireVisibleRemotePermissionItem(name string) error {
 	name = strings.TrimSpace(name)
@@ -29,12 +38,90 @@ func requireVisibleRemotePermissionItem(name string) error {
 	return nil
 }
 
-//export GhostFTPRemoteChmod
-func GhostFTPRemoteChmod(baseValue, nameValue, modeValue *C.char) C.int {
+func remoteChmodBatchTimeout(count int) time.Duration {
+	if count < 1 {
+		count = 1
+	}
+	timeout := 90*time.Second + time.Duration(count-1)*2*time.Second
+	if timeout > 10*time.Minute {
+		return 10 * time.Minute
+	}
+	return timeout
+}
+
+func cancelRemoteChmodBatch() {
+	remoteChmodBatch.mu.Lock()
+	cancel := remoteChmodBatch.cancel
+	remoteChmodBatch.ctx = nil
+	remoteChmodBatch.cancel = nil
+	remoteChmodBatch.base = ""
+	remoteChmodBatch.mode = ""
+	remoteChmodBatch.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func currentRemoteChmodBatch() (context.Context, string, string, bool) {
+	remoteChmodBatch.mu.Lock()
+	defer remoteChmodBatch.mu.Unlock()
+	if remoteChmodBatch.ctx == nil || remoteChmodBatch.cancel == nil {
+		return nil, "", "", false
+	}
+	return remoteChmodBatch.ctx, remoteChmodBatch.base, remoteChmodBatch.mode, true
+}
+
+//export GhostFTPBeginRemoteChmodBatch
+func GhostFTPBeginRemoteChmodBatch(baseValue, modeValue *C.char, countValue C.int) C.int {
+	count := int(countValue)
+	if count < 1 || count > 1000 {
+		bridgeState.mu.Lock()
+		setBridgeError(errors.New("invalid remote permissions batch size"), "Ghost FTP could not start the remote permissions change.")
+		bridgeState.mu.Unlock()
+		return 0
+	}
+
 	bridgeState.mu.Lock()
-	defer bridgeState.mu.Unlock()
 	base, err := requireRemoteSnapshot(goString(baseValue))
 	if err != nil {
+		setBridgeError(err, "Ghost FTP could not start the remote permissions change.")
+		bridgeState.mu.Unlock()
+		return 0
+	}
+	mode := strings.TrimSpace(goString(modeValue))
+	bridgeState.lastError = ""
+	bridgeState.mu.Unlock()
+
+	cancelRemoteChmodBatch()
+	ctx, cancel := context.WithTimeout(context.Background(), remoteChmodBatchTimeout(count))
+	remoteChmodBatch.mu.Lock()
+	remoteChmodBatch.ctx = ctx
+	remoteChmodBatch.cancel = cancel
+	remoteChmodBatch.base = base
+	remoteChmodBatch.mode = mode
+	remoteChmodBatch.mu.Unlock()
+	return 1
+}
+
+//export GhostFTPRemoteChmodBatchItem
+func GhostFTPRemoteChmodBatchItem(nameValue *C.char) C.int {
+	ctx, base, mode, ok := currentRemoteChmodBatch()
+	if !ok {
+		bridgeState.mu.Lock()
+		setBridgeError(errors.New("remote permissions batch is not active"), "Ghost FTP could not change remote permissions.")
+		bridgeState.mu.Unlock()
+		return 0
+	}
+	if err := ctx.Err(); err != nil {
+		bridgeState.mu.Lock()
+		setBridgeError(err, "Ghost FTP remote permissions change was cancelled or timed out.")
+		bridgeState.mu.Unlock()
+		return 0
+	}
+
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if _, err := requireRemoteSnapshot(base); err != nil {
 		setBridgeError(err, "Ghost FTP could not change remote permissions.")
 		return 0
 	}
@@ -43,13 +130,20 @@ func GhostFTPRemoteChmod(baseValue, nameValue, modeValue *C.char) C.int {
 		setBridgeError(err, "Ghost FTP could not change remote permissions.")
 		return 0
 	}
-	mode := strings.TrimSpace(goString(modeValue))
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
 	if err := bridgeState.engine.RemoteChmod(ctx, base, name, mode); err != nil {
 		setBridgeError(err, "Ghost FTP could not change remote permissions.")
 		return 0
 	}
 	bridgeState.lastError = ""
 	return 1
+}
+
+//export GhostFTPEndRemoteChmodBatch
+func GhostFTPEndRemoteChmodBatch() {
+	cancelRemoteChmodBatch()
+}
+
+//export GhostFTPCancelRemoteChmodBatch
+func GhostFTPCancelRemoteChmodBatch() {
+	cancelRemoteChmodBatch()
 }

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -156,6 +156,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        GhostFTPCancelRemoteChmodBatch()
         GhostFTPCancelPendingTrust()
         GhostFTPShutdown()
     }
@@ -545,6 +546,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     @objc private func disconnectTapped() {
+        GhostFTPCancelRemoteChmodBatch()
         setBusy(true, status: "Disconnecting…")
         remoteNavigationGeneration += 1
         remoteMutationGeneration += 1
@@ -700,6 +702,12 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             statusLabel.stringValue = "Permissions: too many selected items."
             return
         }
+        let actionable = selected.filter { !$0.isSymlink }
+        let initiallySkipped = selected.count - actionable.count
+        guard !actionable.isEmpty else {
+            statusLabel.stringValue = "Skipped links: \(initiallySkipped)"
+            return
+        }
         guard let mode = promptPermissionMode() else { return }
         guard isValidPermissionMode(mode) else {
             showError("Permissions must contain exactly 3 or 4 octal digits (0–7).")
@@ -707,19 +715,24 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         }
         let base = remoteCurrent
         runRemoteMutation(status: "Changing remote permissions…") {
+            let baseValue = CStringBox(base)
+            let modeValue = CStringBox(mode)
+            guard GhostFTPBeginRemoteChmodBatch(baseValue.pointer, modeValue.pointer, CInt(actionable.count)) == 1 else {
+                return MutationResult(changed: false, status: "Remote permissions change failed", error: bridgeString(GhostFTPLastError()))
+            }
+            defer { GhostFTPEndRemoteChmodBatch() }
+
             var changed = 0
             var failed = 0
-            var skipped = 0
+            var skipped = initiallySkipped
             var firstError = ""
-            for item in selected {
+            for item in actionable {
                 if item.isSymlink {
                     skipped += 1
                     continue
                 }
-                let baseValue = CStringBox(base)
                 let nameValue = CStringBox(item.name)
-                let modeValue = CStringBox(mode)
-                if GhostFTPRemoteChmod(baseValue.pointer, nameValue.pointer, modeValue.pointer) == 1 {
+                if GhostFTPRemoteChmodBatchItem(nameValue.pointer) == 1 {
                     changed += 1
                 } else {
                     failed += 1

--- a/scripts/test_macos_remote_permissions_contract.py
+++ b/scripts/test_macos_remote_permissions_contract.py
@@ -39,11 +39,14 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
         cls.windows = (ROOT / "internal/desktop/files_actions_windows.go").read_text(encoding="utf-8")
 
     def test_bridge_exposes_snapshot_bound_remote_chmod(self):
-        body = function_body(self.bridge, "func GhostFTPRemoteChmod(")
-        self.assertIn("requireRemoteSnapshot", body)
-        self.assertIn("requireVisibleRemotePermissionItem", body)
-        self.assertIn("engine.RemoteChmod", body)
-        self.assertIn("context.WithTimeout", body)
+        begin = function_body(self.bridge, "func GhostFTPBeginRemoteChmodBatch(")
+        self.assertIn("requireRemoteSnapshot", begin)
+        self.assertIn("remoteChmodBatchTimeout", begin)
+        self.assertIn("context.WithTimeout", begin)
+
+        item = function_body(self.bridge, "func GhostFTPRemoteChmodBatchItem(")
+        self.assertIn("requireVisibleRemotePermissionItem", item)
+        self.assertIn("engine.RemoteChmod", item)
 
         guard = function_body(self.bridge, "func requireVisibleRemotePermissionItem(")
         self.assertIn("snapshotItem(bridgeState.remoteItems", guard)
@@ -59,7 +62,9 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
             'NSTextField(string: "644")',
             "selected.count > 1000",
             "item.isSymlink",
-            "GhostFTPRemoteChmod",
+            "GhostFTPBeginRemoteChmodBatch",
+            "GhostFTPRemoteChmodBatchItem",
+            "GhostFTPEndRemoteChmodBatch",
         ):
             self.assertIn(marker, self.swift)
 
@@ -70,7 +75,7 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
         self.assertIn("value.count == 3 || value.count == 4", validator)
         self.assertIn("$0 >= \"0\" && $0 <= \"7\"", validator)
 
-        bridge = function_body(self.bridge, "func GhostFTPRemoteChmod(")
+        bridge = function_body(self.bridge, "func GhostFTPRemoteChmodBatchItem(")
         self.assertIn("engine.RemoteChmod", bridge)
 
     def test_permissions_batch_reports_success_failure_and_skipped_links(self):
@@ -80,11 +85,30 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
             "var failed = 0",
             "var skipped = 0",
             '"Changed: \\(changed)"',
-            'Failed: \\(failed)',
-            'Skipped links: \\(skipped)',
+            '" • Failed: \\(failed)"',
+            '" • Skipped links: \\(skipped)"',
         ):
             self.assertIn(marker, action)
         self.assertIn("runRemoteMutation", action)
+
+    def test_permissions_batch_uses_one_bounded_cancellable_deadline(self):
+        timeout = function_body(self.bridge, "func remoteChmodBatchTimeout(")
+        self.assertIn("90 * time.Second", timeout)
+        self.assertIn("time.Duration(count-1)*2*time.Second", timeout)
+        self.assertIn("10*time.Minute", timeout)
+
+        begin = function_body(self.bridge, "func GhostFTPBeginRemoteChmodBatch(")
+        self.assertIn("context.WithTimeout(context.Background(), remoteChmodBatchTimeout(count))", begin)
+        self.assertIn("count > 1000", begin)
+
+        cancel = function_body(self.bridge, "func GhostFTPCancelRemoteChmodBatch(")
+        self.assertIn("cancelRemoteChmodBatch", cancel)
+
+        disconnect = function_body(self.swift, "private func disconnectTapped(")
+        cancel_pos = disconnect.find("GhostFTPCancelRemoteChmodBatch()")
+        queue_pos = disconnect.find("engineQueue.async")
+        self.assertGreaterEqual(cancel_pos, 0)
+        self.assertGreater(queue_pos, cancel_pos)
 
     def test_permissions_reuses_remote_mutation_generation_refresh_guard(self):
         runner = function_body(self.swift, "private func runRemoteMutation(")
@@ -99,6 +123,7 @@ class MacOSRemotePermissionsContract(unittest.TestCase):
         self.assertIn("item.IsSymlink", windows)
         self.assertIn('"644"', windows)
         self.assertIn("engine.RemoteChmod", windows)
+        self.assertIn("remoteBatchTimeout(len(items))", windows)
         self.assertIn("- [x] Remote Permissions", self.parity)
 
 


### PR DESCRIPTION
## Authorization

- [ ] This source-code change was explicitly requested or authorized for Ghost FTP.
- [ ] I have read and will follow `LICENSE` and the contribution documentation.

> Ghost FTP is source-available software. Opening a pull request or fork does not itself grant rights beyond the repository license and applicable GitHub platform rights.

## Summary

Describe the change and why it is needed.

## Branding and compatibility

- [ ] New public UI, documentation and release assets use **Ghost FTP**.
- [ ] Any retained `GhostFTP`/`GhostFTP` identifier is required for backward compatibility, migration or installed-application identity and is not user-facing branding.

## Security and privacy

- [ ] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [ ] No automatic external API or hidden network destination was added.
- [ ] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [ ] SFTP host-key verification and pinning remain active.
- [ ] Local path-traversal, symlink, junction and reparse-point protections remain active.
- [ ] No external Go module was added without explicit architecture/security review.
- [ ] Tests, screenshots and fixtures contain no real credentials, production servers or customer data.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/audit_security.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] PHP syntax checks pass when web code changed.
- [ ] Native platform build checks pass for affected platforms.

## Regression coverage

Describe tests added or changed for connections, transfers, paths, profiles, installation/uninstallation, localization, release packaging or other affected behavior.
