### PR TITLE
feat: prepare fail-closed macOS production distribution

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -18,11 +18,15 @@ on:
       - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
       - 'scripts/test_macos_engine_bridge_contract.py'
+      - 'scripts/test_macos_application_parity_contract.py'
+      - 'scripts/test_macos_distribution_contract.py'
       - '.github/workflows/macos-app.yml'
+      - '.github/workflows/macos-production.yml'
   push:
     branches:
       - main
       - 'feature/**'
+      - 'release/**'
     paths:
       - 'VERSION'
       - 'build/icon.png'
@@ -37,7 +41,10 @@ on:
       - 'scripts/audit_version.py'
       - 'scripts/test_macos_windows_parity_contract.py'
       - 'scripts/test_macos_engine_bridge_contract.py'
+      - 'scripts/test_macos_application_parity_contract.py'
+      - 'scripts/test_macos_distribution_contract.py'
       - '.github/workflows/macos-app.yml'
+      - '.github/workflows/macos-production.yml'
 
 permissions:
   contents: read
@@ -68,7 +75,7 @@ jobs:
           echo "MACOS_SOURCE_SHA=$SOURCE_SHA"
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.2.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27.1'
           check-latest: false
@@ -85,15 +92,19 @@ jobs:
           xcrun swiftc --version
           xcrun --sdk macosx --show-sdk-path
 
-      - name: Validate macOS engine and parity contracts
+      - name: Validate macOS engine parity and distribution contracts
         shell: bash
         run: |
           set -euo pipefail
           python3 scripts/test_macos_windows_parity_contract.py
           python3 scripts/test_macos_engine_bridge_contract.py
+          python3 scripts/test_macos_application_parity_contract.py
+          python3 scripts/test_macos_distribution_contract.py
           python3 scripts/audit_platform_contract.py
           python3 scripts/audit_desktop_surface.py
           python3 scripts/audit_version.py
+          bash -n macos/BUILD.sh
+          bash -n macos/SIGN_AND_NOTARIZE.sh
 
       - name: Build universal native macOS app and shared engine
         shell: bash

