### PR TITLE
chore: sync signed Windows release hardening into macOS directory compare

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -108,10 +108,11 @@ The production/release-validation workflows:
 - build Windows/Linux artifacts from exact source;
 - lint/build/verify the Android development APK from exact source;
 - run exact-head authentic Windows/Linux/Android UI evidence without allowing the evidence workflow to commit or push into the tested branch;
-- optionally sign Windows artifacts with a protected trusted Authenticode identity when configured;
-- verify every configured production signature and never label unsigned artifacts as signed;
+- require public Windows release artifacts to be signed with a protected trusted Authenticode identity;
+- fail closed before publication when the production Windows signing identity is absent or either public executable is unsigned;
+- verify every configured production signature and require valid Authenticode status before publication;
 - never generate a self-signed production publisher identity;
-- remove temporary signing material from the runner when signing is used;
+- remove temporary signing material from the runner after signing;
 - assemble only an explicit Windows/Linux public release file set;
 - record the Windows signing state in `BUILD-METADATA.txt`;
 - generate SHA-256 checksums;
@@ -121,7 +122,7 @@ The production/release-validation workflows:
 - verify the registry artifact can be read back;
 - permit latest-only cleanup only after the newly published release has been fully verified.
 
-Private signing material must never be committed to source. Absence of a production code-signing certificate is represented truthfully as an unsigned Windows release rather than “fixed” with an untrusted generated key.
+Private signing material must never be committed to source. Public Windows publication requires the protected production signing identity; absence of that identity causes the release build to fail instead of publishing unsigned Windows binaries. Ordinary CI, development and local builds may remain unsigned because they are not public release artifacts.
 
 Android remains outside the 0.0.5 public release allow-list. A development APK succeeding in CI is not authorization to publish it as a production mobile release.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -96,19 +96,19 @@ Android source reads root `VERSION`, but the maintained artifact is an installab
 
 ## Windows signing state
 
-Windows Authenticode is an **optional production hardening layer**. When a trusted production identity is configured through protected Actions secrets, signatures must verify or publication fails.
+Windows Authenticode is a **required public-release trust boundary**. Public Setup and Portable executables must be signed with the protected trusted production identity, and the signatures must verify successfully before publication can continue.
 
-Without a production certificate, publication remains truthful through:
+The canonical public release state is:
 
 ```text
-WINDOWS_AUTHENTICODE=unsigned
+WINDOWS_AUTHENTICODE=signed
 ```
 
-**Absence of a production Authenticode certificate by itself is not a versioning failure.** Ghost FTP never creates a self-signed production certificate and represents it as a trusted publisher.
+**Absence of the production Authenticode identity is a release failure.** Ghost FTP never creates a self-signed production certificate or publishes unsigned Windows binaries as the current public release. Ordinary CI, development and local builds may remain unsigned because they are not public release artifacts.
 
 ## Version source integrity
 
-Release/CI validation rejects malformed semantic versions, `0.0.0`, release-branch/source-version mismatch, non-exact-main release branches, conflicting current tags/releases, incomplete release assets, architecture-specific public Windows leakage, failed configured signatures, source/main drift, incorrect prerelease flags, missing GHCR exact-version bundle, failed release read-back or failed latest-only retention cleanup.
+Release/CI validation rejects malformed semantic versions, `0.0.0`, release-branch/source-version mismatch, non-exact-main release branches, conflicting current tags/releases, incomplete release assets, architecture-specific public Windows leakage, absent or failed public Windows signatures, source/main drift, incorrect prerelease flags, missing GHCR exact-version bundle, failed release read-back or failed latest-only retention cleanup.
 
 Active release-bound documentation must agree with root `VERSION`, `CHANNEL=Current`, `PRERELEASE=false`, the 14/17 packaging contract and the current package identity.
 
@@ -134,6 +134,7 @@ The exact candidate must pass:
 - Linux trusted transport/AskPass provenance checks;
 - Android source contract, lifecycle connection ownership, strict FTPS/parser bounds, lint, installable development APK and APK verification;
 - universal Windows Setup and Portable production builds with verified native payloads;
+- trusted Authenticode signing and verification for both public Windows executables;
 - Linux Debian/Ubuntu/Fedora/Portable build, metadata, extraction and binary parity;
 - Debian 13 amd64, Ubuntu 26.04 LTS amd64 and Fedora 44 x86_64 install/remove/GUI smoke;
 - 24-language localization and authentic Windows/Linux/Android UI evidence;

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -209,6 +209,12 @@ def main() -> int:
         "WINDOWS_PUBLIC_EXECUTABLES=2",
     )
     require(
+        "scripts/verify_release.py",
+        'PUBLIC_WINDOWS_RELEASE_WORKFLOW = "Publish Ghost FTP"',
+        "public Windows release artifacts must be Authenticode signed",
+        "require_public_release_signatures(ssigned, psigned)",
+    )
+    require(
         "BUILD-WINDOWS-ARCH-STAGE.ps1",
         "function Build-GhostFTPArchitecture",
         "function Sign-WindowsTarget",
@@ -305,7 +311,7 @@ def main() -> int:
     print("LATEST_ONLY_RELEASE_RETENTION=YES")
     print("RELEASE_RETENTION_CHAIN=REQUIRED")
     print("AUTHENTICODE_PRIVATE_KEY_IN_REPOSITORY=BLOCKED")
-    print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
+    print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
     print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("PUBLIC_PLATFORM_ARTIFACTS=14")

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -110,9 +110,9 @@ def main() -> int:
             "major version `0` does not imply prerelease",
             "latest public version",
             "release-retention.yml",
-            "optional production hardening layer",
-            "WINDOWS_AUTHENTICODE=unsigned",
-            "Absence of a production Authenticode certificate by itself is not a versioning failure.",
+            "required public-release trust boundary",
+            "WINDOWS_AUTHENTICODE=signed",
+            "Absence of the production Authenticode identity is a release failure.",
         ),
         "docs/VERSIONING.md",
     )
