### PR TITLE
chore: sync release permission hardening into macOS directory compare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ghostftp-release
@@ -283,6 +282,9 @@ jobs:
     needs: [quality, windows, linux]
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: write
+      packages: write
     env:
       WINDOWS_SIGNING_STATE: ${{ needs.windows.outputs.signing_state }}
     steps:

--- a/scripts/test_release_permissions.py
+++ b/scripts/test_release_permissions.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression tests for least-privilege release workflow permissions."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+
+class ReleasePermissionsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        marker = "\n  publish:\n"
+        if marker not in cls.workflow:
+            raise AssertionError("release workflow is missing the publish job")
+        cls.pre_publish, cls.publish = cls.workflow.split(marker, 1)
+
+    def test_workflow_default_is_read_only(self) -> None:
+        self.assertRegex(
+            self.workflow,
+            re.compile(r"(?m)^permissions:\n  contents: read\n(?:\n|concurrency:)")
+        )
+        self.assertNotIn("packages: write", self.pre_publish)
+        self.assertNotIn("contents: write", self.pre_publish)
+
+    def test_publish_job_has_only_required_write_scopes(self) -> None:
+        required = (
+            "    permissions:\n"
+            "      contents: write\n"
+            "      packages: write\n"
+        )
+        self.assertIn(required, self.publish)
+        self.assertEqual(self.workflow.count("contents: write"), 1)
+        self.assertEqual(self.workflow.count("packages: write"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Syncs current `main` release-permission hardening into `feature/macos-directory-compare` before #279 merge validation. No Directory Compare scope expansion; this restores `behind_by=0` and forces exact-head CI against the current base.