--- a/.github/workflows/macos-production.yml
+++ b/.github/workflows/macos-production.yml
@@ -1,0 +1,174 @@
+name: Ghost FTP macOS Production Artifact
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghostftp-macos-production-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  production:
+    name: Developer ID signed and notarized universal app
+    runs-on: macos-15
+    timeout-minutes: 35
+    environment: macos-production
+    steps:
+      - name: Checkout exact selected source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Confirm exact source and required credentials
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+          DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
+          NOTARY_API_KEY_P8: ${{ secrets.APPLE_NOTARY_API_KEY_P8 }}
+          NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          for value in \
+            "$DEVELOPER_ID_P12_BASE64" \
+            "$DEVELOPER_ID_P12_PASSWORD" \
+            "$DEVELOPER_IDENTITY" \
+            "$NOTARY_API_KEY_P8" \
+            "$NOTARY_API_KEY_ID" \
+            "$NOTARY_ISSUER_ID"; do
+            test -n "$value"
+          done
+          case "$DEVELOPER_IDENTITY" in
+            'Developer ID Application:'*) ;;
+            *) echo 'MACOS_PRODUCTION_FAILED: invalid Developer ID identity' >&2; exit 1 ;;
+          esac
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          check-latest: false
+          cache: false
+
+      - name: Disable Go telemetry and validate source contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          go telemetry off
+          test "$(go telemetry)" = 'off'
+          python3 scripts/test_macos_windows_parity_contract.py
+          python3 scripts/test_macos_application_parity_contract.py
+          python3 scripts/test_macos_distribution_contract.py
+          python3 scripts/audit_security.py
+          python3 scripts/audit_privacy.py
+          bash -n macos/BUILD.sh
+          bash -n macos/SIGN_AND_NOTARIZE.sh
+
+      - name: Provision ephemeral signing and notarization keychain
+        id: signing
+        shell: bash
+        env:
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+          DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
+          NOTARY_API_KEY_P8: ${{ secrets.APPLE_NOTARY_API_KEY_P8 }}
+          NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          keychain="$work/ghostftp-signing.keychain-db"
+          p12="$work/developer-id.p12"
+          api_key="$work/AuthKey.p8"
+          keychain_password="$(openssl rand -hex 32)"
+          profile="ghostftp-notary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          printf '%s' "$DEVELOPER_ID_P12_BASE64" | base64 --decode > "$p12"
+          printf '%s' "$NOTARY_API_KEY_P8" > "$api_key"
+          chmod 600 "$p12" "$api_key"
+
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$p12" \
+            -k "$keychain" \
+            -P "$DEVELOPER_ID_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain"
+          security list-keychains -d user -s "$keychain"
+          security default-keychain -d user -s "$keychain"
+          security find-identity -v -p codesigning "$keychain" | grep -F -- "$DEVELOPER_IDENTITY" >/dev/null
+
+          xcrun notarytool store-credentials "$profile" \
+            --key "$api_key" \
+            --key-id "$NOTARY_API_KEY_ID" \
+            --issuer "$NOTARY_ISSUER_ID"
+
+          rm -f "$p12" "$api_key"
+          {
+            echo "work=$work"
+            echo "keychain=$keychain"
+            echo "profile=$profile"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build sign notarize staple and assess
+        shell: bash
+        env:
+          GOTOOLCHAIN: local
+          GOPROXY: 'off'
+          GOSUMDB: 'off'
+          MACOS_DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
+          MACOS_NOTARY_KEYCHAIN_PROFILE: ${{ steps.signing.outputs.profile }}
+        run: bash macos/SIGN_AND_NOTARIZE.sh
+
+      - name: Verify final notarized artifact
+        shell: bash
+        env:
+          MACOS_DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          version="$(tr -d '\r\n' < VERSION)"
+          archive="macos/dist/Ghost-FTP-${version}-macOS-notarized.app.zip"
+          test -s "$archive"
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          ditto -x -k "$archive" "$work"
+          app="$work/Ghost FTP.app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          xcrun stapler validate "$app"
+          spctl --assess --type execute --verbose=4 "$app"
+          codesign --display --verbose=4 "$app" 2>&1 | grep -F 'runtime'
+          codesign --display --verbose=4 "$app" 2>&1 | grep -F 'Timestamp='
+          codesign --display --verbose=4 "$app" 2>&1 | grep -F -- "$MACOS_DEVELOPER_IDENTITY"
+          echo 'MACOS_PRODUCTION_ARTIFACT_VERIFIED=PASS'
+
+      - name: Store notarized production artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghostftp-macos-notarized
+          if-no-files-found: error
+          retention-days: 14
+          path: macos/dist/Ghost-FTP-*-macOS-notarized.app.zip
+
+      - name: Destroy ephemeral signing keychain
+        if: always() && steps.signing.outputs.work != ''
+        shell: bash
+        env:
+          SIGNING_KEYCHAIN: ${{ steps.signing.outputs.keychain }}
+          SIGNING_WORK: ${{ steps.signing.outputs.work }}
+        run: |
+          set +e
+          security delete-keychain "$SIGNING_KEYCHAIN" >/dev/null 2>&1
+          rm -rf "$SIGNING_WORK"

--- a/.github/workflows/macos-production.yml
+++ b/.github/workflows/macos-production.yml
@@ -90,6 +90,26 @@ jobs:
           keychain_password="$(openssl rand -hex 32)"
           profile="ghostftp-notary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
+          # Publish cleanup locations before handling any decrypted material so
+          # the later always() step can clean even when provisioning fails.
+          {
+            echo "work=$work"
+            echo "keychain=$keychain"
+            echo "profile=$profile"
+          } >> "$GITHUB_OUTPUT"
+
+          cleanup_provisioning() {
+            status=$?
+            if [[ "$status" -ne 0 ]]; then
+              set +e
+              rm -f "$p12" "$api_key"
+              security delete-keychain "$keychain" >/dev/null 2>&1
+              rm -rf "$work"
+            fi
+            return "$status"
+          }
+          trap cleanup_provisioning EXIT
+
           printf '%s' "$DEVELOPER_ID_P12_BASE64" | base64 --decode > "$p12"
           printf '%s' "$NOTARY_API_KEY_P8" > "$api_key"
           chmod 600 "$p12" "$api_key"
@@ -117,11 +137,7 @@ jobs:
             --issuer "$NOTARY_ISSUER_ID"
 
           rm -f "$p12" "$api_key"
-          {
-            echo "work=$work"
-            echo "keychain=$keychain"
-            echo "profile=$profile"
-          } >> "$GITHUB_OUTPUT"
+          trap - EXIT
 
       - name: Build sign notarize staple and assess
         shell: bash

--- a/.github/workflows/macos-production.yml
+++ b/.github/workflows/macos-production.yml
@@ -83,9 +83,11 @@ jobs:
           NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
         run: |
           set -euo pipefail
+          command -v openssl >/dev/null 2>&1
           work="$(mktemp -d)"
           keychain="$work/ghostftp-signing.keychain-db"
-          p12="$work/developer-id.p12"
+          protected_p12="$work/developer-id-protected.p12"
+          import_p12="$work/developer-id-import.p12"
           api_key="$work/AuthKey.p8"
           keychain_password="$(openssl rand -hex 32)"
           profile="ghostftp-notary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -102,7 +104,7 @@ jobs:
             status=$?
             if [[ "$status" -ne 0 ]]; then
               set +e
-              rm -f "$p12" "$api_key"
+              rm -f "$protected_p12" "$import_p12" "$api_key"
               security delete-keychain "$keychain" >/dev/null 2>&1
               rm -rf "$work"
             fi
@@ -110,18 +112,35 @@ jobs:
           }
           trap cleanup_provisioning EXIT
 
-          printf '%s' "$DEVELOPER_ID_P12_BASE64" | base64 --decode > "$p12"
+          printf '%s' "$DEVELOPER_ID_P12_BASE64" | base64 -D > "$protected_p12"
           printf '%s' "$NOTARY_API_KEY_P8" > "$api_key"
-          chmod 600 "$p12" "$api_key"
+          chmod 600 "$protected_p12" "$api_key"
+
+          # `security import -P <passphrase>` exposes the P12 passphrase in
+          # process arguments. Unwrap from an environment-backed passphrase and
+          # immediately re-wrap with an empty one only inside this private temp
+          # directory; security imports that disposable copy as non-extractable.
+          openssl pkcs12 \
+            -in "$protected_p12" \
+            -passin env:DEVELOPER_ID_P12_PASSWORD \
+            -nodes | \
+            openssl pkcs12 \
+              -export \
+              -out "$import_p12" \
+              -passout pass:
+          chmod 600 "$import_p12"
+          rm -f "$protected_p12"
 
           security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$p12" \
+          security import "$import_p12" \
             -k "$keychain" \
-            -P "$DEVELOPER_ID_P12_PASSWORD" \
+            -P '' \
+            -x \
             -T /usr/bin/codesign \
             -T /usr/bin/security
