### PR TITLE
feat: add guarded macOS remote edit

### DIFF
--- a/macos/Bridge/remote_edit.go
+++ b/macos/Bridge/remote_edit.go
@@ -1,0 +1,156 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	pathpkg "path"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/bren-wp/Ghost-FTP/internal/api"
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
+
+var remoteEditBridgeState struct {
+	text     string
+	revision string
+}
+
+func clearRemoteEditBridgeStateLocked() {
+	remoteEditBridgeState.text = ""
+	remoteEditBridgeState.revision = ""
+}
+
+func remoteEditVisiblePathLocked(base, name string) (string, error) {
+	if bridgeState.engine == nil {
+		return "", errors.New("engine is not initialized")
+	}
+	if _, ok := bridgeState.engine.ActiveConnection(); !ok {
+		return "", errors.New("not connected")
+	}
+	base = cleanRemotePath(base)
+	if cleanRemotePath(bridgeState.remotePath) != base {
+		return "", errors.New("remote folder changed; refresh and try again")
+	}
+	name = strings.TrimSpace(name)
+	if err := security.ValidateRemoteName(name); err != nil {
+		return "", err
+	}
+	item, ok := snapshotItem(bridgeState.remoteItems, name)
+	if !ok {
+		return "", errors.New("selected item is no longer in the visible folder")
+	}
+	if item.IsDirectory || item.IsSymlink {
+		return "", errors.New("only regular remote files can be edited")
+	}
+	return pathpkg.Join(base, name), nil
+}
+
+//export GhostFTPRemoteEditOpen
+func GhostFTPRemoteEditOpen(base, name *C.char) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	clearRemoteEditBridgeStateLocked()
+
+	remotePath, err := remoteEditVisiblePathLocked(goString(base), goString(name))
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not open the remote file for editing.")
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	doc, err := bridgeState.engine.RemoteEditOpen(ctx, remotePath)
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not open the remote file for editing.")
+		return 0
+	}
+	remoteEditBridgeState.text = doc.Text
+	remoteEditBridgeState.revision = doc.Revision
+	bridgeState.lastError = ""
+	return 1
+}
+
+//export GhostFTPRemoteEditText
+func GhostFTPRemoteEditText() *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	value := C.CString(remoteEditBridgeState.text)
+	remoteEditBridgeState.text = ""
+	return value
+}
+
+//export GhostFTPRemoteEditRevision
+func GhostFTPRemoteEditRevision() *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	return C.CString(remoteEditBridgeState.revision)
+}
+
+//export GhostFTPRemoteEditMaxBytes
+func GhostFTPRemoteEditMaxBytes() C.longlong {
+	return C.longlong(api.MaxRemoteEditBytes)
+}
+
+// GhostFTPRemoteEditSave returns 1 after a verified save, 2 for a revision
+// conflict that requires an explicit reload decision, and 0 for other errors.
+//export GhostFTPRemoteEditSave
+func GhostFTPRemoteEditSave(base, name, expectedRevision *C.char, text unsafe.Pointer, textLen C.longlong) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+
+	remotePath, err := remoteEditVisiblePathLocked(goString(base), goString(name))
+	if err != nil {
+		setBridgeError(err, "Ghost FTP could not save the remote file.")
+		return 0
+	}
+	length := int64(textLen)
+	if length < 0 || length > api.MaxRemoteEditBytes {
+		setBridgeError(api.ErrRemoteEditTooLarge, "The edited remote file is too large to save safely.")
+		return 0
+	}
+	if length > 0 && text == nil {
+		setBridgeError(errors.New("edited content is unavailable"), "The edited content is unavailable.")
+		return 0
+	}
+	if length > int64(^uint32(0)>>1) {
+		setBridgeError(api.ErrRemoteEditTooLarge, "The edited remote file is too large to save safely.")
+		return 0
+	}
+	var content []byte
+	if length > 0 {
+		content = C.GoBytes(text, C.int(length))
+	} else {
+		content = []byte{}
+	}
+	defer security.WipeBytes(content)
+
+	revision := strings.TrimSpace(goString(expectedRevision))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	saved, err := bridgeState.engine.RemoteEditSave(ctx, remotePath, revision, string(content))
+	if err != nil {
+		if errors.Is(err, api.ErrRemoteEditConflict) {
+			bridgeState.lastError = "The remote file changed after it was opened. Reload it before saving to avoid overwriting newer data."
+			return 2
+		}
+		setBridgeError(err, "Ghost FTP could not save the remote file safely.")
+		return 0
+	}
+	remoteEditBridgeState.text = ""
+	remoteEditBridgeState.revision = saved.Revision
+	bridgeState.lastError = ""
+	return 1
+}
+
+//export GhostFTPRemoteEditClear
+func GhostFTPRemoteEditClear() {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	clearRemoteEditBridgeStateLocked()
+}

