### PR TITLE
security: verify published release asset digests against exact workflow bundle

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -1,0 +1,90 @@
+name: Verify Ghost FTP Release Integrity
+
+on:
+  workflow_run:
+    workflows:
+      - Publish Ghost FTP
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ghostftp-release-integrity-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+      SOURCE_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Validate canonical source run identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$SOURCE_RUN_BRANCH" = 'main' || {
+            echo "Release integrity verification only accepts main; got $SOURCE_RUN_BRANCH" >&2
+            exit 1
+          }
+          [[ "$SOURCE_RUN_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "Invalid source release SHA: $SOURCE_RUN_SHA" >&2
+            exit 1
+          }
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]] || {
+            echo "Invalid source release run id: $SOURCE_RUN_ID" >&2
+            exit 1
+          }
+
+      - name: Checkout exact released source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact release workflow bundle
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317 # v8.0.0
+        with:
+          pattern: ghostftp-release-*
+          path: source-release
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          digest-mismatch: error
+
+      - name: Fetch published release metadata and verify exact digests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          metadata='source-release/BUILD-METADATA.txt'
+          test -s "$metadata"
+          tag="$(awk -F= '$1 == "RELEASE_TAG" { print substr($0, index($0, "=") + 1) }' "$metadata")"
+          [[ "$tag" =~ ^ghostftp-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Invalid release tag in BUILD-METADATA.txt: $tag" >&2
+            exit 1
+          }
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > release.json
+          tag_commit_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$tag" --jq .sha)"
+          test "$tag_commit_sha" = "$SOURCE_RUN_SHA" || {
+            echo "Release tag resolves to $tag_commit_sha, expected $SOURCE_RUN_SHA" >&2
+            exit 1
+          }
+
+          python scripts/verify_release_digest_readback.py \
+            source-release \
+            release.json \
+            --expected-commit "$SOURCE_RUN_SHA"
+
+          echo "RELEASE_TAG_COMMIT_READBACK=PASS ($tag -> $tag_commit_sha)"
+          echo "RELEASE_SOURCE_WORKFLOW_RUN=$SOURCE_RUN_ID"

--- a/scripts/test_release_digest_readback.py
+++ b/scripts/test_release_digest_readback.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from verify_release_digest_readback import verify_release
+from verify_release_digest_readback import expected_release_names, verify_release
 
 
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
@@ -34,8 +34,14 @@ class ReleaseDigestReadbackTests(unittest.TestCase):
         )
         (bundle / "BUILD-METADATA.txt").write_text(metadata, encoding="utf-8")
         (bundle / "RELEASE-NOTES.txt").write_text("Synthetic release notes\n", encoding="utf-8")
-        for index in range(1, 15):
-            (bundle / f"artifact-{index:02d}.bin").write_bytes(f"artifact-{index}\n".encode())
+
+        payload_names = expected_release_names(VERSION) - {
+            "BUILD-METADATA.txt",
+            "RELEASE-NOTES.txt",
+            "SHA256.txt",
+        }
+        for index, name in enumerate(sorted(payload_names), start=1):
+            (bundle / name).write_bytes(f"synthetic-release-payload-{index}\n".encode())
 
         manifest_lines = []
         for path in sorted(bundle.iterdir()):
@@ -114,9 +120,24 @@ class ReleaseDigestReadbackTests(unittest.TestCase):
     def test_internal_sha256_manifest_mismatch_fails(self) -> None:
         temp, bundle, release_json = self.make_fixture()
         self.addCleanup(temp.cleanup)
-        artifact = bundle / "artifact-01.bin"
+        artifact = bundle / f"Ghost-FTP-{VERSION}-Setup.exe"
         artifact.write_bytes(b"changed after manifest\n")
         with self.assertRaisesRegex(ValueError, "SHA256.txt digest mismatch"):