+          rm -f "$import_p12"
           security set-key-partition-list \
             -S apple-tool:,apple:,codesign: \
             -s \
@@ -136,7 +155,7 @@ jobs:
             --key-id "$NOTARY_API_KEY_ID" \
             --issuer "$NOTARY_ISSUER_ID"
 
-          rm -f "$p12" "$api_key"
+          rm -f "$api_key"
           trap - EXIT
 
       - name: Build sign notarize staple and assess

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,62 +1,110 @@
-# Ghost FTP macOS development app
+# Ghost FTP for macOS
 
-The `macos/` tree is the dedicated native macOS development surface for Ghost FTP. It is deliberately separate from the Windows and Linux packaging trees, but it is not a separate product or a reduced feature edition.
+The `macos/` tree is the native macOS desktop surface for Ghost FTP. It is a platform frontend for the same product and shared `internal/api.Engine` used by the maintained desktop code; it is not a separate FTP/SFTP implementation or a reduced edition.
 
-**Windows desktop is the canonical visual and behavior reference.** The target is 1:1 feature parity in the sense that every supported Windows desktop action has an equivalent, real macOS action backed by the same product state and security rules. Native platform primitives may differ where macOS requires them, but capability, labels, ordering, validation, enabled/disabled state and workflow semantics must remain aligned.
+**Windows desktop remains the canonical visual and behavior reference.** macOS uses native AppKit windowing, Keychain, file panels, accessibility and platform signing primitives where appropriate, while capability, validation, security, state ownership and transfer semantics stay aligned with the shared desktop contracts.
 
-The macOS client uses the same typed `internal/api.Engine` as the maintained Windows/Linux desktop clients through an in-process C ABI bridge. UI work follows one non-negotiable rule: **no decorative or dead controls**. A control is added to the visible Mac UI only when the corresponding engine-backed operation is functional and testable.
+## Functional status
 
-## Implemented development surface
+The macOS action inventory in `PARITY.md` is complete. The native AppKit application includes real engine-backed implementations for:
 
-The native AppKit application currently includes:
+- FTP, explicit FTPS and SFTP connection/disconnection;
+- SFTP private-key authentication and strict first-contact host-key trust;
+- Site Manager with Save Profile, Remove Profile, Duplicate and Connect;
+- explicit saved-credential consent and native Keychain-backed durable profile protection;
+- Bookmarks with shared account-bound remote navigation;
+- Local and Remote panes, refresh/up/navigation and native local folder selection;
+- Local/Remote New Folder, Rename and Delete with stale-view rejection;
+- Local/Remote Unicode-aware filtering and bounded recursive search;
+- Remote Permissions/CHMOD;
+- Remote Edit with shared conflict detection and verified read-back;
+- Directory Compare with atomic paired navigation;
+- Upload and Download through the shared transfer engine;
+- native Transfer Queue with Pause, Resume, Cancel, Retry, Clear Finished and four-way queued reordering;
+- Settings backed by shared `model.Settings`, including the shared 24-language registry, Classic Light/Dark appearance, parallelism, independent bandwidth limits, timeout, retries, conflict policy and delete confirmation;
+- privacy-safe About and Diagnostics surfaces.
 
-- FTP, explicit FTPS and SFTP Quick Connect and Disconnect through the shared engine;
-- native private-key file selection for SFTP;
-- strict SFTP pending host-key trust with the bundled AskPass helper and Darwin runtime secret broker;
-- Local and Remote file panes backed by `Engine.LocalList` and `Engine.RemoteList`;
-- local native folder selection, Local/Remote Up and Refresh, and directory double-click navigation;
-- Local and Remote New Folder, Rename and Delete through the shared engine;
-- explicit native confirmation before destructive delete operations;
-- stale-folder and stale-selection rejection before mutations can reach the engine;
-- navigation-generation ownership so an old mutation cannot refresh a newly selected folder;
-- remote file metadata including size, modification time and permissions when provided by the protocol;
-- Remote Permissions/CHMOD through `Engine.RemoteChmod`, with the same 1000-item safety bound as Windows, 3/4-digit octal modes, symbolic-link skipping and success/failure/skipped reporting;
-- Local and Remote current-folder Filter actions using the same Unicode-aware `internal/itemlist.Filter` semantics as Windows/Linux, with authoritative snapshots kept separate from the visible filtered rows and no hidden filesystem/network scan;
-- real Upload and Download queue entry points; regular files use `Engine.AddTransfer` and directories use the bounded `Engine.AddTreeTransfer` path;
-- symbolic-link rejection for transfer actions rather than silent traversal;
-- visible-snapshot binding for transfer actions so stale names cannot be submitted after navigation.
+Every visible parity action is backed by real shared-engine/platform behavior and regression coverage. There are no intentional decorative parity controls.
 
-The password and private-key passphrase fields are cleared from the visible UI immediately when connecting. For SFTP first-contact trust, the transient in-memory connection input is retained only long enough to perform the explicitly approved host-key retry, then discarded; it is not stored as persistent app state.
+## Security and privacy boundary
+
+Ghost FTP for macOS keeps the same security/privacy contract as the rest of the desktop product:
+
+- no telemetry, analytics, advertising, tracking or hidden Ghost FTP backend;
+- no browser IPC, localhost app server or generic JSON credential dispatcher;
+- Swift never receives protected saved-profile credential blobs;
+- saved profile secrets use a native `Security.framework` Keychain-held AES-256 wrapping key with `WhenUnlockedThisDeviceOnly`;
+- runtime secrets remain short-lived and same-user scoped;
+- SFTP host-key verification/pinning remains fail-closed;
+- file mutations and transfers stay bound to authoritative engine snapshots and navigation generations;
+- symbolic links are not silently traversed by transfer actions;
+- no new external runtime dependency is required by the native macOS app.
 
 ## Visual contract
 
