### PR TITLE
test: define native macOS site manager and Keychain contract

### DIFF
--- a/scripts/test_macos_site_manager_contract.py
+++ b/scripts/test_macos_site_manager_contract.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def text(path: str) -> str:
+    p = ROOT / path
+    if not p.exists():
+        raise SystemExit(f"missing required file: {path}")
+    return p.read_text(encoding="utf-8")
+
+
+def require(source: str, *needles: str) -> None:
+    for needle in needles:
+        if needle not in source:
+            raise SystemExit(f"missing contract marker: {needle}")
+
+
+keychain = text("internal/security/profile_secret_darwin.go")
+require(
+    keychain,
+    "#cgo LDFLAGS: -framework Security -framework CoreFoundation",
+    "kSecClassGenericPassword",
+    "kSecAttrAccessibleWhenUnlockedThisDeviceOnly",
+    "darwin-keychain-aesgcm-v1:",
+    "ProtectPersistentProfileBytes",
+    "UnprotectPersistentProfileBytes",
+    "PersistentProfileSecretToRuntime",
+    "ProtectRuntimeBytes",
+)
+if "/usr/bin/security" in keychain or "exec.Command" in keychain:
+    raise SystemExit("Keychain integration must use Security.framework, not shell commands")
+
+profile_crypto = text("internal/config/profile_crypto_darwin.go")
+require(
+    profile_crypto,
+    "ProtectPersistentProfileBytes",
+    "UnprotectPersistentProfileBytes",
+    '"profile-envelope-v1"',
+)
+if "errDarwinPersistentProfilesUnavailable" in profile_crypto:
+    raise SystemExit("Darwin saved-profile fail-closed placeholder must be replaced by Keychain protection")
+
+profiles = text("internal/config/profiles.go")
+require(profiles, "protectStoredProfileSecret(in.Password)", "protectStoredProfileSecret(in.Passphrase)")
+
+remote = text("internal/remote/manager.go")
+require(
+    remote,
+    "PersistentProfileSecretToRuntime",
+    "ownsPasswordBlob",
+    "ownsPassphraseBlob",
+    "forgetOwnedSecrets",
+)
+
+bridge = text("macos/Bridge/profiles.go")
+require(
+    bridge,
+    "GhostFTPRefreshProfiles",
+    "GhostFTPProfileCount",
+    "GhostFTPProfileID",
+    "GhostFTPProfileHasPassword",
+    "GhostFTPProfileHasPassphrase",
+    "GhostFTPSaveProfile",
+    "GhostFTPRemoveProfile",
+    "GhostFTPConnectProfile",
+    "engine.Profiles()",
+    "engine.SaveProfile",
+    "engine.RemoveProfile",
+    "engine.Connect",
+)
+for forbidden in ("json.Marshal", "json.Unmarshal", "PasswordBlob", "PassphraseBlob"):
+    if forbidden in bridge:
+        raise SystemExit(f"macOS typed profile bridge must not expose generic/secret payloads: {forbidden}")
+
+swift = text("macos/Sources/GhostFTPApp/main.swift")
+require(
+    swift,
+    "Site Manager",
+    "SiteManagerWindowController",
+    "Save Profile",
+    "Remove Profile",
+    "Save credentials on this computer?",
+    "Keep saved credentials on this computer?",
+    "GhostFTPRefreshProfiles",
+    "GhostFTPSaveProfile",
+    "GhostFTPRemoveProfile",
+    "GhostFTPConnectProfile",
+    "HasPassword",
+    "HasPassphrase",
+)
+for forbidden in ("PasswordBlob", "PassphraseBlob"):
+    if forbidden in swift:
+        raise SystemExit(f"Swift must never receive saved credential blobs: {forbidden}")
+
+parity = text("macos/PARITY.md")
+for action in ("Site Manager", "Save Profile", "Remove Profile"):
+    require(parity, f"- [x] {action}")
+
+global_parity = text("scripts/test_macos_windows_parity_contract.py")
+for action in ("Site Manager", "Save Profile", "Remove Profile"):
+    require(global_parity, f'"{action}"')
+
+print("macOS Site Manager / Keychain profile contract OK")


### PR DESCRIPTION
## Authorization

- [ ] This source-code change was explicitly requested or authorized for Ghost FTP.
- [ ] I have read and will follow `LICENSE` and the contribution documentation.

> Ghost FTP is source-available software. Opening a pull request or fork does not itself grant rights beyond the repository license and applicable GitHub platform rights.

## Summary

Describe the change and why it is needed.

## Branding and compatibility

- [ ] New public UI, documentation and release assets use **Ghost FTP**.
- [ ] Any retained `GhostFTP`/`GhostFTP` identifier is required for backward compatibility, migration or installed-application identity and is not user-facing branding.

## Security and privacy

- [ ] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [ ] No automatic external API or hidden network destination was added.
- [ ] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [ ] SFTP host-key verification and pinning remain active.
- [ ] Local path-traversal, symlink, junction and reparse-point protections remain active.
- [ ] No external Go module was added without explicit architecture/security review.
- [ ] Tests, screenshots and fixtures contain no real credentials, production servers or customer data.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/audit_security.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] PHP syntax checks pass when web code changed.
- [ ] Native platform build checks pass for affected platforms.

## Regression coverage

Describe tests added or changed for connections, transfers, paths, profiles, installation/uninstallation, localization, release packaging or other affected behavior.