+            verify_release(bundle, release_json, COMMIT)
+
+    def test_noncanonical_local_asset_name_fails_even_with_same_count(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        source = bundle / f"Ghost-FTP-{VERSION}-Portable.exe"
+        source.rename(bundle / "unexpected.bin")
+        with self.assertRaisesRegex(ValueError, "canonical 17-file release set"):
+            verify_release(bundle, release_json, COMMIT)
+
+    def test_non_regular_bundle_entry_fails_closed(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        (bundle / "unexpected-directory").mkdir()
+        with self.assertRaisesRegex(ValueError, "non-regular"):
             verify_release(bundle, release_json, COMMIT)
 
 

--- a/scripts/test_release_digest_readback.py
+++ b/scripts/test_release_digest_readback.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_release_digest_readback import verify_release
+
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+VERSION = "9.8.7"
+TAG = f"ghostftp-v{VERSION}"
+
+
+class ReleaseDigestReadbackTests(unittest.TestCase):
+    def make_fixture(self) -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
+        temp = tempfile.TemporaryDirectory()
+        root = Path(temp.name)
+        bundle = root / "release"
+        bundle.mkdir()
+
+        metadata = "\n".join(
+            [
+                "BRAND=Ghost FTP",
+                f"VERSION={VERSION}",
+                f"RELEASE_TAG={TAG}",
+                f"COMMIT={COMMIT}",
+                "PUBLIC_RELEASE_FILES=17",
+                "TELEMETRY=disabled",
+                "",
+            ]
+        )
+        (bundle / "BUILD-METADATA.txt").write_text(metadata, encoding="utf-8")
+        (bundle / "RELEASE-NOTES.txt").write_text("Synthetic release notes\n", encoding="utf-8")
+        for index in range(1, 15):
+            (bundle / f"artifact-{index:02d}.bin").write_bytes(f"artifact-{index}\n".encode())
+
+        manifest_lines = []
+        for path in sorted(bundle.iterdir()):
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            manifest_lines.append(f"{digest}  {path.name}")
+        (bundle / "SHA256.txt").write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
+
+        assets = []
+        for path in sorted(bundle.iterdir()):
+            assets.append(
+                {
+                    "name": path.name,
+                    "digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+                }
+            )
+        release = {
+            "tag_name": TAG,
+            "target_commitish": COMMIT,
+            "draft": False,
+            "prerelease": False,
+            "immutable": False,
+            "assets": assets,
+        }
+        release_json = root / "release.json"
+        release_json.write_text(json.dumps(release), encoding="utf-8")
+        return temp, bundle, release_json
+
+    def load_release(self, release_json: Path) -> dict:
+        return json.loads(release_json.read_text(encoding="utf-8"))
+
+    def save_release(self, release_json: Path, value: dict) -> None:
+        release_json.write_text(json.dumps(value), encoding="utf-8")
+
+    def test_valid_exact_bundle_passes(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        result = verify_release(bundle, release_json, COMMIT)
+        self.assertEqual(result["tag"], TAG)
+        self.assertEqual(result["commit"], COMMIT)
+        self.assertEqual(result["files"], "17")
+        self.assertEqual(result["immutable"], "NO")
+
+    def test_remote_digest_mismatch_fails(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        release = self.load_release(release_json)
+        release["assets"][0]["digest"] = "sha256:" + "0" * 64
+        self.save_release(release_json, release)
+        with self.assertRaisesRegex(ValueError, "digest mismatch"):
+            verify_release(bundle, release_json, COMMIT)
+
+    def test_missing_remote_digest_fails_closed(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        release = self.load_release(release_json)
+        release["assets"][0]["digest"] = None
+        self.save_release(release_json, release)
+        with self.assertRaisesRegex(ValueError, "has no SHA-256 digest"):
+            verify_release(bundle, release_json, COMMIT)
+
+    def test_remote_asset_set_mismatch_fails(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        release = self.load_release(release_json)
+        release["assets"].pop()
+        self.save_release(release_json, release)
+        with self.assertRaisesRegex(ValueError, "asset set"):
+            verify_release(bundle, release_json, COMMIT)
+
+    def test_source_commit_mismatch_fails(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        with self.assertRaisesRegex(ValueError, "does not match source run"):
+            verify_release(bundle, release_json, "f" * 40)
+
+    def test_internal_sha256_manifest_mismatch_fails(self) -> None:
+        temp, bundle, release_json = self.make_fixture()
+        self.addCleanup(temp.cleanup)
+        artifact = bundle / "artifact-01.bin"
+        artifact.write_bytes(b"changed after manifest\n")
+        with self.assertRaisesRegex(ValueError, "SHA256.txt digest mismatch"):
+            verify_release(bundle, release_json, COMMIT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_integrity_workflow_contract.py
+++ b/scripts/test_release_integrity_workflow_contract.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-integrity.yml"
+
+
+class ReleaseIntegrityWorkflowContractTests(unittest.TestCase):
+    def test_release_integrity_workflow_is_read_only_and_exact_run_bound(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        for marker in (
+            "name: Verify Ghost FTP Release Integrity",
+            "workflow_run:",
+            "- Publish Ghost FTP",
+            "contents: read",
+            "actions: read",
+            "github.event.workflow_run.conclusion == 'success'",
+            "ref: ${{ github.event.workflow_run.head_sha }}",
+            "persist-credentials: false",
+            "actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317",
+            "pattern: ghostftp-release-*",
+            "github-token: ${{ github.token }}",
+            "run-id: ${{ github.event.workflow_run.id }}",
+            "digest-mismatch: error",
+            "gh api \"repos/$GITHUB_REPOSITORY/releases/tags/$tag\" > release.json",
+            "gh api \"repos/$GITHUB_REPOSITORY/commits/$tag\" --jq .sha",
+            "verify_release_digest_readback.py",
+            "--expected-commit \"$SOURCE_RUN_SHA\"",
+            "RELEASE_TAG_COMMIT_READBACK=PASS",
+        ):
+            self.assertIn(marker, text)
+
+        for forbidden in (
+            "contents: write",
+            "actions: write",
+            "packages: write",
+            "id-token: write",
+            "pull_request_target:",
+            "--clobber",
+            "gh release upload",
+            "gh release edit",
+            "gh release delete",
+        ):
+            self.assertNotIn(forbidden, text)
+
+    def test_integrity_workflow_has_no_application_runtime_trigger(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("push:\n", text)
+        self.assertNotIn("pull_request:\n", text)
+        self.assertNotIn("workflow_dispatch:\n", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_release_digest_readback.py
+++ b/scripts/verify_release_digest_readback.py
@@ -24,9 +24,29 @@ def sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def expected_release_names(version: str) -> set[str]:
+    names = {
+        "BUILD-METADATA.txt",
+        "RELEASE-NOTES.txt",
+        "SHA256.txt",
+        f"Ghost-FTP-{version}-Setup.exe",
+        f"Ghost-FTP-{version}-Portable.exe",
+    }
+    for distro in ("Debian", "Ubuntu"):
+        for arch in ("amd64", "arm64", "i386"):
+            names.add(f"Ghost-FTP-{version}-Linux-{distro}-{arch}.deb")
+    for arch in ("x86_64", "aarch64", "i686"):
+        names.add(f"Ghost-FTP-{version}-Linux-Fedora-{arch}.rpm")
+    for arch in ("amd64", "arm64", "i386"):
+        names.add(f"Ghost-FTP-{version}-Linux-Portable-{arch}.tar.gz")
+    if len(names) != EXPECTED_RELEASE_FILES:
+        fail("internal canonical release asset set is invalid")
+    return names
+
+
 def parse_build_metadata(path: Path) -> dict[str, str]:
-    if not path.is_file():
-        fail("BUILD-METADATA.txt is missing from the release bundle")
+    if not path.is_file() or path.is_symlink():
+        fail("BUILD-METADATA.txt is missing or is not a regular release file")
     result: dict[str, str] = {}
     for raw in path.read_text(encoding="utf-8").splitlines():
         if not raw.strip():
@@ -43,8 +63,8 @@ def parse_build_metadata(path: Path) -> dict[str, str]:
 
 
 def parse_manifest(path: Path) -> dict[str, str]:
-    if not path.is_file():
-        fail("SHA256.txt is missing from the release bundle")
+    if not path.is_file() or path.is_symlink():
+        fail("SHA256.txt is missing or is not a regular release file")
     result: dict[str, str] = {}
     for raw in path.read_text(encoding="utf-8").splitlines():
         if not raw.strip():
@@ -55,7 +75,7 @@ def parse_manifest(path: Path) -> dict[str, str]:
         digest, name = match.groups()
         if name in result:
             fail(f"duplicate SHA256.txt entry: {name}")
-        if Path(name).name != name or name in {".", ".."}:
+        if Path(name).name != name or "/" in name or "\\" in name or name in {".", ".."}:
             fail(f"unsafe SHA256.txt filename: {name!r}")
         result[name] = digest
     return result
@@ -68,7 +88,10 @@ def verify_release(bundle_dir: Path, release_json_path: Path, expected_commit: s
     if not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
         fail(f"invalid expected commit SHA: {expected_commit!r}")
 
-    files = sorted(path for path in bundle_dir.iterdir() if path.is_file())
+    entries = sorted(bundle_dir.iterdir(), key=lambda path: path.name)
+    if any(path.is_symlink() or not path.is_file() for path in entries):
+        fail("release bundle contains a symlink, directory or non-regular top-level entry")
+    files = entries
     if len(files) != EXPECTED_RELEASE_FILES:
         fail(f"release bundle has {len(files)} files; expected {EXPECTED_RELEASE_FILES}")
     local_names = {path.name for path in files}
@@ -81,6 +104,8 @@ def verify_release(bundle_dir: Path, release_json_path: Path, expected_commit: s
     match = TAG_RE.fullmatch(tag)
     if not match or match.group(1) != version:
         fail(f"release tag/version mismatch: tag={tag!r} version={version!r}")
+    if local_names != expected_release_names(version):
+        fail("source workflow bundle does not contain the canonical 17-file release set")
     if commit != expected_commit:
         fail(f"BUILD-METADATA commit {commit!r} does not match source run {expected_commit!r}")
     if public_files != str(EXPECTED_RELEASE_FILES):

--- a/scripts/verify_release_digest_readback.py
+++ b/scripts/verify_release_digest_readback.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+TAG_RE = re.compile(r"^ghostftp-v(\d+\.\d+\.\d+)$")
+EXPECTED_RELEASE_FILES = 17
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_build_metadata(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        fail("BUILD-METADATA.txt is missing from the release bundle")
+    result: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        if "=" not in raw:
+            fail(f"invalid BUILD-METADATA.txt line: {raw!r}")
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or key in result:
+            fail(f"invalid or duplicate BUILD-METADATA.txt key: {key!r}")
+        result[key] = value
+    return result
+
+
+def parse_manifest(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        fail("SHA256.txt is missing from the release bundle")
+    result: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", raw)
+        if not match:
+            fail(f"invalid SHA256.txt line: {raw!r}")
+        digest, name = match.groups()
+        if name in result:
+            fail(f"duplicate SHA256.txt entry: {name}")
+        if Path(name).name != name or name in {".", ".."}:
+            fail(f"unsafe SHA256.txt filename: {name!r}")
+        result[name] = digest
+    return result
+
+
+def verify_release(bundle_dir: Path, release_json_path: Path, expected_commit: str) -> dict[str, str]:
+    bundle_dir = bundle_dir.resolve()
+    if not bundle_dir.is_dir():
+        fail(f"release bundle directory is unavailable: {bundle_dir}")
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
+        fail(f"invalid expected commit SHA: {expected_commit!r}")
+
+    files = sorted(path for path in bundle_dir.iterdir() if path.is_file())
+    if len(files) != EXPECTED_RELEASE_FILES:
+        fail(f"release bundle has {len(files)} files; expected {EXPECTED_RELEASE_FILES}")
+    local_names = {path.name for path in files}
+
+    metadata = parse_build_metadata(bundle_dir / "BUILD-METADATA.txt")
+    version = metadata.get("VERSION", "")
+    tag = metadata.get("RELEASE_TAG", "")
+    commit = metadata.get("COMMIT", "")
+    public_files = metadata.get("PUBLIC_RELEASE_FILES", "")
+    match = TAG_RE.fullmatch(tag)
+    if not match or match.group(1) != version:
+        fail(f"release tag/version mismatch: tag={tag!r} version={version!r}")
+    if commit != expected_commit:
+        fail(f"BUILD-METADATA commit {commit!r} does not match source run {expected_commit!r}")
+    if public_files != str(EXPECTED_RELEASE_FILES):
+        fail(f"BUILD-METADATA PUBLIC_RELEASE_FILES={public_files!r}; expected {EXPECTED_RELEASE_FILES}")
+
+    local_digests = {path.name: sha256_file(path) for path in files}
+    manifest = parse_manifest(bundle_dir / "SHA256.txt")
+    expected_manifest_names = local_names - {"SHA256.txt"}
+    if set(manifest) != expected_manifest_names:
+        fail("SHA256.txt asset set does not match the release bundle")
+    for name, digest in manifest.items():
+        if local_digests[name] != digest:
+            fail(f"SHA256.txt digest mismatch for {name}")
+
+    try:
+        release = json.loads(release_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"unable to read GitHub Release metadata: {exc}")
+    if not isinstance(release, dict):
+        fail("GitHub Release metadata is not an object")
+    if release.get("tag_name") != tag:
+        fail(f"GitHub Release tag mismatch: {release.get('tag_name')!r} != {tag!r}")
+    if release.get("target_commitish") != expected_commit:
+        fail(
+            "GitHub Release target commit mismatch: "
+            f"{release.get('target_commitish')!r} != {expected_commit!r}"
+        )
+    if release.get("draft") is not False or release.get("prerelease") is not False:
+        fail("GitHub Release must be a published non-prerelease release")
+
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        fail("GitHub Release assets are unavailable")
+    remote_digests: dict[str, str] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            fail("GitHub Release contains invalid asset metadata")
+        name = asset.get("name")
+        digest = asset.get("digest")
+        if not isinstance(name, str) or not name or name in remote_digests:
+            fail(f"invalid or duplicate GitHub Release asset name: {name!r}")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            fail(f"GitHub Release asset {name!r} has no SHA-256 digest")
+        hex_digest = digest.removeprefix("sha256:")
+        if not SHA256_RE.fullmatch(hex_digest):
+            fail(f"GitHub Release asset {name!r} has malformed digest {digest!r}")
+        remote_digests[name] = hex_digest
+
+    if set(remote_digests) != local_names:
+        fail("GitHub Release asset set does not match the exact source workflow bundle")
+    for name, digest in local_digests.items():
+        if remote_digests[name] != digest:
+            fail(f"GitHub Release digest mismatch for {name}")
+
+    immutable = "YES" if release.get("immutable") is True else "NO"
+    return {
+        "version": version,
+        "tag": tag,
+        "commit": commit,
+        "immutable": immutable,
+        "files": str(len(files)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bundle_dir", type=Path)
+    parser.add_argument("release_json", type=Path)
+    parser.add_argument("--expected-commit", required=True)
+    args = parser.parse_args()
+
+    result = verify_release(args.bundle_dir, args.release_json, args.expected_commit)
+    print(f"RELEASE_ASSET_DIGEST_READBACK=PASS ({result['files']} files)")
+    print(f"RELEASE_TAG={result['tag']}")
+    print(f"RELEASE_COMMIT={result['commit']}")
+    print(f"RELEASE_IMMUTABLE={result['immutable']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Authorization

- [x] This release security hardening was explicitly requested/authorized for Ghost FTP.
- [x] Existing local-first, no-telemetry and minimal-dependency constraints are preserved.

## Summary

Adds a read-only post-publication integrity check that compares every GitHub Release asset digest with the exact verified bundle produced by the successful `Publish Ghost FTP` workflow run.

### Changes

- Add `Verify Ghost FTP Release Integrity`, triggered only after a successful canonical publish workflow.
- Give it only `contents: read` and `actions: read` permissions.
- Checkout the exact published source SHA with persisted credentials disabled.
- Download the exact `ghostftp-release-*` artifact from the source workflow run using the already-pinned `actions/download-artifact` action with `digest-mismatch: error`.
- Verify the release tag resolves to the exact source workflow SHA.
- Add a stdlib-only Python verifier that checks:
  - exactly 17 public release files;
  - BUILD-METADATA version/tag/commit and public file count;
  - internal `SHA256.txt` set and digests;
  - GitHub Release tag/target/draft/prerelease state;
  - exact local/remote asset-name parity;
  - a valid `sha256:` GitHub asset digest for every file;
  - byte-for-byte SHA-256 equality between all 17 source bundle files and published assets.
- Record whether GitHub reports the release as immutable without falsely requiring a feature that is not enabled today.
- Add offline unit tests for success, remote digest mismatch, missing digest, remote asset-set mismatch, source-commit mismatch and internal manifest mismatch.
- Add a workflow contract test that prevents write permissions, mutable-release commands or a broader trigger from being introduced silently.

## Security and privacy

- No application/runtime source changed.
- No database, backend, telemetry, tracking or new runtime dependency is introduced.
- The integrity workflow cannot upload, edit or delete releases, packages or repository content.

## Validation

Merge only after the existing Ghost FTP CI/security/privacy/release audits and Python regression suite are green on the final PR head.