-The macOS frontend follows the maintained Windows layout hierarchy: branded header, profile/application actions, Quick Connect, Local and Remote panes, transfer actions, transfer queue, status and version surfaces. The native AppKit window may use macOS window chrome, focus behavior and accessibility APIs, while the Ghost FTP workspace remains visually aligned with Windows.
-
-The local source palettes are identical to the desktop reference:
+The Mac workspace follows the maintained Windows hierarchy while using native macOS window chrome, focus behavior and accessibility APIs.
 
 - Classic Light: workspace `#EEF1F5`, panel `#F6F8FB`, list `#FAFBFD`.
 - Dark: workspace `#0B0F17`, panel `#121824`, list `#161D2A`.
+- English is the canonical default/fallback and the shared registry exposes the same 24 languages.
+- FTP, explicit FTPS and SFTP remain the desktop protocol set.
 
-The finished Mac client must expose the same **24 languages**, with English as canonical default/fallback, and the same FTP, explicit FTPS and SFTP protocol semantics as the maintained desktop product.
+## Development build
 
-## Privacy and dependency boundary
-
-The Mac app has no telemetry, analytics, advertising, tracking pixels, remote fonts, remote styles or mandatory Ghost FTP account. The build is source-local and must not download runtime UI or application code. The bridge is typed and in-process: no JSON dispatcher, localhost application server or browser IPC is used.
-
-Persistent saved-profile secrets remain fail-closed on macOS until the dedicated Keychain-backed implementation is added behind the same explicit credential-persistence consent and account-identity binding used by the shared desktop model.
-
-## Remaining parity work
-
-The development surface is not yet a complete Mac release. Site Manager, saved-profile Keychain support, Bookmarks, Settings/About/Diagnostics, bounded recursive search, Directory Compare, Remote Edit, full transfer queue controls, localization and the remaining Windows behavior inventory are still tracked in `PARITY.md` and remain intentionally absent until their real engine-backed implementations are ready.
-
-The Mac development artifact is **not part of the current 0.0.5 public release allow-list**. The existing verified Windows/Linux 14-platform-artifact / 17-public-file release contract remains unchanged until macOS reaches full functionality, runtime evidence and distribution/signing/notarization gates.
-
-Build on macOS with:
+Build the universal Intel + Apple Silicon development app on macOS with:
 
 ```bash
 bash macos/BUILD.sh
 ```
 
-The development output is `macos/dist/Ghost-FTP-<VERSION>-macOS.app.zip` and contains `Ghost FTP.app`.
+The output is:
 
-See `PARITY.md` for the exact Windows action inventory that must be completed before macOS can be promoted from development source to a public desktop release platform.
+```text
+macos/dist/Ghost-FTP-<VERSION>-macOS.app.zip
+```
+
+The development artifact is deliberately ad-hoc signed. It is suitable for CI/native regression validation, not for public Gatekeeper distribution.
+
+## Developer ID signing and notarization
+
+`macos/SIGN_AND_NOTARIZE.sh` is the fail-closed production distribution path. It:
+
+1. builds the same universal app with `macos/BUILD.sh`;
+2. requires an installed **Developer ID Application** identity;
+3. replaces every ad-hoc signature explicitly from the innermost nested code outward;
+4. enables Hardened Runtime and a secure timestamp;
+5. verifies signatures and rejects `com.apple.security.get-task-allow`;
+6. submits the signed app archive using `xcrun notarytool`;
+7. continues only after Apple reports an accepted notarization;
+8. staples and validates the ticket;
+9. performs a Gatekeeper `spctl` assessment; and
+10. only then emits `Ghost-FTP-<VERSION>-macOS-notarized.app.zip`.
+
+The reusable signing script accepts only Keychain references:
+
+```bash
+export MACOS_DEVELOPER_IDENTITY='Developer ID Application: Example Company (TEAMID)'
+export MACOS_NOTARY_KEYCHAIN_PROFILE='ghostftp-notary'
+bash macos/SIGN_AND_NOTARIZE.sh
+```
+
+Raw certificate/private-key/notary credentials must never be committed to the repository or passed to this reusable signer.
+
+## GitHub Actions production artifact
+
+`.github/workflows/macos-production.yml` is a manual, environment-gated workflow that prepares the ephemeral Keychain required on a clean GitHub-hosted macOS runner, runs the same signer/notarizer and uploads the verified notarized ZIP as a workflow artifact. Configure these secrets in the protected `macos-production` GitHub Environment:
+
+- `MACOS_DEVELOPER_ID_P12_BASE64`
+- `MACOS_DEVELOPER_ID_P12_PASSWORD`
+- `MACOS_DEVELOPER_IDENTITY`
+- `APPLE_NOTARY_API_KEY_P8`
+- `APPLE_NOTARY_API_KEY_ID`
+- `APPLE_NOTARY_ISSUER_ID`
+
+The workflow destroys the temporary signing Keychain/files in an `always()` cleanup step. It deliberately does **not** modify or upload to an existing public GitHub Release. Promotion of a notarized artifact into a public release remains an explicit release decision rather than an automatic side effect of configuring credentials.
+
+## Release truthfulness
+
+Source/native functionality is complete and continuously validated on universal macOS builds. A public macOS binary can only be called production-distributable after a real Developer ID certificate and Apple notarization credentials have been supplied and `macos-production.yml` (or the equivalent local `SIGN_AND_NOTARIZE.sh` path) has succeeded. Those private Apple credentials are external security material and are intentionally not stored in this repository.
+
+See `PARITY.md` for the completed Windows ↔ macOS action/security contract.

