### PR TITLE
security: harden curl config quoting against control-character injection

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -53,6 +53,11 @@ jobs:
         run: |
           set -euo pipefail
           go test ./internal/remote -run='^$' -fuzz='^FuzzRemoteListingParsers$' -fuzztime=15s
+      - name: Fuzz curl config quoting
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/remote -run='^$' -fuzz='^FuzzCurlConfigQuoting$' -fuzztime=15s
       - name: Fuzz security validators
         shell: bash
         run: |

--- a/internal/remote/curl_config_quoting_security_test.go
+++ b/internal/remote/curl_config_quoting_security_test.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCfgQuoteEscapesCurlConfigControlCharacters(t *testing.T) {
+	input := "folder\tname\nnext\rline\vquote\"slash\\end"
+	got := cfgQuote(input)
+	want := `"folder\tname\nnext\rline\vquote\"slash\\end"`
+	if got != want {
+		t.Fatalf("cfgQuote()=%q want %q", got, want)
+	}
+	if strings.ContainsAny(got, "\t\n\r\v") {
+		t.Fatalf("cfgQuote left a physical config control character in %q", got)
+	}
+}
+
+func TestAppendCfgQuotedBytesMatchesStringQuoting(t *testing.T) {
+	input := []byte("user\tname:pass\nword\rnext\vline\"\\")
+	got := string(appendCfgQuotedBytes(nil, input))
+	want := cfgQuote(string(input))
+	if got != want {
+		t.Fatalf("appendCfgQuotedBytes()=%q want %q", got, want)
+	}
+	if strings.ContainsAny(got, "\t\n\r\v") {
+		t.Fatalf("byte quoting left a physical config control character in %q", got)
+	}
+}
+
+func TestCurlDownloadOutputPathCannotInjectConfigLine(t *testing.T) {
+	path := "/safe/root\nurl = \"https://attacker.invalid/\"/.GhostFTP-part-token"
+	line := "output = " + cfgQuote(path)
+	if strings.ContainsAny(line, "\r\n") {
+		t.Fatalf("quoted output path created an additional physical curl config line: %q", line)
+	}
+	if !strings.Contains(line, `\nurl = \"https://attacker.invalid/\"`) {
+		t.Fatalf("newline was not encoded inside the quoted value: %q", line)
+	}
+}
+
+func FuzzCurlConfigQuoting(f *testing.F) {
+	for _, seed := range []string{
+		"plain",
+		"with spaces",
+		"quote\"and\\slash",
+		"tab\tnewline\ncarriage\rvertical\v",
+		"/tmp/root\nurl = \"https://attacker.invalid/\"/file",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		quoted := cfgQuote(input)
+		if len(quoted) < 2 || quoted[0] != '"' || quoted[len(quoted)-1] != '"' {
+			t.Fatalf("quoted value is not bounded by double quotes: %q", quoted)
+		}
+		if strings.ContainsAny(quoted, "\t\n\r\v") {
+			t.Fatalf("quoted value contains a physical curl config control character: %q", quoted)
+		}
+		byteQuoted := string(appendCfgQuotedBytes(nil, []byte(input)))
+		if byteQuoted != quoted {
+			t.Fatalf("string and byte quoting diverged: string=%q bytes=%q", quoted, byteQuoted)
+		}
+	})
+}

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -355,6 +355,7 @@ func (c *CurlFTP) List(ctx context.Context, p string) ([]model.Item, error) {
 				return nil, errors.New("folder contains too many items for safe display")
 			}
 		}
+	}
 	sortItems(items)
 	return items, nil
 }

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -80,18 +80,47 @@ func (c *CurlFTP) Close() error {
 }
 
 func cfgQuote(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteByte(s[i])
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\v':
+			b.WriteString(`\v`)
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func appendCfgQuotedBytes(dst []byte, value []byte) []byte {
 	dst = append(dst, '"')
 	for _, b := range value {
-		if b == '\\' || b == '"' {
-			dst = append(dst, '\\')
+		switch b {
+		case '\\', '"':
+			dst = append(dst, '\\', b)
+		case '\t':
+			dst = append(dst, '\\', 't')
+		case '\n':
+			dst = append(dst, '\\', 'n')
+		case '\r':
+			dst = append(dst, '\\', 'r')
+		case '\v':
+			dst = append(dst, '\\', 'v')
+		default:
+			dst = append(dst, b)
 		}
-		dst = append(dst, b)
 	}
 	return append(dst, '"')
 }
@@ -326,7 +355,6 @@ func (c *CurlFTP) List(ctx context.Context, p string) ([]model.Item, error) {
 				return nil, errors.New("folder contains too many items for safe display")
 			}
 		}
-	}
 	sortItems(items)
 	return items, nil
 }


### PR DESCRIPTION
## Authorization

- [x] This source-code change was explicitly requested or authorized for Ghost FTP.
- [x] I have read and will follow `LICENSE` and the contribution documentation.

## Summary

Hardens Ghost FTP's `curl --config -` boundary so quoted config values cannot introduce additional physical config lines through control characters.

### Changes

- Escape curl-supported control characters (`\t`, `\n`, `\r`, `\v`) in `cfgQuote` while preserving existing quote/backslash escaping.
- Apply the same encoding to byte-based credential quoting.
- Add regression coverage proving a newline-bearing local download root cannot inject a second curl config directive.
- Add `FuzzCurlConfigQuoting` to check string/byte quoting equivalence and reject physical curl config control characters.
- Run the new target in the existing path-scoped fuzz-smoke workflow.

## Security rationale

Curl config files require one option per physical line. Linux/macOS filesystem paths can contain newline characters, and Ghost FTP's download staging path contains the user-selected root directory. Encoding these characters inside quoted config values removes that line-injection boundary while preserving the intended value using curl's documented quoted-string escapes.

## Security and privacy

- [x] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [x] No automatic external API or hidden network destination was added.
- [x] Passwords, private-key passphrases and private keys remain out of command-line arguments and persistent logs.
- [x] SFTP host-key verification and pinning are unchanged.
- [x] Local path-traversal, symlink, junction and reparse-point protections are unchanged.
- [x] No external Go module was added.
- [x] Tests contain no real credentials, production servers or customer data.

## Validation

CI is expected to run the existing race/vet/security/privacy/release checks, Windows/Linux builds, CodeQL, govulncheck and the expanded fuzz-smoke workflow. Merge only after all applicable checks are green.

## Scope

No protocol behavior, transfer commit semantics, credential storage or dependency model changes. Runtime change is limited to curl config value serialization.