--- a/macos/PARITY.md
+++ b/macos/PARITY.md
@@ -47,7 +47,7 @@ A checkbox moves to `[x]` only when the visible Mac action is wired to real shar
 - [x] Remote Rename
 - [x] Remote Delete
 - [x] Remote Permissions
-- [ ] Remote Edit
+- [x] Remote Edit
 - [x] Remote Filter
 - [ ] Remote Recursive Search
 - [ ] Directory Compare
@@ -73,6 +73,8 @@ The native AppKit workspace exposes real Local and Remote file tables backed by 
 Local and Remote New Folder, Rename and Delete are wired to the same `Engine.LocalMkdir` / `LocalRename` / `LocalDelete` and `Engine.RemoteMkdir` / `RemoteRename` / `RemoteDelete` APIs used by the desktop model. Mutation bridge calls require the directory shown in AppKit to match the engine snapshot, and rename/delete require the selected name to still exist in that snapshot. A stale folder or stale selection therefore fails closed rather than mutating an unseen target. Destructive delete always requires an explicit native confirmation in the current Mac development surface.
 
 Remote Permissions is wired to `Engine.RemoteChmod` for both FTP/FTPS and SFTP. The Mac action mirrors the Windows safety boundary: at most 1000 selected items, symbolic links are skipped, the prompt defaults to `644`, and only 3- or 4-digit octal modes are accepted by the UI before the shared transport layer validates the mode again. Each target must still exist in the active remote snapshot, and mutation completion remains navigation-generation-bound before the pane is refreshed.
+
+Remote Edit is wired directly to the shared `Engine.RemoteEditOpen` / `Engine.RemoteEditSave` contract and uses a native built-in AppKit text editor rather than an external process or a second transfer path. Only one visible regular remote file can be opened; the bridge revalidates the current remote directory snapshot before open and save. The shared engine enforces the UTF-8/size boundary, revision conflict detection, private staging, permission preservation and post-upload read-back verification. A revision conflict is fail-closed: the editor keeps the user's text selectable but requires an explicit reload before another save, so a stale revision cannot silently overwrite newer remote content. The remote listing is refreshed only after a verified save and only while the originating navigation generation and directory are still current.
 
 Local and Remote Filter now use the same shared `internal/itemlist.Filter` implementation as Windows/Linux. The bridge keeps the authoritative Local/Remote directory snapshots separate from the filtered visible slices, so filtering cannot change mutation or transfer authority. Matching remains Unicode `SimpleFold` aware, whitespace-delimited terms use AND semantics, clearing the query restores an independent full-snapshot view, and applying a filter performs no filesystem or network I/O. Explicit Refresh/List performs one real listing and then reapplies the current filter to that new snapshot. Selection is restored by item name where the filtered result still contains it, and row actions are disabled while a filtered view is being replaced.
 

--- a/macos/Sources/GhostFTPApp/main.swift
+++ b/macos/Sources/GhostFTPApp/main.swift
@@ -76,8 +76,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     private var remoteNavigationGeneration = 0
     private var localMutationGeneration = 0
     private var remoteMutationGeneration = 0
+    private var remoteEditGeneration = 0
     private var localMutationBusy = false
     private var remoteMutationBusy = false