--- a/macos/SIGN_AND_NOTARIZE.sh
+++ b/macos/SIGN_AND_NOTARIZE.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION="$(tr -d '\r\n' < "$REPO_ROOT/VERSION")"
+APP="$SCRIPT_DIR/out/Ghost FTP.app"
+DIST="$SCRIPT_DIR/dist"
+SUBMISSION_ZIP="$DIST/Ghost-FTP-${VERSION}-macOS-notary-submission.zip"
+FINAL_ZIP="$DIST/Ghost-FTP-${VERSION}-macOS-notarized.app.zip"
+IDENTITY="${MACOS_DEVELOPER_IDENTITY:-}"
+NOTARY_PROFILE="${MACOS_NOTARY_KEYCHAIN_PROFILE:-}"
+
+fail() {
+  printf 'MACOS_PRODUCTION_SIGNING_FAILED: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "invalid root VERSION: $VERSION"
+[[ -n "$IDENTITY" ]] || fail "MACOS_DEVELOPER_IDENTITY is required"
+[[ "$IDENTITY" == Developer\ ID\ Application:* ]] || fail "MACOS_DEVELOPER_IDENTITY must be a Developer ID Application identity"
+[[ -n "$NOTARY_PROFILE" ]] || fail "MACOS_NOTARY_KEYCHAIN_PROFILE is required"
+
+for tool in codesign security ditto xcrun spctl; do
+  command -v "$tool" >/dev/null 2>&1 || fail "required tool is unavailable: $tool"
+done
+
+# The notary profile and signing identity must already be provisioned in the
+# current macOS user's Keychain. This script never accepts raw certificate,
+# private-key, Apple ID password, app-specific password or API-key material.
+security find-identity -v -p codesigning | grep -F -- "$IDENTITY" >/dev/null \
+  || fail "Developer ID Application identity is not available in the current Keychain"
+
+# Build the already-tested universal development bundle first, then replace
+# every ad-hoc signature explicitly from the inside out. Do not use --deep for
+# signing because it can hide an incomplete nested-code inventory.
+bash "$SCRIPT_DIR/BUILD.sh"
+[[ -d "$APP" ]] || fail "development app bundle was not produced"
+
+ENGINE="$APP/Contents/Frameworks/libGhostFTPEngine.dylib"
+ASKPASS="$APP/Contents/MacOS/GhostFTPAskPass"
+EXECUTABLE="$APP/Contents/MacOS/GhostFTP"
+for file in "$ENGINE" "$ASKPASS" "$EXECUTABLE"; do
+  [[ -s "$file" ]] || fail "missing nested code: $file"
+done
+
+sign_one() {
+  local target="$1"
+  codesign \
+    --force \
+    --sign "$IDENTITY" \
+    --options runtime \
+    --timestamp \
+    "$target"
+}
+
+sign_one "$ENGINE"
+sign_one "$ASKPASS"
+sign_one "$EXECUTABLE"
+sign_one "$APP"
+
+codesign --verify --deep --strict --verbose=2 "$APP"
+for target in "$ENGINE" "$ASKPASS" "$EXECUTABLE" "$APP"; do
+  details="$(codesign --display --verbose=4 "$target" 2>&1)"
+  grep -F 'runtime' <<<"$details" >/dev/null || fail "Hardened Runtime missing from $target"
+  grep -F 'Timestamp=' <<<"$details" >/dev/null || fail "secure timestamp missing from $target"
+done
+if codesign --display --entitlements :- "$APP" 2>/dev/null | grep -F 'com.apple.security.get-task-allow' >/dev/null; then
+  fail "distribution app must not contain com.apple.security.get-task-allow"
+fi
+
+rm -f "$SUBMISSION_ZIP" "$FINAL_ZIP"
+ditto -c -k --sequesterRsrc --keepParent "$APP" "$SUBMISSION_ZIP"
+[[ -s "$SUBMISSION_ZIP" ]] || fail "notary submission archive was not produced"
+
+# The credentials referenced by this profile are intentionally outside the
+# repository and process arguments. The Apple notary service result must be
+# accepted before any final distribution artifact is emitted.
+xcrun notarytool submit "$SUBMISSION_ZIP" \
+  --keychain-profile "$NOTARY_PROFILE" \
+  --wait
+
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+codesign --verify --deep --strict --verbose=2 "$APP"
+spctl --assess --type execute --verbose=4 "$APP"
+
+ditto -c -k --sequesterRsrc --keepParent "$APP" "$FINAL_ZIP"
+[[ -s "$FINAL_ZIP" ]] || fail "final notarized archive was not produced"
+rm -f "$SUBMISSION_ZIP"
+
+printf 'MACOS_PRODUCTION_APP=%s\n' "$APP"
+printf 'MACOS_PRODUCTION_ARTIFACT=%s\n' "$FINAL_ZIP"
+printf 'MACOS_PRODUCTION_VERSION=%s\n' "$VERSION"
+printf 'MACOS_PRODUCTION_SIGNING=developer-id-hardened-runtime\n'
+printf 'MACOS_PRODUCTION_NOTARIZATION=accepted-stapled\n'

--- a/scripts/test_macos_distribution_contract.py
+++ b/scripts/test_macos_distribution_contract.py
@@ -18,7 +18,7 @@ class MacOSDistributionContractTests(unittest.TestCase):
         for marker in (
             "MACOS_DEVELOPER_IDENTITY is required",
             "MACOS_NOTARY_KEYCHAIN_PROFILE is required",
-            "Developer ID Application:",
+            "MACOS_DEVELOPER_IDENTITY must be a Developer ID Application identity",
             "security find-identity -v -p codesigning",
             "--options runtime",
             "--timestamp",

--- a/scripts/test_macos_distribution_contract.py
+++ b/scripts/test_macos_distribution_contract.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    path = ROOT / relative
+    if not path.is_file():
+        raise AssertionError(f"missing required macOS distribution file: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+class MacOSDistributionContractTests(unittest.TestCase):
+    def test_signing_script_is_fail_closed_and_uses_current_apple_distribution_primitives(self) -> None:
+        script = read("macos/SIGN_AND_NOTARIZE.sh")
+        for marker in (
+            "MACOS_DEVELOPER_IDENTITY is required",
+            "MACOS_NOTARY_KEYCHAIN_PROFILE is required",
+            "Developer ID Application:",
+            "security find-identity -v -p codesigning",
+            "--options runtime",
+            "--timestamp",
+            "codesign --verify --deep --strict",
+            "xcrun notarytool submit",
+            "--keychain-profile",
+            "--wait",
+            "xcrun stapler staple",
+            "xcrun stapler validate",
+            "spctl --assess --type execute",
+            "com.apple.security.get-task-allow",
+            "MACOS_PRODUCTION_NOTARIZATION=accepted-stapled",
+        ):
+            self.assertIn(marker, script)
+
+        # Raw signing/notary credential material belongs outside the reusable
+        # production signer. It receives only Keychain references.
+        for forbidden in (
+            "APPLE_ID_PASSWORD",
+            "APP_SPECIFIC_PASSWORD",
+            "APPLE_NOTARY_API_KEY_P8",
+            "MACOS_DEVELOPER_ID_P12_BASE64",
+            "MACOS_DEVELOPER_ID_P12_PASSWORD",
+            "altool",
+        ):
+            self.assertNotIn(forbidden, script)
+
+        # Explicit inside-out signing remains reviewable; never hide nested
+        # code discovery behind codesign --deep during signing.
+        sign_section = script.split("sign_one()", 1)[1].split("codesign --verify", 1)[0]
+        for target in ('sign_one "$ENGINE"', 'sign_one "$ASKPASS"', 'sign_one "$EXECUTABLE"', 'sign_one "$APP"'):
+            self.assertIn(target, sign_section)
+        self.assertNotIn("--deep", sign_section)
+
+    def test_manual_production_workflow_keeps_credentials_ephemeral(self) -> None:
+        workflow = read(".github/workflows/macos-production.yml")
+        for marker in (
+            "workflow_dispatch:",
+            "environment: macos-production",
+            "permissions:\n  contents: read",
+            "MACOS_DEVELOPER_ID_P12_BASE64",
+            "MACOS_DEVELOPER_ID_P12_PASSWORD",
+            "MACOS_DEVELOPER_IDENTITY",
+            "APPLE_NOTARY_API_KEY_P8",
+            "APPLE_NOTARY_API_KEY_ID",
+            "APPLE_NOTARY_ISSUER_ID",
+            "security create-keychain",
+            "security delete-keychain",
+            "notarytool store-credentials",
+            "bash macos/SIGN_AND_NOTARIZE.sh",
+            "Ghost-FTP-*-macOS-notarized.app.zip",
+            "MACOS_PRODUCTION_ARTIFACT_VERIFIED=PASS",
+            "if: always()",
+        ):
+            self.assertIn(marker, workflow)
+
+        # Signing/notarization can create a verified artifact but does not
+        # silently mutate or publish an existing public GitHub release.
+        for forbidden in (
+            "gh release",
+            "softprops/action-gh-release",
+            "contents: write",
+            "release.yml",
+        ):
+            self.assertNotIn(forbidden, workflow)
+
+    def test_development_build_stays_distinct_from_production_distribution(self) -> None:
+        build = read("macos/BUILD.sh")
+        self.assertIn("MACOS_SIGNING=adhoc-development", build)
+        self.assertNotIn("notarytool", build)
+        self.assertNotIn("Developer ID Application", build)
+
+        dev_workflow = read(".github/workflows/macos-app.yml")
+        self.assertIn("Ghost FTP macOS Development App", dev_workflow)
+        self.assertIn("MACOS_APP_SIGNING=adhoc-development", dev_workflow)
+        self.assertNotIn("MACOS_DEVELOPER_ID_P12_BASE64", dev_workflow)
+
+    def test_public_release_remains_separate_until_credentialed_artifact_is_explicitly_promoted(self) -> None:
+        release = read(".github/workflows/release.yml")
+        self.assertNotIn("macOS-notarized.app.zip", release)
+        self.assertNotIn("SIGN_AND_NOTARIZE.sh", release)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_macos_distribution_contract.py
+++ b/scripts/test_macos_distribution_contract.py
@@ -71,9 +71,26 @@ class MacOSDistributionContractTests(unittest.TestCase):
             "bash macos/SIGN_AND_NOTARIZE.sh",
             "Ghost-FTP-*-macOS-notarized.app.zip",
             "MACOS_PRODUCTION_ARTIFACT_VERIFIED=PASS",
+            "cleanup_provisioning()",
+            "trap cleanup_provisioning EXIT",
+            "-passin env:DEVELOPER_ID_P12_PASSWORD",
+            "security import \"$import_p12\"",
+            "-P ''",
+            "-x",
+            "base64 -D",
             "if: always()",
         ):
             self.assertIn(marker, workflow)
+
+        # External credential values must not be expanded into security import
+        # process arguments. The protected P12 passphrase is consumed from the
+        # environment by OpenSSL, and only a disposable empty-passphrase copy
+        # reaches security import before immediate deletion.
+        self.assertNotIn('-P "$DEVELOPER_ID_P12_PASSWORD"', workflow)
+        self.assertLess(workflow.index('echo "work=$work"'), workflow.index("base64 -D"))
+        self.assertLess(workflow.index("trap cleanup_provisioning EXIT"), workflow.index("base64 -D"))
+        self.assertIn('rm -f "$import_p12"', workflow)
+        self.assertIn('rm -f "$protected_p12" "$import_p12" "$api_key"', workflow)
 
         # Signing/notarization can create a verified artifact but does not
         # silently mutate or publish an existing public GitHub release.

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -58,7 +58,47 @@ WINDOWS_PARITY_ACTIONS = (
     "Move Bottom",
 )
 
-IMPLEMENTED_MACOS_ACTIONS = set(WINDOWS_PARITY_ACTIONS)
+IMPLEMENTED_MACOS_ACTIONS = {
+    "Connect",
+    "Disconnect",
+    "Site Manager",
+    "Bookmarks",
+    "Private Key",
+    "Save Profile",
+    "Remove Profile",
+    "Settings",
+    "About",
+    "Diagnostics",
+    "Local Refresh",
+    "Local Choose Folder",
+    "Local Up",
+    "Local New Folder",
+    "Local Rename",
+    "Local Delete",
+    "Local Filter",
+    "Local Recursive Search",
+    "Remote Refresh",
+    "Remote Up",
+    "Remote New Folder",
+    "Remote Rename",
+    "Remote Delete",
+    "Remote Permissions",
+    "Remote Edit",
+    "Remote Filter",
+    "Remote Recursive Search",
+    "Directory Compare",
+    "Upload",
+    "Download",
+    "Pause Queue",
+    "Resume Queue",
+    "Cancel Transfer",
+    "Retry Transfer",
+    "Clear Finished",
+    "Move Top",
+    "Move Up",
+    "Move Down",
+    "Move Bottom",
+}
 
 
 class MacOSWindowsParityContractTests(unittest.TestCase):

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -58,51 +58,11 @@ WINDOWS_PARITY_ACTIONS = (
     "Move Bottom",
 )
 
-IMPLEMENTED_MACOS_ACTIONS = {
-    "Connect",
-    "Disconnect",
-    "Site Manager",
-    "Bookmarks",
-    "Private Key",
-    "Save Profile",
-    "Remove Profile",
-    "Settings",
-    "About",
-    "Diagnostics",
-    "Local Refresh",
-    "Local Choose Folder",
-    "Local Up",
-    "Local New Folder",
-    "Local Rename",
-    "Local Delete",
-    "Local Filter",
-    "Local Recursive Search",
-    "Remote Refresh",
-    "Remote Up",
-    "Remote New Folder",
-    "Remote Rename",
-    "Remote Delete",
-    "Remote Permissions",
-    "Remote Edit",
-    "Remote Filter",
-    "Remote Recursive Search",
-    "Directory Compare",
-    "Upload",
-    "Download",
-    "Pause Queue",
-    "Resume Queue",
-    "Cancel Transfer",
-    "Retry Transfer",
-    "Clear Finished",
-    "Move Top",
-    "Move Up",
-    "Move Down",
-    "Move Bottom",
-}
+IMPLEMENTED_MACOS_ACTIONS = set(WINDOWS_PARITY_ACTIONS)
 
 
 class MacOSWindowsParityContractTests(unittest.TestCase):
-    def test_macos_is_an_active_separate_development_surface(self) -> None:
+    def test_macos_is_an_active_separate_native_surface(self) -> None:
         platform_audit = read("scripts/audit_platform_contract.py")
         desktop_audit = read("scripts/audit_desktop_surface.py")
         for source in (platform_audit, desktop_audit):
@@ -111,12 +71,15 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
             self.assertNotIn("IOS,MACOS", source)
         self.assertNotIn("DARWIN_SOURCE=BLOCKED", platform_audit)
 
-    def test_macos_has_its_own_source_build_and_ci_surface(self) -> None:
+    def test_macos_has_source_development_and_production_distribution_surfaces(self) -> None:
         for relative in (
             "macos/README.md",
             "macos/PARITY.md",
             "macos/BUILD.sh",
+            "macos/SIGN_AND_NOTARIZE.sh",
             ".github/workflows/macos-app.yml",
+            ".github/workflows/macos-production.yml",
+            "scripts/test_macos_distribution_contract.py",
         ):
             self.assertTrue((ROOT / relative).is_file(), relative)
 
@@ -126,12 +89,18 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
         self.assertIn("ghostftp-macos-development", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
 
+        production = read(".github/workflows/macos-production.yml")
+        self.assertIn("workflow_dispatch:", production)
+        self.assertIn("environment: macos-production", production)
+        self.assertIn("bash macos/SIGN_AND_NOTARIZE.sh", production)
+        self.assertIn("permissions:\n  contents: read", production)
+
     def test_windows_is_the_visual_and_behavior_reference(self) -> None:
         readme = read("macos/README.md")
         parity = read("macos/PARITY.md")
         combined = readme + "\n" + parity
         for marker in (
-            "Windows desktop is the canonical visual and behavior reference",
+            "Windows desktop remains the canonical visual and behavior reference",
             "same typed `internal/api.Engine`",
             "no decorative or dead controls",
             "Classic Light",
@@ -152,20 +121,21 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
 
     def test_complete_windows_action_inventory_is_recorded_truthfully(self) -> None:
         parity = read("macos/PARITY.md")
+        self.assertEqual(set(WINDOWS_PARITY_ACTIONS), IMPLEMENTED_MACOS_ACTIONS)
         for action in WINDOWS_PARITY_ACTIONS:
-            expected = "x" if action in IMPLEMENTED_MACOS_ACTIONS else " "
-            self.assertIn(f"- [{expected}] {action}", parity)
-            opposite = " " if expected == "x" else "x"
-            self.assertNotIn(f"- [{opposite}] {action}", parity)
+            self.assertIn(f"- [x] {action}", parity)
+            self.assertNotIn(f"- [ ] {action}", parity)
 
-    def test_macos_does_not_silently_expand_current_public_release(self) -> None:
+    def test_production_preparation_does_not_silently_publish_a_public_release(self) -> None:
         readme = read("macos/README.md")
-        self.assertIn("development surface", readme)
-        self.assertIn("not part of the current 0.0.5 public release allow-list", readme)
+        self.assertIn("Source/native functionality is complete", readme)
+        self.assertIn("Developer ID", readme)
+        self.assertIn("Apple notarization", readme)
+        self.assertIn("does **not** modify or upload to an existing public GitHub Release", readme)
 
         release = read(".github/workflows/release.yml")
-        self.assertNotIn("Ghost-FTP-${VERSION}-macOS", release)
-        self.assertNotIn("macos/BUILD.sh", release)
+        self.assertNotIn("macOS-notarized.app.zip", release)
+        self.assertNotIn("SIGN_AND_NOTARIZE.sh", release)
 
     def test_build_contract_binds_to_root_version_and_app_bundle(self) -> None:
         build = read("macos/BUILD.sh")
@@ -177,6 +147,16 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
         self.assertIn("Ghost-FTP-${VERSION}-macOS.app.zip", build)
         self.assertNotIn("curl ", build)
         self.assertNotIn("wget ", build)
+
+    def test_distribution_contract_is_separate_and_fail_closed(self) -> None:
+        signer = read("macos/SIGN_AND_NOTARIZE.sh")
+        self.assertIn("Developer ID Application:", signer)
+        self.assertIn("--options runtime", signer)
+        self.assertIn("--timestamp", signer)
+        self.assertIn("xcrun notarytool submit", signer)
+        self.assertIn("xcrun stapler staple", signer)
+        self.assertIn("spctl --assess", signer)
+        self.assertIn("accepted-stapled", signer)
 
 
 if __name__ == "__main__":

--- a/scripts/test_macos_windows_parity_contract.py
+++ b/scripts/test_macos_windows_parity_contract.py
@@ -190,7 +190,7 @@ class MacOSWindowsParityContractTests(unittest.TestCase):
 
     def test_distribution_contract_is_separate_and_fail_closed(self) -> None:
         signer = read("macos/SIGN_AND_NOTARIZE.sh")
-        self.assertIn("Developer ID Application:", signer)
+        self.assertIn("MACOS_DEVELOPER_IDENTITY must be a Developer ID Application identity", signer)
         self.assertIn("--options runtime", signer)
         self.assertIn("--timestamp", signer)
         self.assertIn("xcrun notarytool submit", signer)


### PR DESCRIPTION
## Summary

Finish the repository-side macOS distribution boundary after native feature parity became complete.

### Production signing/notarization
- Add `macos/SIGN_AND_NOTARIZE.sh` as the reusable fail-closed production path.
- Require an installed Developer ID Application identity and a pre-provisioned `notarytool` Keychain profile.
- Re-sign nested code explicitly inside-out with Hardened Runtime and secure timestamps.
- Reject `com.apple.security.get-task-allow`.
- Submit with `xcrun notarytool`, require accepted notarization, staple/validate the ticket, run Gatekeeper assessment, and only then emit the final notarized ZIP.
- Keep raw certificate/private-key/notary material outside the reusable signer.

### GitHub Actions
- Add a manual `macos-production` environment-gated workflow for a clean GitHub-hosted macOS runner.
- Provision Developer ID and App Store Connect API-key material only into ephemeral runner files/Keychain.
- Destroy the temporary signing Keychain/files in an `always()` cleanup step.
- Upload a verified notarized workflow artifact only; do not silently modify an existing public GitHub Release.

### Contracts/documentation
- Add a dedicated macOS distribution regression contract.
- Extend universal macOS CI to validate the signer syntax and distribution contract without needing private Apple credentials.
- Update the stale macOS README so it reflects the now-complete native action inventory, Keychain storage, Site Manager, Bookmarks, Settings, Remote Edit, Directory Compare and Transfer Queue.
- Keep public release promotion explicit and separate from merely configuring signing credentials.

## Security

No Apple Developer credential is committed to source. The production signer accepts only Keychain references. CI secret material is scoped to the manual protected environment and ephemeral runner, then cleaned up. No telemetry, external runtime dependency, second protocol stack or generic credential channel is added.

## External gate

A real Developer ID certificate and Apple notarization credentials are intentionally external security material. CI can fully validate the production pipeline contract and universal app, but actual Apple signing/notarization can only execute when those private credentials are supplied to the protected `macos-production` environment.