### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/desktop/other.go
+++ b/internal/desktop/other.go
@@ -356,7 +356,7 @@ func printProfile(profile model.PublicProfile) {
 	fmt.Printf("username=%s\n", profile.Username)
 	fmt.Printf("password-saved=%t\n", profile.HasPassword)
 	fmt.Printf("private-key=%s\n", profile.PrivateKeyPath)
-	fmt.Printf("passphrase-saved=%t\n", profile.HasPassphrase)
+	fmt.Printf("passphrase-saved=%s\n", "redacted")
 	fmt.Printf("fingerprint=%s\n", profile.Fingerprint)
 	fmt.Printf("remote-path=%s\n", profile.RemotePath)
 	fmt.Printf("local-path=%s\n", profile.LocalPath)


### PR DESCRIPTION
Potential fix for [https://github.com/bren-wp/Ghost-FTP/security/code-scanning/2](https://github.com/bren-wp/Ghost-FTP/security/code-scanning/2)

General fix: avoid logging sensitive secrets **and sensitive secret metadata** (such as whether a passphrase is stored). Prefer omission or redaction in profile-print output.

Best fix here (minimal functional impact): in `internal/desktop/other.go`, update `printProfile` to remove the direct exposure of `profile.HasPassphrase`. Keep the output key for compatibility, but print a constant redacted marker instead of the real boolean.

Change needed:
- In `printProfile(profile model.PublicProfile)`, replace:
  - `fmt.Printf("passphrase-saved=%t\n", profile.HasPassphrase)`
- With:
  - `fmt.Printf("passphrase-saved=%s\n", "redacted")`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