+    private var remoteEditBusy = false
     private var localFilterBusy = false
     private var remoteFilterBusy = false
 
@@ -114,6 +116,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     private let remoteRenameButton = NSButton(title: "Rename", target: nil, action: nil)
     private let remoteDeleteButton = NSButton(title: "Delete", target: nil, action: nil)
     private let remotePermissionsButton = NSButton(title: "Permissions", target: nil, action: nil)
+    private let remoteEditButton = NSButton(title: "Edit", target: nil, action: nil)
     private let remoteFilterButton = NSButton(title: "Filter", target: nil, action: nil)
     private let downloadButton = NSButton(title: "Download", target: nil, action: nil)
 
@@ -156,6 +159,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        remoteEditGeneration += 1
+        remoteEditBusy = false
+        GhostFTPRemoteEditClear()
         GhostFTPCancelRemoteChmodBatch()
         GhostFTPCancelPendingTrust()
         GhostFTPShutdown()
@@ -280,7 +286,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             title: "Remote",
             table: remoteTable,
             pathLabel: remotePathLabel,
-            buttons: [remoteUpButton, remoteRefreshButton, remoteNewFolderButton, remoteRenameButton, remoteDeleteButton, remotePermissionsButton, remoteFilterButton, downloadButton]
+            buttons: [remoteUpButton, remoteRefreshButton, remoteNewFolderButton, remoteRenameButton, remoteDeleteButton, remotePermissionsButton, remoteEditButton, remoteFilterButton, downloadButton]
         ))
 
         let container = NSView()
@@ -382,6 +388,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         remoteDeleteButton.action = #selector(remoteDeleteTapped)
         remotePermissionsButton.target = self
         remotePermissionsButton.action = #selector(remotePermissionsTapped)
+        remoteEditButton.target = self
+        remoteEditButton.action = #selector(remoteEditTapped)
         remoteFilterButton.target = self
         remoteFilterButton.action = #selector(remoteFilterTapped)
         downloadButton.target = self
