### PR TITLE
ci: add pinned govulncheck security scan

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,62 @@
+name: Ghost FTP Govulncheck
+
+on:
+  push:
+    branches: [main, 'work/**', 'release/**']
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '41 4 * * 4'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-govulncheck-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+
+jobs:
+  scan:
+    name: Scan reachable Go vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+      - name: Install pinned govulncheck
+        shell: bash
+        env:
+          GOPROXY: https://proxy.golang.org
+          GOSUMDB: sum.golang.org
+        run: |
+          set -euo pipefail
+          install_dir="$RUNNER_TEMP/ghostftp-security-bin"
+          mkdir -p "$install_dir"
+          GOBIN="$install_dir" go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          test -x "$install_dir/govulncheck"
+      - name: Scan Ghost FTP Go packages
+        shell: bash
+        env:
+          GOPROXY: off
+          GOSUMDB: off
+        run: |
+          set -euo pipefail
+          test "$(go telemetry)" = 'off'
+          "$RUNNER_TEMP/ghostftp-security-bin/govulncheck" ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -49,7 +49,7 @@ jobs:
           set -euo pipefail
           install_dir="$RUNNER_TEMP/ghostftp-security-bin"
           mkdir -p "$install_dir"
-          GOBIN="$install_dir" go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          GOBIN="$install_dir" go install golang.org/x/vuln/cmd/govulncheck@709015412431dd2b5b28a53c06c70bc02d49074c
           test -x "$install_dir/govulncheck"
       - name: Scan Ghost FTP Go packages
         shell: bash


### PR DESCRIPTION
## Summary

Adds a dedicated Go vulnerability scan without changing Ghost FTP runtime dependencies or the production/offline build contract.

### Supply-chain and privacy controls

- installs `govulncheck` from exact upstream commit `709015412431dd2b5b28a53c06c70bc02d49074c` (2026-09-08), not `@latest`
- this upstream commit uses `golang.org/x/tools v0.50.0`, avoiding the Go 1.27 SSA panic present in the older v1.1.4 release
- the scanner install step alone may use `proxy.golang.org` + `sum.golang.org`
- project scanning returns to `GOPROXY=off` / `GOSUMDB=off`
- Go telemetry is explicitly disabled before installation and checked again before scanning
- workflow token has only `contents: read`
- checkout/setup-go actions remain pinned to exact SHAs
- runs on pull requests, relevant pushes and a weekly schedule

### Scope

Adds one CI workflow only. No `go.mod`, `go.sum`, runtime code, transport behavior, credential storage, packaging or release logic changes.

### Validation note

The first attempt used released `govulncheck v1.1.4`; it installed correctly but its old `x/tools v0.29.0` panicked under Go 1.27.1. That failure was not suppressed. The workflow was updated to a current exact upstream commit with `x/tools v0.50.0` and is being revalidated.