### PR TITLE
Fail closed on unsigned public Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or (go telemetry).Trim() -ne 'off') {
             throw 'Go telemetry is not disabled.'
           }
-      - name: Prepare optional protected Authenticode identity
+      - name: Require protected Authenticode identity
         id: signing
         shell: pwsh
         env:
@@ -100,16 +100,10 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           if ([string]::IsNullOrWhiteSpace($env:PFX_BASE64)) {
-            if (-not [string]::IsNullOrWhiteSpace($env:PFX_PASSWORD)) {
-              throw 'Signing password is configured without GHOSTFTP_SIGNING_PFX_BASE64.'
-            }
-            "state=unsigned" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host 'WINDOWS_RELEASE_SIGNING=UNSIGNED'
-            Write-Host 'No production signing identity is configured; artifacts will remain explicitly unsigned.'
-            exit 0
+            throw 'Official Ghost FTP publication requires GHOSTFTP_SIGNING_PFX_BASE64.'
           }
           if ([string]::IsNullOrWhiteSpace($env:PFX_PASSWORD)) {
-            throw 'GHOSTFTP_SIGNING_PFX_BASE64 is configured but GHOSTFTP_SIGNING_PASSWORD is missing.'
+            throw 'Official Ghost FTP publication requires GHOSTFTP_SIGNING_PASSWORD.'
           }
           try {
             $bytes = [Convert]::FromBase64String($env:PFX_BASE64)
@@ -140,11 +134,9 @@ jobs:
             if (-not (Test-Path $path -PathType Leaf) -or (Get-Item $path).Length -le 0) {
               throw "Missing Windows artifact: $path"
             }
-            if ('${{ steps.signing.outputs.state }}' -eq 'signed') {
-              $signature = Get-AuthenticodeSignature -FilePath $path
-              if (-not $signature.SignerCertificate -or $signature.Status -ne 'Valid') {
-                throw "Production Authenticode verification failed for ${path}: $($signature.Status) $($signature.StatusMessage)"
-              }
+            $signature = Get-AuthenticodeSignature -FilePath $path
+            if (-not $signature.SignerCertificate -or $signature.Status -ne 'Valid') {
+              throw "Production Authenticode verification failed for ${path}: $($signature.Status) $($signature.StatusMessage)"
             }
           }
           if (Get-ChildItem -LiteralPath dist -File | Where-Object { $_.Name -match '(?i)-(?:x64|x86|x32)\.exe$' }) {
@@ -309,14 +301,10 @@ jobs:
           test "$version" = "$source_version"
           release_channel='current'
           release_title="Ghost FTP $version"
-          case "$WINDOWS_SIGNING_STATE" in
-            signed|unsigned) ;;
-            *) echo "Invalid Windows signing state: $WINDOWS_SIGNING_STATE" >&2; exit 1 ;;
-          esac
-          if [[ "$WINDOWS_SIGNING_STATE" = 'unsigned' ]]; then
-            echo '::warning::Publishing current release with explicitly unsigned Windows artifacts. BUILD-METADATA.txt records WINDOWS_AUTHENTICODE=unsigned.'
-            printf '### Windows signing\nCurrent release is being published with **unsigned** Windows artifacts. Integrity remains bound to the exact release commit and SHA256.txt.\n' >> "$GITHUB_STEP_SUMMARY"
-          fi
+          test "$WINDOWS_SIGNING_STATE" = 'signed' || {
+            echo "Official Ghost FTP publication requires trusted Authenticode; got state: $WINDOWS_SIGNING_STATE" >&2
+            exit 1
+          }
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "VERSION=$version" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=ghostftp-v$version" >> "$GITHUB_ENV"

--- a/scripts/audit_release.py
+++ b/scripts/audit_release.py
@@ -66,8 +66,12 @@ def main() -> int:
         "GHOSTFTP_SIGNING_PFX_BASE64",
         "GHOSTFTP_SIGNING_PASSWORD",
         "GHOSTFTP_SIGNING_TIMESTAMP_URL",
-        "state=unsigned",
+        "Require protected Authenticode identity",
+        "Official Ghost FTP publication requires GHOSTFTP_SIGNING_PFX_BASE64.",
+        "Official Ghost FTP publication requires GHOSTFTP_SIGNING_PASSWORD.",
         "state=signed",
+        "test \"$WINDOWS_SIGNING_STATE\" = 'signed'",
+        "Get-AuthenticodeSignature -FilePath $path",
         "WINDOWS_AUTHENTICODE=${WINDOWS_SIGNING_STATE}",
         "python scripts/audit_platform_contract.py",
         "python scripts/audit_desktop_surface.py",
@@ -125,6 +129,8 @@ def main() -> int:
         "setup-x64.exe",
         "setup-x86.exe",
         "setup-x32.exe",
+        "state=unsigned",
+        "publishing current release with explicitly unsigned windows artifacts",
     ):
         if forbidden in lowered:
             fail(f"release workflow contains retired/incompatible publication marker: {forbidden}")
@@ -312,6 +318,7 @@ def main() -> int:
     print("RELEASE_RETENTION_CHAIN=REQUIRED")
     print("AUTHENTICODE_PRIVATE_KEY_IN_REPOSITORY=BLOCKED")
     print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES")
+    print("PUBLIC_WINDOWS_AUTHENTICODE=REQUIRED_AND_VERIFIED")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
     print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("PUBLIC_PLATFORM_ARTIFACTS=14")

--- a/scripts/audit_version.py
+++ b/scripts/audit_version.py
@@ -232,8 +232,9 @@ def main() -> int:
             "packages: write",
             "Publish verified bundle to GitHub Packages",
             "test \"$remote_prerelease\" = 'false'",