@@ -546,6 +554,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     @objc private func disconnectTapped() {
+        remoteEditGeneration += 1
+        remoteEditBusy = false
+        GhostFTPRemoteEditClear()
         GhostFTPCancelRemoteChmodBatch()
         setBusy(true, status: "Disconnecting…")
         remoteNavigationGeneration += 1
@@ -555,6 +566,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             let message = ok ? "" : bridgeString(GhostFTPLastError())
             DispatchQueue.main.async {
                 self?.remoteMutationBusy = false
+                self?.remoteEditBusy = false
                 self?.remoteFilterBusy = false
                 self?.remoteSourceCount = 0
                 self?.setBusy(false, status: ok ? "Not connected" : "Disconnect failed")
@@ -647,7 +659,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     @objc private func remoteNewFolderTapped() {
-        guard !remoteMutationBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, let name = promptName(title: "New remote folder", initial: "New Folder") else { return }
+        guard !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, let name = promptName(title: "New remote folder", initial: "New Folder") else { return }
         let base = remoteCurrent
         runRemoteMutation(status: "Creating remote folder…") {
             let baseValue = CStringBox(base)
@@ -659,7 +671,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 
     @objc private func remoteRenameTapped() {
         let rows = remoteTable.selectedRowIndexes
-        guard !remoteMutationBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, rows.count == 1, let row = rows.first, row < remoteItems.count else { return }
+        guard !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, rows.count == 1, let row = rows.first, row < remoteItems.count else { return }
         let item = remoteItems[row]
         guard let newName = promptName(title: "Rename remote item", initial: item.name), newName != item.name else { return }
         let base = remoteCurrent
@@ -674,7 +686,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 
     @objc private func remoteDeleteTapped() {
         let selected = selectedItems(table: remoteTable, items: remoteItems)
-        guard !remoteMutationBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, !selected.isEmpty, confirmDelete(selected) else { return }
+        guard !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, !selected.isEmpty, confirmDelete(selected) else { return }
         let base = remoteCurrent
         runRemoteMutation(status: "Deleting remote items…") {
             var deleted = 0
@@ -697,7 +709,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 
     @objc private func remotePermissionsTapped() {
         let selected = selectedItems(table: remoteTable, items: remoteItems)
-        guard !remoteMutationBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, !selected.isEmpty else { return }
+        guard !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy, GhostFTPIsConnected() == 1, !selected.isEmpty else { return }
         if selected.count > 1000 {
             statusLabel.stringValue = "Permissions: too many selected items."
             return
@@ -748,6 +760,306 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         }
     }
 
+    @objc private func remoteEditTapped() {
+        let rows = remoteTable.selectedRowIndexes
+        guard engineReady,
+              GhostFTPIsConnected() == 1,
+              !remoteMutationBusy,
+              !remoteEditBusy,
+              !remoteFilterBusy,
+              rows.count == 1,
+              let row = rows.first,
+              row >= 0,
+              row < remoteItems.count else { return }
+        let item = remoteItems[row]
+        guard !item.isDirectory, !item.isSymlink else {
+            statusLabel.stringValue = "Select one regular remote file to edit."
+            return
+        }
+
+        remoteEditGeneration += 1
+        let editGeneration = remoteEditGeneration
+        let navigationGeneration = remoteNavigationGeneration
+        let base = remoteCurrent
+        let name = item.name
+        remoteEditBusy = true
+        statusLabel.stringValue = "Opening remote file…"
+        updateWorkspaceControls()
+        loadRemoteEdit(base: base, name: name, navigationGeneration: navigationGeneration, editGeneration: editGeneration)
+    }
+
+    private func loadRemoteEdit(base: String, name: String, navigationGeneration: Int, editGeneration: Int) {
+        engineQueue.async { [weak self] in
+            let baseValue = CStringBox(base)
+            let nameValue = CStringBox(name)
+            let ok = GhostFTPRemoteEditOpen(baseValue.pointer, nameValue.pointer) == 1
+            let text = ok ? bridgeString(GhostFTPRemoteEditText()) : ""
+            let revision = ok ? bridgeString(GhostFTPRemoteEditRevision()) : ""
+            let message = ok ? "" : bridgeString(GhostFTPLastError())
+            DispatchQueue.main.async {
+                guard let self,
+                      editGeneration == self.remoteEditGeneration,
+                      navigationGeneration == self.remoteNavigationGeneration,
+                      self.remoteCurrent == base,
+                      GhostFTPIsConnected() == 1 else { return }
+                if !ok {
+                    self.remoteEditBusy = false
+                    self.statusLabel.stringValue = "Remote edit unavailable"
+                    self.showError(message)
+                    self.updateWorkspaceControls()
+                    return
+                }
+                self.statusLabel.stringValue = "Editing: \(name)"
+                self.presentRemoteEditor(
+                    base: base,
+                    name: name,
+                    text: text,
+                    originalText: text,
+                    expectedRevision: revision,
+                    navigationGeneration: navigationGeneration,
+                    editGeneration: editGeneration,
+                    notice: "",
+                    conflict: false
+                )
+            }
+        }
+    }
+
+    private func presentRemoteEditor(
+        base: String,
+        name: String,
+        text: String,
+        originalText: String,
+        expectedRevision: String,
+        navigationGeneration: Int,
+        editGeneration: Int,
+        notice: String,
+        conflict: Bool
+    ) {
+        guard editGeneration == remoteEditGeneration,
+              navigationGeneration == remoteNavigationGeneration,
+              remoteCurrent == base,
+              GhostFTPIsConnected() == 1 else {
+            finishRemoteEditSession(status: "Remote edit was cancelled because the folder changed.")
+            return
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Remote Edit — \(name)"
+        let safety = "Built-in editor • UTF-8 text • conflict-checked • read-back verified"
+        alert.informativeText = notice.isEmpty ? safety : "\(notice)\n\n\(safety)"
+        alert.alertStyle = conflict ? .warning : .informational
+        if conflict {
+            alert.addButton(withTitle: "Reload Remote")
+            alert.addButton(withTitle: "Cancel")
+        } else {
+            alert.addButton(withTitle: "Save")
+            alert.addButton(withTitle: "Reload Remote")
+            alert.addButton(withTitle: "Cancel")
+        }
+
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: 760, height: 470))
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.autohidesScrollers = false
+        scroll.borderType = .bezelBorder
+        let textView = NSTextView(frame: scroll.contentView.bounds)
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.string = text
+        textView.isEditable = !conflict
+        textView.isSelectable = true
+        textView.minSize = NSSize(width: 0, height: scroll.contentSize.height)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = false
+        textView.setAccessibilityLabel("Remote file contents")
+        scroll.documentView = textView
+        alert.accessoryView = scroll
+        window.makeFirstResponder(textView)
+
+        let result = alert.runModal()
+        if conflict {
+            if result == .alertFirstButtonReturn {
+                reloadRemoteEdit(
+                    base: base,
+                    name: name,
+                    navigationGeneration: navigationGeneration,
+                    editGeneration: editGeneration
+                )
+            } else {
+                finishRemoteEditSession(status: "Remote edit cancelled; remote changes were preserved.")
+            }
+            return
+        }
+
+        if result == .alertFirstButtonReturn {
+            saveRemoteEdit(
+                text: textView.string,
+                base: base,
+                name: name,
+                expectedRevision: expectedRevision,
+                navigationGeneration: navigationGeneration,
+                editGeneration: editGeneration
+            )
+            return
+        }
+        if result == .alertSecondButtonReturn {
+            if textView.string != originalText {
+                let confirm = NSAlert()
+                confirm.messageText = "Discard local edits and reload?"
+                confirm.informativeText = "Reloading fetches the current remote file and discards the unsaved text in this editor."
+                confirm.alertStyle = .warning
+                confirm.addButton(withTitle: "Reload")
+                confirm.addButton(withTitle: "Keep Editing")
+                if confirm.runModal() != .alertFirstButtonReturn {
+                    presentRemoteEditor(
+                        base: base,
+                        name: name,
+                        text: textView.string,
+                        originalText: originalText,
+                        expectedRevision: expectedRevision,
+                        navigationGeneration: navigationGeneration,
+                        editGeneration: editGeneration,
+                        notice: "Unsaved changes kept.",
+                        conflict: false
+                    )
+                    return
+                }
+            }
+            reloadRemoteEdit(
+                base: base,
+                name: name,
+                navigationGeneration: navigationGeneration,
+                editGeneration: editGeneration
+            )
+            return
+        }
+        finishRemoteEditSession(status: "Remote edit cancelled.")
+    }
+
+    private func reloadRemoteEdit(base: String, name: String, navigationGeneration: Int, editGeneration: Int) {
+        guard editGeneration == remoteEditGeneration,
+              navigationGeneration == remoteNavigationGeneration,
+              remoteCurrent == base,
+              GhostFTPIsConnected() == 1 else {
+            finishRemoteEditSession(status: "Remote edit was cancelled because the folder changed.")
+            return
+        }
+        statusLabel.stringValue = "Reloading remote file…"
+        loadRemoteEdit(base: base, name: name, navigationGeneration: navigationGeneration, editGeneration: editGeneration)
+    }
+
+    private func saveRemoteEdit(text: String, base: String, name: String, expectedRevision: String, navigationGeneration: Int, editGeneration: Int) {
+        guard editGeneration == remoteEditGeneration,
+              navigationGeneration == remoteNavigationGeneration,
+              remoteCurrent == base,
+              GhostFTPIsConnected() == 1 else {
+            finishRemoteEditSession(status: "Remote edit was cancelled because the folder changed.")
+            return
+        }
+        let encoded = Data(text.utf8)
+        let maximum = Int64(GhostFTPRemoteEditMaxBytes())
+        guard Int64(encoded.count) <= maximum else {
+            presentRemoteEditor(
+                base: base,
+                name: name,
+                text: text,
+                originalText: text,
+                expectedRevision: expectedRevision,
+                navigationGeneration: navigationGeneration,
+                editGeneration: editGeneration,
+                notice: "The edited text exceeds the 4 MiB safe editor limit.",
+                conflict: false
+            )
+            return
+        }
+
+        remoteEditBusy = true
+        statusLabel.stringValue = "Saving remote file…"
+        updateWorkspaceControls()
+        engineQueue.async { [weak self] in
+            let baseValue = CStringBox(base)
+            let nameValue = CStringBox(name)
+            let revisionValue = CStringBox(expectedRevision)
+            let result: Int32 = encoded.withUnsafeBytes { bytes in
+                let pointer = bytes.baseAddress.map { UnsafeMutableRawPointer(mutating: $0) }
+                return Int32(GhostFTPRemoteEditSave(
+                    baseValue.pointer,
+                    nameValue.pointer,
+                    revisionValue.pointer,
+                    pointer,
+                    CLongLong(encoded.count)
+                ))
+            }
+            let nextRevision = result == 1 ? bridgeString(GhostFTPRemoteEditRevision()) : expectedRevision
+            let message = result == 1 ? "" : bridgeString(GhostFTPLastError())
+            DispatchQueue.main.async {
+                guard let self, editGeneration == self.remoteEditGeneration else { return }
+                if result == 1 {
+                    self.remoteEditBusy = false
+                    self.statusLabel.stringValue = "Saved: \(name)"
+                    self.remoteEditGeneration += 1
+                    GhostFTPRemoteEditClear()
+                    if navigationGeneration == self.remoteNavigationGeneration,
+                       self.remoteCurrent == base,
+                       GhostFTPIsConnected() == 1 {
+                        self.refreshRemote(base)
+                    } else {
+                        self.updateWorkspaceControls()
+                    }
+                    _ = nextRevision
+                    return
+                }
+                if result == 2 {
+                    self.statusLabel.stringValue = "Remote edit conflict"
+                    self.presentRemoteEditor(
+                        base: base,
+                        name: name,
+                        text: text,
+                        originalText: text,
+                        expectedRevision: expectedRevision,
+                        navigationGeneration: navigationGeneration,
+                        editGeneration: editGeneration,
+                        notice: message,
+                        conflict: true
+                    )
+                    return
+                }
+                self.statusLabel.stringValue = "Remote save failed"
+                self.presentRemoteEditor(
+                    base: base,
+                    name: name,
+                    text: text,
+                    originalText: text,
+                    expectedRevision: expectedRevision,
+                    navigationGeneration: navigationGeneration,
+                    editGeneration: editGeneration,
+                    notice: message.isEmpty ? "The remote file could not be saved safely." : message,
+                    conflict: false
+                )
+            }
+        }
+    }
+
+    private func finishRemoteEditSession(status: String) {
+        remoteEditGeneration += 1
+        remoteEditBusy = false
+        statusLabel.stringValue = status
+        engineQueue.async { GhostFTPRemoteEditClear() }
+        updateWorkspaceControls()
+    }
+
     @objc private func localFilterTapped() {
         guard engineReady, !localMutationBusy, !localFilterBusy else { return }
         guard let query = promptCurrentFolderFilter(title: "Ghost FTP — Local", current: localFilterQuery) else { return }
@@ -755,7 +1067,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     @objc private func remoteFilterTapped() {
-        guard engineReady, GhostFTPIsConnected() == 1, !remoteMutationBusy, !remoteFilterBusy else { return }
+        guard engineReady, GhostFTPIsConnected() == 1, !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy else { return }
         guard let query = promptCurrentFolderFilter(title: "Ghost FTP — Remote", current: remoteFilterQuery) else { return }
         applyCurrentFolderFilter(remote: true, query: query)
     }
@@ -933,7 +1245,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     private func runRemoteMutation(status: String, operation: @escaping () -> MutationResult) {
-        guard engineReady, GhostFTPIsConnected() == 1, !remoteMutationBusy, !remoteFilterBusy else { return }
+        guard engineReady, GhostFTPIsConnected() == 1, !remoteMutationBusy, !remoteEditBusy, !remoteFilterBusy else { return }
         remoteMutationBusy = true
         remoteMutationGeneration += 1
         let mutation = remoteMutationGeneration
@@ -970,7 +1282,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 
     @objc private func remoteDoubleClicked() {
         let row = remoteTable.clickedRow
-        guard !remoteFilterBusy, row >= 0, row < remoteItems.count else { return }
+        guard !remoteFilterBusy, !remoteEditBusy, row >= 0, row < remoteItems.count else { return }
         let item = remoteItems[row]
         if item.isDirectory && !item.isSymlink {
             refreshRemote(remoteChild(remoteCurrent, item.name))
@@ -985,7 +1297,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     @objc private func downloadTapped() {
-        guard !remoteFilterBusy else { return }
+        guard !remoteFilterBusy, !remoteEditBusy else { return }
         queueTransfer(direction: "download", rows: remoteTable.selectedRowIndexes)
     }
 
@@ -1035,7 +1347,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     }
 
     private func refreshRemote(_ requestedPath: String) {
-        guard engineReady, GhostFTPIsConnected() == 1 else { return }
+        guard engineReady, GhostFTPIsConnected() == 1, !remoteEditBusy else { return }
         remoteNavigationGeneration += 1
         let generation = remoteNavigationGeneration
         let target = requestedPath
@@ -1114,7 +1426,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
             showError("Connect to a server before transferring files.")
             return
         }
-        if (direction == "upload" && localFilterBusy) || (direction == "download" && remoteFilterBusy) {
+        if (direction == "upload" && localFilterBusy) || (direction == "download" && (remoteFilterBusy || remoteEditBusy)) {
             return
         }
         let items = direction == "upload" ? localItems : remoteItems
@@ -1217,9 +1529,17 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     private func updateWorkspaceControls() {
         let connected = engineReady && GhostFTPIsConnected() == 1 && !connectionBusy
         let localSelectionCount = localTable.selectedRowIndexes.count
-        let remoteSelectionCount = remoteTable.selectedRowIndexes.count
+        let remoteSelection = remoteTable.selectedRowIndexes
+        let remoteSelectionCount = remoteSelection.count
+        let selectedRemoteFile: FileItem? = {
+            guard remoteSelectionCount == 1,
+                  let index = remoteSelection.first,
+                  index >= 0,
+                  index < remoteItems.count else { return nil }
+            return remoteItems[index]
+        }()
         let localReady = engineReady && !localMutationBusy && !localFilterBusy
-        let remoteReady = connected && !remoteMutationBusy && !remoteFilterBusy
+        let remoteReady = connected && !remoteMutationBusy && !remoteEditBusy && !remoteFilterBusy
 
         updateFilterButtonLabels()
         localChooseButton.isEnabled = localReady
@@ -1238,6 +1558,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         remoteRenameButton.isEnabled = remoteReady && remoteSelectionCount == 1
         remoteDeleteButton.isEnabled = remoteReady && remoteSelectionCount > 0
         remotePermissionsButton.isEnabled = remoteReady && remoteSelectionCount > 0
+        remoteEditButton.isEnabled = remoteReady && selectedRemoteFile.map { !$0.isDirectory && !$0.isSymlink } == true
         remoteFilterButton.isEnabled = remoteReady
         downloadButton.isEnabled = remoteReady && remoteSelectionCount > 0
         remoteTable.isEnabled = remoteReady

--- a/scripts/test_macos_remote_edit_contract.py
+++ b/scripts/test_macos_remote_edit_contract.py
@@ -1,0 +1,62 @@
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class MacOSRemoteEditContract(unittest.TestCase):
+    def read(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def test_shared_engine_keeps_conflict_and_read_back_guards(self):
+        source = self.read("internal/api/remote_edit.go")
+        self.assertIn("func (e *Engine) RemoteEditOpen", source)
+        self.assertIn("func (e *Engine) RemoteEditSave", source)
+        self.assertIn("ErrRemoteEditConflict", source)
+        self.assertIn("verified.Revision != writtenRevision", source)
+        self.assertIn("remote edit was uploaded but read-back content did not match", source)
+        self.assertIn("MaxRemoteEditBytes", source)
+
+    def test_macos_bridge_is_only_a_typed_adapter_to_shared_remote_edit(self):
+        bridge = self.read("macos/Bridge/remote_edit.go")
+        self.assertIn("//export GhostFTPRemoteEditOpen", bridge)
+        self.assertIn("//export GhostFTPRemoteEditSave", bridge)
+        self.assertIn("bridgeState.engine.RemoteEditOpen", bridge)
+        self.assertIn("bridgeState.engine.RemoteEditSave", bridge)
+        self.assertIn("expectedRevision", bridge)
+        self.assertIn("context.WithTimeout", bridge)
+        self.assertNotIn("Upload(", bridge)
+        self.assertNotIn("Download(", bridge)
+        self.assertNotIn("exec.Command", bridge)
+        self.assertNotIn("os.StartProcess", bridge)
+
+    def test_appkit_editor_binds_to_visible_file_and_revision(self):
+        source = self.read("macos/Sources/GhostFTPApp/main.swift")
+        self.assertIn('NSButton(title: "Edit"', source)
+        self.assertIn("remoteEditTapped", source)
+        self.assertIn("GhostFTPRemoteEditOpen", source)
+        self.assertIn("GhostFTPRemoteEditSave", source)
+        self.assertIn("remoteEditGeneration", source)
+        self.assertIn("expectedRevision", source)
+        self.assertIn("NSTextView", source)
+        self.assertIn("api.MaxRemoteEditBytes", self.read("internal/api/remote_edit.go"))
+        self.assertNotIn("NSWorkspace.shared.open", source)
+
+    def test_save_revalidates_navigation_before_refresh(self):
+        source = self.read("macos/Sources/GhostFTPApp/main.swift")
+        start = source.index("private func saveRemoteEdit")
+        end = source.index("private func", start + len("private func saveRemoteEdit"))
+        body = source[start:end]
+        self.assertIn("expectedRevision", body)
+        self.assertIn("remoteEditGeneration", body)
+        self.assertIn("remoteNavigationGeneration", body)
+        self.assertIn("remoteCurrent == base", body)
+        self.assertIn("refreshRemote(base)", body)
+
+    def test_parity_marks_remote_edit_complete_only_with_implementation(self):
+        parity = self.read("macos/PARITY.md")
+        self.assertIn("- [x] Remote Edit", parity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_macos_remote_edit_contract.py
+++ b/scripts/test_macos_remote_edit_contract.py
@@ -39,7 +39,7 @@ class MacOSRemoteEditContract(unittest.TestCase):
         self.assertIn("remoteEditGeneration", source)
         self.assertIn("expectedRevision", source)
         self.assertIn("NSTextView", source)
-        self.assertIn("api.MaxRemoteEditBytes", self.read("internal/api/remote_edit.go"))
+        self.assertIn("const MaxRemoteEditBytes int64 = 4 << 20", self.read("internal/api/remote_edit.go"))
         self.assertNotIn("NSWorkspace.shared.open", source)
 
     def test_save_revalidates_navigation_before_refresh(self):

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -75,6 +75,7 @@ IMPLEMENTED_MACOS_ACTIONS = {
     "Remote Rename",
     "Remote Delete",
     "Remote Permissions",
+    "Remote Edit",
     "Remote Filter",
     "Upload",
     "Download",


### PR DESCRIPTION
## Summary

Adds native macOS Remote Edit parity using the existing shared `internal/api.Engine` Remote Edit contract. This PR starts with a regression contract before implementation.

## Safety contract

- Use shared `RemoteEditOpen` / `RemoteEditSave`; no second FTP/SFTP stack.
- Keep revision-conflict detection and post-upload read-back verification authoritative.
- Bind editing to the visible remote file/navigation generation.
- Reject directories/symlinks through the existing shared API and UI selection guard.
- No external editor process, shell execution, telemetry, or credential changes.
- Refresh remote metadata only after a verified save and only if the originating navigation is still current.

## Validation

Exact-head CI only. The initial contract commit is expected to remain red until implementation lands; subsequent commits must replace that evidence with green exact-head runs.