### PR TITLE
chore: sync CodeQL hardening into macOS directory compare

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: Ghost FTP CodeQL
+
+on:
+  push:
+    branches: [main, 'work/**', 'release/**']
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 3'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ghostftp-codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+  GOPROXY: off
+  GOSUMDB: off
+
+jobs:
+  analyze:
+    name: Analyze Go security
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4 / CodeQL bundle 2.27.0
+        with:
+          languages: go
+          build-mode: manual
+      - name: Build analyzed Go source
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./...
+          go vet ./...
+      - name: Analyze
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4 / CodeQL bundle 2.27.0
+        with:
+          category: '/language:go'


### PR DESCRIPTION
Syncs current `main` pinned CodeQL workflow into `feature/macos-directory-compare` before #279 merge validation. No Directory Compare scope expansion; this restores `behind_by=0` and forces exact-head validation against the current base.