### PR TITLE
Harden Android FTP authentication error privacy

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   android-apk:
-    name: Android lint and installable APK
+    name: Android tests, lint and installable APK
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -57,12 +57,12 @@ jobs:
           python scripts/test_android_contract.py
           python scripts/test_android_passive_data_contract.py
           python scripts/test_android_mobile_navigation_contract.py
-      - name: Lint and build APK
+      - name: Test, lint and build APK
         working-directory: android
         shell: bash
         run: |
           set -euo pipefail
-          gradle :app:lintDebug :app:packageGhostFtpApk --no-daemon --stacktrace
+          gradle :app:testDebugUnitTest :app:lintDebug :app:packageGhostFtpApk --no-daemon --stacktrace
       - name: Verify APK contract
         shell: bash
         run: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,6 +43,10 @@ android {
     }
 }
 
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+}
+
 tasks.register('packageGhostFtpApk', Copy) {
     dependsOn 'assembleDebug'
     from(layout.buildDirectory.file('outputs/apk/debug/app-debug.apk'))

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -71,12 +71,14 @@ final class FtpSession implements Closeable {
         }
 
         String user = username == null || username.trim().isEmpty() ? "anonymous" : username.trim();
-        Reply userReply = command("USER " + sanitizeArgument(user));
+        Reply userReply = authenticationCommand("USER " + sanitizeArgument(user));
         if (userReply.code == 331) {
-            Reply passwordReply = command("PASS " + sanitizeArgument(password == null ? "" : password));
-            expectAuthentication(passwordReply);
-        } else {
-            expect(userReply, 230);
+            Reply passwordReply = authenticationCommand("PASS " + sanitizeArgument(password == null ? "" : password));
+            if (passwordReply.code != 230 && passwordReply.code != 202) {
+                rejectAuthentication(passwordReply.code);
+            }
+        } else if (userReply.code != 230) {
+            rejectAuthentication(userReply.code);
         }
         expect(command("TYPE I"), 200);
         if (secure) {
@@ -397,6 +399,20 @@ final class FtpSession implements Closeable {
         return readReply();
     }
 
+    private Reply authenticationCommand(String command) throws IOException {
+        try {
+            return command(command);
+        } catch (IOException ignored) {
+            hardClose();
+            throw new IOException("FTP authentication failed before a valid server response was received.");
+        }
+    }
+
+    private void rejectAuthentication(int responseCode) throws IOException {
+        hardClose();
+        throw new IOException("FTP authentication failed (server response code " + responseCode + ").");
+    }
+
     private Reply readReply() throws IOException {
         ensureStreams();
         String first = reader.readLine();
@@ -598,13 +614,6 @@ final class FtpSession implements Closeable {
         if (reader == null || writer == null) {
             throw new IOException("Control connection is not available.");
         }
-    }
-
-    private static void expectAuthentication(Reply reply) throws IOException {
-        if (reply.code == 230 || reply.code == 202) {
-            return;
-        }
-        throw new IOException("FTP authentication failed (server response code " + reply.code + ").");
     }
 
     private static void expect(Reply reply, int... allowed) throws IOException {

--- a/android/app/src/main/java/app/ghostftp/client/FtpSession.java
+++ b/android/app/src/main/java/app/ghostftp/client/FtpSession.java
@@ -73,7 +73,8 @@ final class FtpSession implements Closeable {
         String user = username == null || username.trim().isEmpty() ? "anonymous" : username.trim();
         Reply userReply = command("USER " + sanitizeArgument(user));
         if (userReply.code == 331) {
-            expect(command("PASS " + sanitizeArgument(password == null ? "" : password)), 230, 202);
+            Reply passwordReply = command("PASS " + sanitizeArgument(password == null ? "" : password));
+            expectAuthentication(passwordReply);
         } else {
             expect(userReply, 230);
         }
@@ -597,6 +598,13 @@ final class FtpSession implements Closeable {
         if (reader == null || writer == null) {
             throw new IOException("Control connection is not available.");
         }
+    }
+
+    private static void expectAuthentication(Reply reply) throws IOException {
+        if (reply.code == 230 || reply.code == 202) {
+            return;
+        }
+        throw new IOException("FTP authentication failed (server response code " + reply.code + ").");
     }
 
     private static void expect(Reply reply, int... allowed) throws IOException {

--- a/android/app/src/test/java/app/ghostftp/client/FtpSessionAuthenticationTest.java
+++ b/android/app/src/test/java/app/ghostftp/client/FtpSessionAuthenticationTest.java
@@ -23,6 +23,26 @@ public final class FtpSessionAuthenticationTest {
     @Test
     public void rejectedPasswordReplyDoesNotLeakSecret() throws Exception {
         String secret = "ghostftp-regression-secret-7419";
+        assertPasswordFailureRedacted(
+                secret,
+                "FTP authentication failed (server response code 530).",
+                "530-Authentication rejected for " + secret,
+                "530 Do not expose " + secret);
+    }
+
+    @Test
+    public void malformedPasswordReplyDoesNotLeakSecret() throws Exception {
+        String secret = "ghostftp-malformed-secret-8526";
+        assertPasswordFailureRedacted(
+                secret,
+                "FTP authentication failed before a valid server response was received.",
+                "not-a-valid-ftp-reply " + secret);
+    }
+
+    private static void assertPasswordFailureRedacted(
+            String secret,
+            String expectedMessage,
+            String... passwordReplies) throws Exception {
         ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
 
         try (ServerSocket server = new ServerSocket(0)) {
@@ -34,8 +54,9 @@ public final class FtpSessionAuthenticationTest {
                     assertEquals("USER test-user", reader.readLine());
                     send(writer, "331 Password required");
                     assertEquals("PASS " + secret, reader.readLine());
-                    send(writer, "530-Authentication rejected for " + secret);
-                    send(writer, "530 Do not expose " + secret);
+                    for (String reply : passwordReplies) {
+                        send(writer, reply);
+                    }
                 }
                 return null;
             });
@@ -43,7 +64,7 @@ public final class FtpSessionAuthenticationTest {
             FtpSession session = new FtpSession("127.0.0.1", server.getLocalPort(), false);
             try {
                 IOException failure = assertThrows(IOException.class, () -> session.connect("test-user", secret));
-                assertEquals("FTP authentication failed (server response code 530).", failure.getMessage());
+                assertEquals(expectedMessage, failure.getMessage());
                 assertFalse(failure.getMessage().contains(secret));
                 serverRun.get(5, TimeUnit.SECONDS);
             } finally {

--- a/android/app/src/test/java/app/ghostftp/client/FtpSessionAuthenticationTest.java
+++ b/android/app/src/test/java/app/ghostftp/client/FtpSessionAuthenticationTest.java
@@ -1,0 +1,62 @@
+package app.ghostftp.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public final class FtpSessionAuthenticationTest {
+    @Test
+    public void rejectedPasswordReplyDoesNotLeakSecret() throws Exception {
+        String secret = "ghostftp-regression-secret-7419";
+        ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
+
+        try (ServerSocket server = new ServerSocket(0)) {
+            Future<?> serverRun = serverExecutor.submit(() -> {
+                try (Socket client = server.accept();
+                     BufferedReader reader = new BufferedReader(new InputStreamReader(client.getInputStream(), StandardCharsets.US_ASCII));
+                     BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(client.getOutputStream(), StandardCharsets.US_ASCII))) {
+                    send(writer, "220 Test FTP ready");
+                    assertEquals("USER test-user", reader.readLine());
+                    send(writer, "331 Password required");
+                    assertEquals("PASS " + secret, reader.readLine());
+                    send(writer, "530-Authentication rejected for " + secret);
+                    send(writer, "530 Do not expose " + secret);
+                }
+                return null;
+            });
+
+            FtpSession session = new FtpSession("127.0.0.1", server.getLocalPort(), false);
+            try {
+                IOException failure = assertThrows(IOException.class, () -> session.connect("test-user", secret));
+                assertEquals("FTP authentication failed (server response code 530).", failure.getMessage());
+                assertFalse(failure.getMessage().contains(secret));
+                serverRun.get(5, TimeUnit.SECONDS);
+            } finally {
+                session.abort();
+            }
+        } finally {
+            serverExecutor.shutdownNow();
+        }
+    }
+
+    private static void send(BufferedWriter writer, String line) throws IOException {
+        writer.write(line);
+        writer.write("\r\n");
+        writer.flush();
+    }
+}


### PR DESCRIPTION
## Problem
Android FTP authentication used generic server-reply error paths for `USER` / `PASS` failures. Those paths could include the full server-controlled reply body in exceptions shown by the UI. A malicious or misconfigured FTP server could therefore echo submitted authentication data in a normal rejection or malformed reply and cause Ghost FTP to display it.

## Fix
- Route FTP authentication commands through an auth-specific wrapper that discards raw reply/parsing exception text and closes the failed session.
- Report explicit authentication rejection using only the numeric FTP response code; no server-controlled reply body is propagated.
- Add JVM regression tests with a local fake FTP server for both multiline `530` rejection and malformed post-`PASS` replies containing synthetic secrets.
- Add JUnit 4.13.2 as an Android test-only dependency.
- Gate the existing Android APK workflow on `:app:testDebugUnitTest` before lint/build/package.

## Scope
No version bump. No protocol behavior change for successful authentication. No signing/store/notarization claims.

Base main SHA audited before branch creation: `8d8f4a5b587554b0b8bffe4af5bbfed2c2fed43c`.