### PR TITLE
chore: sync main into macOS directory compare

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -1,0 +1,70 @@
+name: Ghost FTP Fuzz Smoke
+
+on:
+  push:
+    branches: [main, 'work/**', 'release/**']
+    paths:
+      - 'internal/remote/**'
+      - 'internal/security/**'
+      - '.github/workflows/fuzz-smoke.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/remote/**'
+      - 'internal/security/**'
+      - '.github/workflows/fuzz-smoke.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-fuzz-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+  GOPROXY: off
+  GOSUMDB: off
+
+jobs:
+  fuzz:
+    name: Security parser fuzz smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+      - name: Fuzz remote listing parsers
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/remote -run='^$' -fuzz='^FuzzRemoteListingParsers$' -fuzztime=15s
+      - name: Fuzz security validators
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/security -run='^$' -fuzz='^FuzzSecurityValidators$' -fuzztime=15s
+      - name: Store fuzz failure corpus
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-fuzz-failure-corpus
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            internal/remote/testdata/fuzz/**
+            internal/security/testdata/fuzz/**

--- a/internal/remote/parser_fuzz_test.go
+++ b/internal/remote/parser_fuzz_test.go
@@ -1,0 +1,52 @@
+package remote
+
+import "testing"
+
+func FuzzRemoteListingParsers(f *testing.F) {
+	for _, seed := range [][]byte{
+		[]byte("type=file;size=42;modify=20260912103045; report.txt\r\n"),
+		[]byte("type=dir;modify=20260912103045; public_html\r\n"),
+		[]byte("type=OS.unix=slink;size=0; link -> target\r\n"),
+		[]byte("-rw-r--r-- 1 user group 42 Sep 12 10:30 report.txt"),
+		[]byte("lrwxrwxrwx 1 user group 6 Sep 12 10:30 link -> target"),
+		[]byte("09-12-26  10:30AM  <DIR>          public_html"),
+		[]byte("09-12-26  10:30AM  123456 report.zip"),
+		[]byte("type=file;size=999999999999999999999999999999; huge.bin"),
+		[]byte("\x00\xff\xfe malformed"),
+		{},
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		line := string(data)
+
+		if item, ok := parseMLSDLine(line); ok {
+			if item.Name == "" || item.Name == "." || item.Name == ".." {
+				t.Fatalf("MLSD parser accepted unsafe empty/dot name %q", item.Name)
+			}
+			if item.Size < 0 {
+				t.Fatalf("MLSD parser produced negative size %d", item.Size)
+			}
+		}
+
+		items, _, err := parseMLSD(data)
+		if err == nil {
+			if len(items) > maxDirectoryItems {
+				t.Fatalf("MLSD parser exceeded item limit: %d", len(items))
+			}
+			for _, item := range items {
+				if item.Name == "" || item.Name == "." || item.Name == ".." {
+					t.Fatalf("MLSD parser returned unsafe name %q", item.Name)
+				}
+				if item.Size < 0 {
+					t.Fatalf("MLSD parser returned negative size %d", item.Size)
+				}
+			}
+		}
+
+		if item, ok := parseListLine(line); ok && item.Size < 0 {
+			t.Fatalf("LIST parser produced negative size %d", item.Size)
+		}
+	})
+}

--- a/internal/security/validate_fuzz_test.go
+++ b/internal/security/validate_fuzz_test.go
@@ -1,0 +1,62 @@
+package security
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzSecurityValidators(f *testing.F) {
+	for _, seed := range []string{
+		"example.com",
+		"[2001:db8::1]",
+		"2001:db8::1",
+		"public_html/file.txt",
+		"../escape",
+		"report.txt",
+		"CON",
+		"secret-value",
+		"line\r\nbreak",
+		"\x00",
+		"",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		if err := ValidateRemotePath(value); err == nil {
+			if len(value) > 4096 || !utf8.ValidString(value) || strings.ContainsAny(value, "\x00\r\n") {
+				t.Fatalf("ValidateRemotePath accepted structurally forbidden input %q", value)
+			}
+			for _, part := range strings.Split(strings.ReplaceAll(value, "\\", "/"), "/") {
+				if part == ".." {
+					t.Fatalf("ValidateRemotePath accepted traversal input %q", value)
+				}
+			}
+		}
+
+		if err := ValidateRemoteName(value); err == nil {
+			if value == "" || value == "." || value == ".." || len(value) > 1024 || !utf8.ValidString(value) || strings.ContainsAny(value, "\x00\r\n/\\") {
+				t.Fatalf("ValidateRemoteName accepted structurally forbidden input %q", value)
+			}
+		}
+
+		if err := ValidateName(value); err == nil {
+			if value == "" || value != strings.TrimSpace(value) || value == "." || value == ".." || len(value) > 255 || !utf8.ValidString(value) || !safeName.MatchString(value) || strings.HasSuffix(value, ".") || strings.HasSuffix(value, " ") {
+				t.Fatalf("ValidateName accepted structurally forbidden input %q", value)
+			}
+		}
+
+		if err := ValidateHost(value); err == nil {
+			if value == "" || value != strings.TrimSpace(value) || len(value) > 253 || !utf8.ValidString(value) || strings.ContainsAny(value, "\x00\r\n\t /\\@") {
+				t.Fatalf("ValidateHost accepted structurally forbidden input %q", value)
+			}
+		}
+
+		if err := ValidateSecret(value); err == nil {
+			if len(value) > 8192 || !utf8.ValidString(value) || strings.ContainsAny(value, "\x00\r\n") {
+				t.Fatalf("ValidateSecret accepted structurally forbidden input %q", value)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Syncs the latest `main` security-fuzz CI commit into `feature/macos-directory-compare` before #279 can be validated for merge. No Directory Compare scope expansion; this restores `behind_by=0` and forces exact-head validation against the current base.