@@ -278,7 +278,7 @@ def main() -> int:
             "LINUX_FEDORA_RPM=x86_64,aarch64,i686",
             "LINUX_PORTABLE=amd64,arm64,i386",
             "GHCR_CURRENT_BUNDLE=REQUIRED",
-            "CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO",
+            "CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES",
             "TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED",
         ),
         "scripts/audit_release.py",
@@ -305,7 +305,7 @@ def main() -> int:
     print("MINIMUM_PUBLIC_VERSION=0.0.1")
     print("LATEST_ONLY_RELEASE_RETENTION=YES")
     print("ACTIVE_VERSIONING_DOC_BOUND_TO_VERSION=YES")
-    print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=NO")
+    print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
     print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("CURRENT_GITHUB_PACKAGE=GHCR_RELEASE_BUNDLE")

--- a/scripts/test_verify_release_signing_policy.py
+++ b/scripts/test_verify_release_signing_policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_RELEASE = ROOT / "scripts" / "verify_release.py"
+
+spec = importlib.util.spec_from_file_location("ghostftp_verify_release", VERIFY_RELEASE)
+assert spec is not None and spec.loader is not None
+verify_release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(verify_release)
+
+
+class PublicReleaseSigningPolicyTests(unittest.TestCase):
+    def test_public_release_requires_both_artifacts_signed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be Authenticode signed"):
+            verify_release.require_public_release_signatures(
+                False,
+                False,
+                verify_release.PUBLIC_WINDOWS_RELEASE_WORKFLOW,
+            )
+        with self.assertRaisesRegex(ValueError, "must be Authenticode signed"):
+            verify_release.require_public_release_signatures(
+                True,
+                False,
+                verify_release.PUBLIC_WINDOWS_RELEASE_WORKFLOW,
+            )
+        with self.assertRaisesRegex(ValueError, "must be Authenticode signed"):
+            verify_release.require_public_release_signatures(
+                False,
+                True,
+                verify_release.PUBLIC_WINDOWS_RELEASE_WORKFLOW,
+            )
+
+    def test_public_release_accepts_both_artifacts_signed(self) -> None:
+        verify_release.require_public_release_signatures(
+            True,
+            True,
+            verify_release.PUBLIC_WINDOWS_RELEASE_WORKFLOW,
+        )
+
+    def test_non_release_builds_remain_signing_optional(self) -> None:
+        for workflow in ("Ghost FTP CI", "", "Local build"):
+            verify_release.require_public_release_signatures(False, False, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import re
 import struct
 from pathlib import Path
@@ -10,6 +11,7 @@ from pathlib import Path
 I386 = 0x014C
 AMD64 = 0x8664
 GUI_SUBSYSTEM = 2
+PUBLIC_WINDOWS_RELEASE_WORKFLOW = "Publish Ghost FTP"
 
 ARCH_SPECS = {
     "x86": {"machine": I386, "magic": 0x10B, "pe": "PE32", "data_dir": 96},
@@ -144,6 +146,22 @@ def read_pe(path: Path, expected_arch: str | None = None):
     return data, bool(cert_offset and cert_size), arch, required_mitigations
 
 
+def require_public_release_signatures(
+    setup_signed: bool,
+    portable_signed: bool,
+    workflow_name: str | None = None,
+) -> None:
+    if workflow_name is None:
+        workflow_name = os.environ.get("GITHUB_WORKFLOW", "")
+    if workflow_name.strip() != PUBLIC_WINDOWS_RELEASE_WORKFLOW:
+        return
+    if not setup_signed or not portable_signed:
+        raise ValueError(
+            "public Windows release artifacts must be Authenticode signed; "
+            "configure the trusted production signing identity before publishing"
+        )
+
+
 def sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -172,6 +190,7 @@ def main() -> None:
     arch = next(iter(arches))
     (sdat, ssigned, _, mitigations), (pdat, psigned, _, _) = results
 
+    require_public_release_signatures(ssigned, psigned)
     assert_no_telemetry_markers(args.setup, sdat)
     assert_no_telemetry_markers(args.portable, pdat)
     hashes = {sha256(sdat), sha256(pdat)}


### PR DESCRIPTION
Syncs current `main` at `8232304ddc62051434fa5eecf0dc9a52b3056425` into `feature/macos-directory-compare` before #279 merge validation. The new base requires trusted Authenticode for public Windows releases and updates release audits/docs; it does not modify the macOS Directory Compare implementation. No feature scope expansion.