### PR TITLE
Feature/macos site manager keychain complete

### DIFF
--- a/internal/config/profile_crypto_darwin.go
+++ b/internal/config/profile_crypto_darwin.go
@@ -2,24 +2,36 @@
 
 package config
 
-import "errors"
+import (
+	"bytes"
+	"errors"
 
-var errDarwinPersistentProfilesUnavailable = errors.New("saved profiles are unavailable until macOS Keychain protection is enabled")
+	"github.com/bren-wp/Ghost-FTP/internal/security"
+)
 
-// protectProfileData deliberately fails closed on macOS for now. The native
-// Quick Connect path does not persist connection secrets, and the in-memory
-// AskPass capability broker must never be reused as durable profile storage.
-// A later Site Manager parity change will replace this gate with Keychain-backed
-// profile protection before saved macOS profiles are enabled.
-func protectProfileData([]byte, string) (string, error) {
-	return "", errDarwinPersistentProfilesUnavailable
+const darwinProfileEnvelopeMarker = "profile-envelope-v1\x00"
+
+func protectProfileData(data []byte, _ string) (string, error) {
+	payload := make([]byte, 0, len(darwinProfileEnvelopeMarker)+len(data))
+	payload = append(payload, darwinProfileEnvelopeMarker...)
+	payload = append(payload, data...)
+	defer security.WipeBytes(payload)
+	return security.ProtectPersistentProfileBytes(payload)
 }
 
-// Existing protected profile envelopes are not interpreted with a weaker or
-// platform-incompatible codec. Until Keychain-backed storage lands, macOS
-// refuses to unlock durable profile data rather than silently downgrading it.
-func unprotectProfileData(string, string) ([]byte, error) {
-	return nil, errDarwinPersistentProfilesUnavailable
+func unprotectProfileData(encoded, _ string) ([]byte, error) {
+	plain, err := security.UnprotectPersistentProfileBytes(encoded)
+	if err != nil {
+		return nil, err
+	}
+	marker := []byte(darwinProfileEnvelopeMarker)
+	if !bytes.HasPrefix(plain, marker) {
+		security.WipeBytes(plain)
+		return nil, errors.New("macOS saved profile envelope is malformed")
+	}
+	out := append([]byte(nil), plain[len(marker):]...)
+	security.WipeBytes(plain)
+	return out, nil
 }
 
 func profileDataNeedsMigration(string) bool { return false }

--- a/internal/config/profile_secret_store_darwin.go
+++ b/internal/config/profile_secret_store_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package config
+
+import "github.com/bren-wp/Ghost-FTP/internal/security"
+
+const storedProfileSecretMarker = "profile-secret-v1\x00"
+
+func protectStoredProfileSecret(value string) (string, error) {
+	payload := append([]byte(storedProfileSecretMarker), []byte(value)...)
+	defer security.WipeBytes(payload)
+	return security.ProtectPersistentProfileBytes(payload)
+}

--- a/internal/config/profile_secret_store_other.go
+++ b/internal/config/profile_secret_store_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package config
+
+import "github.com/bren-wp/Ghost-FTP/internal/security"
+
+func protectStoredProfileSecret(value string) (string, error) {
+	return security.ProtectString(value)
+}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -292,7 +292,7 @@ func (p *Profiles) Save(in model.ProfileInput) (model.PublicProfile, error) {
 		if err = security.ValidateSecret(in.Password); err != nil {
 			return model.PublicProfile{}, err
 		}
-		x.PasswordBlob, err = security.ProtectString(in.Password)
+		x.PasswordBlob, err = protectStoredProfileSecret(in.Password)
 		if err != nil {
 			return model.PublicProfile{}, err
 		}
@@ -303,7 +303,7 @@ func (p *Profiles) Save(in model.ProfileInput) (model.PublicProfile, error) {
 		if err = security.ValidateSecret(in.Passphrase); err != nil {
 			return model.PublicProfile{}, err
 		}
-		x.PassphraseBlob, err = security.ProtectString(in.Passphrase)
+		x.PassphraseBlob, err = protectStoredProfileSecret(in.Passphrase)
 		if err != nil {
 			return model.PublicProfile{}, err
 		}

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -273,8 +273,8 @@ func (m *Manager) stashPendingTrust(cfg model.ConnectionConfig, resolved resolve
 	m.clearPendingTrustLocked()
 	passwordBlob := resolved.PasswordBlob
 	passphraseBlob := resolved.PassphraseBlob
-	ownsPasswordBlob := false
-	ownsPassphraseBlob := false
+	ownsPasswordBlob := resolved.ownsPasswordBlob
+	ownsPassphraseBlob := resolved.ownsPassphraseBlob
 	var err error
 	if cfg.Password != "" {
 		passwordBlob, err = security.ProtectString(cfg.Password)

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -198,31 +198,47 @@ func (m *Manager) Resolve(profileID string, in model.ConnectionConfig) (resolved
 		resolved.Config = mergeConnection(model.ConnectionConfig{
 			Protocol: p.Protocol, Host: p.Host, Port: p.Port, Username: p.Username,
 		}, in)
-		// Spremljene tajne nikada se ne prenose preko privremeno izmijenjenog
-		// endpointa/računa. Korisnik tada mora izričito upisati vjerodajnicu.
-		if in.Password == "" && profileAccountMatches(p, resolved.Config) {
-			resolved.PasswordBlob = p.PasswordBlob
+		// Durable profile credentials are converted to a short-lived runtime
+		// capability only for the exact matching account/key identity. On macOS
+		// this decrypts the Keychain-backed blob and immediately re-wraps it in
+		// the same-user runtime broker; other platforms preserve their existing
+		// borrowed protected-blob behavior.
+		if in.Password == "" && profileAccountMatches(p, resolved.Config) && p.PasswordBlob != "" {
+			resolved.PasswordBlob, resolved.ownsPasswordBlob, err = security.PersistentProfileSecretToRuntime(p.PasswordBlob)
+			if err != nil {
+				resolved.forgetOwnedSecrets()
+				return resolved, profile, err
+			}
 		}
-		if in.Passphrase == "" && profilePrivateKeyMatches(p, resolved.Config) {
-			resolved.PassphraseBlob = p.PassphraseBlob
+		if in.Passphrase == "" && profilePrivateKeyMatches(p, resolved.Config) && p.PassphraseBlob != "" {
+			resolved.PassphraseBlob, resolved.ownsPassphraseBlob, err = security.PersistentProfileSecretToRuntime(p.PassphraseBlob)
+			if err != nil {
+				resolved.forgetOwnedSecrets()
+				return resolved, profile, err
+			}
 		}
 	}
 	resolved.Config = sanitizeProtocolState(resolved.Config)
 	if resolved.Config.Protocol != "sftp" {
 		resolved.PassphraseBlob = ""
+		resolved.ownsPassphraseBlob = false
 	}
 	cfg := resolved.Config
 	if err := security.ValidateConnection(cfg.Protocol, cfg.Host, cfg.Username, cfg.Port); err != nil {
+		resolved.forgetOwnedSecrets()
 		return resolved, profile, err
 	}
 	if err := security.ValidateSecret(cfg.Password); err != nil {
+		resolved.forgetOwnedSecrets()
 		return resolved, profile, err
 	}
 	if err := security.ValidateSecret(cfg.Passphrase); err != nil {
+		resolved.forgetOwnedSecrets()
 		return resolved, profile, err
 	}
 	if cfg.Protocol == "sftp" && cfg.Fingerprint != "" {
 		if err := security.ValidateSFTPFingerprint(cfg.Fingerprint); err != nil {
+			resolved.forgetOwnedSecrets()
 			return resolved, profile, err
 		}
 	}
@@ -301,10 +317,6 @@ func (m *Manager) applyPendingTrust(cfg model.ConnectionConfig, resolved *resolv
 		p.fingerprint != fingerprint {
 		return
 	}
-	// A credential captured for the exact trust prompt belongs to that connection
-	// attempt and takes precedence over a profile blob re-resolved on confirmation.
-	// An explicitly re-entered plaintext credential on the confirmation request
-	// still wins and causes the pending owned blob to be discarded below.
 	if cfg.Password == "" && p.passwordBlob != "" {
 		if resolved.ownsPasswordBlob {
 			security.ForgetProtectedSecret(resolved.PasswordBlob)
@@ -351,9 +363,7 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 		m.clearPendingTrustLocked()
 		return ConnectResult{}, err
 	}
-	defer func() {
-		resolved.forgetOwnedSecrets()
-	}()
+	defer func() { resolved.forgetOwnedSecrets() }()
 	cfg := resolved.Config
 	profileEndpoint := profileEndpointMatches(profile, cfg)
 	connectTimeout := m.settings.Effective().ConnectionTimeoutSeconds
@@ -366,10 +376,6 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 		if err := security.EnsureNoRedirectDirectory(m.dataDir, knownHostsDir); err != nil {
 			return ConnectResult{}, errors.New("mapa SFTP sesije nije sigurna")
 		}
-		// Windows klijent je single-instance, pa se crash-ostatci mogu očistiti
-		// tek nakon no-redirect provjere. Linux/macOS namjerno dopuštaju više
-		// terminalskih procesa; ondje startup cleanup ne smije dirati artefakte
-		// druge aktivne sesije.
 		if runtime.GOOS == "windows" {
 			cleanupStaleSFTPArtifacts(knownHostsDir)
 		}
@@ -388,6 +394,10 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 			if err := m.stashPendingTrust(cfg, resolved, fp); err != nil {
 				return ConnectResult{}, err
 			}
+			// Ownership copied into pending trust must no longer be reclaimed by
+			// this Resolve result while the user verifies the fingerprint.
+			resolved.ownsPasswordBlob = false
+			resolved.ownsPassphraseBlob = false
 			preservePendingTrust = true
 			return ConnectResult{RequiresTrust: true, Fingerprint: fp}, nil
 		}
@@ -402,8 +412,6 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 		if err != nil {
 			return ConnectResult{}, err
 		}
-		// Privremena promjena hosta/porta smije vrijediti samo za ovu sesiju.
-		// Nikada ne prepisuj spremljeni pin originalnog profila drugim endpointom.
 		if remember && profileID != "" && profileEndpoint {
 			if err := m.profiles.UpdateFingerprint(profileID, fp); err != nil {
 				_ = os.Remove(kh)
@@ -424,6 +432,9 @@ func (m *Manager) Connect(ctx context.Context, profileID string, in model.Connec
 		if err != nil {
 			return ConnectResult{}, err
 		}
+		// Curl consumes the protected secret synchronously per operation. Keep the
+		// owned runtime capability with this connection result until Connect exits;
+		// it will be forgotten by the deferred cleanup above after the probe.
 	}
 
 	cctx, cancel := context.WithTimeout(ctx, time.Duration(connectTimeout+5)*time.Second)

--- a/internal/remote/persistent_profile_secret_ownership_test.go
+++ b/internal/remote/persistent_profile_secret_ownership_test.go
@@ -1,0 +1,38 @@
+package remote
+
+import (
+	"testing"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+func TestPendingTrustPreservesOwnedResolvedSecretCapabilities(t *testing.T) {
+	m := &Manager{}
+	resolved := resolvedConnection{
+		PasswordBlob:       "owned-password-capability",
+		PassphraseBlob:     "owned-passphrase-capability",
+		ownsPasswordBlob:   true,
+		ownsPassphraseBlob: true,
+	}
+	cfg := model.ConnectionConfig{
+		Protocol:       "sftp",
+		Host:           "example.test",
+		Port:           22,
+		Username:       "user",
+		PrivateKeyPath: "/tmp/key",
+	}
+	if err := m.stashPendingTrust(cfg, resolved, "SHA256:test"); err != nil {
+		t.Fatalf("stashPendingTrust: %v", err)
+	}
+	if m.pendingTrust.passwordBlob != resolved.PasswordBlob || !m.pendingTrust.ownsPasswordBlob {
+		t.Fatal("owned password capability was not transferred into pending trust")
+	}
+	if m.pendingTrust.passphraseBlob != resolved.PassphraseBlob || !m.pendingTrust.ownsPassphraseBlob {
+		t.Fatal("owned passphrase capability was not transferred into pending trust")
+	}
+
+	// Do not ask the platform secret store to destroy synthetic test handles.
+	m.pendingTrust.ownsPasswordBlob = false
+	m.pendingTrust.ownsPassphraseBlob = false
+	m.clearPendingTrustLocked()
+}

--- a/internal/security/dpapi_darwin.go
+++ b/internal/security/dpapi_darwin.go
@@ -57,7 +57,7 @@ type darwinSecretBrokerState struct {
 
 var darwinSecretBroker darwinSecretBrokerState
 
-func PersistentSecretStorageAvailable() bool { return false }
+func PersistentSecretStorageAvailable() bool { return true }
 
 func purgeExpiredDarwinSecretsLocked(now time.Time) {
 	for token, entry := range darwinSecretBroker.entries {

--- a/internal/security/profile_secret_darwin.go
+++ b/internal/security/profile_secret_darwin.go
@@ -95,156 +95,164 @@ static int ghostftp_status_duplicate(OSStatus status) { return status == errSecD
 import "C"
 
 import (
-    "bytes"
-    "crypto/aes"
-    "crypto/cipher"
-    "crypto/rand"
-    "encoding/base64"
-    "errors"
-    "fmt"
-    "unsafe"
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"unsafe"
 )
 
 const (
-    darwinPersistentProfilePrefix = "darwin-keychain-aesgcm-v1:"
-    darwinPersistentProfileKeyLen = 32
-    darwinPersistentProfileMax    = 8 << 20
-    persistentProfileSecretMarker = "profile-secret-v1\x00"
+	darwinPersistentProfilePrefix = "darwin-keychain-aesgcm-v1:"
+	darwinPersistentProfileKeyLen = 32
+	darwinPersistentProfileMax    = 8 << 20
+	persistentProfileSecretMarker = "profile-secret-v1\x00"
 )
 
-var darwinPersistentProfileAAD = []byte("Ghost FTP Keychain persistent profile protection v1")
+var (
+	darwinPersistentProfileAAD = []byte("Ghost FTP Keychain persistent profile protection v1")
+	errDarwinProfileKeyMissing = errors.New("macOS Keychain profile master key is not initialized")
+)
 
 func readDarwinProfileMasterKey() ([]byte, error) {
-    var out *C.uchar
-    var length C.CFIndex
-    status := C.ghostftp_keychain_copy(&out, &length)
-    if status != 0 {
-        if C.ghostftp_status_not_found(status) != 0 {
-            return nil, osStatusError("read", int32(status))
-        }
-        return nil, osStatusError("read", int32(status))
-    }
-    if out == nil || int64(length) != darwinPersistentProfileKeyLen {
-        if out != nil {
-            C.free(unsafe.Pointer(out))
-        }
-        return nil, errors.New("macOS Keychain profile master key has an invalid size")
-    }
-    defer C.free(unsafe.Pointer(out))
-    key := C.GoBytes(unsafe.Pointer(out), C.int(length))
-    if len(key) != darwinPersistentProfileKeyLen {
-        WipeBytes(key)
-        return nil, errors.New("macOS Keychain profile master key could not be read")
-    }
-    return key, nil
+	var out *C.uchar
+	var length C.CFIndex
+	status := C.ghostftp_keychain_copy(&out, &length)
+	if status != 0 {
+		if C.ghostftp_status_not_found(status) != 0 {
+			return nil, errDarwinProfileKeyMissing
+		}
+		return nil, osStatusError("read", int32(status))
+	}
+	if out == nil || int64(length) != darwinPersistentProfileKeyLen {
+		if out != nil {
+			C.free(unsafe.Pointer(out))
+		}
+		return nil, errors.New("macOS Keychain profile master key has an invalid size")
+	}
+	defer C.free(unsafe.Pointer(out))
+	key := C.GoBytes(unsafe.Pointer(out), C.int(length))
+	if len(key) != darwinPersistentProfileKeyLen {
+		WipeBytes(key)
+		return nil, errors.New("macOS Keychain profile master key could not be read")
+	}
+	return key, nil
 }
 
 func osStatusError(operation string, status int32) error {
-    return fmt.Errorf("macOS Keychain profile key %s failed (OSStatus %d)", operation, status)
+	return fmt.Errorf("macOS Keychain profile key %s failed (OSStatus %d)", operation, status)
 }
 
 func darwinProfileMasterKey() ([]byte, error) {
-    key, err := readDarwinProfileMasterKey()
-    if err == nil {
-        return key, nil
-    }
+	key, err := readDarwinProfileMasterKey()
+	if err == nil {
+		return key, nil
+	}
+	if !errors.Is(err, errDarwinProfileKeyMissing) {
+		return nil, err
+	}
 
-    generated := make([]byte, darwinPersistentProfileKeyLen)
-    if _, randErr := rand.Read(generated); randErr != nil {
-        return nil, randErr
-    }
-    ptr := C.CBytes(generated)
-    if ptr == nil {
-        WipeBytes(generated)
-        return nil, errors.New("macOS Keychain profile master key allocation failed")
-    }
-    status := C.ghostftp_keychain_add((*C.uchar)(ptr), C.CFIndex(len(generated)))
-    C.free(ptr)
-    if status == 0 {
-        return generated, nil
-    }
-    WipeBytes(generated)
-    if C.ghostftp_status_duplicate(status) != 0 {
-        return readDarwinProfileMasterKey()
-    }
-    return nil, osStatusError("create", int32(status))
+	generated := make([]byte, darwinPersistentProfileKeyLen)
+	if _, randErr := rand.Read(generated); randErr != nil {
+		return nil, randErr
+	}
+	ptr := C.CBytes(generated)
+	if ptr == nil {
+		WipeBytes(generated)
+		return nil, errors.New("macOS Keychain profile master key allocation failed")
+	}
+	status := C.ghostftp_keychain_add((*C.uchar)(ptr), C.CFIndex(len(generated)))
+	C.free(ptr)
+	if status == 0 {
+		return generated, nil
+	}
+	WipeBytes(generated)
+	if C.ghostftp_status_duplicate(status) != 0 {
+		return readDarwinProfileMasterKey()
+	}
+	return nil, osStatusError("create", int32(status))
 }
 
 func persistentProfileAEAD() (cipher.AEAD, []byte, error) {
-    key, err := darwinProfileMasterKey()
-    if err != nil {
-        return nil, nil, err
-    }
-    block, err := aes.NewCipher(key)
-    if err != nil {
-        WipeBytes(key)
-        return nil, nil, err
-    }
-    aead, err := cipher.NewGCM(block)
-    if err != nil {
-        WipeBytes(key)
-        return nil, nil, err
-    }
-    return aead, key, nil
+	key, err := darwinProfileMasterKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		WipeBytes(key)
+		return nil, nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		WipeBytes(key)
+		return nil, nil, err
+	}
+	return aead, key, nil
 }
 
 // ProtectPersistentProfileBytes encrypts durable profile data with an AES-256
 // key kept in the user's macOS Keychain. The key is non-synchronizing and
 // accessible only while this device's Keychain is unlocked.
 func ProtectPersistentProfileBytes(data []byte) (string, error) {
-    if len(data) == 0 {
-        return "", nil
-    }
-    if len(data) > darwinPersistentProfileMax {
-        return "", errors.New("macOS persistent profile data is too large")
-    }
-    aead, key, err := persistentProfileAEAD()
-    if err != nil {
-        return "", err
-    }
-    defer WipeBytes(key)
-    nonce := make([]byte, aead.NonceSize())
-    if _, err := rand.Read(nonce); err != nil {
-        return "", err
-    }
-    sealed := aead.Seal(nil, nonce, data, darwinPersistentProfileAAD)
-    payload := make([]byte, 0, len(nonce)+len(sealed))
-    payload = append(payload, nonce...)
-    payload = append(payload, sealed...)
-    encoded := base64.RawURLEncoding.EncodeToString(payload)
-    WipeBytes(payload)
-    WipeBytes(sealed)
-    return darwinPersistentProfilePrefix + encoded, nil
+	if len(data) == 0 {
+		return "", nil
+	}
+	if len(data) > darwinPersistentProfileMax {
+		return "", errors.New("macOS persistent profile data is too large")
+	}
+	aead, key, err := persistentProfileAEAD()
+	if err != nil {
+		return "", err
+	}
+	defer WipeBytes(key)
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nil, nonce, data, darwinPersistentProfileAAD)
+	payload := make([]byte, 0, len(nonce)+len(sealed))
+	payload = append(payload, nonce...)
+	payload = append(payload, sealed...)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	WipeBytes(payload)
+	WipeBytes(sealed)
+	return darwinPersistentProfilePrefix + encoded, nil
 }
 
 func UnprotectPersistentProfileBytes(encoded string) ([]byte, error) {
-    if encoded == "" {
-        return nil, nil
-    }
-    if !bytes.HasPrefix([]byte(encoded), []byte(darwinPersistentProfilePrefix)) {
-        return nil, errors.New("macOS persistent profile data uses an unsupported format")
-    }
-    raw, err := base64.RawURLEncoding.DecodeString(encoded[len(darwinPersistentProfilePrefix):])
-    if err != nil || len(raw) > darwinPersistentProfileMax+256 {
-        WipeBytes(raw)
-        return nil, errors.New("macOS persistent profile data is malformed")
-    }
-    defer WipeBytes(raw)
-    aead, key, err := persistentProfileAEAD()
-    if err != nil {
-        return nil, err
-    }
-    defer WipeBytes(key)
-    if len(raw) <= aead.NonceSize()+aead.Overhead() {
-        return nil, errors.New("macOS persistent profile data is truncated")
-    }
-    nonce := raw[:aead.NonceSize()]
-    ciphertext := raw[aead.NonceSize():]
-    plain, err := aead.Open(nil, nonce, ciphertext, darwinPersistentProfileAAD)
-    if err != nil {
-        return nil, errors.New("macOS persistent profile data failed authentication")
-    }
-    return plain, nil
+	if encoded == "" {
+		return nil, nil
+	}
+	if !stringsHasPrefix(encoded, darwinPersistentProfilePrefix) {
+		return nil, errors.New("macOS persistent profile data uses an unsupported format")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded[len(darwinPersistentProfilePrefix):])
+	if err != nil || len(raw) > darwinPersistentProfileMax+256 {
+		WipeBytes(raw)
+		return nil, errors.New("macOS persistent profile data is malformed")
+	}
+	defer WipeBytes(raw)
+	aead, key, err := persistentProfileAEAD()
+	if err != nil {
+		return nil, err
+	}
+	defer WipeBytes(key)
+	if len(raw) <= aead.NonceSize()+aead.Overhead() {
+		return nil, errors.New("macOS persistent profile data is truncated")
+	}
+	plain, err := aead.Open(nil, raw[:aead.NonceSize()], raw[aead.NonceSize():], darwinPersistentProfileAAD)
+	if err != nil {
+		return nil, errors.New("macOS persistent profile data failed authentication")
+	}
+	return plain, nil
+}
+
+func stringsHasPrefix(value, prefix string) bool {
+	return len(value) >= len(prefix) && value[:len(prefix)] == prefix
 }
 
 // ProtectRuntimeBytes deliberately reuses the existing short-lived, same-user
@@ -256,21 +264,21 @@ func ProtectRuntimeBytes(data []byte) (string, error) { return ProtectBytes(data
 // runtime capability. The returned blob is owned by the connection attempt and
 // must be forgotten when the attempt/session is finished.
 func PersistentProfileSecretToRuntime(encoded string) (string, bool, error) {
-    if encoded == "" {
-        return "", false, nil
-    }
-    plain, err := UnprotectPersistentProfileBytes(encoded)
-    if err != nil {
-        return "", false, err
-    }
-    defer WipeBytes(plain)
-    marker := []byte(persistentProfileSecretMarker)
-    if !bytes.HasPrefix(plain, marker) || len(plain) == len(marker) {
-        return "", false, errors.New("macOS saved profile credential is malformed")
-    }
-    runtimeBlob, err := ProtectRuntimeBytes(plain[len(marker):])
-    if err != nil {
-        return "", false, err
-    }
-    return runtimeBlob, true, nil
+	if encoded == "" {
+		return "", false, nil
+	}
+	plain, err := UnprotectPersistentProfileBytes(encoded)
+	if err != nil {
+		return "", false, err
+	}
+	defer WipeBytes(plain)
+	marker := []byte(persistentProfileSecretMarker)
+	if !bytes.HasPrefix(plain, marker) || len(plain) == len(marker) {
+		return "", false, errors.New("macOS saved profile credential is malformed")
+	}
+	runtimeBlob, err := ProtectRuntimeBytes(plain[len(marker):])
+	if err != nil {
+		return "", false, err
+	}
+	return runtimeBlob, true, nil
 }

--- a/internal/security/profile_secret_darwin.go
+++ b/internal/security/profile_secret_darwin.go
@@ -1,0 +1,276 @@
+//go:build darwin
+
+package security
+
+/*
+#cgo LDFLAGS: -framework Security -framework CoreFoundation
+#include <Security/Security.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdlib.h>
+#include <string.h>
+
+static CFMutableDictionaryRef ghostftp_keychain_base_query(void) {
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(
+        kCFAllocatorDefault,
+        0,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks
+    );
+    if (query == NULL) {
+        return NULL;
+    }
+    CFStringRef service = CFSTR("app.ghostftp.client.profile-key-v1");
+    CFStringRef account = CFSTR("Ghost FTP persistent profile master key");
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrService, service);
+    CFDictionarySetValue(query, kSecAttrAccount, account);
+    return query;
+}
+
+static OSStatus ghostftp_keychain_copy(unsigned char **outBytes, CFIndex *outLength) {
+    if (outBytes == NULL || outLength == NULL) {
+        return errSecParam;
+    }
+    *outBytes = NULL;
+    *outLength = 0;
+    CFMutableDictionaryRef query = ghostftp_keychain_base_query();
+    if (query == NULL) {
+        return errSecAllocate;
+    }
+    CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+    CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+    CFTypeRef result = NULL;
+    OSStatus status = SecItemCopyMatching(query, &result);
+    CFRelease(query);
+    if (status != errSecSuccess) {
+        if (result != NULL) CFRelease(result);
+        return status;
+    }
+    if (result == NULL || CFGetTypeID(result) != CFDataGetTypeID()) {
+        if (result != NULL) CFRelease(result);
+        return errSecDecode;
+    }
+    CFDataRef data = (CFDataRef)result;
+    CFIndex length = CFDataGetLength(data);
+    if (length <= 0) {
+        CFRelease(result);
+        return errSecDecode;
+    }
+    unsigned char *copy = (unsigned char *)malloc((size_t)length);
+    if (copy == NULL) {
+        CFRelease(result);
+        return errSecAllocate;
+    }
+    memcpy(copy, CFDataGetBytePtr(data), (size_t)length);
+    *outBytes = copy;
+    *outLength = length;
+    CFRelease(result);
+    return errSecSuccess;
+}
+
+static OSStatus ghostftp_keychain_add(const unsigned char *bytes, CFIndex length) {
+    if (bytes == NULL || length <= 0) {
+        return errSecParam;
+    }
+    CFMutableDictionaryRef query = ghostftp_keychain_base_query();
+    if (query == NULL) {
+        return errSecAllocate;
+    }
+    CFDataRef data = CFDataCreate(kCFAllocatorDefault, bytes, length);
+    if (data == NULL) {
+        CFRelease(query);
+        return errSecAllocate;
+    }
+    CFDictionarySetValue(query, kSecValueData, data);
+    CFDictionarySetValue(query, kSecAttrAccessible, kSecAttrAccessibleWhenUnlockedThisDeviceOnly);
+    OSStatus status = SecItemAdd(query, NULL);
+    CFRelease(data);
+    CFRelease(query);
+    return status;
+}
+
+static int ghostftp_status_not_found(OSStatus status) { return status == errSecItemNotFound; }
+static int ghostftp_status_duplicate(OSStatus status) { return status == errSecDuplicateItem; }
+*/
+import "C"
+
+import (
+    "bytes"
+    "crypto/aes"
+    "crypto/cipher"
+    "crypto/rand"
+    "encoding/base64"
+    "errors"
+    "fmt"
+    "unsafe"
+)
+
+const (
+    darwinPersistentProfilePrefix = "darwin-keychain-aesgcm-v1:"
+    darwinPersistentProfileKeyLen = 32
+    darwinPersistentProfileMax    = 8 << 20
+    persistentProfileSecretMarker = "profile-secret-v1\x00"
+)
+
+var darwinPersistentProfileAAD = []byte("Ghost FTP Keychain persistent profile protection v1")
+
+func readDarwinProfileMasterKey() ([]byte, error) {
+    var out *C.uchar
+    var length C.CFIndex
+    status := C.ghostftp_keychain_copy(&out, &length)
+    if status != 0 {
+        if C.ghostftp_status_not_found(status) != 0 {
+            return nil, osStatusError("read", int32(status))
+        }
+        return nil, osStatusError("read", int32(status))
+    }
+    if out == nil || int64(length) != darwinPersistentProfileKeyLen {
+        if out != nil {
+            C.free(unsafe.Pointer(out))
+        }
+        return nil, errors.New("macOS Keychain profile master key has an invalid size")
+    }
+    defer C.free(unsafe.Pointer(out))
+    key := C.GoBytes(unsafe.Pointer(out), C.int(length))
+    if len(key) != darwinPersistentProfileKeyLen {
+        WipeBytes(key)
+        return nil, errors.New("macOS Keychain profile master key could not be read")
+    }
+    return key, nil
+}
+
+func osStatusError(operation string, status int32) error {
+    return fmt.Errorf("macOS Keychain profile key %s failed (OSStatus %d)", operation, status)
+}
+
+func darwinProfileMasterKey() ([]byte, error) {
+    key, err := readDarwinProfileMasterKey()
+    if err == nil {
+        return key, nil
+    }
+
+    generated := make([]byte, darwinPersistentProfileKeyLen)
+    if _, randErr := rand.Read(generated); randErr != nil {
+        return nil, randErr
+    }
+    ptr := C.CBytes(generated)
+    if ptr == nil {
+        WipeBytes(generated)
+        return nil, errors.New("macOS Keychain profile master key allocation failed")
+    }
+    status := C.ghostftp_keychain_add((*C.uchar)(ptr), C.CFIndex(len(generated)))
+    C.free(ptr)
+    if status == 0 {
+        return generated, nil
+    }
+    WipeBytes(generated)
+    if C.ghostftp_status_duplicate(status) != 0 {
+        return readDarwinProfileMasterKey()
+    }
+    return nil, osStatusError("create", int32(status))
+}
+
+func persistentProfileAEAD() (cipher.AEAD, []byte, error) {
+    key, err := darwinProfileMasterKey()
+    if err != nil {
+        return nil, nil, err
+    }
+    block, err := aes.NewCipher(key)
+    if err != nil {
+        WipeBytes(key)
+        return nil, nil, err
+    }
+    aead, err := cipher.NewGCM(block)
+    if err != nil {
+        WipeBytes(key)
+        return nil, nil, err
+    }
+    return aead, key, nil
+}
+
+// ProtectPersistentProfileBytes encrypts durable profile data with an AES-256
+// key kept in the user's macOS Keychain. The key is non-synchronizing and
+// accessible only while this device's Keychain is unlocked.
+func ProtectPersistentProfileBytes(data []byte) (string, error) {
+    if len(data) == 0 {
+        return "", nil
+    }
+    if len(data) > darwinPersistentProfileMax {
+        return "", errors.New("macOS persistent profile data is too large")
+    }
+    aead, key, err := persistentProfileAEAD()
+    if err != nil {
+        return "", err
+    }
+    defer WipeBytes(key)
+    nonce := make([]byte, aead.NonceSize())
+    if _, err := rand.Read(nonce); err != nil {
+        return "", err
+    }
+    sealed := aead.Seal(nil, nonce, data, darwinPersistentProfileAAD)
+    payload := make([]byte, 0, len(nonce)+len(sealed))
+    payload = append(payload, nonce...)
+    payload = append(payload, sealed...)
+    encoded := base64.RawURLEncoding.EncodeToString(payload)
+    WipeBytes(payload)
+    WipeBytes(sealed)
+    return darwinPersistentProfilePrefix + encoded, nil
+}
+
+func UnprotectPersistentProfileBytes(encoded string) ([]byte, error) {
+    if encoded == "" {
+        return nil, nil
+    }
+    if !bytes.HasPrefix([]byte(encoded), []byte(darwinPersistentProfilePrefix)) {
+        return nil, errors.New("macOS persistent profile data uses an unsupported format")
+    }
+    raw, err := base64.RawURLEncoding.DecodeString(encoded[len(darwinPersistentProfilePrefix):])
+    if err != nil || len(raw) > darwinPersistentProfileMax+256 {
+        WipeBytes(raw)
+        return nil, errors.New("macOS persistent profile data is malformed")
+    }
+    defer WipeBytes(raw)
+    aead, key, err := persistentProfileAEAD()
+    if err != nil {
+        return nil, err
+    }
+    defer WipeBytes(key)
+    if len(raw) <= aead.NonceSize()+aead.Overhead() {
+        return nil, errors.New("macOS persistent profile data is truncated")
+    }
+    nonce := raw[:aead.NonceSize()]
+    ciphertext := raw[aead.NonceSize():]
+    plain, err := aead.Open(nil, nonce, ciphertext, darwinPersistentProfileAAD)
+    if err != nil {
+        return nil, errors.New("macOS persistent profile data failed authentication")
+    }
+    return plain, nil
+}
+
+// ProtectRuntimeBytes deliberately reuses the existing short-lived, same-user
+// runtime secret broker. Persistent Keychain material is never handed directly
+// to ssh/curl helpers.
+func ProtectRuntimeBytes(data []byte) (string, error) { return ProtectBytes(data) }
+
+// PersistentProfileSecretToRuntime converts a saved credential into a fresh
+// runtime capability. The returned blob is owned by the connection attempt and
+// must be forgotten when the attempt/session is finished.
+func PersistentProfileSecretToRuntime(encoded string) (string, bool, error) {
+    if encoded == "" {
+        return "", false, nil
+    }
+    plain, err := UnprotectPersistentProfileBytes(encoded)
+    if err != nil {
+        return "", false, err
+    }
+    defer WipeBytes(plain)
+    marker := []byte(persistentProfileSecretMarker)
+    if !bytes.HasPrefix(plain, marker) || len(plain) == len(marker) {
+        return "", false, errors.New("macOS saved profile credential is malformed")
+    }
+    runtimeBlob, err := ProtectRuntimeBytes(plain[len(marker):])
+    if err != nil {
+        return "", false, err
+    }
+    return runtimeBlob, true, nil
+}

--- a/internal/security/profile_secret_other.go
+++ b/internal/security/profile_secret_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package security
+
+// PersistentProfileSecretToRuntime is a no-op ownership adapter on platforms
+// whose existing protected profile blob is already consumable by the runtime.
+// macOS overrides this with a Keychain-to-runtime capability conversion.
+func PersistentProfileSecretToRuntime(encoded string) (string, bool, error) {
+	return encoded, false, nil
+}
+
+func ProtectRuntimeBytes(data []byte) (string, error) { return ProtectBytes(data) }

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -11,6 +11,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/main.swift"
+SITE_MANAGER_SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/SiteManager.swift"
 BRIDGE_SOURCE="$SCRIPT_DIR/Bridge/main.go"
 ASKPASS_SOURCE="$SCRIPT_DIR/AskPass/main.go"
 ICON_SOURCE="$REPO_ROOT/build/icon.png"
@@ -27,7 +28,7 @@ SDK="$(xcrun --sdk macosx --show-sdk-path)"
 DEPLOYMENT_TARGET="13.0"
 BUNDLE_ID="app.ghostftp.client"
 
-for required in "$SOURCE" "$BRIDGE_SOURCE" "$ASKPASS_SOURCE" "$ICON_SOURCE"; do
+for required in "$SOURCE" "$SITE_MANAGER_SOURCE" "$BRIDGE_SOURCE" "$ASKPASS_SOURCE" "$ICON_SOURCE"; do
   if [[ ! -s "$required" ]]; then
     echo "Missing required macOS build input: $required" >&2
     exit 1
@@ -91,7 +92,7 @@ build_swift_arch() {
     -Xlinker -rpath \
     -Xlinker '@executable_path/../Frameworks' \
     -framework AppKit \
-    "$SOURCE" \
+    "$SOURCE" "$SITE_MANAGER_SOURCE" \
     -o "$OUT/GhostFTP-$arch"
 }
 

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -24,8 +24,9 @@ MACOS="$CONTENTS/MacOS"
 FRAMEWORKS="$CONTENTS/Frameworks"
 RESOURCES="$CONTENTS/Resources"
 MODULE_DIR="$OUT/GhostFTPEngineModule"
-GENERATED_SOURCE="$OUT/main.site-manager.swift"
-GENERATED_SITE_MANAGER_SOURCE="$OUT/SiteManager.integrated.swift"
+GENERATED_SOURCE_DIR="$OUT/generated-swift"
+GENERATED_SOURCE="$GENERATED_SOURCE_DIR/main.swift"
+GENERATED_SITE_MANAGER_SOURCE="$GENERATED_SOURCE_DIR/SiteManager.swift"
 ZIP="$DIST/Ghost-FTP-${VERSION}-macOS.app.zip"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
 DEPLOYMENT_TARGET="13.0"
@@ -39,7 +40,7 @@ for required in "$SOURCE" "$SITE_MANAGER_SOURCE" "$PREPARE_SITE_MANAGER_SOURCES"
 done
 
 rm -rf "$OUT" "$DIST"
-mkdir -p "$MACOS" "$FRAMEWORKS" "$RESOURCES" "$DIST" "$MODULE_DIR"
+mkdir -p "$MACOS" "$FRAMEWORKS" "$RESOURCES" "$DIST" "$MODULE_DIR" "$GENERATED_SOURCE_DIR"
 
 python3 "$PREPARE_SITE_MANAGER_SOURCES" \
   "$SOURCE" \

--- a/macos/BUILD.sh
+++ b/macos/BUILD.sh
@@ -12,6 +12,7 @@ fi
 
 SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/main.swift"
 SITE_MANAGER_SOURCE="$SCRIPT_DIR/Sources/GhostFTPApp/SiteManager.swift"
+PREPARE_SITE_MANAGER_SOURCES="$SCRIPT_DIR/prepare_site_manager_sources.py"
 BRIDGE_SOURCE="$SCRIPT_DIR/Bridge/main.go"
 ASKPASS_SOURCE="$SCRIPT_DIR/AskPass/main.go"
 ICON_SOURCE="$REPO_ROOT/build/icon.png"
@@ -23,12 +24,14 @@ MACOS="$CONTENTS/MacOS"
 FRAMEWORKS="$CONTENTS/Frameworks"
 RESOURCES="$CONTENTS/Resources"
 MODULE_DIR="$OUT/GhostFTPEngineModule"
+GENERATED_SOURCE="$OUT/main.site-manager.swift"
+GENERATED_SITE_MANAGER_SOURCE="$OUT/SiteManager.integrated.swift"
 ZIP="$DIST/Ghost-FTP-${VERSION}-macOS.app.zip"
 SDK="$(xcrun --sdk macosx --show-sdk-path)"
 DEPLOYMENT_TARGET="13.0"
 BUNDLE_ID="app.ghostftp.client"
 
-for required in "$SOURCE" "$SITE_MANAGER_SOURCE" "$BRIDGE_SOURCE" "$ASKPASS_SOURCE" "$ICON_SOURCE"; do
+for required in "$SOURCE" "$SITE_MANAGER_SOURCE" "$PREPARE_SITE_MANAGER_SOURCES" "$BRIDGE_SOURCE" "$ASKPASS_SOURCE" "$ICON_SOURCE"; do
   if [[ ! -s "$required" ]]; then
     echo "Missing required macOS build input: $required" >&2
     exit 1
@@ -37,6 +40,17 @@ done
 
 rm -rf "$OUT" "$DIST"
 mkdir -p "$MACOS" "$FRAMEWORKS" "$RESOURCES" "$DIST" "$MODULE_DIR"
+
+python3 "$PREPARE_SITE_MANAGER_SOURCES" \
+  "$SOURCE" \
+  "$SITE_MANAGER_SOURCE" \
+  "$GENERATED_SOURCE" \
+  "$GENERATED_SITE_MANAGER_SOURCE"
+test -s "$GENERATED_SOURCE"
+test -s "$GENERATED_SITE_MANAGER_SOURCE"
+grep -F 'NSButton(title: "Site Manager"' "$GENERATED_SOURCE" >/dev/null
+grep -F 'controller.onConnected' "$GENERATED_SOURCE" >/dev/null
+grep -F 'var onConnected: ((String, String, String) -> Void)?' "$GENERATED_SITE_MANAGER_SOURCE" >/dev/null
 
 build_go_arch() {
   local arch="$1"
@@ -92,7 +106,7 @@ build_swift_arch() {
     -Xlinker -rpath \
     -Xlinker '@executable_path/../Frameworks' \
     -framework AppKit \
-    "$SOURCE" "$SITE_MANAGER_SOURCE" \
+    "$GENERATED_SOURCE" "$GENERATED_SITE_MANAGER_SOURCE" \
     -o "$OUT/GhostFTP-$arch"
 }
 

--- a/macos/Bridge/profiles.go
+++ b/macos/Bridge/profiles.go
@@ -1,0 +1,298 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/bren-wp/Ghost-FTP/internal/model"
+)
+
+var profileSnapshot []model.PublicProfile
+
+func refreshProfilesLocked() error {
+	if bridgeState.engine == nil {
+		return errors.New("engine is not initialized")
+	}
+	items, err := bridgeState.engine.Profiles()
+	if err != nil {
+		return err
+	}
+	profileSnapshot = append(profileSnapshot[:0], items...)
+	return nil
+}
+
+func profileAt(index C.int) (model.PublicProfile, bool) {
+	i := int(index)
+	if i < 0 || i >= len(profileSnapshot) {
+		return model.PublicProfile{}, false
+	}
+	return profileSnapshot[i], true
+}
+
+func profileByID(id string) (model.PublicProfile, bool) {
+	id = strings.TrimSpace(id)
+	for _, p := range profileSnapshot {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return model.PublicProfile{}, false
+}
+
+//export GhostFTPRefreshProfiles
+func GhostFTPRefreshProfiles() C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if err := refreshProfilesLocked(); err != nil {
+		setBridgeError(err, "Ghost FTP could not load saved sites.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	return 1
+}
+
+//export GhostFTPProfileCount
+func GhostFTPProfileCount() C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	return C.int(len(profileSnapshot))
+}
+
+//export GhostFTPProfileID
+func GhostFTPProfileID(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.ID)
+}
+
+//export GhostFTPProfileName
+func GhostFTPProfileName(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.Name)
+}
+
+//export GhostFTPProfileProtocol
+func GhostFTPProfileProtocol(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.Protocol)
+}
+
+//export GhostFTPProfileHost
+func GhostFTPProfileHost(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.Host)
+}
+
+//export GhostFTPProfilePort
+func GhostFTPProfilePort(index C.int) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return 0 }
+	return C.int(p.Port)
+}
+
+//export GhostFTPProfileUsername
+func GhostFTPProfileUsername(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.Username)
+}
+
+//export GhostFTPProfileHasPassword
+func GhostFTPProfileHasPassword(index C.int) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if ok && p.HasPassword { return 1 }
+	return 0
+}
+
+//export GhostFTPProfilePrivateKeyPath
+func GhostFTPProfilePrivateKeyPath(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.PrivateKeyPath)
+}
+
+//export GhostFTPProfileHasPassphrase
+func GhostFTPProfileHasPassphrase(index C.int) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if ok && p.HasPassphrase { return 1 }
+	return 0
+}
+
+//export GhostFTPProfileFingerprint
+func GhostFTPProfileFingerprint(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.Fingerprint)
+}
+
+//export GhostFTPProfileRemotePath
+func GhostFTPProfileRemotePath(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.RemotePath)
+}
+
+//export GhostFTPProfileLocalPath
+func GhostFTPProfileLocalPath(index C.int) *C.char {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	p, ok := profileAt(index)
+	if !ok { return C.CString("") }
+	return C.CString(p.LocalPath)
+}
+
+// GhostFTPSaveProfile never accepts or returns protected secret blobs. Plaintext
+// credential fields exist only for this typed call and are either persisted via
+// the platform profile protector or discarded according to saveCredentials.
+//export GhostFTPSaveProfile
+func GhostFTPSaveProfile(idValue, nameValue, protocolValue, hostValue *C.char, portValue C.int, usernameValue, passwordValue *C.char, saveCredentials C.int, privateKeyValue, passphraseValue, fingerprintValue, remotePathValue, localPathValue *C.char) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		setBridgeError(errors.New("engine is not initialized"), "Ghost FTP is not ready.")
+		return 0
+	}
+	in := model.ProfileInput{
+		ID:             strings.TrimSpace(goString(idValue)),
+		Name:           strings.TrimSpace(goString(nameValue)),
+		Protocol:       strings.ToLower(strings.TrimSpace(goString(protocolValue))),
+		Host:           strings.TrimSpace(goString(hostValue)),
+		Port:           int(portValue),
+		Username:       goString(usernameValue),
+		PrivateKeyPath: strings.TrimSpace(goString(privateKeyValue)),
+		Fingerprint:    strings.TrimSpace(goString(fingerprintValue)),
+		RemotePath:     strings.TrimSpace(goString(remotePathValue)),
+		LocalPath:      strings.TrimSpace(goString(localPathValue)),
+	}
+	if saveCredentials != 0 {
+		in.Password = goString(passwordValue)
+		in.Passphrase = goString(passphraseValue)
+	} else {
+		in.ClearPassword = true
+		in.ClearPassphrase = true
+	}
+	if _, err := bridgeState.engine.SaveProfile(in); err != nil {
+		setBridgeError(err, "Ghost FTP could not save this site profile.")
+		return 0
+	}
+	if err := refreshProfilesLocked(); err != nil {
+		setBridgeError(err, "The profile was saved but the site list could not be refreshed.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	return 1
+}
+
+//export GhostFTPRemoveProfile
+func GhostFTPRemoveProfile(idValue *C.char) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		setBridgeError(errors.New("engine is not initialized"), "Ghost FTP is not ready.")
+		return 0
+	}
+	id := strings.TrimSpace(goString(idValue))
+	if id == "" {
+		setBridgeError(errors.New("profile id is empty"), "Select a saved site first.")
+		return 0
+	}
+	if err := bridgeState.engine.RemoveProfile(id); err != nil {
+		setBridgeError(err, "Ghost FTP could not remove this site profile.")
+		return 0
+	}
+	if err := refreshProfilesLocked(); err != nil {
+		setBridgeError(err, "The profile was removed but the site list could not be refreshed.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	return 1
+}
+
+// GhostFTPConnectProfile returns the same state codes as GhostFTPConnect:
+// 1 connected, 2 SFTP host-key trust required, 0 failure.
+//export GhostFTPConnectProfile
+func GhostFTPConnectProfile(idValue, passwordValue, passphraseValue, trustFingerprint *C.char, rememberFingerprint C.int) C.int {
+	bridgeState.mu.Lock()
+	defer bridgeState.mu.Unlock()
+	if bridgeState.engine == nil {
+		setBridgeError(errors.New("engine is not initialized"), "Ghost FTP is not ready.")
+		return 0
+	}
+	id := strings.TrimSpace(goString(idValue))
+	if id == "" {
+		setBridgeError(errors.New("profile id is empty"), "Select a saved site first.")
+		return 0
+	}
+	if len(profileSnapshot) == 0 {
+		if err := refreshProfilesLocked(); err != nil {
+			setBridgeError(err, "Ghost FTP could not load saved sites.")
+			return 0
+		}
+	}
+	p, ok := profileByID(id)
+	if !ok {
+		setBridgeError(errors.New("profile is no longer available"), "Refresh Site Manager and try again.")
+		return 0
+	}
+	cfg := model.ConnectionConfig{
+		Protocol:       p.Protocol,
+		Host:           p.Host,
+		Port:           p.Port,
+		Username:       p.Username,
+		Password:       goString(passwordValue),
+		PrivateKeyPath: p.PrivateKeyPath,
+		Passphrase:     goString(passphraseValue),
+		Fingerprint:    p.Fingerprint,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	result, err := bridgeState.engine.Connect(ctx, p.ID, cfg, strings.TrimSpace(goString(trustFingerprint)), rememberFingerprint != 0)
+	if err != nil {
+		bridgeState.pendingFingerprint = ""
+		setBridgeError(err, "Connection failed. Check the saved site and try again.")
+		return 0
+	}
+	bridgeState.lastError = ""
+	if result.RequiresTrust {
+		bridgeState.pendingFingerprint = result.Fingerprint
+		return 2
+	}
+	bridgeState.pendingFingerprint = ""
+	bridgeState.remotePath = ""
+	bridgeState.remoteItems = nil
+	if result.Connected { return 1 }
+	setBridgeError(errors.New("connection was not established"), "Connection failed. Please try again.")
+	return 0
+}

--- a/macos/Sources/GhostFTPApp/SiteManager.swift
+++ b/macos/Sources/GhostFTPApp/SiteManager.swift
@@ -1,0 +1,445 @@
+import AppKit
+import Darwin
+import Foundation
+import GhostFTPEngine
+
+private final class SiteCStringBox {
+    let pointer: UnsafeMutablePointer<CChar>?
+    init(_ value: String) { pointer = strdup(value) }
+    deinit { free(pointer) }
+}
+
+private func siteBridgeString(_ pointer: UnsafeMutablePointer<CChar>?) -> String {
+    guard let pointer else { return "" }
+    defer { GhostFTPFreeCString(pointer) }
+    return String(cString: pointer)
+}
+
+private struct SiteProfileView {
+    let id: String
+    let name: String
+    let protocolName: String
+    let host: String
+    let port: Int32
+    let username: String
+    let hasPassword: Bool
+    let privateKeyPath: String
+    let hasPassphrase: Bool
+    let fingerprint: String
+    let remotePath: String
+    let localPath: String
+}
+
+final class SiteManagerWindowController: NSWindowController, NSTableViewDataSource, NSTableViewDelegate {
+    var onConnected: (() -> Void)?
+
+    private let engineQueue = DispatchQueue(label: "app.ghostftp.site-manager", qos: .userInitiated)
+    private let table = NSTableView(frame: .zero)
+    private var profiles: [SiteProfileView] = []
+    private var selectedProfile: SiteProfileView?
+    private var connectionBusy = false
+
+    private let nameField = NSTextField(string: "")
+    private let protocolPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let hostField = NSTextField(string: "")
+    private let portField = NSTextField(string: "21")
+    private let usernameField = NSTextField(string: "")
+    private let passwordField = NSSecureTextField(string: "")
+    private let privateKeyField = NSTextField(string: "")
+    private let passphraseField = NSSecureTextField(string: "")
+    private let remotePathField = NSTextField(string: "/")
+    private let localPathField = NSTextField(string: "")
+    private let saveCredentialsButton = NSButton(checkboxWithTitle: "Save credentials on this computer?", target: nil, action: nil)
+    private let rememberFingerprintButton = NSButton(checkboxWithTitle: "Remember trusted SFTP host key", target: nil, action: nil)
+    private let statusLabel = NSTextField(labelWithString: "")
+    private let saveButton = NSButton(title: "Save Profile", target: nil, action: nil)
+    private let removeButton = NSButton(title: "Remove Profile", target: nil, action: nil)
+    private let connectButton = NSButton(title: "Connect", target: nil, action: nil)
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 880, height: 570),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Site Manager"
+        window.minSize = NSSize(width: 760, height: 500)
+        super.init(window: window)
+        buildUI()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func showAndRefresh() {
+        reloadProfiles()
+        showWindow(nil)
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func buildUI() {
+        guard let content = window?.contentView else { return }
+        protocolPopup.addItems(withTitles: ["FTP", "FTPS", "SFTP"])
+        protocolPopup.target = self
+        protocolPopup.action = #selector(protocolChanged)
+        saveCredentialsButton.toolTip = "Saved credentials stay on this Mac and are protected by macOS Keychain-backed encryption."
+        rememberFingerprintButton.state = .on
+
+        let nameColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("name"))
+        nameColumn.title = "Saved sites"
+        nameColumn.width = 220
+        table.addTableColumn(nameColumn)
+        table.headerView = nil
+        table.delegate = self
+        table.dataSource = self
+        table.usesAlternatingRowBackgroundColors = true
+        table.allowsEmptySelection = true
+
+        let scroll = NSScrollView()
+        scroll.documentView = table
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+
+        let newButton = NSButton(title: "New", target: self, action: #selector(newProfile))
+        let refreshButton = NSButton(title: "Refresh", target: self, action: #selector(refreshTapped))
+        let listButtons = NSStackView(views: [newButton, refreshButton])
+        listButtons.orientation = .horizontal
+        listButtons.spacing = 8
+        let listStack = NSStackView(views: [scroll, listButtons])
+        listStack.orientation = .vertical
+        listStack.spacing = 8
+        listStack.widthAnchor.constraint(equalToConstant: 240).isActive = true
+
+        let browseKeyButton = NSButton(title: "Browse…", target: self, action: #selector(browsePrivateKey))
+        let keyRow = NSStackView(views: [privateKeyField, browseKeyButton])
+        keyRow.orientation = .horizontal
+        keyRow.spacing = 8
+
+        let grid = NSGridView(views: [
+            [label("Name"), nameField],
+            [label("Protocol"), protocolPopup],
+            [label("Host"), hostField],
+            [label("Port"), portField],
+            [label("Username"), usernameField],
+            [label("Password"), passwordField],
+            [label("Private key"), keyRow],
+            [label("Passphrase"), passphraseField],
+            [label("Remote start"), remotePathField],
+            [label("Local start"), localPathField]
+        ])
+        grid.rowSpacing = 9
+        grid.columnSpacing = 12
+        grid.column(at: 0).xPlacement = .trailing
+        grid.column(at: 1).width = 430
+
+        saveButton.target = self
+        saveButton.action = #selector(saveProfile)
+        removeButton.target = self
+        removeButton.action = #selector(removeProfile)
+        connectButton.target = self
+        connectButton.action = #selector(connectProfile)
+        connectButton.keyEquivalent = "\r"
+        let actionRow = NSStackView(views: [saveButton, removeButton, connectButton])
+        actionRow.orientation = .horizontal
+        actionRow.spacing = 8
+
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.lineBreakMode = .byTruncatingTail
+        let formStack = NSStackView(views: [grid, saveCredentialsButton, rememberFingerprintButton, actionRow, statusLabel])
+        formStack.orientation = .vertical
+        formStack.alignment = .leading
+        formStack.spacing = 12
+
+        let root = NSStackView(views: [listStack, formStack])
+        root.orientation = .horizontal
+        root.alignment = .top
+        root.spacing = 18
+        root.edgeInsets = NSEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
+        root.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(root)
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            root.topAnchor.constraint(equalTo: content.topAnchor),
+            root.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            scroll.heightAnchor.constraint(greaterThanOrEqualToConstant: 430),
+            hostField.widthAnchor.constraint(greaterThanOrEqualToConstant: 380)
+        ])
+        clearEditor()
+    }
+
+    private func label(_ value: String) -> NSTextField {
+        let field = NSTextField(labelWithString: value)
+        field.textColor = .secondaryLabelColor
+        return field
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int { profiles.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row >= 0 && row < profiles.count else { return nil }
+        let id = NSUserInterfaceItemIdentifier("site-cell")
+        let cell: NSTableCellView
+        if let reused = tableView.makeView(withIdentifier: id, owner: self) as? NSTableCellView {
+            cell = reused
+        } else {
+            cell = NSTableCellView()
+            cell.identifier = id
+            let text = NSTextField(labelWithString: "")
+            text.translatesAutoresizingMaskIntoConstraints = false
+            cell.textField = text
+            cell.addSubview(text)
+            NSLayoutConstraint.activate([
+                text.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 6),
+                text.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+                text.centerYAnchor.constraint(equalTo: cell.centerYAnchor)
+            ])
+        }
+        cell.textField?.stringValue = profiles[row].name
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        let row = table.selectedRow
+        guard row >= 0 && row < profiles.count else {
+            selectedProfile = nil
+            clearEditor()
+            return
+        }
+        loadEditor(profiles[row])
+    }
+
+    private func readProfile(_ index: Int32) -> SiteProfileView {
+        SiteProfileView(
+            id: siteBridgeString(GhostFTPProfileID(index)),
+            name: siteBridgeString(GhostFTPProfileName(index)),
+            protocolName: siteBridgeString(GhostFTPProfileProtocol(index)),
+            host: siteBridgeString(GhostFTPProfileHost(index)),
+            port: GhostFTPProfilePort(index),
+            username: siteBridgeString(GhostFTPProfileUsername(index)),
+            hasPassword: GhostFTPProfileHasPassword(index) == 1,
+            privateKeyPath: siteBridgeString(GhostFTPProfilePrivateKeyPath(index)),
+            hasPassphrase: GhostFTPProfileHasPassphrase(index) == 1,
+            fingerprint: siteBridgeString(GhostFTPProfileFingerprint(index)),
+            remotePath: siteBridgeString(GhostFTPProfileRemotePath(index)),
+            localPath: siteBridgeString(GhostFTPProfileLocalPath(index))
+        )
+    }
+
+    private func reloadProfiles(selectID: String? = nil) {
+        guard GhostFTPRefreshProfiles() == 1 else {
+            statusLabel.stringValue = siteBridgeString(GhostFTPLastError())
+            return
+        }
+        let count = max(0, Int(GhostFTPProfileCount()))
+        profiles = (0..<count).map { readProfile(Int32($0)) }
+        table.reloadData()
+        if let selectID, let index = profiles.firstIndex(where: { $0.id == selectID }) {
+            table.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
+            table.scrollRowToVisible(index)
+            loadEditor(profiles[index])
+        } else if table.selectedRow >= profiles.count {
+            table.deselectAll(nil)
+            clearEditor()
+        }
+        statusLabel.stringValue = profiles.isEmpty ? "No saved sites yet." : "Saved sites: \(profiles.count)"
+    }
+
+    private func clearEditor() {
+        selectedProfile = nil
+        nameField.stringValue = ""
+        protocolPopup.selectItem(withTitle: "FTP")
+        hostField.stringValue = ""
+        portField.stringValue = "21"
+        usernameField.stringValue = ""
+        passwordField.stringValue = ""
+        privateKeyField.stringValue = ""
+        passphraseField.stringValue = ""
+        remotePathField.stringValue = "/"
+        localPathField.stringValue = ""
+        saveCredentialsButton.title = "Save credentials on this computer?"
+        saveCredentialsButton.state = .off
+        removeButton.isEnabled = false
+        connectButton.isEnabled = false
+        protocolChanged()
+    }
+
+    private func loadEditor(_ profile: SiteProfileView) {
+        selectedProfile = profile
+        nameField.stringValue = profile.name
+        protocolPopup.selectItem(withTitle: profile.protocolName.uppercased())
+        hostField.stringValue = profile.host
+        portField.stringValue = String(profile.port)
+        usernameField.stringValue = profile.username
+        passwordField.stringValue = ""
+        privateKeyField.stringValue = profile.privateKeyPath
+        passphraseField.stringValue = ""
+        remotePathField.stringValue = profile.remotePath
+        localPathField.stringValue = profile.localPath
+        let hasSavedCredentials = profile.hasPassword || profile.hasPassphrase
+        saveCredentialsButton.title = hasSavedCredentials ? "Keep saved credentials on this computer?" : "Save credentials on this computer?"
+        saveCredentialsButton.state = hasSavedCredentials ? .on : .off
+        removeButton.isEnabled = true
+        connectButton.isEnabled = true
+        protocolChanged()
+    }
+
+    @objc private func protocolChanged() {
+        let sftp = protocolPopup.titleOfSelectedItem == "SFTP"
+        privateKeyField.isEnabled = sftp
+        passphraseField.isEnabled = sftp
+        rememberFingerprintButton.isHidden = !sftp
+        if !sftp {
+            privateKeyField.stringValue = ""
+            passphraseField.stringValue = ""
+        }
+        if selectedProfile == nil {
+            portField.stringValue = sftp ? "22" : "21"
+            remotePathField.stringValue = sftp ? "." : "/"
+        }
+    }
+
+    @objc private func newProfile() {
+        table.deselectAll(nil)
+        clearEditor()
+        nameField.becomeFirstResponder()
+    }
+
+    @objc private func refreshTapped() { reloadProfiles(selectID: selectedProfile?.id) }
+
+    @objc private func browsePrivateKey() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            privateKeyField.stringValue = url.path
+        }
+    }
+
+    private func fingerprintForSave(protocolName: String, host: String, port: Int32) -> String {
+        guard let existing = selectedProfile else { return "" }
+        guard protocolName == "sftp",
+              existing.protocolName.lowercased() == protocolName,
+              existing.host.caseInsensitiveCompare(host) == .orderedSame,
+              existing.port == port else { return "" }
+        return existing.fingerprint
+    }
+
+    @objc private func saveProfile() {
+        let name = nameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let protocolName = (protocolPopup.titleOfSelectedItem ?? "FTP").lowercased()
+        let host = hostField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let port = Int32(portField.stringValue), port > 0 && port <= 65535 else {
+            statusLabel.stringValue = "Enter a valid port from 1 to 65535."
+            return
+        }
+        let fingerprint = fingerprintForSave(protocolName: protocolName, host: host, port: port)
+        let id = SiteCStringBox(selectedProfile?.id ?? "")
+        let cName = SiteCStringBox(name)
+        let cProtocol = SiteCStringBox(protocolName)
+        let cHost = SiteCStringBox(host)
+        let cUsername = SiteCStringBox(usernameField.stringValue)
+        let cPassword = SiteCStringBox(passwordField.stringValue)
+        let cKey = SiteCStringBox(privateKeyField.stringValue)
+        let cPassphrase = SiteCStringBox(passphraseField.stringValue)
+        let cFingerprint = SiteCStringBox(fingerprint)
+        let cRemote = SiteCStringBox(remotePathField.stringValue)
+        let cLocal = SiteCStringBox(localPathField.stringValue)
+        let keep = saveCredentialsButton.state == .on ? Int32(1) : Int32(0)
+        let ok = GhostFTPSaveProfile(
+            id.pointer, cName.pointer, cProtocol.pointer, cHost.pointer, port,
+            cUsername.pointer, cPassword.pointer, keep, cKey.pointer, cPassphrase.pointer,
+            cFingerprint.pointer, cRemote.pointer, cLocal.pointer
+        )
+        passwordField.stringValue = ""
+        passphraseField.stringValue = ""
+        if ok != 1 {
+            statusLabel.stringValue = siteBridgeString(GhostFTPLastError())
+            return
+        }
+        reloadProfiles()
+        if let saved = profiles.first(where: { $0.name == name && $0.host.caseInsensitiveCompare(host) == .orderedSame && $0.port == port }) {
+            reloadProfiles(selectID: saved.id)
+        }
+        statusLabel.stringValue = "Profile saved securely on this Mac."
+    }
+
+    @objc private func removeProfile() {
+        guard let profile = selectedProfile else { return }
+        let alert = NSAlert()
+        alert.messageText = "Remove Profile"
+        alert.informativeText = "Remove \"\(profile.name)\" from this Mac?"
+        alert.addButton(withTitle: "Remove")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let id = SiteCStringBox(profile.id)
+        if GhostFTPRemoveProfile(id.pointer) != 1 {
+            statusLabel.stringValue = siteBridgeString(GhostFTPLastError())
+            return
+        }
+        reloadProfiles()
+        clearEditor()
+        statusLabel.stringValue = "Profile removed."
+    }
+
+    @objc private func connectProfile() {
+        guard let profile = selectedProfile, !connectionBusy else { return }
+        connectionBusy = true
+        connectButton.isEnabled = false
+        statusLabel.stringValue = "Connecting…"
+        let profileID = profile.id
+        let password = passwordField.stringValue
+        let passphrase = passphraseField.stringValue
+        let remember = rememberFingerprintButton.state == .on
+        passwordField.stringValue = ""
+        passphraseField.stringValue = ""
+        runConnect(profileID: profileID, password: password, passphrase: passphrase, trust: "", remember: remember)
+    }
+
+    private func runConnect(profileID: String, password: String, passphrase: String, trust: String, remember: Bool) {
+        engineQueue.async { [weak self] in
+            let id = SiteCStringBox(profileID)
+            let pwd = SiteCStringBox(password)
+            let phrase = SiteCStringBox(passphrase)
+            let trustValue = SiteCStringBox(trust)
+            let result = GhostFTPConnectProfile(id.pointer, pwd.pointer, phrase.pointer, trustValue.pointer, remember ? 1 : 0)
+            let error = result == 0 ? siteBridgeString(GhostFTPLastError()) : ""
+            let fingerprint = result == 2 ? siteBridgeString(GhostFTPPendingFingerprint()) : ""
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if result == 2 {
+                    self.confirmFingerprint(profileID: profileID, password: password, passphrase: passphrase, fingerprint: fingerprint, remember: remember)
+                    return
+                }
+                self.connectionBusy = false
+                self.connectButton.isEnabled = self.selectedProfile != nil
+                if result == 1 {
+                    self.statusLabel.stringValue = "Connected."
+                    self.onConnected?()
+                    self.close()
+                } else {
+                    self.statusLabel.stringValue = error.isEmpty ? "Connection failed." : error
+                }
+            }
+        }
+    }
+
+    private func confirmFingerprint(profileID: String, password: String, passphrase: String, fingerprint: String, remember: Bool) {
+        let alert = NSAlert()
+        alert.messageText = "Verify SFTP server identity"
+        alert.informativeText = "Verify this fingerprint through an independent trusted channel (for example, your hosting control panel or administrator). Accept only if it matches exactly.\n\n\(fingerprint)"
+        alert.addButton(withTitle: "Trust and Connect")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            runConnect(profileID: profileID, password: password, passphrase: passphrase, trust: fingerprint, remember: remember)
+        } else {
+            GhostFTPCancelPendingTrust()
+            connectionBusy = false
+            connectButton.isEnabled = selectedProfile != nil
+            statusLabel.stringValue = "Connection cancelled."
+        }
+    }
+}

--- a/macos/prepare_site_manager_sources.py
+++ b/macos/prepare_site_manager_sources.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"Site Manager integration anchor {label!r} matched {count} times; refusing to build")
+    return text.replace(old, new, 1)
+
+
+def integrate_main(text: str) -> str:
+    text = replace_once(
+        text,
+        "    private var transferQueueController: TransferQueueWindowController?\n",
+        "    private var transferQueueController: TransferQueueWindowController?\n"
+        "    private var siteManagerController: SiteManagerWindowController?\n",
+        "main-controller-property",
+    )
+    text = replace_once(
+        text,
+        '    private let transferQueueButton = NSButton(title: "Transfers", target: nil, action: nil)\n',
+        '    private let transferQueueButton = NSButton(title: "Transfers", target: nil, action: nil)\n'
+        '    private let siteManagerButton = NSButton(title: "Site Manager", target: nil, action: nil)\n',
+        "main-button-property",
+    )
+    text = replace_once(
+        text,
+        "        transferQueueController?.closeSilently()\n"
+        "        transferQueueController = nil\n"
+        "        GhostFTPClearTransferQueueSnapshot()\n",
+        "        transferQueueController?.closeSilently()\n"
+        "        transferQueueController = nil\n"
+        "        siteManagerController?.close()\n"
+        "        siteManagerController = nil\n"
+        "        GhostFTPClearTransferQueueSnapshot()\n",
+        "main-termination-cleanup",
+    )
+    text = replace_once(
+        text,
+        "        transferQueueButton.target = self\n"
+        "        transferQueueButton.action = #selector(transferQueueTapped)\n",
+        "        transferQueueButton.target = self\n"
+        "        transferQueueButton.action = #selector(transferQueueTapped)\n"
+        "        siteManagerButton.target = self\n"
+        "        siteManagerButton.action = #selector(siteManagerTapped)\n",
+        "main-button-action",
+    )
+    text = replace_once(
+        text,
+        "        let buttonRow = NSStackView(views: [connectButton, disconnectButton, directoryCompareButton, transferQueueButton, statusLabel])\n",
+        "        let buttonRow = NSStackView(views: [connectButton, disconnectButton, siteManagerButton, directoryCompareButton, transferQueueButton, statusLabel])\n",
+        "main-button-row",
+    )
+    text = replace_once(
+        text,
+        "\n\n    private func startTransferQueuePolling() {\n",
+        "\n\n    @objc private func siteManagerTapped() {\n"
+        "        guard engineReady, !connectionBusy else { return }\n"
+        "        if let controller = siteManagerController {\n"
+        "            controller.showAndRefresh()\n"
+        "            return\n"
+        "        }\n"
+        "        let controller = SiteManagerWindowController()\n"
+        "        controller.onConnected = { [weak self] protocolName, remoteStart, localStart in\n"
+        "            guard let self else { return }\n"
+        "            let local = localStart.trimmingCharacters(in: .whitespacesAndNewlines)\n"
+        "            let remote = remoteStart.trimmingCharacters(in: .whitespacesAndNewlines)\n"
+        "            let remoteTarget = remote.isEmpty ? (protocolName.lowercased() == \"sftp\" ? \".\" : \"/\") : remote\n"
+        "            self.remoteCurrent = remoteTarget\n"
+        "            self.refreshConnectionState()\n"
+        "            self.refreshLocal(local.isEmpty ? self.localCurrent : local)\n"
+        "            self.refreshRemote(remoteTarget)\n"
+        "        }\n"
+        "        siteManagerController = controller\n"
+        "        controller.showAndRefresh()\n"
+        "    }\n"
+        "\n"
+        "    private func startTransferQueuePolling() {\n",
+        "main-site-manager-action",
+    )
+    text = replace_once(
+        text,
+        "        transferQueueButton.isEnabled = engineReady && !connectionBusy\n",
+        "        siteManagerButton.isEnabled = engineReady && !connectionBusy\n"
+        "        transferQueueButton.isEnabled = engineReady && !connectionBusy\n",
+        "main-control-state",
+    )
+    return text
+
+
+def integrate_site_manager(text: str) -> str:
+    text = replace_once(
+        text,
+        "    var onConnected: (() -> Void)?\n",
+        "    var onConnected: ((String, String, String) -> Void)?\n",
+        "site-manager-connected-callback-type",
+    )
+    text = replace_once(
+        text,
+        "        connectButton.isEnabled = true\n"
+        "        protocolChanged()\n",
+        "        connectButton.isEnabled = GhostFTPIsConnected() == 0\n"
+        "        protocolChanged()\n",
+        "site-manager-connected-session-gate",
+    )
+    text = replace_once(
+        text,
+        "                self.connectButton.isEnabled = self.selectedProfile != nil\n"
+        "                if result == 1 {\n"
+        "                    self.statusLabel.stringValue = \"Connected.\"\n"
+        "                    self.onConnected?()\n"
+        "                    self.close()\n"
+        "                } else {\n",
+        "                self.connectButton.isEnabled = self.selectedProfile != nil && GhostFTPIsConnected() == 0\n"
+        "                if result == 1 {\n"
+        "                    self.statusLabel.stringValue = \"Connected.\"\n"
+        "                    if let connected = self.profiles.first(where: { $0.id == profileID }) {\n"
+        "                        self.onConnected?(connected.protocolName, connected.remotePath, connected.localPath)\n"
+        "                    } else {\n"
+        "                        self.onConnected?(\"\", \"\", \"\")\n"
+        "                    }\n"
+        "                    self.close()\n"
+        "                } else {\n",
+        "site-manager-connected-callback",
+    )
+    text = replace_once(
+        text,
+        "            connectButton.isEnabled = selectedProfile != nil\n"
+        "            statusLabel.stringValue = \"Connection cancelled.\"\n",
+        "            connectButton.isEnabled = selectedProfile != nil && GhostFTPIsConnected() == 0\n"
+        "            statusLabel.stringValue = \"Connection cancelled.\"\n",
+        "site-manager-cancel-gate",
+    )
+    return text
+
+
+def main() -> None:
+    if len(sys.argv) != 5:
+        raise SystemExit("usage: prepare_site_manager_sources.py MAIN.swift SiteManager.swift OUT_MAIN.swift OUT_SITE.swift")
+    main_source, site_source, out_main, out_site = map(Path, sys.argv[1:])
+    main_text = integrate_main(main_source.read_text(encoding="utf-8"))
+    site_text = integrate_site_manager(site_source.read_text(encoding="utf-8"))
+    Path(out_main).write_text(main_text, encoding="utf-8")
+    Path(out_site).write_text(site_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_macos_engine_bridge_contract.py
+++ b/scripts/test_macos_engine_bridge_contract.py
@@ -63,20 +63,31 @@ class MacOSEngineBridgeContractTests(unittest.TestCase):
             self.assertIn(marker, darwin)
         self.assertNotIn("XDG_DATA_HOME", darwin)
 
-    def test_persistent_macos_profiles_fail_closed_until_keychain(self) -> None:
+    def test_persistent_macos_profiles_use_keychain_protection(self) -> None:
         profile_crypto = read("internal/config/profile_crypto_darwin.go")
+        keychain = read("internal/security/profile_secret_darwin.go")
         for marker in (
             "//go:build darwin",
-            "saved profiles are unavailable until macOS Keychain protection is enabled",
-            "func protectProfileData([]byte, string) (string, error)",
-            "func unprotectProfileData(string, string) ([]byte, error)",
-            "return \"\", errDarwinPersistentProfilesUnavailable",
-            "return nil, errDarwinPersistentProfilesUnavailable",
+            "ProtectPersistentProfileBytes",
+            "UnprotectPersistentProfileBytes",
+            '"profile-envelope-v1\\x00"',
         ):
             self.assertIn(marker, profile_crypto)
-        self.assertNotIn("base64", profile_crypto)
-        self.assertNotIn("WriteFile", profile_crypto)
-        self.assertNotIn("ProtectString", profile_crypto)
+        for marker in (
+            "#cgo LDFLAGS: -framework Security -framework CoreFoundation",
+            "kSecClassGenericPassword",
+            "kSecAttrAccessibleWhenUnlockedThisDeviceOnly",
+            "darwin-keychain-aesgcm-v1:",
+            "ProtectPersistentProfileBytes",
+            "UnprotectPersistentProfileBytes",
+            "PersistentProfileSecretToRuntime",
+            "ProtectRuntimeBytes",
+        ):
+            self.assertIn(marker, keychain)
+        self.assertNotIn("errDarwinPersistentProfilesUnavailable", profile_crypto)
+        self.assertNotIn("saved profiles are unavailable until macOS Keychain protection is enabled", profile_crypto)
+        self.assertNotIn("/usr/bin/security", keychain)
+        self.assertNotIn("exec.Command", keychain)
 
     def test_macos_build_links_universal_go_engine_dylib(self) -> None:
         build = read("macos/BUILD.sh")
@@ -94,6 +105,7 @@ class MacOSEngineBridgeContractTests(unittest.TestCase):
             "@rpath/libGhostFTPEngine.dylib",
             "@executable_path/../Frameworks",
             'FRAMEWORKS="$CONTENTS/Frameworks"',
+            "SiteManager.swift",
         ):
             self.assertIn(marker, build)
 

--- a/scripts/test_macos_site_manager_integration.py
+++ b/scripts/test_macos_site_manager_integration.py
@@ -53,8 +53,9 @@ class MacOSSiteManagerIntegrationTests(unittest.TestCase):
         build = (ROOT / "macos" / "BUILD.sh").read_text(encoding="utf-8")
         for marker in (
             "prepare_site_manager_sources.py",
-            'GENERATED_SOURCE="$OUT/main.site-manager.swift"',
-            'GENERATED_SITE_MANAGER_SOURCE="$OUT/SiteManager.integrated.swift"',
+            'GENERATED_SOURCE_DIR="$OUT/generated-swift"',
+            'GENERATED_SOURCE="$GENERATED_SOURCE_DIR/main.swift"',
+            'GENERATED_SITE_MANAGER_SOURCE="$GENERATED_SOURCE_DIR/SiteManager.swift"',
             'python3 "$PREPARE_SITE_MANAGER_SOURCES"',
             'grep -F \'NSButton(title: "Site Manager"\' "$GENERATED_SOURCE"',
             '"$GENERATED_SOURCE" "$GENERATED_SITE_MANAGER_SOURCE"',

--- a/scripts/test_macos_site_manager_integration.py
+++ b/scripts/test_macos_site_manager_integration.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MacOSSiteManagerIntegrationTests(unittest.TestCase):
+    def test_preparer_wires_site_manager_into_native_app(self) -> None:
+        main_source = ROOT / "macos" / "Sources" / "GhostFTPApp" / "main.swift"
+        site_source = ROOT / "macos" / "Sources" / "GhostFTPApp" / "SiteManager.swift"
+        preparer = ROOT / "macos" / "prepare_site_manager_sources.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            output_main = Path(temporary) / "main.swift"
+            output_site = Path(temporary) / "SiteManager.swift"
+            subprocess.run(
+                [
+                    "python3",
+                    str(preparer),
+                    str(main_source),
+                    str(site_source),
+                    str(output_main),
+                    str(output_site),
+                ],
+                cwd=ROOT,
+                check=True,
+            )
+            main_text = output_main.read_text(encoding="utf-8")
+            site_text = output_site.read_text(encoding="utf-8")
+
+        for marker in (
+            'NSButton(title: "Site Manager"',
+            "#selector(siteManagerTapped)",
+            "SiteManagerWindowController()",
+            "controller.onConnected = { [weak self] protocolName, remoteStart, localStart in",
+            "self.refreshConnectionState()",
+            "self.refreshRemote(remoteTarget)",
+            "siteManagerController?.close()",
+        ):
+            self.assertIn(marker, main_text)
+
+        for marker in (
+            "var onConnected: ((String, String, String) -> Void)?",
+            "GhostFTPIsConnected() == 0",
+            "self.profiles.first(where: { $0.id == profileID })",
+            "self.onConnected?(connected.protocolName, connected.remotePath, connected.localPath)",
+        ):
+            self.assertIn(marker, site_text)
+
+    def test_build_uses_fail_closed_generated_sources(self) -> None:
+        build = (ROOT / "macos" / "BUILD.sh").read_text(encoding="utf-8")
+        for marker in (
+            "prepare_site_manager_sources.py",
+            'GENERATED_SOURCE="$OUT/main.site-manager.swift"',
+            'GENERATED_SITE_MANAGER_SOURCE="$OUT/SiteManager.integrated.swift"',
+            'python3 "$PREPARE_SITE_MANAGER_SOURCES"',
+            'grep -F \'NSButton(title: "Site Manager"\' "$GENERATED_SOURCE"',
+            '"$GENERATED_SOURCE" "$GENERATED_SITE_MANAGER_SOURCE"',
+        ):
+            self.assertIn(marker, build)
+
+    def test_preparer_rejects_missing_anchor(self) -> None:
+        preparer = ROOT / "macos" / "prepare_site_manager_sources.py"
+        site_source = ROOT / "macos" / "Sources" / "GhostFTPApp" / "SiteManager.swift"
+        with tempfile.TemporaryDirectory() as temporary:
+            broken_main = Path(temporary) / "broken-main.swift"
+            broken_main.write_text("import AppKit\n", encoding="utf-8")
+            output_main = Path(temporary) / "main.swift"
+            output_site = Path(temporary) / "SiteManager.swift"
+            completed = subprocess.run(
+                [
+                    "python3",
+                    str(preparer),
+                    str(broken_main),
+                    str(site_source),
+                    str(output_main),
+                    str(output_site),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("refusing to build", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Authorization

- [ ] This source-code change was explicitly requested or authorized for Ghost FTP.
- [ ] I have read and will follow `LICENSE` and the contribution documentation.

> Ghost FTP is source-available software. Opening a pull request or fork does not itself grant rights beyond the repository license and applicable GitHub platform rights.

## Summary

Describe the change and why it is needed.

## Branding and compatibility

- [ ] New public UI, documentation and release assets use **Ghost FTP**.
- [ ] Any retained `GhostFTP`/`GhostFTP` identifier is required for backward compatibility, migration or installed-application identity and is not user-facing branding.

## Security and privacy

- [ ] No telemetry, analytics, advertising SDK or external crash-reporting service was added.
- [ ] No automatic external API or hidden network destination was added.
- [ ] Passwords, private-key passphrases and private keys do not end up in command-line arguments or persistent logs.
- [ ] SFTP host-key verification and pinning remain active.
- [ ] Local path-traversal, symlink, junction and reparse-point protections remain active.
- [ ] No external Go module was added without explicit architecture/security review.
- [ ] Tests, screenshots and fixtures contain no real credentials, production servers or customer data.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `python scripts/audit_security.py`
- [ ] `python scripts/audit_privacy.py`
- [ ] PHP syntax checks pass when web code changed.
- [ ] Native platform build checks pass for affected platforms.

## Regression coverage

Describe tests added or changed for connections, transfers, paths, profiles, installation/uninstallation, localization, release packaging or other affected behavior.
