### PR TITLE
chore: sync latest security hardening into macOS directory compare

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,62 @@
+name: Ghost FTP Govulncheck
+
+on:
+  push:
+    branches: [main, 'work/**', 'release/**']
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '41 4 * * 4'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-govulncheck-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+
+jobs:
+  scan:
+    name: Scan reachable Go vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+      - name: Disable Go telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+      - name: Install pinned govulncheck
+        shell: bash
+        env:
+          GOPROXY: https://proxy.golang.org
+          GOSUMDB: sum.golang.org
+        run: |
+          set -euo pipefail
+          install_dir="$RUNNER_TEMP/ghostftp-security-bin"
+          mkdir -p "$install_dir"
+          GOBIN="$install_dir" go install golang.org/x/vuln/cmd/govulncheck@709015412431dd2b5b28a53c06c70bc02d49074c
+          test -x "$install_dir/govulncheck"
+      - name: Scan Ghost FTP Go packages
+        shell: bash
+        env:
+          GOPROXY: off
+          GOSUMDB: off
+        run: |
+          set -euo pipefail
+          test "$(go telemetry)" = 'off'
+          "$RUNNER_TEMP/ghostftp-security-bin/govulncheck" ./...

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # Ghost FTP security
 
-Ghost FTP **0.0.4** uses explicit transport, path, secret, process and release boundaries. Security-sensitive behavior is implemented in typed code and covered by platform-specific regression tests, exact-head native builds and repository audits.
+Ghost FTP **0.0.5** uses explicit transport, path, secret, process and release boundaries. Security-sensitive behavior is implemented in typed code and covered by platform-specific regression tests, exact-head native builds and repository audits.
 
 ## Supported transport security
 
@@ -13,7 +13,7 @@ Ghost FTP supports FTP, FTPS and SFTP on the maintained desktop engine.
 
 Connection profiles are validated before use: host, port, protocol, remote path, credential fields and key/fingerprint inputs pass through bounded validation logic.
 
-The Android development client preserves the same no-silent-downgrade and strict FTPS certificate/hostname-verification intent while using platform-native storage/activity boundaries. Its APK is development evidence in 0.0.4, not a public release artifact.
+The Android development client preserves the same no-silent-downgrade and strict FTPS certificate/hostname-verification intent while using platform-native storage/activity boundaries. Its APK is development evidence in 0.0.5, not a public release artifact.
 
 ## SFTP host-key trust
 
@@ -123,7 +123,7 @@ The production/release-validation workflows:
 
 Private signing material must never be committed to source. Absence of a production code-signing certificate is represented truthfully as an unsigned Windows release rather than “fixed” with an untrusted generated key.
 
-Android remains outside the 0.0.4 public release allow-list. A development APK succeeding in CI is not authorization to publish it as a production mobile release.
+Android remains outside the 0.0.5 public release allow-list. A development APK succeeding in CI is not authorization to publish it as a production mobile release.
 
 ## GitHub Packages boundary
 
@@ -131,7 +131,7 @@ The current package at `ghcr.io/bren-wp/ghost-ftp` is a release distribution bun
 
 ## Security testing
 
-The exact 0.0.4 candidate is expected to pass:
+The exact 0.0.5 candidate is expected to pass:
 
 ```text
 go test -race ./...


### PR DESCRIPTION
Syncs the two latest `main` commits into `feature/macos-directory-compare` before #279 merge validation:

- documentation alignment to 0.0.5
- pinned govulncheck security workflow

No Directory Compare scope expansion. This is only to restore `behind_by=0` and force exact-head CI on the current base.