### PR TITLE
ci: add pinned CodeQL Go analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: Ghost FTP CodeQL
+
+on:
+  push:
+    branches: [main, 'work/**', 'release/**']
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 3'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ghostftp-codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+  GOPROXY: off
+  GOSUMDB: off
+
+jobs:
+  analyze:
+    name: Analyze Go security
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4 / CodeQL bundle 2.27.0
+        with:
+          languages: go
+          build-mode: manual
+      - name: Build analyzed Go source
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./...
+          go vet ./...
+      - name: Analyze
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4 / CodeQL bundle 2.27.0
+        with:
+          category: '/language:go'


### PR DESCRIPTION
## Summary

Adds a dedicated CodeQL security-analysis workflow for the Go codebase without adding any application/runtime dependency.

### Security properties

- GitHub CodeQL action is pinned to exact commit `b96794f015dfd88f77b49b1c93e0fa7110f94c63` (v4 / CodeQL bundle 2.27.0)
- checkout and setup-go remain pinned to exact action SHAs
- workflow token is limited to `contents: read` and `security-events: write`
- Go toolchain remains `GOTOOLCHAIN=local`, `GOPROXY=off`, `GOSUMDB=off`
- Go telemetry is explicitly disabled
- analysis uses the repository's existing Go 1.27.1 and runs `go test ./...` plus `go vet ./...` as the traced manual build
- scheduled weekly analysis supplements push and pull-request scanning

### Scope

Adds one CI workflow only. No `go.mod`, production source, transport code, credential handling, packaging or release behavior changes.