### PR TITLE
chore: sync curl config hardening into macOS directory compare

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -53,6 +53,11 @@ jobs:
         run: |
           set -euo pipefail
           go test ./internal/remote -run='^$' -fuzz='^FuzzRemoteListingParsers$' -fuzztime=15s
+      - name: Fuzz curl config quoting
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/remote -run='^$' -fuzz='^FuzzCurlConfigQuoting$' -fuzztime=15s
       - name: Fuzz security validators
         shell: bash
         run: |

--- a/internal/remote/curl_config_quoting_security_test.go
+++ b/internal/remote/curl_config_quoting_security_test.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCfgQuoteEscapesCurlConfigControlCharacters(t *testing.T) {
+	input := "folder\tname\nnext\rline\vquote\"slash\\end"
+	got := cfgQuote(input)
+	want := `"folder\tname\nnext\rline\vquote\"slash\\end"`
+	if got != want {
+		t.Fatalf("cfgQuote()=%q want %q", got, want)
+	}
+	if strings.ContainsAny(got, "\t\n\r\v") {
+		t.Fatalf("cfgQuote left a physical config control character in %q", got)
+	}
+}
+
+func TestAppendCfgQuotedBytesMatchesStringQuoting(t *testing.T) {
+	input := []byte("user\tname:pass\nword\rnext\vline\"\\")
+	got := string(appendCfgQuotedBytes(nil, input))
+	want := cfgQuote(string(input))
+	if got != want {
+		t.Fatalf("appendCfgQuotedBytes()=%q want %q", got, want)
+	}
+	if strings.ContainsAny(got, "\t\n\r\v") {
+		t.Fatalf("byte quoting left a physical config control character in %q", got)
+	}
+}
+
+func TestCurlDownloadOutputPathCannotInjectConfigLine(t *testing.T) {
+	path := "/safe/root\nurl = \"https://attacker.invalid/\"/.GhostFTP-part-token"
+	line := "output = " + cfgQuote(path)
+	if strings.ContainsAny(line, "\r\n") {
+		t.Fatalf("quoted output path created an additional physical curl config line: %q", line)
+	}
+	if !strings.Contains(line, `\nurl = \"https://attacker.invalid/\"`) {
+		t.Fatalf("newline was not encoded inside the quoted value: %q", line)
+	}
+}
+
+func FuzzCurlConfigQuoting(f *testing.F) {
+	for _, seed := range []string{
+		"plain",
+		"with spaces",
+		"quote\"and\\slash",
+		"tab\tnewline\ncarriage\rvertical\v",
+		"/tmp/root\nurl = \"https://attacker.invalid/\"/file",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		quoted := cfgQuote(input)
+		if len(quoted) < 2 || quoted[0] != '"' || quoted[len(quoted)-1] != '"' {
+			t.Fatalf("quoted value is not bounded by double quotes: %q", quoted)
+		}
+		if strings.ContainsAny(quoted, "\t\n\r\v") {
+			t.Fatalf("quoted value contains a physical curl config control character: %q", quoted)
+		}
+		byteQuoted := string(appendCfgQuotedBytes(nil, []byte(input)))
+		if byteQuoted != quoted {
+			t.Fatalf("string and byte quoting diverged: string=%q bytes=%q", quoted, byteQuoted)
+		}
+	})
+}

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -355,6 +355,7 @@ func (c *CurlFTP) List(ctx context.Context, p string) ([]model.Item, error) {
 				return nil, errors.New("folder contains too many items for safe display")
 			}
 		}
+	}
 	sortItems(items)
 	return items, nil
 }

--- a/internal/remote/curl_ftp.go
+++ b/internal/remote/curl_ftp.go
@@ -80,18 +80,47 @@ func (c *CurlFTP) Close() error {
 }
 
 func cfgQuote(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteByte(s[i])
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\v':
+			b.WriteString(`\v`)
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func appendCfgQuotedBytes(dst []byte, value []byte) []byte {
 	dst = append(dst, '"')
 	for _, b := range value {
-		if b == '\\' || b == '"' {
-			dst = append(dst, '\\')
+		switch b {
+		case '\\', '"':
+			dst = append(dst, '\\', b)
+		case '\t':
+			dst = append(dst, '\\', 't')
+		case '\n':
+			dst = append(dst, '\\', 'n')
+		case '\r':
+			dst = append(dst, '\\', 'r')
+		case '\v':
+			dst = append(dst, '\\', 'v')
+		default:
+			dst = append(dst, b)
 		}
-		dst = append(dst, b)
 	}
 	return append(dst, '"')
 }
@@ -326,7 +355,6 @@ func (c *CurlFTP) List(ctx context.Context, p string) ([]model.Item, error) {
 				return nil, errors.New("folder contains too many items for safe display")
 			}
 		}
-	}
 	sortItems(items)
 	return items, nil
 }


### PR DESCRIPTION
Syncs current `main` into `feature/macos-directory-compare` before #279 merge validation. Current main contains the merged curl-config control-character hardening and its security fuzz coverage. No Directory Compare scope expansion; this restores the feature to the current security baseline and forces exact-head validation again.