-            "state=unsigned",
+            "Require protected Authenticode identity",
             "state=signed",
+            "test \"$WINDOWS_SIGNING_STATE\" = 'signed'",
             "LINUX_DEBIAN_DEB=amd64,arm64,i386",
             "LINUX_UBUNTU_DEB=amd64,arm64,i386",
             "LINUX_FEDORA_RPM=x86_64,aarch64,i686",
@@ -243,6 +244,8 @@ def main() -> int:
         ),
         ".github/workflows/release.yml",
     )
+    if "state=unsigned" in release_workflow:
+        fail("official public release workflow must not permit unsigned Windows publication")
     if "--prerelease" in release_workflow:
         fail("current 0.0.x release workflow must not mark the GitHub Release as prerelease")
 
@@ -279,6 +282,7 @@ def main() -> int:
             "LINUX_PORTABLE=amd64,arm64,i386",
             "GHCR_CURRENT_BUNDLE=REQUIRED",
             "CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES",
+            "PUBLIC_WINDOWS_AUTHENTICODE=REQUIRED_AND_VERIFIED",
             "TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED",
         ),
         "scripts/audit_release.py",
@@ -306,6 +310,7 @@ def main() -> int:
     print("LATEST_ONLY_RELEASE_RETENTION=YES")
     print("ACTIVE_VERSIONING_DOC_BOUND_TO_VERSION=YES")
     print("CURRENT_WINDOWS_RELEASE_REQUIRES_TRUSTED_AUTHENTICODE=YES")
+    print("PUBLIC_WINDOWS_AUTHENTICODE=REQUIRED_AND_VERIFIED")
     print("TRUSTED_AUTHENTICODE_WHEN_CONFIGURED=VERIFIED")
     print("SELF_SIGNED_PRODUCTION_IDENTITY=BLOCKED")
     print("CURRENT_GITHUB_PACKAGE=GHCR_RELEASE_BUNDLE")

--- a/scripts/test_public_release_signing_contract.py
+++ b/scripts/test_public_release_signing_contract.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Regression contract for fail-closed Windows signing in official releases."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+VERIFY_RELEASE = ROOT / "scripts" / "verify_release.py"
+
+
+class PublicReleaseSigningContractTest(unittest.TestCase):
+    def test_official_release_requires_protected_authenticode_identity(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("name: Publish Ghost FTP", workflow)
+        self.assertIn("Require protected Authenticode identity", workflow)
+        self.assertIn(
+            "Official Ghost FTP publication requires GHOSTFTP_SIGNING_PFX_BASE64.",
+            workflow,
+        )
+        self.assertIn(
+            "Official Ghost FTP publication requires GHOSTFTP_SIGNING_PASSWORD.",
+            workflow,
+        )
+        self.assertIn('"state=signed"', workflow)
+        self.assertNotIn('"state=unsigned"', workflow)
+        self.assertNotIn("Publishing current release with explicitly unsigned Windows artifacts", workflow)
+
+    def test_official_release_verifies_signatures_before_publication(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("Get-AuthenticodeSignature -FilePath $path", workflow)
+        self.assertIn("$signature.Status -ne 'Valid'", workflow)
+        self.assertNotIn("if ('${{ steps.signing.outputs.state }}' -eq 'signed')", workflow)
+        self.assertIn("test \"$WINDOWS_SIGNING_STATE\" = 'signed'", workflow)
+        self.assertIn("WINDOWS_AUTHENTICODE=${WINDOWS_SIGNING_STATE}", workflow)
+
+    def test_release_verifier_keeps_public_workflow_fail_closed(self) -> None:
+        verifier = VERIFY_RELEASE.read_text(encoding="utf-8")
+
+        self.assertIn('PUBLIC_WINDOWS_RELEASE_WORKFLOW = "Publish Ghost FTP"', verifier)
+        self.assertIn("requires trusted Authenticode", verifier)
+        self.assertIn("require_public_release_signatures", verifier)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_public_release_signing_contract.py
+++ b/scripts/test_public_release_signing_contract.py
@@ -42,7 +42,8 @@ class PublicReleaseSigningContractTest(unittest.TestCase):
         verifier = VERIFY_RELEASE.read_text(encoding="utf-8")
 
         self.assertIn('PUBLIC_WINDOWS_RELEASE_WORKFLOW = "Publish Ghost FTP"', verifier)
-        self.assertIn("requires trusted Authenticode", verifier)
+        self.assertIn("public Windows release artifacts must be Authenticode signed", verifier)
+        self.assertIn("trusted production signing identity", verifier)
         self.assertIn("require_public_release_signatures", verifier)
 
 


### PR DESCRIPTION
## Problem
The canonical `Publish Ghost FTP` workflow advertised an unsigned public-release path even though `scripts/verify_release.py` already rejects unsigned Windows Setup/Portable artifacts when running inside that workflow. This left the release workflow and its automated policy checks semantically inconsistent.

## Fix
- Require the protected production Authenticode PFX and password in the official release workflow.
- Remove the `state=unsigned` publication path and unsigned-release warning/continuation.
- Verify Authenticode unconditionally on both public Windows executables before staging them.
- Require the publish job to receive `WINDOWS_SIGNING_STATE=signed`.
- Update the release audit to reject reintroduction of an unsigned official-release path.
- Add a dedicated regression test for the public signing contract.

## Scope
Local/development and ordinary CI Windows builds may remain unsigned. This PR changes only the official `Publish Ghost FTP` public-release contract. It does not add credentials to the repository, does not create self-signed production identities, does not bump `VERSION`, and makes no claim that a new release was published.

Base main SHA: `f3d4bb3458e20cfa3fb07deebcfac4cf903091b0`.